### PR TITLE
feat: execute `cancel process instance` batch operation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -320,7 +320,9 @@ public final class EngineProcessors {
         writers,
         commandDistributionBehavior,
         scheduledTaskStateFactory,
-        searchClientsProxy);
+        searchClientsProxy,
+        processingState,
+        partitionId);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExcludeAuthorizationCheck
+public final class BatchOperationExecuteProcessor
+    implements TypedRecordProcessor<BatchOperationExecutionRecord> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationExecuteProcessor.class);
+
+  private static final int BATCH_SIZE = 10;
+
+  private final TypedCommandWriter commandWriter;
+  private final StateWriter stateWriter;
+  private final int partitionId;
+  private final BatchOperationState batchOperationState;
+
+  public BatchOperationExecuteProcessor(
+      final Writers writers, final ProcessingState processingState, final int partitionId) {
+    commandWriter = writers.command();
+    stateWriter = writers.state();
+    batchOperationState = processingState.getBatchOperationState();
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  @SuppressWarnings("checkstyle:MissingSwitchDefault")
+  public void processRecord(final TypedRecord<BatchOperationExecutionRecord> command) {
+    final var executionRecord = command.getValue();
+    LOGGER.debug(
+        "Processing new command with key '{}' on partition{} : {}",
+        command.getKey(),
+        partitionId,
+        executionRecord);
+    final long batchKey = executionRecord.getBatchOperationKey();
+
+    final var batchOperation = getBatchOperation(batchKey);
+    if (batchOperation == null) {
+      LOGGER.debug("No batch operation found for key '{}'.", batchKey);
+      return;
+    }
+
+    final var entityKeys = batchOperationState.getNextItemKeys(batchKey, BATCH_SIZE);
+    if (entityKeys.isEmpty()) {
+      LOGGER.debug(
+          "No items to process for BatchOperation {} on partition {}", batchKey, partitionId);
+
+      appendBatchOperationExecutionCompletedEvent(command.getValue());
+      return;
+    }
+
+    appendBatchOperationExecutionExecutingEvent(command.getValue(), Set.copyOf(entityKeys));
+
+    switch (batchOperation.getBatchOperationType()) {
+      case PROCESS_CANCELLATION ->
+          entityKeys.forEach(entityKey -> cancelProcessInstance(entityKey, batchKey));
+    }
+
+    appendBatchOperationExecutionExecutedEvent(command.getValue(), Set.copyOf(entityKeys));
+
+    LOGGER.debug(
+        "Scheduling next batch for BatchOperation {} on partition {}", batchKey, partitionId);
+    final var followupCommand = new BatchOperationExecutionRecord();
+    followupCommand.setBatchOperationKey(batchKey);
+    commandWriter.appendFollowUpCommand(
+        command.getKey(), BatchOperationExecutionIntent.EXECUTE, followupCommand, batchKey);
+  }
+
+  private PersistedBatchOperation getBatchOperation(final long batchOperationKey) {
+    return batchOperationState.get(batchOperationKey).orElse(null);
+  }
+
+  private void cancelProcessInstance(final long processInstanceKey, final long batchKey) {
+    LOGGER.info("Cancelling process instance with key '{}'", processInstanceKey);
+
+    final var command = new ProcessInstanceRecord();
+    command.setProcessInstanceKey(processInstanceKey);
+    commandWriter.appendFollowUpCommand(
+        processInstanceKey, ProcessInstanceIntent.CANCEL, command, batchKey);
+  }
+
+  private void appendBatchOperationExecutionExecutingEvent(
+      final BatchOperationExecutionRecord executionRecord, final Set<Long> keys) {
+    final var batchExecute = new BatchOperationExecutionRecord();
+    batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
+    batchExecute.setItemKeys(keys);
+    stateWriter.appendFollowUpEvent(
+        executionRecord.getBatchOperationKey(),
+        BatchOperationExecutionIntent.EXECUTING,
+        batchExecute);
+  }
+
+  private void appendBatchOperationExecutionExecutedEvent(
+      final BatchOperationExecutionRecord executionRecord, final Set<Long> keys) {
+    final var batchExecute = new BatchOperationExecutionRecord();
+    batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
+    batchExecute.setItemKeys(keys);
+    stateWriter.appendFollowUpEvent(
+        executionRecord.getBatchOperationKey(),
+        BatchOperationExecutionIntent.EXECUTED,
+        batchExecute);
+  }
+
+  private void appendBatchOperationExecutionCompletedEvent(
+      final BatchOperationExecutionRecord executionRecord) {
+    final var batchExecute = new BatchOperationExecutionRecord();
+    batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
+    stateWriter.appendFollowUpEvent(
+        executionRecord.getBatchOperationKey(),
+        BatchOperationExecutionIntent.COMPLETED,
+        batchExecute);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
@@ -34,17 +34,29 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
   }
 
   @Override
+  public void appendFollowUpCommand(
+      final long key, final Intent intent, final RecordValue value, final long operationReference) {
+    appendRecord(key, intent, value, operationReference);
+  }
+
+  @Override
   public boolean canWriteCommandOfLength(final int commandLength) {
     return resultBuilder().canWriteEventOfLength(commandLength);
   }
 
   private void appendRecord(final long key, final Intent intent, final RecordValue value) {
+    appendRecord(key, intent, value, -1);
+  }
+
+  private void appendRecord(
+      final long key, final Intent intent, final RecordValue value, final long operationReference) {
     final var metadata =
         new RecordMetadata()
             .recordType(RecordType.COMMAND)
             .intent(intent)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason("");
+            .rejectionReason("")
+            .operationReference(operationReference);
     resultBuilder().appendRecord(key, value, metadata);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -35,6 +35,17 @@ public interface TypedCommandWriter {
   void appendFollowUpCommand(long key, Intent intent, RecordValue value);
 
   /**
+   * Append a follow up command to the result builder
+   *
+   * @param intent the intent of the command
+   * @param value the record of the command
+   * @param operationReference the operation reference of the command
+   * @throws ExceededBatchRecordSizeException if the appended command doesn't fit into the
+   *     RecordBatch
+   */
+  void appendFollowUpCommand(long key, Intent intent, RecordValue value, long operationReference);
+
+  /**
    * @param commandLength the length of the command that will be written
    * @return true if a command of the given length can be written
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCompletedApplier.java
@@ -23,7 +23,6 @@ public class BatchOperationCompletedApplier
 
   @Override
   public void applyState(final long key, final BatchOperationExecutionRecord value) {
-    // TODO
-    // batchOperationState.complete(key, value);
+    batchOperationState.complete(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCompletedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+
+public class BatchOperationCompletedApplier
+    implements TypedEventApplier<BatchOperationExecutionIntent, BatchOperationExecutionRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationCompletedApplier(final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(final long key, final BatchOperationExecutionRecord value) {
+    // TODO
+    // batchOperationState.complete(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationExecutingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationExecutingApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+
+public class BatchOperationExecutingApplier
+    implements TypedEventApplier<BatchOperationExecutionIntent, BatchOperationExecutionRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationExecutingApplier(final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(final long key, final BatchOperationExecutionRecord value) {
+    batchOperationState.removeItemKeys(value.getBatchOperationKey(), value.getItemKeys());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -590,6 +591,14 @@ public final class EventAppliers implements EventApplier {
     register(
         BatchOperationChunkIntent.CREATED,
         new BatchOperationChunkCreatedApplier(state.getBatchOperationState()));
+    register(
+        BatchOperationExecutionIntent.EXECUTING,
+        new BatchOperationExecutingApplier(state.getBatchOperationState()));
+    register(BatchOperationExecutionIntent.EXECUTED, NOOP_EVENT_APPLIER);
+
+    register(
+        BatchOperationExecutionIntent.COMPLETED,
+        new BatchOperationCompletedApplier(state.getBatchOperationState()));
   }
 
   private void registerIdentitySetupAppliers() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -131,6 +131,13 @@ public class DbBatchOperationState implements MutableBatchOperationState {
   }
 
   @Override
+  public void complete(final long batchOperationKey) {
+    LOGGER.trace("Completing batch operation with key {}", batchOperationKey);
+    batchKey.wrapLong(batchOperationKey);
+    batchOperationColumnFamily.deleteExisting(batchKey);
+  }
+
+  @Override
   public Optional<PersistedBatchOperation> get(final long key) {
     batchKey.wrapLong(key);
     return Optional.ofNullable(batchOperationColumnFamily.get(batchKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -129,7 +129,6 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     CREATED,
     ACTIVATED,
     PAUSED,
-    CANCELED,
-    COMPLETED
+    CANCELED
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -25,8 +25,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   private final LongProperty keyProp = new LongProperty("key");
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
-      new EnumProperty<>(
-          "batchOperationType", BatchOperationType.class, BatchOperationType.UNSPECIFIED);
+      new EnumProperty<>("batchOperationType", BatchOperationType.class);
   private final EnumProperty<BatchOperationStatus> statusProp =
       new EnumProperty<>("status", BatchOperationStatus.class);
   private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -23,4 +23,6 @@ public interface MutableBatchOperationState extends BatchOperationState {
   void appendItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 
   void removeItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
+
+  void complete(final long batchOperationKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
@@ -45,7 +45,7 @@ public final class CreateBatchOperationMultiPartitionTest {
     final long batchOperationKey =
         engine
             .batchOperation()
-            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
             .withFilter(new UnsafeBuffer("{\"processInstanceKeys\": [1, 2, 3]}".getBytes()))
             .create()
             .getValue()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -51,7 +51,7 @@ public final class CreateBatchOperationTest {
     final var batchOperationKey =
         engine
             .batchOperation()
-            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
             .withFilter(new UnsafeBuffer())
             .expectRejection()
             .create()
@@ -75,7 +75,7 @@ public final class CreateBatchOperationTest {
     final var batchOperationKey =
         engine
             .batchOperation()
-            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
             .withFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{}")))
             .expectRejection()
             .create()
@@ -117,7 +117,7 @@ public final class CreateBatchOperationTest {
     final long batchOperationKey =
         engine
             .batchOperation()
-            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
             .withFilter(filterBuffer)
             .create()
             .getValue()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public final class ExecuteBatchOperationTest {
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  private final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
+
+  @Test
+  public void shouldExecuteBatchOperationForProcessInstanceCancellation() {
+    // given
+    final var processInstanceKeys = Set.of(1L, 2L, 3L);
+    final var batchOperationKey =
+        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have several process cancellation commands
+    processInstanceKeys.forEach(
+        key -> {
+          assertThat(RecordingExporter.processInstanceRecords().withProcessInstanceKey(key))
+              .extracting(Record::getIntent)
+              .containsSequence(ProcessInstanceIntent.CANCEL);
+        });
+  }
+
+  @Test
+  public void shouldDoNothingIfThereIsNoBatchOperation() {
+    // given
+    final var batchOperationKey = 1L;
+
+    // when
+    engine
+        .batchOperation()
+        .newExecution(BatchOperationType.PROCESS_CANCELLATION)
+        .withBatchOperationKey(batchOperationKey)
+        .createCanceled();
+
+    // then
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey))
+        .extracting(Record::getIntent)
+        .doesNotContain(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+  }
+
+  private long createNewProcessInstanceCancellationBatchOperation(final Set<Long> itemKeys) {
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
+            .total(itemKeys.size())
+            .build();
+    Mockito.when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
+        .thenReturn(result);
+
+    final var filterBuffer =
+        convertToBuffer(
+            new ProcessInstanceFilter.Builder().processInstanceKeys(1L, 3L, 8L).build());
+
+    return engine
+        .batchOperation()
+        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+        .withFilter(filterBuffer)
+        .create()
+        .getValue()
+        .getBatchOperationKey();
+  }
+
+  private static UnsafeBuffer convertToBuffer(final Object object) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
+  }
+
+  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
+    final var entity = mock(ProcessInstanceEntity.class);
+    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
+    return entity;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -231,7 +231,7 @@ public class CommandDistributionIdempotencyTest {
                 () ->
                     ENGINE
                         .batchOperation()
-                        .ofType(BatchOperationType.PROCESS_CANCELLATION)
+                        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
                         .withFilter(
                             new UnsafeBuffer(
                                 MsgPackConverter.convertToMsgPack(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -76,11 +76,11 @@ public class BatchOperationStateTest {
 
     // when
     final var batchOperationKey = 1L;
-    final var roleRecord =
+    final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
             .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
-    state.create(batchOperationKey, roleRecord);
+    state.create(batchOperationKey, batchRecord);
 
     // then
     final var pendingKeys = new ArrayList<>();
@@ -93,11 +93,11 @@ public class BatchOperationStateTest {
   void startedBatchShouldNotBePending() {
     // given
     final var batchOperationKey = 1L;
-    final var roleRecord =
+    final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
             .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
-    state.create(batchOperationKey, roleRecord);
+    state.create(batchOperationKey, batchRecord);
 
     // when
     state.appendItemKeys(
@@ -283,6 +283,23 @@ public class BatchOperationStateTest {
         batchOperationKey, LongStream.range(0, numKeys).boxed().collect(Collectors.toSet()));
 
     return batchOperationKey;
+  }
+
+  @Test
+  void completedBatchShouldBeRemoved() {
+    // given
+    final var batchOperationKey = 1L;
+    final var batchRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    state.create(batchOperationKey, batchRecord);
+
+    // when
+    state.complete(batchOperationKey);
+
+    // then
+    assertThat(state.get(batchOperationKey)).isEmpty();
   }
 
   private static UnsafeBuffer convertToBuffer(final Object object) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -35,7 +35,7 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Long getBatchOperationKey() {
+  public long getBatchOperationKey() {
     return batchOperationKeyProp.getValue();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -39,7 +39,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Long getBatchOperationKey() {
+  public long getBatchOperationKey() {
     return batchOperationKeyProp.getValue();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -26,8 +26,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
-      new EnumProperty<>(
-          PROP_BATCH_OPERATION_TYPE, BatchOperationType.class, BatchOperationType.UNSPECIFIED);
+      new EnumProperty<>(PROP_BATCH_OPERATION_TYPE, BatchOperationType.class);
   private final BinaryProperty entityFilterProp =
       new BinaryProperty(PROP_ENTITY_FILTER, new UnsafeBuffer());
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -31,7 +31,7 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Long getBatchOperationKey() {
+  public long getBatchOperationKey() {
     return batchOperationKeyProp.getValue();
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
@@ -17,10 +17,10 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum BatchOperationExecutionIntent implements Intent {
   EXECUTE((short) 0),
-  //  EXECUTING((short) 1),
-  //  EXECUTED((short) 2),
+  EXECUTING((short) 1),
+  EXECUTED((short) 2),
 
-  //  COMPLETED((short) 3),
+  COMPLETED((short) 3),
 
   CANCEL((short) 4),
   //  CANCELED((short) 5),
@@ -65,6 +65,10 @@ public enum BatchOperationExecutionIntent implements Intent {
   @Override
   public boolean isEvent() {
     switch (this) {
+      case EXECUTING:
+      case EXECUTED:
+      case COMPLETED:
+        return true;
       default:
         return false;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
@@ -45,6 +45,12 @@ public enum BatchOperationExecutionIntent implements Intent {
     switch (value) {
       case 0:
         return EXECUTE;
+      case 1:
+        return EXECUTING;
+      case 2:
+        return EXECUTED;
+      case 3:
+        return COMPLETED;
       case 4:
         return CANCEL;
       case 6:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
@@ -20,5 +20,5 @@ public interface BatchOperationRelated {
   /**
    * @return the key of the batch operation aka operation reference key
    */
-  Long getBatchOperationKey();
+  long getBatchOperationKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
@@ -16,6 +16,5 @@
 package io.camunda.zeebe.protocol.record.value;
 
 public enum BatchOperationType {
-  PROCESS_CANCELLATION,
-  UNSPECIFIED
+  PROCESS_CANCELLATION
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
@@ -23,6 +23,17 @@ public interface TaskResultBuilder {
   boolean appendCommandRecord(final long key, final Intent intent, final UnifiedRecordValue value);
 
   /**
+   * Appends a record to the result
+   *
+   * @return returns true if the record still fits into the result, false otherwise
+   */
+  boolean appendCommandRecord(
+      final long key,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final long operationReference);
+
+  /**
    * Appends a record to the result without a key
    *
    * @return returns true if the record still fits into the result, false otherwise

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilder.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -39,6 +41,15 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
   @Override
   public boolean appendCommandRecord(
       final long key, final Intent intent, final UnifiedRecordValue value) {
+    return appendCommandRecord(key, intent, value, operationReferenceNullValue());
+  }
+
+  @Override
+  public boolean appendCommandRecord(
+      final long key,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final long operationReference) {
     final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());
     if (valueType == null) {
       // usually happens when the record is not registered at the TypedStreamEnvironment
@@ -55,7 +66,8 @@ public final class BufferedTaskResultBuilder implements TaskResultBuilder {
             .intent(intent)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
-            .valueType(valueType);
+            .valueType(valueType)
+            .operationReference(operationReference);
     final var either = mutableRecordBatch.appendRecord(key, metadata, -1, value);
 
     either.ifRight(ok -> cache.add(intent, key));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationExecutionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationExecutionRecordStream.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import java.util.stream.Stream;
+
+public class BatchOperationExecutionRecordStream
+    extends ExporterRecordStream<
+        BatchOperationExecutionRecordValue, BatchOperationExecutionRecordStream> {
+
+  public BatchOperationExecutionRecordStream(
+      final Stream<Record<BatchOperationExecutionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected BatchOperationExecutionRecordStream supply(
+      final Stream<Record<BatchOperationExecutionRecordValue>> wrappedStream) {
+    return new BatchOperationExecutionRecordStream(wrappedStream);
+  }
+
+  public BatchOperationExecutionRecordStream withBatchOperationKey(final long batchOperationKey) {
+    return valueFilter(v -> v.getBatchOperationKey() == batchOperationKey);
+  }
+
+  public BatchOperationExecutionRecordStream withItemKey(final long itemKey) {
+    return valueFilter(v -> v.getItemKeys().contains(itemKey));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationR
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -567,6 +568,16 @@ public final class RecordingExporter implements Exporter {
   public static BatchOperationChunkRecordStream batchOperationChunkRecords(
       final BatchOperationChunkIntent intent) {
     return batchOperationChunkRecords().withIntent(intent);
+  }
+
+  public static BatchOperationExecutionRecordStream batchOperationExecutionRecords() {
+    return new BatchOperationExecutionRecordStream(
+        records(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionRecordValue.class));
+  }
+
+  public static BatchOperationExecutionRecordStream batchOperationExecutionRecords(
+      final BatchOperationIntent intent) {
+    return batchOperationExecutionRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

With the last merged PR for https://github.com/camunda/camunda/issues/29697 we have now item keys in the state where we want to start the actual operation. Current we just support process instance cancellation. 

The new BatchOperationExecuteProcessor loads the item keys (process instance keys in this case) from state as chunks, and appends process instance cancellation commands in order to start the real execution. Before it fires a executing event, and after the chunk a executed event. At the end, a new execute command will be appended. 

Completed event just happens if we have no items at the beginning of the processor, so we can be sure that all cancellation events where be processed before. 

**Operation Reference**

Besides this, we use the operation reference to track all follow up commands like process instance cancellation if they are part of a batch operation. This is needed for a follow up issue where we aggregate the status of those commands in the exporters. => https://github.com/camunda/camunda/issues/29701

Later we have the plan to replace the usage of the reference with an own field, there is an follow up issue for it: https://github.com/camunda/camunda/issues/30289


## Related issues

closes #29886
