### PR TITLE
[C8 API] Allow excluding multiple process instances

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BasicStringFilterProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BasicStringFilterProperty.java
@@ -24,12 +24,13 @@ public class BasicStringFilterProperty {
   private String neq;
   private Boolean exists;
   private List<String> in = new ArrayList<>();
+  private List<String> notIn = new ArrayList<>();
 
   public String getEq() {
     return eq;
   }
 
-  public void setEq(String eq) {
+  public void setEq(final String eq) {
     this.eq = eq;
   }
 
@@ -37,7 +38,7 @@ public class BasicStringFilterProperty {
     return neq;
   }
 
-  public void setNeq(String neq) {
+  public void setNeq(final String neq) {
     this.neq = neq;
   }
 
@@ -45,7 +46,7 @@ public class BasicStringFilterProperty {
     return exists;
   }
 
-  public void setExists(Boolean exists) {
+  public void setExists(final Boolean exists) {
     this.exists = exists;
   }
 
@@ -53,7 +54,15 @@ public class BasicStringFilterProperty {
     return in;
   }
 
-  public void setIn(List<String> in) {
+  public void setIn(final List<String> in) {
     this.in = in;
+  }
+
+  public List<String> getNotIn() {
+    return notIn;
+  }
+
+  public void setNotIn(final List<String> notIn) {
+    this.notIn = notIn;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicLongProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicLongProperty.java
@@ -16,6 +16,12 @@
 package io.camunda.client.api.search.filter.builder;
 
 import io.camunda.client.api.search.filter.BasicStringFilterProperty;
+import java.util.List;
 
 public interface BasicLongProperty
-    extends PropertyBase<Long, BasicStringFilterProperty, BasicLongProperty> {}
+    extends PropertyBase<Long, BasicStringFilterProperty, BasicLongProperty> {
+
+  BasicLongProperty notIn(final List<Long> values);
+
+  BasicLongProperty notIn(final Long... values);
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/RequestMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/RequestMapper.java
@@ -62,6 +62,13 @@ public class RequestMapper {
       object.getIn().forEach(protocolObject::add$InItem);
     }
 
+    if (object.getNotIn() == null) {
+      protocolObject.set$NotIn(null);
+    } else {
+      protocolObject.set$NotIn(new ArrayList<>());
+      object.getNotIn().forEach(protocolObject::add$NotInItem);
+    }
+
     return protocolObject;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/ResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/ResponseMapper.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class ResponseMapper {
 
   public static AdHocSubprocessActivityRequestFilter fromProtocolObject(
-      io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter protocolObject) {
+      final io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -40,7 +40,7 @@ public class ResponseMapper {
   }
 
   public static BasicStringFilterProperty fromProtocolObject(
-      io.camunda.client.protocol.rest.BasicStringFilterProperty protocolObject) {
+      final io.camunda.client.protocol.rest.BasicStringFilterProperty protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -55,11 +55,18 @@ public class ResponseMapper {
       object.setIn(new ArrayList<>());
       object.getIn().addAll(protocolObject.get$In());
     }
+    if (protocolObject.get$NotIn() == null) {
+      object.setNotIn(null);
+    } else {
+      object.setNotIn(new ArrayList<>());
+      object.getNotIn().addAll(protocolObject.get$NotIn());
+    }
+
     return object;
   }
 
   public static DateTimeFilterProperty fromProtocolObject(
-      io.camunda.client.protocol.rest.DateTimeFilterProperty protocolObject) {
+      final io.camunda.client.protocol.rest.DateTimeFilterProperty protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -82,7 +89,7 @@ public class ResponseMapper {
   }
 
   public static GroupChangeset fromProtocolObject(
-      io.camunda.client.protocol.rest.GroupChangeset protocolObject) {
+      final io.camunda.client.protocol.rest.GroupChangeset protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -93,7 +100,7 @@ public class ResponseMapper {
   }
 
   public static IntegerFilterProperty fromProtocolObject(
-      io.camunda.client.protocol.rest.IntegerFilterProperty protocolObject) {
+      final io.camunda.client.protocol.rest.IntegerFilterProperty protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -116,7 +123,7 @@ public class ResponseMapper {
   }
 
   public static JobChangeset fromProtocolObject(
-      io.camunda.client.protocol.rest.JobChangeset protocolObject) {
+      final io.camunda.client.protocol.rest.JobChangeset protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -128,7 +135,7 @@ public class ResponseMapper {
   }
 
   public static ProblemDetail fromProtocolObject(
-      io.camunda.client.protocol.rest.ProblemDetail protocolObject) {
+      final io.camunda.client.protocol.rest.ProblemDetail protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -143,7 +150,7 @@ public class ResponseMapper {
   }
 
   public static ProcessInstanceStateFilterProperty fromProtocolObject(
-      io.camunda.client.protocol.rest.ProcessInstanceStateFilterProperty protocolObject) {
+      final io.camunda.client.protocol.rest.ProcessInstanceStateFilterProperty protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -166,7 +173,7 @@ public class ResponseMapper {
   }
 
   public static StringFilterProperty fromProtocolObject(
-      io.camunda.client.protocol.rest.StringFilterProperty protocolObject) {
+      final io.camunda.client.protocol.rest.StringFilterProperty protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -186,7 +193,7 @@ public class ResponseMapper {
   }
 
   public static ProcessInstanceVariableFilterRequest fromProtocolObject(
-      io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest protocolObject) {
+      final io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -198,7 +205,8 @@ public class ResponseMapper {
   }
 
   public static List<ProcessInstanceVariableFilterRequest> fromProtocolList(
-      List<io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest> protocolList) {
+      final List<io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest>
+          protocolList) {
     if (protocolList == null) {
       return null;
     }
@@ -209,7 +217,7 @@ public class ResponseMapper {
   }
 
   public static UserTaskVariableFilterRequest fromProtocolObject(
-      io.camunda.client.protocol.rest.UserTaskVariableFilterRequest protocolObject) {
+      final io.camunda.client.protocol.rest.UserTaskVariableFilterRequest protocolObject) {
     if (protocolObject == null) {
       return null;
     }
@@ -221,7 +229,7 @@ public class ResponseMapper {
   }
 
   public static List<UserTaskVariableFilterRequest> fromUserTaskVariableFilterRequestList(
-      List<io.camunda.client.protocol.rest.UserTaskVariableFilterRequest> protocolList) {
+      final List<io.camunda.client.protocol.rest.UserTaskVariableFilterRequest> protocolList) {
     if (protocolList == null) {
       return null;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
@@ -61,13 +61,13 @@ public class BasicLongPropertyImpl implements BasicLongProperty {
   }
 
   @Override
-  public BasicLongProperty nin(final List<Long> values) {
-    filterProperty.set$Nin(values.stream().map(String::valueOf).collect(Collectors.toList()));
+  public BasicLongProperty notIn(final List<Long> values) {
+    filterProperty.set$NotIn(values.stream().map(String::valueOf).collect(Collectors.toList()));
     return this;
   }
 
   @Override
-  public BasicLongProperty nin(final Long... value) {
-    return nin(CollectionUtil.toList(value));
+  public BasicLongProperty notIn(final Long... value) {
+    return notIn(CollectionUtil.toList(value));
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
@@ -59,4 +59,15 @@ public class BasicLongPropertyImpl implements BasicLongProperty {
   public BasicStringFilterProperty build() {
     return ResponseMapper.fromProtocolObject(filterProperty);
   }
+
+  @Override
+  public BasicLongProperty nin(final List<Long> values) {
+    filterProperty.set$Nin(values.stream().map(String::valueOf).collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public BasicLongProperty nin(final Long... value) {
+    return nin(CollectionUtil.toList(value));
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -140,7 +140,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     // when
     client
         .newProcessInstanceSearchRequest()
-        .filter(f -> f.processInstanceKey(b -> b.nin(1L, 10L)))
+        .filter(f -> f.processInstanceKey(b -> b.notIn(1L, 10L)))
         .send()
         .join();
 
@@ -151,7 +151,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(filter).isNotNull();
     final BasicStringFilterProperty processInstanceKey = filter.getProcessInstanceKey();
     assertThat(processInstanceKey).isNotNull();
-    assertThat(processInstanceKey.get$Nin()).isEqualTo(Arrays.asList("1", "10"));
+    assertThat(processInstanceKey.get$NotIn()).isEqualTo(Arrays.asList("1", "10"));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -117,7 +117,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
   }
 
   @Test
-  void shouldSearchProcessInstanceByProcessInstanceKeyLongFilter() {
+  void shouldSearchProcessInstanceByProcessInstanceKeyLongInFilter() {
     // when
     client
         .newProcessInstanceSearchRequest()
@@ -133,6 +133,25 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final BasicStringFilterProperty processInstanceKey = filter.getProcessInstanceKey();
     assertThat(processInstanceKey).isNotNull();
     assertThat(processInstanceKey.get$In()).isEqualTo(Arrays.asList("1", "10"));
+  }
+
+  @Test
+  void shouldSearchProcessInstanceByProcessInstanceKeyLongNinFilter() {
+    // when
+    client
+        .newProcessInstanceQuery()
+        .filter(f -> f.processInstanceKey(b -> b.nin(1L, 10L)))
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceSearchQuery request =
+        gatewayService.getLastRequest(ProcessInstanceSearchQuery.class);
+    final ProcessInstanceFilter filter = request.getFilter();
+    assertThat(filter).isNotNull();
+    final BasicStringFilterProperty processInstanceKey = filter.getProcessInstanceKey();
+    assertThat(processInstanceKey).isNotNull();
+    assertThat(processInstanceKey.get$Nin()).isEqualTo(Arrays.asList("1", "10"));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -139,7 +139,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
   void shouldSearchProcessInstanceByProcessInstanceKeyLongNinFilter() {
     // when
     client
-        .newProcessInstanceQuery()
+        .newProcessInstanceSearchRequest()
         .filter(f -> f.processInstanceKey(b -> b.nin(1L, 10L)))
         .send()
         .join();

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -40,7 +40,7 @@
       <when test="operation.operator.name().equals('IN')">
         IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
       </when>
-      <when test="operation.operator.name().equals('NIN')">
+      <when test="operation.operator.name().equals('NOT_IN')">
         NOT IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
       </when>
       <when test="operation.operator.name().equals('LIKE')">

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -40,6 +40,9 @@
       <when test="operation.operator.name().equals('IN')">
         IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
       </when>
+      <when test="operation.operator.name().equals('NIN')">
+        NOT IN <foreach collection="operation.values" item="value" open="(" separator=", " close=")">#{value}</foreach>
+      </when>
       <when test="operation.operator.name().equals('LIKE')">
         LIKE #{operation.value, typeHandler=io.camunda.db.rdbms.sql.typehandler.WildcardTransformingStringTypeHandler}
           ESCAPE ${escapeChar}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -159,7 +159,7 @@ class DecisionInstanceSearchTest {
         EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionKey();
     final var result =
         camundaClient
-            .newDecisionInstanceQuery()
+            .newDecisionInstanceSearchRequest()
             .filter(f -> f.decisionDefinitionKey(b -> b.nin(Long.MAX_VALUE, decisionDefinitionKey)))
             .send()
             .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -160,7 +160,8 @@ class DecisionInstanceSearchTest {
     final var result =
         camundaClient
             .newDecisionInstanceSearchRequest()
-            .filter(f -> f.decisionDefinitionKey(b -> b.nin(Long.MAX_VALUE, decisionDefinitionKey)))
+            .filter(
+                f -> f.decisionDefinitionKey(b -> b.notIn(Long.MAX_VALUE, decisionDefinitionKey)))
             .send()
             .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -33,6 +33,7 @@ class DecisionInstanceSearchTest {
 
   private static final String DECISION_DEFINITION_ID_1 = "decision_1";
   private static final String DECISION_DEFINITION_ID_2 = "invoiceAssignApprover";
+  private static final String DECISION_DEFINITION_ID_3 = "invoiceClassification";
   private static CamundaClient camundaClient;
   // evaluated decisions mapped by decision definition id
   private static final Map<String, EvaluateDecisionResponse> EVALUATED_DECISIONS = new HashMap<>();
@@ -148,6 +149,26 @@ class DecisionInstanceSearchTest {
         .isEqualTo(decisionDefinitionKey);
     assertThat(result.items().getFirst().getDecisionInstanceKey())
         .isEqualTo(EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+  }
+
+  @Test
+  public void shouldRetrieveDecisionInstanceByDecisionKeyFilterNotIn(
+      final CamundaClient camundaClient) {
+    // when
+    final long decisionDefinitionKey =
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionKey();
+    final var result =
+        camundaClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.decisionDefinitionKey(b -> b.nin(Long.MAX_VALUE, decisionDefinitionKey)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items())
+        .extracting(DecisionInstance::getDecisionDefinitionId)
+        .containsExactlyInAnyOrder(DECISION_DEFINITION_ID_2, DECISION_DEFINITION_ID_3);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -249,7 +249,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var result =
         camundaClient
             .newProcessInstanceSearchRequest()
-            .filter(f -> f.processInstanceKey(b -> b.nin(processInstanceKeys)))
+            .filter(f -> f.processInstanceKey(b -> b.notIn(processInstanceKeys)))
             .send()
             .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -238,6 +238,30 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
   }
 
   @Test
+  void shouldQueryProcessInstancesByKeyFilterNotIn() {
+    // given
+    final List<Long> processInstanceKeys =
+        PROCESS_INSTANCES.subList(0, 2).stream()
+            .map(ProcessInstanceEvent::getProcessInstanceKey)
+            .toList();
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(f -> f.processInstanceKey(b -> b.nin(processInstanceKeys)))
+            .send()
+            .join();
+
+    final var numberOfExpectedProcessInstances =
+        (PROCESS_INSTANCES.size() + 1) - 2; // includes 1 child process, minus 2 excluded
+
+    // then
+    assertThat(result.items().size()).isEqualTo(numberOfExpectedProcessInstances);
+    assertThat(result.items()).extracting("processInstanceKey").doesNotContain(processInstanceKeys);
+  }
+
+  @Test
   void shouldQueryProcessInstancesByProcessDefinitionId() {
     // given
     final String bpmnProcessId = "service_tasks_v1";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -248,7 +248,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(f -> f.processInstanceKey(b -> b.nin(processInstanceKeys)))
             .send()
             .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -221,7 +221,7 @@ class VariableSearchTest {
     final var result =
         camundaClient
             .newVariableSearchRequest()
-            .filter(f -> f.processInstanceKey(b -> b.nin(variable.getProcessInstanceKey())))
+            .filter(f -> f.processInstanceKey(b -> b.notIn(variable.getProcessInstanceKey())))
             .send()
             .join();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -216,6 +216,20 @@ class VariableSearchTest {
   }
 
   @Test
+  void shouldQueryByProcessInstanceKeyFilterNotIn() {
+    // when
+    final var result =
+        camundaClient
+            .newVariableQuery()
+            .filter(f -> f.processInstanceKey(b -> b.nin(variable.getProcessInstanceKey())))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(0);
+  }
+
+  @Test
   void shouldQueryByTenantId() {
     // when
     final var result =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchTest.java
@@ -220,7 +220,7 @@ class VariableSearchTest {
     // when
     final var result =
         camundaClient
-            .newVariableQuery()
+            .newVariableSearchRequest()
             .filter(f -> f.processInstanceKey(b -> b.nin(variable.getProcessInstanceKey())))
             .send()
             .join();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -356,7 +356,7 @@ public final class SearchQueryBuilders {
           case LOWER_THAN_EQUALS ->
               rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(op.value()));
           case IN -> queries.add(intTerms(field, op.values()));
-          case NIN -> queries.add(mustNot(intTerms(field, op.values())));
+          case NOT_IN -> queries.add(mustNot(intTerms(field, op.values())));
           default -> throw unexpectedOperation("Integer", op.operator());
         }
       }
@@ -393,7 +393,7 @@ public final class SearchQueryBuilders {
           case LOWER_THAN_EQUALS ->
               rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(op.value()));
           case IN -> queries.add(longTerms(field, op.values()));
-          case NIN -> queries.add(mustNot(longTerms(field, op.values())));
+          case NOT_IN -> queries.add(mustNot(longTerms(field, op.values())));
           default -> throw unexpectedOperation("Long", op.operator());
         }
       }
@@ -422,7 +422,7 @@ public final class SearchQueryBuilders {
                   case EXISTS -> exists(field);
                   case NOT_EXISTS -> mustNot(exists(field));
                   case IN -> stringTerms(field, op.values());
-                  case NIN -> mustNot(stringTerms(field, op.values()));
+                  case NOT_IN -> mustNot(stringTerms(field, op.values()));
                   case LIKE -> wildcardQuery(field, op.value());
                   default -> throw unexpectedOperation("String", op.operator());
                 });

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -356,6 +356,7 @@ public final class SearchQueryBuilders {
           case LOWER_THAN_EQUALS ->
               rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(op.value()));
           case IN -> queries.add(intTerms(field, op.values()));
+          case NIN -> queries.add(mustNot(intTerms(field, op.values())));
           default -> throw unexpectedOperation("Integer", op.operator());
         }
       }
@@ -392,6 +393,7 @@ public final class SearchQueryBuilders {
           case LOWER_THAN_EQUALS ->
               rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(op.value()));
           case IN -> queries.add(longTerms(field, op.values()));
+          case NIN -> queries.add(mustNot(longTerms(field, op.values())));
           default -> throw unexpectedOperation("Long", op.operator());
         }
       }
@@ -420,6 +422,7 @@ public final class SearchQueryBuilders {
                   case EXISTS -> exists(field);
                   case NOT_EXISTS -> mustNot(exists(field));
                   case IN -> stringTerms(field, op.values());
+                  case NIN -> mustNot(stringTerms(field, op.values()));
                   case LIKE -> wildcardQuery(field, op.value());
                   default -> throw unexpectedOperation("String", op.operator());
                 });

--- a/search/search-domain/src/main/java/io/camunda/search/filter/Operator.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/Operator.java
@@ -17,7 +17,7 @@ public enum Operator {
   LOWER_THAN("lt"),
   LOWER_THAN_EQUALS("lte"),
   IN("in"),
-  NIN("nin"),
+  NOT_IN("notIn"),
   LIKE("like");
 
   private final String value;

--- a/search/search-domain/src/main/java/io/camunda/search/filter/Operator.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/Operator.java
@@ -17,6 +17,7 @@ public enum Operator {
   LOWER_THAN("lt"),
   LOWER_THAN_EQUALS("lte"),
   IN("in"),
+  NIN("nin"),
   LIKE("like");
 
   private final String value;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4460,15 +4460,15 @@ components:
           description: Checks for inequality with the provided value.
           type: string
         $exists:
-          description: Checks if the current property exists.¡
+          description: Checks if the current property exists.
           type: boolean
         $in:
           description: Checks if the property matches any of the provided values.
           type: array
           items:
             type: string
-        $nin:
-          description: Checks if the property does not match any of the provided values (i.e., it must match none of them).
+        $notIn:
+          description: Checks if the property matches none of the provided values.
           type: array
           items:
             type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4460,10 +4460,15 @@ components:
           description: Checks for inequality with the provided value.
           type: string
         $exists:
-          description: Checks if the current property exists.
+          description: Checks if the current property exists.¡
           type: boolean
         $in:
           description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            type: string
+        $nin:
+          description: Checks if the property does not match any of the provided values (i.e., it must match none of them).
           type: array
           items:
             type: string

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -182,6 +182,12 @@ public abstract class RestControllerTest {
                               stringValues
                                   ? op.values().stream().map(implicitTpl::formatted).toList()
                                   : op.values());
+                      case NIN ->
+                          keyValueTpl.formatted(
+                              "$nin",
+                              stringValues
+                                  ? op.values().stream().map(implicitTpl::formatted).toList()
+                                  : op.values());
                       case LIKE -> explicitTpl.formatted("$like", op.value());
                     })
             .collect(Collectors.joining(","));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -182,9 +182,9 @@ public abstract class RestControllerTest {
                               stringValues
                                   ? op.values().stream().map(implicitTpl::formatted).toList()
                                   : op.values());
-                      case NIN ->
+                      case NOT_IN ->
                           keyValueTpl.formatted(
-                              "$nin",
+                              "$notIn",
                               stringValues
                                   ? op.values().stream().map(implicitTpl::formatted).toList()
                                   : op.values());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds support for the $nin (not in) operator for Long-type filter properties in the Camunda 8 V2 API.

It enables the Operate UI, as part of its migration to the V2 API, to filter process instances by excluding specific instance keys using the /v2/process-instances/search endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30225
