### PR TITLE
feat: add or queries to ProcessInstanceFilter

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -122,4 +122,7 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
 
   /** Filter by error message using {@link StringProperty} consumer */
   ProcessInstanceFilter errorMessage(final Consumer<StringProperty> fn);
+
+  /** Filter by or conjunction using {@link ProcessInstanceFilter} consumer */
+  ProcessInstanceFilter or(final List<Consumer<ProcessInstanceFilter>> fns);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -30,6 +30,7 @@ import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ProcessInstanceStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.ProcessInstanceFilterFields;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -278,6 +279,40 @@ public class ProcessInstanceFilterImpl
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setErrorMessage(RequestMapper.toProtocolObject(property.build()));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter or(final List<Consumer<ProcessInstanceFilter>> fns) {
+    // TODO implement this properly
+    for (final Consumer<ProcessInstanceFilter> fn : fns) {
+      final ProcessInstanceFilterImpl orFilter = new ProcessInstanceFilterImpl();
+      fn.accept(orFilter);
+      final io.camunda.client.protocol.rest.ProcessInstanceFilter protocolFilter =
+          orFilter.getSearchRequestProperty();
+      final ProcessInstanceFilterFields protocolFilterFields = new ProcessInstanceFilterFields();
+      protocolFilterFields.setProcessDefinitionId(protocolFilter.getProcessDefinitionId());
+      protocolFilterFields.setProcessDefinitionName(protocolFilter.getProcessDefinitionName());
+      protocolFilterFields.setProcessDefinitionVersion(
+          protocolFilter.getProcessDefinitionVersion());
+      protocolFilterFields.setProcessDefinitionVersionTag(
+          protocolFilter.getProcessDefinitionVersionTag());
+      protocolFilterFields.setProcessDefinitionKey(protocolFilter.getProcessDefinitionKey());
+      protocolFilterFields.setBatchOperationId(protocolFilter.getBatchOperationId());
+      protocolFilterFields.setErrorMessage(protocolFilter.getErrorMessage());
+      protocolFilterFields.setStartDate(protocolFilter.getStartDate());
+      protocolFilterFields.setEndDate(protocolFilter.getEndDate());
+      protocolFilterFields.setState(protocolFilter.getState());
+      protocolFilterFields.setHasIncident(protocolFilter.getHasIncident());
+      protocolFilterFields.setTenantId(protocolFilter.getTenantId());
+      protocolFilterFields.setVariables(protocolFilter.getVariables());
+      protocolFilterFields.setProcessInstanceKey(protocolFilter.getProcessInstanceKey());
+      protocolFilterFields.setParentProcessInstanceKey(
+          protocolFilter.getParentProcessInstanceKey());
+      protocolFilterFields.setParentFlowNodeInstanceKey(
+          protocolFilter.getParentFlowNodeInstanceKey());
+      filter.add$OrItem(protocolFilterFields);
+    }
     return this;
   }
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -38,7 +38,9 @@
     FROM ${prefix}PROCESS_INSTANCE pi
     <!-- TODO: only when definition filters are active -->
     LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
-    <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
+    <where>
+      <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
+    </where>
   </select>
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->
@@ -64,7 +66,15 @@
     pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
     LEFT JOIN ${prefix}PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
-    <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
+    <where>
+      <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
+      <if test="filter.orOperations != null and !filter.orOperations.isEmpty()">
+        AND
+        <foreach open="(" close=")" collection="filter.orOperations" item="filter" separator=" OR ">
+          <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
+        </foreach>
+      </if>
+    </where>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
@@ -72,112 +82,113 @@
   </select>
 
   <sql id="searchFilter">
