### PR TITLE
ci: don't exit status 1 when c8run label is not found in labels

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -31,12 +31,10 @@ jobs:
           run: |
             echo "project_id=33" >> "$GITHUB_OUTPUT"
             echo "now=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-        
+
             labels=$(jq -r '.issue.labels[].name' "$GITHUB_EVENT_PATH")
             if echo "$labels" | grep -q  "^component/c8run$"; then
               echo "match=true" >> "$GITHUB_OUTPUT"
-            else
-              exit 1
             fi
 
         - name: Generate GitHub token


### PR DESCRIPTION
## Description

@ThorbenLindhauer reported that this github action that runs whenever any issue is closed reports itself as a failed job any time the c8run label is not applied. However, the github action should still report success because there is no error. It simply wasn't a c8run issue.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
