### PR TITLE
[Backport stable/8.5] fix: do not throw a NullPointerException when the firstSegment is null in SegmentedJournal

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -151,7 +151,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public boolean isEmpty() {
-    return writer.getNextIndex() - getFirstSegment().index() == 0;
+    return writer.getNextIndex() - getFirstIndex() == 0;
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #30234 to `stable/8.5`.

relates to 