### PR TITLE
feat: remove a limiter on appends based on avg append latency

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -105,11 +105,6 @@
 
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-math3</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -44,7 +44,6 @@ public final class RaftMemberContext {
   private long responseTime;
   private int inFlightAppendCount;
   private boolean appendSucceeded;
-  private long appendTime;
   private boolean configuring;
   private boolean installing;
   private int failures;
@@ -182,7 +181,6 @@ public final class RaftMemberContext {
   /** Starts an append request to the member. */
   public void startAppend() {
     inFlightAppendCount++;
-    appendTime = System.currentTimeMillis();
   }
 
   /** Completes an append request to the member. */
@@ -259,7 +257,6 @@ public final class RaftMemberContext {
         .add("heartbeatTime", heartbeatTime)
         .add("appending", inFlightAppendCount)
         .add("appendSucceeded", appendSucceeded)
-        .add("appendTime", appendTime)
         .add("configuring", configuring)
         .add("installing", installing)
         .add("failures", failures)

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -215,11 +215,7 @@ final class LeaderAppender {
                 // Complete the append to the member.
                 final long appendLatency = System.currentTimeMillis() - timestamp;
                 metrics.appendComplete(appendLatency, member.getMember().memberId().id());
-                if (!request.entries().isEmpty()) {
-                  member.completeAppend(appendLatency);
-                } else {
-                  member.completeAppend();
-                }
+                member.completeAppend();
 
                 if (error == null) {
                   LOGGER.trace("Received {} from {}", response, member.getMember().memberId());


### PR DESCRIPTION
## Description
The condition `(now() - (appendLatency.mean() / maxAppendsPerMember) >= appendTimeStart)` may be superfluous as we already limit the number of inflight requests to maxAppendsPerMember.

Looking into the implementation of `DescriptiveStatistics` class it's not been implemented with performance in mind, as it create a lot of temporary `double[] ` instead of using a fixed size circular buffer.

A better solution would be to implement #30379, but it's outside the scope of this PR

FYI @ChrisKujawa 