### PR TITLE
fix: use default token for GH action

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -17,7 +17,7 @@ permissions:
   packages: none
   pages: none
   pull-requests: none
-  repository-projects: none
+  repository-projects: write
   security-events: none
   statuses: write
 
@@ -37,20 +37,12 @@ jobs:
               echo "match=true" >> "$GITHUB_OUTPUT"
             fi
 
-        - name: Generate GitHub token
-          if: ${{ steps.vars.outputs.match == 'true' }}
-          uses: tibdex/github-app-token@v2
-          id: generate-github-token
-          with:
-            app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-            private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-
         - name: Update Closed At field
           if: ${{ steps.vars.outputs.match == 'true' }}
           uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d # main
           id: update-closed-at
           with:
-            github_token: ${{ steps.generate-github-token.outputs.token }}
+            github_token: ${{ secrets.GITHUB_TOKEN }}
             organization: ${{ github.repository_owner }}
             project_number: ${{ steps.vars.outputs.project_id }}
             content_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixing failing GH workflow to add closed at to c8run tickets (used to show closed issues on distros team board)..

https://github.com/camunda/team-distribution/issues/467

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