-    WHERE 1 = 1
-    <!-- basic filters -->
-    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.processInstanceKeyOperations" item="operation">
-        AND PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionIdOperations" item="operation">
-        AND pi.PROCESS_DEFINITION_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
-        AND pi.PROCESS_DEFINITION_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.parentProcessInstanceKeyOperations != null and !filter.parentProcessInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.parentProcessInstanceKeyOperations" item="operation">
-        AND PARENT_PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.parentFlowNodeInstanceKeyOperations != null and !filter.parentFlowNodeInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.parentFlowNodeInstanceKeyOperations" item="operation">
-        AND PARENT_ELEMENT_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
-      <foreach collection="filter.stateOperations" item="operation">
-        AND pi.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
-      <foreach collection="filter.tenantIdOperations" item="operation">
-        AND TENANT_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.hasIncident != null">
-      <if test="filter.hasIncident == true">
-        AND pi.NUM_INCIDENTS > 0
+    <trim prefixOverrides="AND">
+      <!-- basic filters -->
+      <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.processInstanceKeyOperations" item="operation">
+          AND PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-      <if test="filter.hasIncident == false">
-        AND pi.NUM_INCIDENTS = 0
+      <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionIdOperations" item="operation">
+          AND pi.PROCESS_DEFINITION_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-    </if>
-
-    <!-- date filters -->
-    <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">
-      <foreach collection="filter.startDateOperations" item="operation">
-        AND START_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.endDateOperations != null and !filter.endDateOperations.isEmpty()">
-      <foreach collection="filter.endDateOperations" item="operation">
-        AND END_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-
-    <!-- process definition filters -->
-    <if test="filter.processDefinitionNameOperations != null and !filter.processDefinitionNameOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionNameOperations" item="operation">
-        AND pd.NAME <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.processDefinitionVersionOperations != null and !filter.processDefinitionVersionOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionVersionOperations" item="operation">
-        AND pd.VERSION <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.processDefinitionVersionTagOperations != null and !filter.processDefinitionVersionTagOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionVersionTagOperations" item="operation">
-        AND pd.VERSION_TAG <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-
-    <!-- Variable filters -->
-    <if test="filter.variableFilters != null and !filter.variableFilters.isEmpty()">
-      <foreach collection="filter.variableFilters" item="variableFilter"
-        open="AND (" separator=" AND " close=")">
-        EXISTS (
-        SELECT 1
-        FROM ${prefix}VARIABLE v
-        WHERE v.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND v.VAR_NAME = #{variableFilter.name}
-        <if
-          test="variableFilter.valueOperations != null and !variableFilter.valueOperations.isEmpty()">
-          <foreach collection="variableFilter.valueOperations" item="operation">
-            AND
-            <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
-          </foreach>
+      <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+          AND pi.PROCESS_DEFINITION_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.parentProcessInstanceKeyOperations != null and !filter.parentProcessInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.parentProcessInstanceKeyOperations" item="operation">
+          AND PARENT_PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.parentFlowNodeInstanceKeyOperations != null and !filter.parentFlowNodeInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.parentFlowNodeInstanceKeyOperations" item="operation">
+          AND PARENT_ELEMENT_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+        <foreach collection="filter.stateOperations" item="operation">
+          AND pi.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+        <foreach collection="filter.tenantIdOperations" item="operation">
+          AND pi.TENANT_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.hasIncident != null">
+        <if test="filter.hasIncident == true">
+          AND pi.NUM_INCIDENTS > 0
         </if>
-        )
-      </foreach>
-    </if>
+        <if test="filter.hasIncident == false">
+          AND pi.NUM_INCIDENTS = 0
+        </if>
+      </if>
 
