### PR TITLE
fix: adjust the format to gateway-address setting in connectors

### DIFF
--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,4 +1,4 @@
-zeebe.client.broker.gateway-address=127.0.0.1:26500
+zeebe.client.broker.gateway-address=http://127.0.0.1:26500
 zeebe.client.security.plaintext=true
 camunda.operate.client.url=http://localhost:8080
 camunda.operate.client.username=demo

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -41,12 +41,21 @@ if [[ "$returnCode" != 0 ]]; then
    echo "test failed"
    exit 1
 fi
-
 printf "\nTest: test --config flag\n"
 
 PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.Camunda.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
 echo $PREFIX
 if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
+   echo "test failed"
+   exit 1
+fi
+
+
+printf "\nTest: connectors api \n"
+
+STATUS="$( curl localhost:8085/actuator/health | jq '.status' )"
+echo $STATUS
+if [[ "$STATUS" != "\"UP\"" ]]; then
    echo "test failed"
    exit 1
 fi


### PR DESCRIPTION
## Description

The gateway-address now requires a protocol in the url rather than just the host. I'll see if I can link other issues.

I think this might be related:
https://github.com/camunda/camunda/issues/30386

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
