### PR TITLE
Create group processor/applier should work with `groupId`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -27,7 +27,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public class GroupCreateProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
 
   public static final String GROUP_ALREADY_EXISTS_ERROR_MESSAGE =
-      "Expected to create group with name '%s', but a group with this name already exists.";
+      "Expected to create group with ID '%s', but a group with this ID already exists.";
   private final GroupState groupState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -53,9 +53,20 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
 
   @Override
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
+    final var record = command.getValue();
+    final var groupId = record.getGroupId();
+    final var persistedGroup = groupState.get(groupId);
+    if (persistedGroup.isPresent()) {
+      final var errorMessage = GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(groupId);
+      rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      return;
+    }
+
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.CREATE);
     final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
+
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
@@ -63,15 +74,6 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
       return;
     }
 
-    final var record = command.getValue();
-    final var groupName = record.getName();
-    final var groupKey = groupState.get(record.getGroupId());
-    if (groupKey.isPresent()) {
-      final var errorMessage = GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(groupName);
-      rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      return;
-    }
     final long key = keyGenerator.nextKey();
     record.setGroupKey(key);
 
@@ -88,11 +90,11 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
     groupState
-        .get(record.getGroupKey())
+        .get(record.getGroupId())
         .ifPresentOrElse(
             persistedGroup -> {
               final var errorMessage =
-                  GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(persistedGroup.getName());
+                  GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(persistedGroup.getGroupId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
             () -> stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.CREATED, record));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupCreatedApplier.java
@@ -22,6 +22,6 @@ public class GroupCreatedApplier implements TypedEventApplier<GroupIntent, Group
 
   @Override
   public void applyState(final long key, final GroupRecord value) {
-    groupState.create(key, value);
+    groupState.create(value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -58,7 +58,7 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public void create(final long groupKey, final GroupRecord group) {
+  public void create(final GroupRecord group) {
     groupId.wrapString(group.getGroupId());
     persistedGroup.wrap(group);
     groupColumnFamily.insert(groupId, persistedGroup);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -59,7 +59,7 @@ public class DbGroupState implements MutableGroupState {
 
   @Override
   public void create(final long groupKey, final GroupRecord group) {
-    groupId.wrapString(String.valueOf(groupKey));
+    groupId.wrapString(group.getGroupId());
     persistedGroup.wrap(group);
     groupColumnFamily.insert(groupId, persistedGroup);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -22,17 +22,22 @@ import java.util.stream.StreamSupport;
 public class PersistedGroup extends UnpackedObject implements DbValue {
 
   private final LongProperty groupKeyProp = new LongProperty("groupKey");
+  private final StringProperty groupIdProp = new StringProperty("groupId");
   private final StringProperty nameProp = new StringProperty("name");
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>("tenantIds", StringValue::new);
 
   public PersistedGroup() {
-    super(3);
-    declareProperty(groupKeyProp).declareProperty(nameProp).declareProperty(tenantIdsProp);
+    super(4);
+    declareProperty(groupKeyProp)
+        .declareProperty(groupIdProp)
+        .declareProperty(nameProp)
+        .declareProperty(tenantIdsProp);
   }
 
   public void wrap(final GroupRecord group) {
     groupKeyProp.setValue(group.getGroupKey());
+    groupIdProp.setValue(group.getGroupId());
     nameProp.setValue(group.getNameBuffer());
     tenantIdsProp.reset();
   }
@@ -43,6 +48,15 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   public PersistedGroup setGroupKey(final long groupKey) {
     groupKeyProp.setValue(groupKey);
+    return this;
+  }
+
+  public String getGroupId() {
+    return BufferUtil.bufferAsString(groupIdProp.getValue());
+  }
+
+  public PersistedGroup setGroupId(final String groupId) {
+    groupIdProp.setValue(groupId);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 
 public interface MutableGroupState extends GroupState {
 
-  void create(final long groupKey, final GroupRecord group);
+  void create(final GroupRecord group);
 
   void update(final long groupKey, final GroupRecord group);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -506,10 +506,11 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
 
   private long createGroup(final long entityKey, final EntityType entityType) {
     final var groupKey = random.nextLong();
+    final var groupId = String.valueOf(groupKey);
     final var group =
         new GroupRecord()
             .setGroupKey(groupKey)
-            .setGroupId(Strings.newRandomValidIdentityId())
+            .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
             .setEntityKey(entityKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -601,10 +601,11 @@ final class AuthorizationCheckBehaviorTest {
 
   private long createGroup(final long entityKey, final EntityType entityType) {
     final var groupKey = random.nextLong();
+    final var groupId = String.valueOf(groupKey);
     final var group =
         new GroupRecord()
             .setGroupKey(groupKey)
-            .setGroupId(Strings.newRandomValidIdentityId())
+            .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
             .setEntityKey(entityKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -248,10 +248,7 @@ public class CommandDistributionIdempotencyTest {
           },
           {
             "Group.CREATE is idempotent",
-            new Scenario(
-                ValueType.GROUP,
-                GroupIntent.CREATE,
-                CommandDistributionIdempotencyTest::createGroup),
+            new Scenario(ValueType.GROUP, GroupIntent.CREATE, () -> createGroup("123")),
             GroupCreateProcessor.class
           },
           {
@@ -260,8 +257,11 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.GROUP,
                 GroupIntent.DELETE,
                 () -> {
-                  final var group = createGroup();
-                  return ENGINE.group().deleteGroup(group.getKey()).delete();
+                  // TODO: refactor with https://github.com/camunda/camunda/issues/30025
+                  final var groupId = "456";
+                  final var groupKey = Long.parseLong(groupId);
+                  createGroup(groupId);
+                  return ENGINE.group().deleteGroup(groupKey).delete();
                 }),
             GroupDeleteProcessor.class
           },
@@ -271,10 +271,13 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.GROUP,
                 GroupIntent.UPDATE,
                 () -> {
-                  final var group = createGroup();
+                  // TODO: refactor with https://github.com/camunda/camunda/issues/30024
+                  final var groupId = "789";
+                  final var groupKey = Long.parseLong(groupId);
+                  createGroup(groupId);
                   return ENGINE
                       .group()
-                      .updateGroup(group.getKey())
+                      .updateGroup(groupKey)
                       .withName(UUID.randomUUID().toString())
                       .update();
                 }),
@@ -286,11 +289,14 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.GROUP,
                 GroupIntent.ADD_ENTITY,
                 () -> {
-                  final var group = createGroup();
+                  // TODO: refactor with https://github.com/camunda/camunda/issues/30028
+                  final var groupId = "321";
+                  final var groupKey = Long.parseLong(groupId);
+                  createGroup(groupId);
                   final var user = createUser();
                   return ENGINE
                       .group()
-                      .addEntity(group.getKey())
+                      .addEntity(groupKey)
                       .withEntityKey(user.getKey())
                       .withEntityType(EntityType.USER)
                       .add();
@@ -303,17 +309,20 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.GROUP,
                 GroupIntent.REMOVE_ENTITY,
                 () -> {
-                  final var group = createGroup();
+                  // TODO: refactor with https://github.com/camunda/camunda/issues/30029
+                  final var groupId = "654";
+                  final var groupKey = Long.parseLong(groupId);
+                  createGroup(groupId);
                   final var user = createUser();
                   ENGINE
                       .group()
-                      .addEntity(group.getKey())
+                      .addEntity(groupKey)
                       .withEntityKey(user.getKey())
                       .withEntityType(EntityType.USER)
                       .add();
                   return ENGINE
                       .group()
-                      .removeEntity(group.getKey())
+                      .removeEntity(groupKey)
                       .withEntityKey(user.getKey())
                       .withEntityType(EntityType.USER)
                       .remove();
@@ -662,8 +671,8 @@ public class CommandDistributionIdempotencyTest {
         .create();
   }
 
-  private static Record<GroupRecordValue> createGroup() {
-    return ENGINE.group().newGroup(UUID.randomUUID().toString()).create();
+  private static Record<GroupRecordValue> createGroup(final String groupId) {
+    return ENGINE.group().newGroup(UUID.randomUUID().toString()).withGroupId(groupId).create();
   }
 
   private static Record<RoleRecordValue> createRole() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -81,6 +81,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValu
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
@@ -248,7 +249,10 @@ public class CommandDistributionIdempotencyTest {
           },
           {
             "Group.CREATE is idempotent",
-            new Scenario(ValueType.GROUP, GroupIntent.CREATE, () -> createGroup("123")),
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.CREATE,
+                () -> createGroup(Strings.newRandomValidIdentityId())),
             GroupCreateProcessor.class
           },
           {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -51,7 +51,9 @@ public class AddEntityGroupMultiPartitionTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
 
     assertThat(
@@ -113,7 +115,9 @@ public class AddEntityGroupMultiPartitionTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
 
     // then
@@ -143,7 +147,9 @@ public class AddEntityGroupMultiPartitionTest {
 
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
@@ -40,7 +41,7 @@ public class CreateGroupMultiPartitionTest {
   public void shouldDistributeGroupCreateCommand() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupId = UUID.randomUUID().toString();
+    final var groupId = Strings.newRandomValidIdentityId();
     engine.group().newGroup(name).withGroupId(groupId).create();
 
     assertThat(
@@ -86,7 +87,7 @@ public class CreateGroupMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupId = UUID.randomUUID().toString();
+    final var groupId = Strings.newRandomValidIdentityId();
     engine.group().newGroup(name).withGroupId(groupId).create();
 
     // then
@@ -109,7 +110,7 @@ public class CreateGroupMultiPartitionTest {
 
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupId = UUID.randomUUID().toString();
+    final var groupId = Strings.newRandomValidIdentityId();
     engine.group().newGroup(name).withGroupId(groupId).create();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
@@ -40,7 +40,8 @@ public class CreateGroupMultiPartitionTest {
   public void shouldDistributeGroupCreateCommand() {
     // when
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).create();
+    final var groupId = UUID.randomUUID().toString();
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     assertThat(
             RecordingExporter.records()
@@ -85,7 +86,8 @@ public class CreateGroupMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).create();
+    final var groupId = UUID.randomUUID().toString();
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     // then
     assertThat(
@@ -107,7 +109,8 @@ public class CreateGroupMultiPartitionTest {
 
     // when
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).create();
+    final var groupId = UUID.randomUUID().toString();
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
@@ -39,7 +39,9 @@ public class DeleteGroupMultiPartitionTest {
   public void shouldDistributeGroupDeleteCommand() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().deleteGroup(groupKey).delete();
 
     assertThat(
@@ -92,7 +94,9 @@ public class DeleteGroupMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().deleteGroup(groupKey).delete();
 
     // then
@@ -111,7 +115,9 @@ public class DeleteGroupMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptGroupCreateForPartition(partitionId);
     }
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().deleteGroup(groupKey).delete();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
@@ -30,17 +31,19 @@ public class GroupTest {
   @Test
   public void shouldCreateGroup() {
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
 
     final var createdGroup = groupRecord.getValue();
     assertThat(createdGroup).hasName(name);
+    assertThat(createdGroup).hasGroupId(groupId);
   }
 
   @Test
   public void shouldNotDuplicate() {
     // given
     final var name = UUID.randomUUID().toString();
-    final var groupId = UUID.randomUUID().toString();
+    final var groupId = Strings.newRandomValidIdentityId();
     final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -37,34 +36,38 @@ public class GroupTest {
     assertThat(createdGroup).hasName(name);
   }
 
-  @Ignore("Re-enable with https://github.com/camunda/camunda/issues/30022")
   @Test
   public void shouldNotDuplicate() {
     // given
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupId = UUID.randomUUID().toString();
+    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
-    final var duplicatedGroupRecord = engine.group().newGroup(name).expectRejection().create();
+    final var duplicatedGroupRecord =
+        engine.group().newGroup(name).withGroupId(groupId).expectRejection().create();
 
     final var createdGroup = groupRecord.getValue();
     Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
+    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("groupId", groupId);
 
     assertThat(duplicatedGroupRecord)
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
-            "Expected to create group with name '%s', but a group with this name already exists."
-                .formatted(name));
+            "Expected to create group with ID '%s', but a group with this ID already exists."
+                .formatted(groupId));
   }
 
   @Test
   public void shouldUpdateGroup() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30024
     // given
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
-    final var groupKey = groupRecord.getKey();
     final var updatedName = name + "-updated";
     final var updatedGroupRecord =
         engine.group().updateGroup(groupKey).withName(updatedName).update();
@@ -75,6 +78,7 @@ public class GroupTest {
 
   @Test
   public void shouldRejectUpdatedIfNoGroupExists() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30024
     // when
     final var groupKey = 1L;
     final var updatedName = "yolo";
@@ -91,7 +95,10 @@ public class GroupTest {
 
   @Test
   public void shouldAddEntityToGroup() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30028
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var userKey =
         engine
             .user()
@@ -102,7 +109,7 @@ public class GroupTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().newGroup(name).withGroupId(groupId).create().getValue().getGroupKey();
 
     // when
     final var updatedGroup =
@@ -120,6 +127,7 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfGroupIsNotPresentWhileAddingEntity() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30028
     // when
     final var notPresentGroupKey = 1L;
     final var notPresentUpdateRecord =
@@ -135,13 +143,15 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfEntityIsNotPresent() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30028
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
     final var createdGroup = groupRecord.getValue();
-    final var groupKey = createdGroup.getGroupKey();
     final var notPresentUpdateRecord =
         engine
             .group()
@@ -162,10 +172,12 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfEntityIsAlreadyAssigned() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30028
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
-    final var groupKey = groupRecord.getValue().getGroupKey();
+    engine.group().newGroup(name).withGroupId(groupId).create();
     final var userKey =
         engine
             .user()
@@ -197,7 +209,10 @@ public class GroupTest {
 
   @Test
   public void shouldRemoveEntityToGroup() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30029
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var userKey =
         engine
             .user()
@@ -208,7 +223,7 @@ public class GroupTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
 
     // when
@@ -230,6 +245,7 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfGroupIsNotPresentEntityRemoval() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30029
     // when
     final var notPresentGroupKey = 1L;
     final var notPresentUpdateRecord =
@@ -245,13 +261,15 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfEntityIsNotPresentEntityRemoval() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30029
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
     final var createdGroup = groupRecord.getValue();
-    final var groupKey = createdGroup.getGroupKey();
     final var notPresentUpdateRecord =
         engine
             .group()
@@ -272,9 +290,12 @@ public class GroupTest {
 
   @Test
   public void shouldDeleteGroup() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30025
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
     final var deletedGroup = engine.group().deleteGroup(groupKey).delete().getValue();
@@ -285,7 +306,10 @@ public class GroupTest {
 
   @Test
   public void shouldDeleteGroupWithAssignedEntities() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30025
     // given
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
     final var userKey =
         engine
             .user()
@@ -296,7 +320,7 @@ public class GroupTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().newGroup(name).withGroupId(groupId).create().getValue().getGroupKey();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
 
     // when
@@ -317,6 +341,7 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfGroupIsNotPresentOnDeletion() {
+    // TODO: refactor the test with https://github.com/camunda/camunda/issues/30025
     // when
     final var notPresentGroupKey = 1L;
     final var notPresentUpdateRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -49,7 +49,9 @@ public class RemoveEntityGroupMultiPartitionTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
     engine
         .group()
@@ -117,7 +119,9 @@ public class RemoveEntityGroupMultiPartitionTest {
             .create()
             .getKey();
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
     engine
         .group()
@@ -153,7 +157,9 @@ public class RemoveEntityGroupMultiPartitionTest {
 
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
     engine
         .group()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -39,10 +39,11 @@ public class UpdateGroupMultiPartitionTest {
   public void shouldDistributeGroupUpdateCommand() {
     // given
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
 
     // when
-    final var groupKey = groupRecord.getKey();
     engine.group().updateGroup(groupKey).withName("updated-" + name).update();
 
     assertThat(
@@ -95,7 +96,9 @@ public class UpdateGroupMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var groupKey = engine.group().newGroup(name).create().getKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(name).withGroupId(groupId).create();
     engine.group().updateGroup(groupKey).withName(name + "-updated").update();
 
     // then
@@ -113,7 +116,9 @@ public class UpdateGroupMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptGroupCommandForPartition(partitionId, GroupIntent.CREATE);
     }
-    final var groupKey = engine.group().newGroup(UUID.randomUUID().toString()).create().getKey();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup(UUID.randomUUID().toString()).withGroupId(groupId).create().getKey();
 
     // when
     final var name = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -235,11 +235,13 @@ public class MappingTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mappingRecord =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create();
-    final var group = engine.group().newGroup("group").create();
+    final var groupId = "123";
+    final var groupKey = Long.parseLong(groupId);
+    engine.group().newGroup("group").withGroupId(groupId).create();
     final var role = engine.role().newRole("role").create();
     engine
         .group()
-        .addEntity(group.getKey())
+        .addEntity(groupKey)
         .withEntityKey(mappingRecord.getKey())
         .withEntityType(EntityType.MAPPING)
         .add();
@@ -256,7 +258,7 @@ public class MappingTest {
     // then
     Assertions.assertThat(
             RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
-                .withGroupKey(group.getKey())
+                .withGroupKey(groupKey)
                 .withEntityKey(mappingRecord.getKey())
                 .exists())
         .isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -113,7 +113,9 @@ public class AddEntityTenantTest {
   public void shouldAddGroupToTenant() {
     // given
     final var entityType = GROUP;
-    final var entityKey = createGroup();
+    final var groupId = "123";
+    final var entityKey = Long.parseLong(groupId);
+    createGroup(groupId);
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine
@@ -224,8 +226,14 @@ public class AddEntityTenantTest {
         .getValue();
   }
 
-  private long createGroup() {
-    return engine.group().newGroup("groupName").create().getValue().getGroupKey();
+  private long createGroup(final String groupId) {
+    return engine
+        .group()
+        .newGroup("groupName")
+        .withGroupId(groupId)
+        .create()
+        .getValue()
+        .getGroupKey();
   }
 
   private String createMapping() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -47,6 +48,7 @@ public class DeleteUserTest {
     assertThat(deletedUser).isNotNull().hasFieldOrPropertyWithValue("userKey", userRecord.getKey());
   }
 
+  @Ignore("Re-enable with https://github.com/camunda/camunda/issues/30028")
   @Test
   public void shouldCleanupMembership() {
     final var username = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -55,9 +55,11 @@ public class GroupAppliersTest {
   @Test
   void shouldCreateGroup() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
 
     // when
     groupCreatedApplier.applyState(groupKey, groupRecord);
@@ -73,10 +75,12 @@ public class GroupAppliersTest {
   @Test
   void shouldUpdateGroup() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var updatedGroupName = "updatedGroup";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     final var persistedGroup = groupState.get(groupKey);
     assertThat(persistedGroup.isPresent()).isTrue();
@@ -107,10 +111,12 @@ public class GroupAppliersTest {
             .setPassword("password")
             .setEmail("test@example.com");
     userState.create(userRecord);
-    final var groupKey = 2L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var entityType = EntityType.USER;
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
 
@@ -134,10 +140,12 @@ public class GroupAppliersTest {
             .setClaimName("claimName")
             .setClaimValue("claimValue");
     mappingState.create(mappingRecord);
-    final var groupKey = 2L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var entityType = EntityType.MAPPING;
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
 
@@ -163,10 +171,12 @@ public class GroupAppliersTest {
             .setPassword("password")
             .setEmail("test@example.com");
     userState.create(userRecord);
-    final var groupKey = 2L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var entityType = EntityType.USER;
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
@@ -191,10 +201,12 @@ public class GroupAppliersTest {
             .setClaimName("claimName")
             .setClaimValue("claimValue");
     mappingState.create(mappingRecord);
-    final var groupKey = 2L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var entityType = EntityType.MAPPING;
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
@@ -212,17 +224,17 @@ public class GroupAppliersTest {
   @Test
   void shouldDeleteGroup() {
     // given
-    // a group
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupCreatedApplier.applyState(groupKey, groupRecord);
 
     // when
     groupDeletedApplier.applyState(groupKey, groupRecord);
 
     // then
-    // the group state is cleaned up
     final var group = groupState.get(groupKey);
     assertThat(group.isPresent()).isFalse();
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -58,18 +58,17 @@ public class GroupAppliersTest {
     final var groupId = "1";
     final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord =
-        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
+    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
 
     // when
     groupCreatedApplier.applyState(groupKey, groupRecord);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isTrue();
     final var persistedGroup = group.get();
-    assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
     assertThat(persistedGroup.getName()).isEqualTo(groupName);
+    assertThat(persistedGroup.getGroupId()).isEqualTo(groupId);
   }
 
   @Test
@@ -81,8 +80,8 @@ public class GroupAppliersTest {
     final var updatedGroupName = "updatedGroup";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
-    final var persistedGroup = groupState.get(groupKey);
+    groupState.create(groupRecord);
+    final var persistedGroup = groupState.get(groupId);
     assertThat(persistedGroup.isPresent()).isTrue();
     assertThat(persistedGroup.get().getName()).isEqualTo(groupName);
     final var updatedGroupRecord =
@@ -92,7 +91,7 @@ public class GroupAppliersTest {
     groupUpdatedApplier.applyState(groupKey, updatedGroupRecord);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isTrue();
     final var persistedUpdatedGroup = group.get();
     assertThat(persistedUpdatedGroup.getGroupKey()).isEqualTo(groupKey);
@@ -117,7 +116,7 @@ public class GroupAppliersTest {
     final var entityType = EntityType.USER;
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
 
     // when
@@ -146,7 +145,7 @@ public class GroupAppliersTest {
     final var entityType = EntityType.MAPPING;
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
 
     // when
@@ -177,7 +176,7 @@ public class GroupAppliersTest {
     final var entityType = EntityType.USER;
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
@@ -207,7 +206,7 @@ public class GroupAppliersTest {
     final var entityType = EntityType.MAPPING;
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupRecord.setEntityKey(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
@@ -235,7 +234,7 @@ public class GroupAppliersTest {
     groupDeletedApplier.applyState(groupKey, groupRecord);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isFalse();
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -164,7 +164,7 @@ public class MappingAppliersTest {
             .setGroupId(groupId)
             .setEntityKey(mappingKey)
             .setEntityType(EntityType.MAPPING);
-    groupState.create(groupKey, group);
+    groupState.create(group);
     groupState.addEntity(groupKey, group);
     // create authorization
     authorizationState.create(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -155,11 +155,13 @@ public class MappingAppliersTest {
     tenantState.createTenant(tenant);
     tenantState.addEntity(tenant);
     // create group
-    final long groupKey = 4L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     mappingState.addGroup(mappingKey, groupKey);
     final var group =
         new GroupRecord()
             .setGroupKey(groupKey)
+            .setGroupId(groupId)
             .setEntityKey(mappingKey)
             .setEntityType(EntityType.MAPPING);
     groupState.create(groupKey, group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -35,19 +35,16 @@ public class GroupStateTest {
   void shouldCreateGroup() {
     // given
     final var groupId = "1";
-    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord =
-        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
+    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
 
     // when
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isTrue();
     final var persistedGroup = group.get();
-    assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
     assertThat(persistedGroup.getName()).isEqualTo(groupName);
   }
 
@@ -71,7 +68,7 @@ public class GroupStateTest {
     final var groupName = "group";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
 
     final var updatedGroupName = "updatedGroup";
     groupRecord.setName(updatedGroupName);
@@ -80,7 +77,7 @@ public class GroupStateTest {
     groupState.update(groupKey, groupRecord);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isTrue();
     final var persistedGroup = group.get();
     assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
@@ -95,7 +92,7 @@ public class GroupStateTest {
     final var groupName = "group";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
 
     // when
     final var userKey = 2L;
@@ -117,7 +114,7 @@ public class GroupStateTest {
     final var groupName = "group";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     final var userKey = 2L;
     groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
     groupState.addEntity(groupKey, groupRecord);
@@ -142,7 +139,7 @@ public class GroupStateTest {
     final var groupName = "group";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     final var userKey = 2L;
     groupRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
     groupState.addEntity(groupKey, groupRecord);
@@ -166,7 +163,7 @@ public class GroupStateTest {
     final var groupName = "group";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
     groupState.addEntity(groupKey, groupRecord);
     groupRecord.setEntityKey(3L).setEntityType(EntityType.MAPPING);
@@ -176,7 +173,7 @@ public class GroupStateTest {
     groupState.delete(groupKey);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group).isEmpty();
 
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
@@ -192,13 +189,13 @@ public class GroupStateTest {
     final var tenantId = "tenant1";
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
 
     // when
     groupState.addTenant(groupKey, tenantId);
 
     // then
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
     assertThat(group.isPresent()).isTrue();
     assertThat(group.get().getTenantIdsList()).containsExactly(tenantId);
   }
@@ -215,12 +212,12 @@ public class GroupStateTest {
     // Create a group and add tenants
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
-    groupState.create(groupKey, groupRecord);
+    groupState.create(groupRecord);
     groupState.addTenant(groupKey, tenantId1);
     groupState.addTenant(groupKey, tenantId2);
 
     // Ensure tenants are added correctly
-    final var groupBeforeRemove = groupState.get(groupKey);
+    final var groupBeforeRemove = groupState.get(groupId);
     assertThat(groupBeforeRemove.isPresent()).isTrue();
     assertThat(groupBeforeRemove.get().getTenantIdsList()).containsExactly(tenantId1, tenantId2);
 
@@ -228,7 +225,7 @@ public class GroupStateTest {
     groupState.removeTenant(groupKey, tenantId1);
 
     // then
-    final var groupAfterRemove = groupState.get(groupKey);
+    final var groupAfterRemove = groupState.get(groupId);
     assertThat(groupAfterRemove.isPresent()).isTrue();
     assertThat(groupAfterRemove.get().getTenantIdsList()).containsExactly(tenantId2);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -34,9 +34,11 @@ public class GroupStateTest {
   @Test
   void shouldCreateGroup() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
 
     // when
     groupState.create(groupKey, groupRecord);
@@ -52,10 +54,10 @@ public class GroupStateTest {
   @Test
   void shouldReturnNullIfGroupDoesNotExist() {
     // given
-    final var groupKey = 2L;
+    final var groupId = "groupId";
 
     // when
-    final var group = groupState.get(groupKey);
+    final var group = groupState.get(groupId);
 
     // then
     assertThat(group.isPresent()).isFalse();
@@ -64,9 +66,11 @@ public class GroupStateTest {
   @Test
   void shouldUpdateGroup() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
 
     final var updatedGroupName = "updatedGroup";
@@ -86,9 +90,11 @@ public class GroupStateTest {
   @Test
   void shouldAddEntity() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
 
     // when
@@ -106,9 +112,11 @@ public class GroupStateTest {
   @Test
   void shouldReturnEntitiesByType() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     final var userKey = 2L;
     groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
@@ -129,9 +137,11 @@ public class GroupStateTest {
   @Test
   void shouldRemoveEntity() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     final var userKey = 2L;
     groupRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
@@ -151,9 +161,11 @@ public class GroupStateTest {
   @Test
   void shouldDeleteGroup() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
     groupState.addEntity(groupKey, groupRecord);
@@ -174,10 +186,12 @@ public class GroupStateTest {
   @Test
   void shouldAddTenant() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var tenantId = "tenant1";
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
 
     // when
@@ -192,13 +206,15 @@ public class GroupStateTest {
   @Test
   void shouldRemoveTenant() {
     // given
-    final var groupKey = 1L;
+    final var groupId = "1";
+    final var groupKey = Long.parseLong(groupId);
     final var groupName = "group";
     final var tenantId1 = "tenant1";
     final var tenantId2 = "tenant2";
 
     // Create a group and add tenants
-    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    final var groupRecord =
+        new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupKey, groupRecord);
     groupState.addTenant(groupKey, tenantId1);
     groupState.addTenant(groupKey, tenantId2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -69,6 +69,11 @@ public class GroupClient {
       groupRecord.setName(name);
     }
 
+    public GroupCreateClient withGroupId(final String groupId) {
+      groupRecord.setGroupId(groupId);
+      return this;
+    }
+
     public Record<GroupRecordValue> create() {
       final long position = writer.writeCommand(GroupIntent.CREATE, groupRecord);
       return expectation.apply(position);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1046,6 +1046,8 @@ public class CompactRecordLogger {
     builder
         .append("Key=")
         .append(shortenKey(value.getGroupKey()))
+        .append(", Id=")
+        .append(formatId(value.getGroupId()))
         .append(", Name=")
         .append(formatId(value.getName()))
         .append(", EntityKey=")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Enable the processors/appliers to work with ID on group creation

## Related issues

closes #30022 