-    <!-- Error message filters -->
-    <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
-      <foreach collection="filter.errorMessageOperations" item="operation">
-        AND EXISTS (
-        SELECT 1
-        FROM INCIDENT i
-        WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        )
-      </foreach>
-    </if>
+      <!-- date filters -->
+      <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">
+        <foreach collection="filter.startDateOperations" item="operation">
+          AND START_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.endDateOperations != null and !filter.endDateOperations.isEmpty()">
+        <foreach collection="filter.endDateOperations" item="operation">
+          AND END_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <!-- process definition filters -->
+      <if test="filter.processDefinitionNameOperations != null and !filter.processDefinitionNameOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionNameOperations" item="operation">
+          AND pd.NAME <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionVersionOperations != null and !filter.processDefinitionVersionOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionVersionOperations" item="operation">
+          AND pd.VERSION <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionVersionTagOperations != null and !filter.processDefinitionVersionTagOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionVersionTagOperations" item="operation">
+          AND pd.VERSION_TAG <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <!-- Variable filters -->
+      <if test="filter.variableFilters != null and !filter.variableFilters.isEmpty()">
+        <foreach collection="filter.variableFilters" item="variableFilter"
+          open="AND (" separator=" AND " close=")">
+          EXISTS (
+          SELECT 1
+          FROM ${prefix}VARIABLE v
+          WHERE v.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND v.VAR_NAME = #{variableFilter.name}
+          <if
+            test="variableFilter.valueOperations != null and !variableFilter.valueOperations.isEmpty()">
+            <foreach collection="variableFilter.valueOperations" item="operation">
+              AND
+              <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
+            </foreach>
+          </if>
+          )
+        </foreach>
+      </if>
+
+      <!-- Error message filters -->
+      <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
+        <foreach collection="filter.errorMessageOperations" item="operation">
+          AND EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          )
+        </foreach>
+      </if>
+    </trim>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -437,6 +437,30 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
   }
 
   @Test
+  void shouldQueryProcessInstancesByOrFilters() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.tenantId("<default>")
+                        .or(
+                            Arrays.asList(
+                                f2 -> f2.hasIncident(true),
+                                f3 ->
+                                    f3.processDefinitionId(
+                                        b -> b.in("manual_process", "child_process_v1")))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(3);
+    assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
+        .containsExactlyInAnyOrder("manual_process", "child_process_v1", "incident_process_v1");
+  }
+
+  @Test
   void shouldQueryProcessInstancesByStateFilterLike() {
     // when
     final var result =

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -13,6 +13,7 @@ import static io.camunda.util.CollectionUtil.collectValues;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +34,8 @@ public record ProcessInstanceFilter(
     List<Operation<String>> tenantIdOperations,
     List<VariableValueFilter> variableFilters,
     List<Operation<String>> batchOperationIdOperations,
-    List<Operation<String>> errorMessageOperations)
+    List<Operation<String>> errorMessageOperations,
+    List<ProcessInstanceFilter> orOperations)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -73,6 +75,7 @@ public record ProcessInstanceFilter(
     private List<VariableValueFilter> variableFilters;
     private List<Operation<String>> batchOperationIdOperations;
     private List<Operation<String>> errorMessageOperations;
+    private List<ProcessInstanceFilter> orOperations;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
       processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
@@ -292,6 +295,14 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder addOrOperation(final ProcessInstanceFilter orOperation) {
+      if (orOperations == null) {
+        orOperations = new ArrayList<>();
+      }
+      orOperations.add(orOperation);
+      return this;
+    }
+
     @Override
     public ProcessInstanceFilter build() {
       return new ProcessInstanceFilter(
@@ -311,7 +322,8 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(variableFilters, Collections.emptyList()),
           Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()),
+          orOperations);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4551,7 +4551,7 @@ components:
           description: The parent flow node instance key.
           allOf:
             - $ref: "#/components/schemas/BasicStringFilterProperty"
-    ProcessInstanceFilter:
+    ProcessInstanceFilterFields:
       description: Process instance search filter.
       type: object
       allOf:
@@ -4585,6 +4585,17 @@ components:
           description: The error message related to the process.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
+    ProcessInstanceFilter:
+      description: Process instance search filter.
+      allOf:
+        - $ref: "#/components/schemas/ProcessInstanceFilterFields"
+        - type: object
+          properties:
+            $or:
+              description: Filter properties used in 'or' conjunction.
+              type: array
+              items:
+                $ref: "#/components/schemas/ProcessInstanceFilterFields"
     ProcessInstanceVariableFilterRequest:
       description: Process instance variable filter.
       type: object


### PR DESCRIPTION
## Description

- Define OpenAPI or queries for `ProcessInstanceFilter` with inheritance.
- Add mapper & reuse existing code.
- Add RDBMS implementation.
- Add ES/OS implementation.
- Add client/java implementation.
- Add QA test.

## Related issues

related to https://github.com/camunda/operate/issues/6867
