### PR TITLE
Refactor `DbGroupState` to be id-based

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -65,7 +65,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
 
     final var record = command.getValue();
     final var groupName = record.getName();
-    final var groupKey = groupState.getGroupKeyByName(groupName);
+    final var groupKey = groupState.get(record.getGroupId());
     if (groupKey.isPresent()) {
       final var errorMessage = GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(groupName);
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
@@ -88,7 +88,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
     groupState
-        .get(record.getGroupKey())
+        .get(record.getGroupId())
         .ifPresentOrElse(
             persistedGroup -> {
               final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -88,7 +88,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
     groupState
-        .get(record.getGroupId())
+        .get(record.getGroupKey())
         .ifPresentOrElse(
             persistedGroup -> {
               final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -63,7 +63,6 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
       return;
     }
 
-    final var updatedGroupName = record.getName();
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
             .addResourceId(persistedRecord.get().getName());
@@ -72,15 +71,6 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
-      return;
-    }
-
-    if (groupState.getGroupKeyByName(updatedGroupName).isPresent()) {
-      final var errorMessage =
-          "Expected to update group with name '%s', but a group with this name already exists."
-              .formatted(updatedGroupName);
-      rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -171,8 +171,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
 
   private boolean checkGroupAssignment(
       final String entityId, final TypedRecord<TenantRecord> command, final String tenantId) {
-    // TODO remove the Long parsing once Groups are migrated to work with ids instead of keys
-    final var group = groupState.get(Long.parseLong(entityId));
+    final var group = groupState.get(entityId);
     if (group.isEmpty()) {
       createEntityNotExistRejectCommand(command, entityId, EntityType.GROUP, tenantId);
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -129,11 +129,10 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public Optional<Long> getGroupKeyByName(final String groupName) {
-//    this.groupName.wrapString(groupName);
-//    final var groupKey = groupByNameColumnFamily.get(this.groupName);
-//    return Optional.ofNullable(groupKey).map(key -> key.inner().getValue());
-    return Optional.empty();
+  public Optional<PersistedGroup> get(final String groupId) {
+    this.groupId.wrapString(groupId);
+    final var persistedGroup = groupColumnFamily.get(this.groupId);
+    return Optional.ofNullable(persistedGroup);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -15,9 +15,11 @@ import java.util.Optional;
 
 public interface GroupState {
 
+  // TODO: remove this method once every entity is switched to IDs
+  // this method is used in AuthorizationCheckBehavior to retrieve groups by key from mapping
   Optional<PersistedGroup> get(long groupKey);
 
-  Optional<Long> getGroupKeyByName(String groupName);
+  Optional<PersistedGroup> get(String groupId);
 
   Optional<EntityType> getEntityType(long groupKey, long entityKey);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -36,6 +37,7 @@ public class GroupTest {
     assertThat(createdGroup).hasName(name);
   }
 
+  @Ignore("Re-enable with https://github.com/camunda/camunda/issues/30022")
   @Test
   public void shouldNotDuplicate() {
     // given
@@ -85,26 +87,6 @@ public class GroupTest {
         .hasRejectionReason(
             "Expected to update group with key '%d', but a group with this key does not exist."
                 .formatted(groupKey));
-  }
-
-  @Test
-  public void shouldRejectUpdatedIfSameNameGroupExists() {
-    // given
-    final var groupName = "yolo";
-    final var groupKey = engine.group().newGroup(groupName).create().getKey();
-    final var anotherGroupName = "yolo2";
-    engine.group().newGroup(anotherGroupName).create();
-
-    // when
-    final var updatedGroupRecord =
-        engine.group().updateGroup(groupKey).withName(anotherGroupName).expectRejection().update();
-
-    // then
-    assertThat(updatedGroupRecord)
-        .hasRejectionType(RejectionType.ALREADY_EXISTS)
-        .hasRejectionReason(
-            "Expected to update group with name '%s', but a group with this name already exists."
-                .formatted(anotherGroupName));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -225,8 +225,6 @@ public class GroupAppliersTest {
     // the group state is cleaned up
     final var group = groupState.get(groupKey);
     assertThat(group.isPresent()).isFalse();
-    final var groupKeyByName = groupState.getGroupKeyByName(groupName);
-    assertThat(groupKeyByName.isPresent()).isFalse();
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -50,22 +50,6 @@ public class GroupStateTest {
   }
 
   @Test
-  void shouldReturnKeyForGroupName() {
-    // given
-    final var groupKey = 1L;
-    final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
-    groupState.create(groupKey, groupRecord);
-
-    // when
-    final var key = groupState.getGroupKeyByName(groupName);
-
-    // then
-    assertThat(key.isPresent()).isTrue();
-    assertThat(key.get()).isEqualTo(groupKey);
-  }
-
-  @Test
   void shouldReturnNullIfGroupDoesNotExist() {
     // given
     final var groupKey = 2L;
@@ -75,18 +59,6 @@ public class GroupStateTest {
 
     // then
     assertThat(group.isPresent()).isFalse();
-  }
-
-  @Test
-  void shouldReturnNullIfNameDoesNotExist() {
-    // given
-    final var groupName = "group";
-
-    // when
-    final var key = groupState.getGroupKeyByName(groupName);
-
-    // then
-    assertThat(key.isPresent()).isFalse();
   }
 
   @Test
@@ -109,10 +81,6 @@ public class GroupStateTest {
     final var persistedGroup = group.get();
     assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
     assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
-
-    final var groupKeyByName = groupState.getGroupKeyByName(updatedGroupName);
-    assertThat(groupKeyByName.isPresent()).isTrue();
-    assertThat(groupKeyByName.get()).isEqualTo(groupKey);
   }
 
   @Test
@@ -198,9 +166,6 @@ public class GroupStateTest {
     // then
     final var group = groupState.get(groupKey);
     assertThat(group).isEmpty();
-
-    final var groupKeyByName = groupState.getGroupKeyByName(groupName);
-    assertThat(groupKeyByName).isEmpty();
 
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Groups are going to be id-based. All CF working with keys are changed to use ids instead. The GROUP_BY_NAME is removed entirely.

## Related issues

closes #30159 
