### PR TITLE
feat: Trigger `canceling` task listeners on user task cancelation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.util.Either;
+import java.util.Collections;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
@@ -136,7 +137,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             context,
             cancelingUserTask.get(),
             cancelingListeners.getFirst(),
-            cancelingUserTask.get().getChangedAttributes());
+            Collections.emptyList());
         return TransitionOutcome.AWAIT;
       } else {
         userTaskBehavior.userTaskCanceled(cancelingUserTask.get());
@@ -184,10 +185,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
     final var creatingListeners = element.getTaskListeners(ZeebeTaskListenerEventType.creating);
     if (!creatingListeners.isEmpty()) {
       jobBehavior.createNewTaskListenerJob(
-          context,
-          userTaskRecord,
-          creatingListeners.getFirst(),
-          userTaskRecord.getChangedAttributes());
+          context, userTaskRecord, creatingListeners.getFirst(), Collections.emptyList());
       lifecycleState = LifecycleState.CREATING;
     } else {
       userTaskRecord.unsetAssignee();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -32,5 +32,10 @@ public final class UserTaskCancelingV2Applier
 
     // Clean up data that may have been persisted by a previous transition
     variableState.removeVariableDocumentState(value.getElementInstanceKey());
+    userTaskState.deleteIntermediateStateIfExists(key);
+    userTaskState.deleteRecordRequestMetadata(key);
+
+    // Persist new data related to "canceling" user task transition
+    userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -528,6 +528,28 @@ public class TaskListenerBlockedTransitionTest {
   }
 
   @Test
+  public void shouldCreateFirstCancelingTaskListenerJob() {
+    // given
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createUserTaskWithTaskListeners(
+                ZeebeTaskListenerEventType.canceling, listenerType));
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).expectTerminating().cancel();
+
+    // then
+    helper.assertActivatedJob(
+        processInstanceKey,
+        listenerType,
+        job ->
+            Assertions.assertThat(job)
+                .describedAs("Expect activated job to be 'CANCELLING' task listener job")
+                .hasJobKind(JobKind.TASK_LISTENER)
+                .hasJobListenerEventType(JobListenerEventType.CANCELING));
+  }
+
+  @Test
   public void shouldCancelTaskListenerJobWhenTerminatingElementInstance() {
     // given
     final long processInstanceKey =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -254,6 +254,14 @@ public final class ProcessInstanceClient {
                 .withProcessInstanceKey(processInstanceKey)
                 .getFirst();
 
+    public static final Function<Long, Record<ProcessInstanceRecordValue>> TERMINATING_EXPECTATION =
+        (processInstanceKey) ->
+            RecordingExporter.processInstanceRecords()
+                .withRecordKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.ELEMENT_TERMINATING)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst();
+
     public static final Function<Long, Record<ProcessInstanceRecordValue>> REJECTION_EXPECTATION =
         (processInstanceKey) ->
             RecordingExporter.processInstanceRecords()
@@ -288,6 +296,11 @@ public final class ProcessInstanceClient {
 
     public ExistingInstanceClient expectRejection() {
       expectation = REJECTION_EXPECTATION;
+      return this;
+    }
+
+    public ExistingInstanceClient expectTerminating() {
+      expectation = TERMINATING_EXPECTATION;
       return this;
     }
 


### PR DESCRIPTION
## Description

This PR introduces the ability to trigger `"canceling"` task listeners when a user task is canceled. It ensures that a dedicated listener job is created for the first `canceling` listener, enabling the execution of custom logic during task cancellation. 

The PR also handles the necessary state management, including cleaning up data from ongoing transitions and preparing the user task for the `canceling` listener execution. Tests were extended to validate the new behavior and state transitions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28568
