### PR TITLE
feat: add utils for TopPanel

### DIFF
--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -109,52 +109,6 @@ const mockEndpoints = [
       );
     },
   ),
-  rest.get(
-    '/v2/process-instances/:processInstanceKey/statistics/flownode-instances',
-    async (req: RestRequest<any>, res, ctx) => {
-      return res(
-        ctx.json({
-          items: [
-            {
-              flowNodeId: 'Gateway_15jzrqe',
-              active: 0,
-              canceled: 0,
-              incidents: 1,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'exclusiveGateway',
-              active: 0,
-              canceled: 0,
-              incidents: 0,
-              completed: 1,
-            },
-            {
-              flowNodeId: 'alwaysFailingTask',
-              active: 1,
-              canceled: 0,
-              incidents: 0,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'messageCatchEvent',
-              active: 0,
-              canceled: 0,
-              incidents: 1,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'upperTask',
-              active: 1,
-              canceled: 0,
-              incidents: 0,
-              completed: 0,
-            },
-          ],
-        }),
-      );
-    },
-  ),
 ];
 
 const handlers: RequestHandler[] = [...mockEndpoints];

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -109,6 +109,52 @@ const mockEndpoints = [
       );
     },
   ),
+  rest.get(
+    '/v2/process-instances/:processInstanceKey/statistics/flownode-instances',
+    async (req: RestRequest<any>, res, ctx) => {
+      return res(
+        ctx.json({
+          items: [
+            {
+              flowNodeId: 'Gateway_15jzrqe',
+              active: 0,
+              canceled: 0,
+              incidents: 1,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'exclusiveGateway',
+              active: 0,
+              canceled: 0,
+              incidents: 0,
+              completed: 1,
+            },
+            {
+              flowNodeId: 'alwaysFailingTask',
+              active: 1,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'messageCatchEvent',
+              active: 0,
+              canceled: 0,
+              incidents: 1,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'upperTask',
+              active: 1,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+          ],
+        }),
+      );
+    },
+  ),
 ];
 
 const handlers: RequestHandler[] = [...mockEndpoints];

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -6,6 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+/*
+ * DEPRECATED: The `flowNodeSelectionStore` is being deprecated and replaced with
+ * utility functions and hooks in `flowNodeSelection.ts` as part of the Operate v2 migration.
+ *
+ * Please avoid adding new functionality to this store and migrate existing logic
+ * to the new utils and hooks where possible.
+ */
+
 import {IReactionDisposer, makeAutoObservable, when, reaction} from 'mobx';
 import {FlowNodeInstance} from './flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';

