### PR TITLE
fix: filter by version tag in search process definition endpoint

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
@@ -51,6 +51,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Demo process")
             .setVersion(1)
+            .setVersionTag("demoVersionTag")
             .setBpmnProcessId("demoProcess")
             .setBpmnXml(resourceXml));
 
@@ -62,6 +63,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Error process")
             .setVersion(1)
+            .setVersionTag("errorVersionTag")
             .setBpmnProcessId("errorProcess")
             .setBpmnXml(resourceXml));
 
@@ -73,6 +75,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Complex process")
             .setVersion(1)
+            .setVersionTag("complexVersionTag")
             .setBpmnProcessId("complexProcess")
             .setBpmnXml(resourceXml));
 
@@ -194,5 +197,17 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
     assertThat(processDefinitionResults.getItems().get(0).getBpmnProcessId())
         .isEqualTo("complexProcess");
+  }
+
+  @Test
+  public void shouldFilterProcessDefinitionsByVersionTag() {
+    final Results<ProcessDefinition> processDefinitionResults =
+        dao.search(
+            new Query<ProcessDefinition>()
+                .setFilter(new ProcessDefinition().setVersionTag("demoVersionTag")));
+
+    assertThat(processDefinitionResults.getItems().get(0).getVersionTag())
+        .isEqualTo("demoVersionTag");
+    assertThat(processDefinitionResults.getItems()).hasSize(1);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
@@ -128,6 +128,7 @@ public class ElasticsearchProcessDefinitionDao extends ElasticsearchDao<ProcessD
       queryBuilders.add(buildTermQuery(ProcessDefinition.TENANT_ID, filter.getTenantId()));
       queryBuilders.add(buildTermQuery(ProcessDefinition.VERSION, filter.getVersion()));
       queryBuilders.add(buildTermQuery(ProcessDefinition.KEY, filter.getKey()));
+      queryBuilders.add(buildTermQuery(ProcessDefinition.VERSION_TAG, filter.getVersionTag()));
       searchSourceBuilder.query(
           ElasticsearchUtil.joinWithAnd(queryBuilders.toArray(new QueryBuilder[] {})));
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -112,7 +112,8 @@ public class OpensearchProcessDefinitionDao
                       ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId()),
                   queryDSLWrapper.term(ProcessDefinition.TENANT_ID, filter.getTenantId()),
                   queryDSLWrapper.term(ProcessDefinition.VERSION, filter.getVersion()),
-                  queryDSLWrapper.term(ProcessDefinition.KEY, filter.getKey()))
+                  queryDSLWrapper.term(ProcessDefinition.KEY, filter.getKey()),
+                  queryDSLWrapper.term(ProcessDefinition.VERSION_TAG, filter.getVersionTag()))
               .filter(Objects::nonNull)
               .collect(Collectors.toList());
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchProcessDefinitionDaoTest {
+
+  @Mock private SearchSourceBuilder mockSearchSourceBuilder;
+
+  private ElasticsearchProcessDefinitionDao underTest;
+
+  @BeforeEach
+  void setup() {
+    underTest = spy(new ElasticsearchProcessDefinitionDao());
+  }
+
+  @Test
+  void testBuildFilteringWithValidFields() {
+    // Given
+    final ProcessDefinition filter = new ProcessDefinition();
+    filter
+        .setKey(123L)
+        .setBpmnProcessId("demoBpmnProcessId")
+        .setTenantId("demoTenant")
+        .setName("demoName")
+        .setVersion(1)
+        .setVersionTag("demoVersionTag");
+    final Query<ProcessDefinition> inputQuery = new Query<ProcessDefinition>().setFilter(filter);
+
+    // When
+    underTest.buildFiltering(inputQuery, mockSearchSourceBuilder);
+
+    // Then
+    verify(underTest, times(1)).buildTermQuery(ProcessDefinition.NAME, filter.getName());
+    verify(underTest, times(1))
+        .buildTermQuery(ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId());
+    verify(underTest, times(1)).buildTermQuery(ProcessDefinition.TENANT_ID, filter.getTenantId());
+    verify(underTest, times(1)).buildTermQuery(ProcessDefinition.VERSION, filter.getVersion());
+    verify(underTest, times(1))
+        .buildTermQuery(ProcessDefinition.VERSION_TAG, filter.getVersionTag());
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.dao.opensearch;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
+import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+class OpensearchProcessDefinitionDaoTest {
+
+  @Mock private OpensearchQueryDSLWrapper mockQueryWrapper;
+
+  @Mock private OpensearchRequestDSLWrapper mockRequestWrapper;
+
+  @Mock private RichOpenSearchClient mockOpensearchClient;
+
+  @Mock private ProcessIndex mockProcessIndex;
+
+  @InjectMocks private OpensearchProcessDefinitionDao underTest;
+
+  @BeforeEach
+  void setup() {
+    underTest =
+        new OpensearchProcessDefinitionDao(
+            mockQueryWrapper, mockRequestWrapper, mockOpensearchClient, mockProcessIndex);
+  }
+
+  @Test
+  void testBuildFilteringWithValidFields() {
+    // Given
+    final SearchRequest.Builder mockSearchRequest = Mockito.mock(SearchRequest.Builder.class);
+    final ProcessDefinition filter = new ProcessDefinition();
+    filter
+        .setKey(123L)
+        .setBpmnProcessId("demoBpmnProcessId")
+        .setTenantId("demoTenant")
+        .setName("demoName")
+        .setVersion(1)
+        .setVersionTag("demoVersionTag");
+    final Query<ProcessDefinition> inputQuery = new Query<ProcessDefinition>().setFilter(filter);
+
+    // When
+    underTest.buildFiltering(inputQuery, mockSearchRequest);
+
+    // Then
+    verify(mockQueryWrapper, times(1)).term(ProcessDefinition.NAME, filter.getName());
+    verify(mockQueryWrapper, times(1))
+        .term(ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId());
+    verify(mockQueryWrapper, times(1)).term(ProcessDefinition.TENANT_ID, filter.getTenantId());
+    verify(mockQueryWrapper, times(1)).term(ProcessDefinition.VERSION, filter.getVersion());
+    verify(mockQueryWrapper, times(1)).term(ProcessDefinition.VERSION_TAG, filter.getVersionTag());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a version tag filter to the `/v1/process-definitions/search` endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30374
