### PR TITLE
[Backport stable/8.4] fix: do not initialize BrokerInfo from config 

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
@@ -34,7 +34,22 @@ public class ClusterTopologyManagerStep
         .onComplete(
             (ignore, error) -> {
               if (error == null) {
+<<<<<<< HEAD:broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterTopologyManagerStep.java
                 brokerStartupContext.setClusterTopology(clusterTopologyService);
+=======
+                brokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
+                final var brokerInfo = brokerStartupContext.getBrokerInfo();
+                final var clusterConfiguration =
+                    brokerStartupContext
+                        .getBrokerClient()
+                        .getTopologyManager()
+                        .getClusterConfiguration();
+                brokerInfo
+                    .setClusterSize(clusterConfiguration.clusterSize())
+                    .setPartitionsCount(clusterConfiguration.partitionCount())
+                    .setReplicationFactor(clusterConfiguration.minReplicationFactor());
+
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
                 started.complete(brokerStartupContext);
               } else {
                 started.completeExceptionally(error);

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -11,7 +11,11 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionRaftListener;
+<<<<<<< HEAD:broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+=======
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
@@ -96,11 +100,18 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private volatile boolean allPartitionsInstalled = false;
   private volatile boolean brokerStarted = false;
   private final HealthMonitor healthMonitor;
-  private final MemberId nodeId;
 
+<<<<<<< HEAD:broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
   public BrokerHealthCheckService(final BrokerInfo localBroker) {
     nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
     healthMonitor = new CriticalComponentsHealthMonitor("Broker-" + nodeId, actor, LOG);
+=======
+  public BrokerHealthCheckService(
+      final MemberId nodeId, final HealthTreeMetrics healthGraphMetrics) {
+    healthMonitor =
+        new CriticalComponentsHealthMonitor(
+            "Broker-" + nodeId, actor, healthGraphMetrics, Optional.empty(), LOG);
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
   }
 
   public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -9,18 +9,29 @@ package io.camunda.zeebe.broker.system.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
+<<<<<<< HEAD:broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+=======
+import io.atomix.cluster.MemberId;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
 import org.junit.Test;
 
 public class BrokerHealthCheckServiceTest {
 
+  private final MemberId member = MemberId.from("member-1");
+
   @Test
   public void shouldNotBeReadyHealthyOrStartedBeforePartitionManagerIsRegistered() {
     // given
+<<<<<<< HEAD:broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
     final var brokerInfo = mock(BrokerInfo.class);
     final var healthCheckService = new BrokerHealthCheckService(brokerInfo);
+=======
+    final var healthCheckService =
+        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
 
     // when
 
@@ -40,8 +51,13 @@ public class BrokerHealthCheckServiceTest {
   @Test
   public void shouldThrowIllegalStateExceptionIfStatusIsUpdatedBeforePartitionsAreKnown() {
     // given
+<<<<<<< HEAD:broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
     final var brokerInfo = mock(BrokerInfo.class);
     final var healthCheckService = new BrokerHealthCheckService(brokerInfo);
+=======
+    final var healthCheckService =
+        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+>>>>>>> 9f146675 (fix: initialize BrokerInfo from ClusterConfiguration instead of configuration):zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
 
     // when + then
 


### PR DESCRIPTION
# Description
Backport of #30217 to `stable/8.4`.

relates to #30110 #29612