### PR TITLE
[Backport stable/8.6] ci: always trigger Tasklist CI on workflow_dispatch

### DIFF
--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -40,6 +40,10 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+<<<<<<< HEAD
+=======
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
+>>>>>>> 8aeeb344 (ci: always trigger Tasklist CI on workflow_dispatch)
 
   run-tests:
     name: run-tests
@@ -47,3 +51,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
+<<<<<<< HEAD
+=======
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' }}
+>>>>>>> 8aeeb344 (ci: always trigger Tasklist CI on workflow_dispatch)


### PR DESCRIPTION
# Description
Backport of #29974 to `stable/8.6`.

relates to 