### PR TITLE
fix: remove pip caching

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -105,7 +105,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: "pip"
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -112,7 +112,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: "pip"
 
       - name: Run tests
         shell: bash


### PR DESCRIPTION
## Description  

This PR fixes a workflow failure caused by `setup-python@v5` when attempting to cache dependencies without a `requirements.txt` or `pyproject.toml` file.  
To resolve this, the `cache: "pip"` option has been removed from the workflow file, allowing the setup step to proceed without errors.  

## Checklist  

- [ ] for CI changes:  
  - [ ] structural/foundational changes signed off by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)  
  - [ ] [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)  
  - [ ] enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)  

## Related issues  

closes # 