### PR TITLE
feat: include native libs into package to avoid polluting /tmp

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -723,7 +723,7 @@
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8 -Xshare:auto</extraJvmArguments>
+            -Dfile.encoding=UTF-8 -Xshare:auto -Djava.library.path="$BASEDIR/native-libs"</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
@@ -857,6 +857,26 @@
             <dep>io.camunda.optimize:optimize-webjar</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.rocksdb</groupId>
+                  <artifactId>rocksdbjni</artifactId>
+                  <version>${version.rocksdbjni}</version>
+                  <includes>*.so,*.dll,</includes>
+                  <outputDirectory>${project.build.directory}/native-libraries</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -863,7 +863,7 @@
             <goals>
               <goal>unpack</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <artifactItems>
                 <artifactItem>

--- a/dist/src/main/assembly.xml
+++ b/dist/src/main/assembly.xml
@@ -21,6 +21,10 @@
       <directory>${maven.multiModuleProjectDirectory}/licenses</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/native-libraries</directory>
+      <outputDirectory>native-libs</outputDirectory>
+    </fileSet>
   </fileSets>
 
   <files>


### PR DESCRIPTION
## Description
A folder native-libs/ is added to the package which contains all *.so, *.dll files from rocksdb. The folder is then set as "java.library.path". The property is set as "$BASE_DIR/native-libs" so that it's correctly used when the script is invoked from the root of the package or from the "bin/" directory as well.

> [!Note]
> I started from @lenaschoenburg patch from [comment](https://github.com/camunda/camunda/issues/28892#issuecomment-2691101777)

### Test procedure

#### Preparation
Verify that in `main` when the broker script is started (with ES turned on) you can see that by invoking the command `watch -n 1 "ls /tmp  | grep rocksdb"` you see unpacked librocksdbjni\*.so files.

> [!NOTE]
> when the broker is stopped, those files are deleted, so it may not be a problem on all systems

#### Test
- Clean install the package
- Unpack `dist/target/camunda-zeebe-8.8.0-SNAPSHOT.zip`
- Run in separate terminal `watch -n 1 "ls /tmp  | grep rocksdb"`
- Run `bin/broker` and verify there is no _librocksdbjni\*_
- Run `cd bin && ./broker` and verify there is no _librocksdbjni\*_

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [X] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28892 