--- a/operate/client/src/modules/utils/flowNodeSelection.test.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getSelectedRunningInstanceCount} from './flowNodeSelection';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+
+describe('getSelectedRunningInstanceCount', () => {
+  beforeEach(() => {
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+  });
+
+  it('should return 0 if no selection is made', () => {
+    flowNodeSelectionStore.setSelection(null);
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 if the selection is a placeholder', () => {
+    flowNodeSelectionStore.setSelection({
+      flowNodeId: 'someNode',
+      flowNodeInstanceId: 'someInstance',
+      isPlaceholder: true,
+    });
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 if the root node is selected', () => {
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 if the selection has no flowNodeId', () => {
+    flowNodeSelectionStore.setSelection({
+      flowNodeId: undefined,
+    });
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 if a specific flow node instance is selected and it is not running', () => {
+    flowNodeSelectionStore.setSelection({
+      flowNodeId: 'someNode',
+      flowNodeInstanceId: 'someInstance',
+    });
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+
+  it('should handle edge cases with invalid selection', () => {
+    flowNodeSelectionStore.setSelection({});
+    const result = getSelectedRunningInstanceCount(10);
+    expect(result).toBe(0);
+  });
+});

--- a/operate/client/src/modules/utils/flowNodeSelection.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+
+const getSelectedRunningInstanceCount = (
+  totalRunningInstancesForFlowNode: number,
+) => {
+  const currentSelection = flowNodeSelectionStore.state.selection;
+
+  if (currentSelection === null) {
+    return 0;
+  }
+
+  if (
+    currentSelection.isPlaceholder ||
+    flowNodeSelectionStore.isRootNodeSelected ||
+    currentSelection.flowNodeId === undefined
+  ) {
+    return 0;
+  }
+
+  if (currentSelection.flowNodeInstanceId !== undefined) {
+    return flowNodeMetaDataStore.isSelectedInstanceRunning ? 1 : 0;
+  }
+
+  return totalRunningInstancesForFlowNode;
+};
+
+export {getSelectedRunningInstanceCount};

--- a/operate/client/src/modules/utils/modification.test.ts
+++ b/operate/client/src/modules/utils/modification.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {finishMovingToken} from './modifications';
+import {modificationsStore} from 'modules/stores/modifications';
+import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
+import {tracking} from 'modules/tracking';
+
+jest.mock('modules/stores/modifications', () => ({
+  modificationsStore: {
+    state: {
+      sourceFlowNodeIdForMoveOperation: null,
+      sourceFlowNodeInstanceKeyForMoveOperation: null,
+      status: 'disabled',
+    },
+    addMoveModification: jest.fn(),
+  },
+}));
+
+jest.mock('modules/bpmn-js/utils/isMultiInstance', () => ({
+  isMultiInstance: jest.fn(),
+}));
+
+jest.mock('modules/tracking', () => ({
+  tracking: {
+    track: jest.fn(),
+  },
+}));
+
+describe('finishMovingToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    modificationsStore.state.sourceFlowNodeIdForMoveOperation = 'sourceNode';
+    modificationsStore.state.sourceFlowNodeInstanceKeyForMoveOperation = null;
+  });
+
+  it('should track the move-token event', () => {
+    finishMovingToken(5, 3, 'targetNode');
+
+    expect(tracking.track).toHaveBeenCalledWith({
+      eventName: 'move-token',
+    });
+  });
+
+  it('should add a move modification when targetFlowNodeId is provided', () => {
+    (isMultiInstance as jest.Mock).mockReturnValue(false);
+
+    finishMovingToken(5, 3, 'targetNode');
+
+    expect(modificationsStore.addMoveModification).toHaveBeenCalledWith({
+      sourceFlowNodeId: 'sourceNode',
+      sourceFlowNodeInstanceKey: undefined,
+      targetFlowNodeId: 'targetNode',
+      affectedTokenCount: 5,
+      visibleAffectedTokenCount: 3,
+      newScopeCount: 5,
+    });
+  });
+
+  it('should set newScopeCount to 1 for multi-instance source nodes', () => {
+    (isMultiInstance as jest.Mock).mockReturnValue(true);
+
+    finishMovingToken(5, 3, 'targetNode');
+
+    expect(modificationsStore.addMoveModification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newScopeCount: 1,
+      }),
+    );
+  });
+
+  it('should not add a move modification if targetFlowNodeId is undefined', () => {
+    finishMovingToken(5, 3);
+
+    expect(modificationsStore.addMoveModification).not.toHaveBeenCalled();
+  });
+
+  it('should reset the modification state after finishing the move', () => {
+    finishMovingToken(5, 3, 'targetNode');
+
+    expect(modificationsStore.state.status).toBe('enabled');
+    expect(
+      modificationsStore.state.sourceFlowNodeIdForMoveOperation,
+    ).toBeNull();
+    expect(
+      modificationsStore.state.sourceFlowNodeInstanceKeyForMoveOperation,
+    ).toBeNull();
+  });
+});

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -32,6 +32,9 @@ const finishMovingToken = (
     sourceFlowNodeIdForMoveOperation !== null
   ) {
     if (sourceFlowNodeInstanceKeyForMoveOperation === null) {
+      // TODO: [OPERATE-V2-MIGRATION] After migrating processInstanceDetailsDiagramStore to a query,
+      // consider passing the resolved sourceFlowNode as a parameter to finishMovingToken
+      // instead of accessing it directly from processInstanceDetailsDiagramStore.businessObjects.
       newScopeCount = isMultiInstance(
         processInstanceDetailsDiagramStore.businessObjects[
           sourceFlowNodeIdForMoveOperation

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
+import {modificationsStore} from 'modules/stores/modifications';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {tracking} from 'modules/tracking';
+
+const finishMovingToken = (
+  affectedTokenCount: number,
+  visibleAffectedTokenCount: number,
+  targetFlowNodeId?: string,
+) => {
+  tracking.track({
+    eventName: 'move-token',
+  });
+
+  let newScopeCount = 1;
+
+  const {
+    sourceFlowNodeIdForMoveOperation,
+    sourceFlowNodeInstanceKeyForMoveOperation,
+  } = modificationsStore.state;
+
+  if (
+    targetFlowNodeId !== undefined &&
+    sourceFlowNodeIdForMoveOperation !== null
+  ) {
+    if (sourceFlowNodeInstanceKeyForMoveOperation === null) {
+      newScopeCount = isMultiInstance(
+        processInstanceDetailsDiagramStore.businessObjects[
+          sourceFlowNodeIdForMoveOperation
+        ],
+      )
+        ? 1
+        : affectedTokenCount;
+    }
+
+    modificationsStore.addMoveModification({
+      sourceFlowNodeId: sourceFlowNodeIdForMoveOperation,
+      sourceFlowNodeInstanceKey:
+        sourceFlowNodeInstanceKeyForMoveOperation ?? undefined,
+      targetFlowNodeId,
+      affectedTokenCount,
+      visibleAffectedTokenCount,
+      newScopeCount,
+    });
+  }
+
+  modificationsStore.state.status = 'enabled';
+  modificationsStore.state.sourceFlowNodeIdForMoveOperation = null;
+  modificationsStore.state.sourceFlowNodeInstanceKeyForMoveOperation = null;
+};
+
+export {finishMovingToken};

--- a/operate/client/src/modules/utils/statistics/flownodeInstance.test.tsx
+++ b/operate/client/src/modules/utils/statistics/flownodeInstance.test.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useEffect} from 'react';
+import {renderHook} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {getStatisticsByFlowNode} from './flownodeInstances';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+
+describe('getStatisticsByFlowNode', () => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    useEffect(() => {
+      return () => {
+        processInstanceDetailsDiagramStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
+    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+  });
+
+  it('should return statistics for valid flow nodes', () => {
+    const data = [
+      {
+        flowNodeId: 'StartEvent_1',
+        active: 5,
+        incidents: 2,
+        completed: 10,
+        canceled: 1,
+      },
+      {
+        flowNodeId: 'Activity_0qtp1k6',
+        active: 3,
+        incidents: 1,
+        completed: 7,
+        canceled: 0,
+      },
+    ];
+
+    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({
+      StartEvent_1: {
+        active: 5,
+        filteredActive: 5,
+        incidents: 2,
+        completed: 10,
+        completedEndEvents: 0,
+        canceled: 1,
+      },
+      Activity_0qtp1k6: {
+        active: 3,
+        filteredActive: 3,
+        incidents: 1,
+        completed: 7,
+        completedEndEvents: 0,
+        canceled: 0,
+      },
+    });
+  });
+
+  it('should handle missing business objects', () => {
+    const data = [
+      {
+        flowNodeId: 'StartEvent_1',
+        active: 5,
+        incidents: 2,
+        completed: 10,
+        canceled: 1,
+      },
+      {
+        flowNodeId: 'missing_node',
+        active: 3,
+        incidents: 1,
+        completed: 7,
+        canceled: 0,
+      },
+    ];
+
+    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({
+      StartEvent_1: {
+        active: 5,
+        filteredActive: 5,
+        incidents: 2,
+        completed: 10,
+        completedEndEvents: 0,
+        canceled: 1,
+      },
+    });
+  });
+
+  it('should handle modification mode', () => {
+    modificationsStore.enableModificationMode();
+
+    const data = [
+      {
+        flowNodeId: 'StartEvent_1',
+        active: 5,
+        incidents: 2,
+        completed: 10,
+        canceled: 1,
+      },
+    ];
+
+    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({
+      StartEvent_1: {
+        active: 5,
+        filteredActive: 5,
+        incidents: 2,
+        completed: 0,
+        completedEndEvents: 0,
+        canceled: 0,
+      },
+    });
+  });
+
+  it('should handle end events correctly', () => {
+    const data = [
+      {
+        flowNodeId: 'Event_0bonl61',
+        active: 0,
+        incidents: 0,
+        completed: 10,
+        canceled: 0,
+      },
+    ];
+
+    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({
+      Event_0bonl61: {
+        active: 0,
+        filteredActive: 0,
+        incidents: 0,
+        completed: 0,
+        completedEndEvents: 10,
+        canceled: 0,
+      },
+    });
+  });
+
+  it('should return an empty object if no valid data is provided', () => {
+    const data = [
+      {
+        flowNodeId: 'node1',
+        active: 5,
+        incidents: 2,
+        completed: 10,
+        canceled: 1,
+      },
+    ];
+
+    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toEqual({});
+  });
+});

--- a/operate/client/src/modules/utils/statistics/flownodeInstances.ts
+++ b/operate/client/src/modules/utils/statistics/flownodeInstances.ts
@@ -20,6 +20,9 @@ const getStatisticsByFlowNode = (data: ProcessDefinitionStatistic[]) => {
   return data.reduce<{
     [key: string]: Omit<Statistic, 'flowNodeId'>;
   }>((statistics, {flowNodeId: id, active, incidents, completed, canceled}) => {
+    // TODO: [OPERATE-V2-MIGRATION] After migrating processInstanceDetailsDiagramStore to a query,
+    // consider passing the resolved flowNode as a parameter to getStatisticsByFlowNode
+    // instead of accessing it directly from processInstanceDetailsDiagramStore.businessObjects.
     const businessObject =
       processInstanceDetailsDiagramStore.businessObjects[id];
 

--- a/operate/client/src/modules/utils/statistics/flownodeInstances.ts
+++ b/operate/client/src/modules/utils/statistics/flownodeInstances.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessDefinitionStatistic} from '@vzeta/camunda-api-zod-schemas/operate';
+import {isProcessEndEvent} from 'modules/bpmn-js/utils/isProcessEndEvent';
+import {modificationsStore} from 'modules/stores/modifications';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+
+type Statistic = ProcessDefinitionStatistic & {
+  filteredActive: number;
+  completedEndEvents: number;
+};
+
+const getStatisticsByFlowNode = (data: ProcessDefinitionStatistic[]) => {
+  return data.reduce<{
+    [key: string]: Omit<Statistic, 'flowNodeId'>;
+  }>((statistics, {flowNodeId: id, active, incidents, completed, canceled}) => {
+    const businessObject =
+      processInstanceDetailsDiagramStore.businessObjects[id];
+
+    if (businessObject === undefined) {
+      return statistics;
+    }
+
+    statistics[id] = {
+      active,
+      filteredActive: businessObject?.$type !== 'bpmn:SubProcess' ? active : 0,
+      incidents,
+      completed: !isProcessEndEvent(businessObject) ? completed : 0,
+      completedEndEvents: isProcessEndEvent(businessObject) ? completed : 0,
+      canceled,
+      ...(modificationsStore.isModificationModeEnabled
+        ? {
+            completed: 0,
+            completedEndEvents: 0,
+            canceled: 0,
+          }
+        : {}),
+    };
+
+    return statistics;
+  }, {});
+};
+
+export {getStatisticsByFlowNode};

--- a/operate/client/yarn.lock
+++ b/operate/client/yarn.lock
@@ -12402,16 +12402,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12507,14 +12498,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13950,7 +13934,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13963,15 +13947,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

This PR is adding utils for the v2 TopPanel component. These are essentially methods extracted from `flowNodeSelectionStore`, `modificationStore` and `processInstanceDetailsStatisticsStore`.

As a rule of thumb, I'm dividing the store logic into :
- `utils` : refer to any store logic necessary for migration that don't rely on hooks. I'm introducing them in this PR.
- `queries` : refer to logic related to data fetching and transformation. Ideally we don't want our queries to rely on stores (but they might need to in the short term). I'm introducing them in #30407 
- `hooks` : refer to methods that heavily relies on stores and queries. They can't be defined as utils because they depend on hooks. The longterm plan for these (when stores are removed) is to either turn them into parsers or custom hooks that are fully compatible with TanStack queries. I'm introducing them in #30408

## Related issues

related to #30263
