### PR TITLE
feat: add statistics queries for TopPanel

### DIFF
--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
@@ -8,7 +8,7 @@
 
 import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
-import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {useExecutedFlowNodes} from './useExecutedFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
@@ -18,7 +18,7 @@ import {useEffect} from 'react';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
 
-describe('useFlownodeInstancesStatistics', () => {
+describe('useExecutedFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
     useEffect(() => {
       return () => {
@@ -46,20 +46,27 @@ describe('useFlownodeInstancesStatistics', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch flownode instances statistics successfully', async () => {
+  it('should fetch executed flow nodes successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
-          flowNodeId: 'node1',
-          active: 5,
+          flowNodeId: 'StartEvent_1',
+          active: 0,
           completed: 10,
           canceled: 0,
           incidents: 0,
         },
         {
-          flowNodeId: 'node2',
-          active: 3,
+          flowNodeId: 'Activity_0qtp1k6',
+          active: 0,
           completed: 7,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          flowNodeId: 'Gateway_1',
+          active: 0,
+          completed: 0,
           canceled: 0,
           incidents: 0,
         },
@@ -68,7 +75,7 @@ describe('useFlownodeInstancesStatistics', () => {
 
     mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -76,49 +83,28 @@ describe('useFlownodeInstancesStatistics', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual(mockData);
-  });
-
-  it('should handle select', async () => {
-    const mockData: GetProcessInstanceStatisticsResponseBody = {
-      items: [
-        {
-          flowNodeId: 'node1',
-          active: 5,
-          completed: 10,
-          canceled: 0,
-          incidents: 0,
-        },
-        {
-          flowNodeId: 'node2',
-          active: 3,
-          completed: 7,
-          canceled: 0,
-          incidents: 0,
-        },
-      ],
-    };
-
-    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
-
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data.items.length),
+    expect(result.current.data).toEqual([
       {
-        wrapper: Wrapper,
+        flowNodeId: 'StartEvent_1',
+        active: 0,
+        completed: 10,
+        canceled: 0,
+        incidents: 0,
       },
-    );
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data).toEqual(mockData.items.length);
+      {
+        flowNodeId: 'Activity_0qtp1k6',
+        active: 0,
+        completed: 7,
+        canceled: 0,
+        incidents: 0,
+      },
+    ]);
   });
 
-  it('should handle server error while fetching flownode instances overlay statistics', async () => {
+  it('should handle server error while fetching executed flow nodes', async () => {
     mockFetchFlownodeInstancesStatistics().withServerError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -129,10 +115,10 @@ describe('useFlownodeInstancesStatistics', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching flownode instances overlay statistics', async () => {
+  it('should handle network error while fetching executed flow nodes', async () => {
     mockFetchFlownodeInstancesStatistics().withNetworkError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -146,33 +132,20 @@ describe('useFlownodeInstancesStatistics', () => {
   it('should handle empty data', async () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual({items: []});
+    expect(result.current.data).toEqual([]);
   });
 
   it('should handle loading state', async () => {
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
-  });
-
-  it('should not fetch data when enabled is false', async () => {
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data, false),
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.isFetched).toBe(false);
-    expect(result.current.data).toBeUndefined();
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNodes.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNodes.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+
+const executedFlowNodesParser = (
+  response: GetProcessInstanceStatisticsResponseBody,
+) =>
+  response.items.filter(({completed}) => {
+    return completed > 0;
+  });
+
+const useExecutedFlowNodes = () => {
+  return useFlownodeInstancesStatistics(executedFlowNodesParser);
+};
+
+export {useExecutedFlowNodes};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
@@ -6,28 +6,36 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {skipToken, UseQueryOptions} from '@tanstack/react-query';
+import {
+  skipToken,
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+} from '@tanstack/react-query';
 import {RequestError} from 'modules/request';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
 import {fetchFlownodeInstancesStatistics} from 'modules/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {isEmpty} from 'lodash';
 
 function getQueryKey(processInstanceKey?: string) {
   return ['flownodeInstancesStatistics', processInstanceKey];
 }
 
-function useFlownodeInstancesStatisticsOptions<
+function getFlownodeInstancesStatisticsOptions<
   T = GetProcessInstanceStatisticsResponseBody,
 >(
+  processInstanceId?: string,
   select?: (data: GetProcessInstanceStatisticsResponseBody) => T,
   enabled: boolean = true,
 ): UseQueryOptions<GetProcessInstanceStatisticsResponseBody, RequestError, T> {
-  const {processInstanceId} = useProcessInstancePageParams();
-
   return {
     queryKey: getQueryKey(processInstanceId),
     queryFn:
-      enabled && !!processInstanceId
+      enabled &&
+      !!processInstanceId &&
+      !isEmpty(processInstanceDetailsDiagramStore.businessObjects)
         ? async () => {
             const {response, error} =
               await fetchFlownodeInstancesStatistics(processInstanceId);
@@ -43,4 +51,17 @@ function useFlownodeInstancesStatisticsOptions<
   };
 }
 
-export {useFlownodeInstancesStatisticsOptions};
+const useFlownodeInstancesStatistics = <
+  T = GetProcessInstanceStatisticsResponseBody,
+>(
+  select?: (data: GetProcessInstanceStatisticsResponseBody) => T,
+  enabled: boolean = true,
+): UseQueryResult<T, RequestError> => {
+  const {processInstanceId} = useProcessInstancePageParams();
+
+  return useQuery(
+    getFlownodeInstancesStatisticsOptions(processInstanceId, select, enabled),
+  );
+};
+
+export {useFlownodeInstancesStatistics};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
@@ -8,7 +8,7 @@
 
 import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
-import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {useFlownodeStatistics} from './useFlownodeStatistics';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
@@ -18,7 +18,7 @@ import {useEffect} from 'react';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
 
-describe('useFlownodeInstancesStatistics', () => {
+describe('useFlownodeStatistics', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
     useEffect(() => {
       return () => {
@@ -46,18 +46,18 @@ describe('useFlownodeInstancesStatistics', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch flownode instances statistics successfully', async () => {
+  it('should fetch parsed flownode statistics successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
-          flowNodeId: 'node1',
+          flowNodeId: 'StartEvent_1',
           active: 5,
           completed: 10,
           canceled: 0,
           incidents: 0,
         },
         {
-          flowNodeId: 'node2',
+          flowNodeId: 'Activity_0qtp1k6',
           active: 3,
           completed: 7,
           canceled: 0,
@@ -68,7 +68,7 @@ describe('useFlownodeInstancesStatistics', () => {
 
     mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
@@ -76,49 +76,18 @@ describe('useFlownodeInstancesStatistics', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual(mockData);
+    expect(result.current.data).toEqual([
+      {id: 'StartEvent_1', count: 5, flowNodeState: 'active'},
+      {id: 'StartEvent_1', count: 10, flowNodeState: 'completed'},
+      {id: 'Activity_0qtp1k6', count: 3, flowNodeState: 'active'},
+      {id: 'Activity_0qtp1k6', count: 7, flowNodeState: 'completed'},
+    ]);
   });
 
-  it('should handle select', async () => {
-    const mockData: GetProcessInstanceStatisticsResponseBody = {
-      items: [
-        {
-          flowNodeId: 'node1',
-          active: 5,
-          completed: 10,
-          canceled: 0,
-          incidents: 0,
-        },
-        {
-          flowNodeId: 'node2',
-          active: 3,
-          completed: 7,
-          canceled: 0,
-          incidents: 0,
-        },
-      ],
-    };
-
-    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
-
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data.items.length),
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data).toEqual(mockData.items.length);
-  });
-
-  it('should handle server error while fetching flownode instances overlay statistics', async () => {
+  it('should handle server error while fetching flownode statistics', async () => {
     mockFetchFlownodeInstancesStatistics().withServerError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
@@ -129,10 +98,10 @@ describe('useFlownodeInstancesStatistics', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching flownode instances overlay statistics', async () => {
+  it('should handle network error while fetching flownode statistics', async () => {
     mockFetchFlownodeInstancesStatistics().withNetworkError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
@@ -146,33 +115,20 @@ describe('useFlownodeInstancesStatistics', () => {
   it('should handle empty data', async () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual({items: []});
+    expect(result.current.data).toEqual([]);
   });
 
   it('should handle loading state', async () => {
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
-  });
-
-  it('should not fetch data when enabled is false', async () => {
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data, false),
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.isFetched).toBe(false);
-    expect(result.current.data).toBeUndefined();
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+import {getStatisticsByFlowNode} from 'modules/utils/statistics/flownodeInstances';
+
+const statisticsByFlowNodeParser = (
+  response: GetProcessInstanceStatisticsResponseBody,
+) => {
+  return Object.keys(getStatisticsByFlowNode(response.items)).flatMap((id) => {
+    const types = [
+      'active',
+      'incidents',
+      'canceled',
+      'completed',
+      'completedEndEvents',
+    ] as const;
+
+    const statistic = getStatisticsByFlowNode(response.items)[id];
+
+    return types.reduce<
+      {
+        id: string;
+        count: number;
+        flowNodeState: FlowNodeState | 'completedEndEvents';
+      }[]
+    >((states, flowNodeState) => {
+      const count =
+        flowNodeState === 'active'
+          ? (statistic?.['filteredActive'] ?? 0)
+          : (statistic?.[flowNodeState] ?? 0);
+
+      if (count === 0) {
+        return states;
+      }
+
+      return [
+        ...states,
+        {
+          id,
+          count,
+          flowNodeState,
+        },
+      ];
+    }, []);
+  });
+};
+
+const useFlownodeStatistics = () => {
+  return useFlownodeInstancesStatistics(statisticsByFlowNodeParser);
+};
+
+export {useFlownodeStatistics};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
@@ -8,7 +8,7 @@
 
 import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
-import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {useSelectableFlowNodes} from './useSelectableFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
@@ -18,7 +18,7 @@ import {useEffect} from 'react';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
 
-describe('useFlownodeInstancesStatistics', () => {
+describe('useSelectableFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
     useEffect(() => {
       return () => {
@@ -46,20 +46,27 @@ describe('useFlownodeInstancesStatistics', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch flownode instances statistics successfully', async () => {
+  it('should fetch selectable flow nodes successfully', async () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
-          flowNodeId: 'node1',
+          flowNodeId: 'StartEvent_1',
           active: 5,
           completed: 10,
           canceled: 0,
           incidents: 0,
         },
         {
-          flowNodeId: 'node2',
+          flowNodeId: 'Activity_0qtp1k6',
           active: 3,
           completed: 7,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          flowNodeId: 'Gateway_1',
+          active: 0,
+          completed: 0,
           canceled: 0,
           incidents: 0,
         },
@@ -68,7 +75,7 @@ describe('useFlownodeInstancesStatistics', () => {
 
     mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -76,49 +83,17 @@ describe('useFlownodeInstancesStatistics', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual(mockData);
+    expect(result.current.data).toEqual([
+      'StartEvent_1',
+      'Activity_0qtp1k6',
+      'Gateway_1',
+    ]);
   });
 
-  it('should handle select', async () => {
-    const mockData: GetProcessInstanceStatisticsResponseBody = {
-      items: [
-        {
-          flowNodeId: 'node1',
-          active: 5,
-          completed: 10,
-          canceled: 0,
-          incidents: 0,
-        },
-        {
-          flowNodeId: 'node2',
-          active: 3,
-          completed: 7,
-          canceled: 0,
-          incidents: 0,
-        },
-      ],
-    };
-
-    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
-
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data.items.length),
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data).toEqual(mockData.items.length);
-  });
-
-  it('should handle server error while fetching flownode instances overlay statistics', async () => {
+  it('should handle server error while fetching selectable flow nodes', async () => {
     mockFetchFlownodeInstancesStatistics().withServerError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -129,10 +104,10 @@ describe('useFlownodeInstancesStatistics', () => {
     expect(result.current.error?.response).toBeDefined();
   });
 
-  it('should handle network error while fetching flownode instances overlay statistics', async () => {
+  it('should handle network error while fetching selectable flow nodes', async () => {
     mockFetchFlownodeInstancesStatistics().withNetworkError();
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
@@ -146,33 +121,20 @@ describe('useFlownodeInstancesStatistics', () => {
   it('should handle empty data', async () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
 
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual({items: []});
+    expect(result.current.data).toEqual([]);
   });
 
   it('should handle loading state', async () => {
-    const {result} = renderHook(() => useFlownodeInstancesStatistics(), {
+    const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
-  });
-
-  it('should not fetch data when enabled is false', async () => {
-    const {result} = renderHook(
-      () => useFlownodeInstancesStatistics((data) => data, false),
-      {
-        wrapper: Wrapper,
-      },
-    );
-
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.isFetched).toBe(false);
-    expect(result.current.data).toBeUndefined();
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+
+const selectableFlowNodesParser = (
+  response: GetProcessInstanceStatisticsResponseBody,
+) => response.items.map(({flowNodeId}) => flowNodeId);
+
+const useSelectableFlowNodes = () => {
+  return useFlownodeInstancesStatistics(selectableFlowNodesParser);
+};
+
+export {useSelectableFlowNodes};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {
+  useTotalRunningInstancesForFlowNode,
+  useTotalRunningInstancesForFlowNodes,
+  useTotalRunningInstancesVisibleForFlowNode,
+  useTotalRunningInstancesVisibleForFlowNodes,
+} from './useTotalRunningInstancesForFlowNode';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+import {useEffect} from 'react';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+
+describe('useTotalRunningInstancesForFlowNode hooks', () => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    useEffect(() => {
+      return () => {
+        processInstanceDetailsDiagramStore.reset();
+      };
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(async () => {
+    jest
+      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
+      .mockReturnValue({processInstanceId: 'processInstanceId123'});
+
+    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
+    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch total running instances for a single flow node', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          flowNodeId: 'StartEvent_1',
+          active: 5,
+          incidents: 2,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(
+      () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBe(7); // active + incidents
+  });
+
+  it('should fetch total running instances for multiple flow nodes', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          flowNodeId: 'StartEvent_1',
+          active: 5,
+          incidents: 2,
+          completed: 0,
+          canceled: 0,
+        },
+        {
+          flowNodeId: 'Activity_0qtp1k6',
+          active: 3,
+          incidents: 1,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(
+      () =>
+        useTotalRunningInstancesForFlowNodes([
+          'StartEvent_1',
+          'Activity_0qtp1k6',
+        ]),
+      {wrapper: Wrapper},
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toStrictEqual({
+      Activity_0qtp1k6: 4,
+      StartEvent_1: 7,
+    }); // [active + incidents for node1, node2]
+  });
+
+  it('should fetch total visible running instances for a single flow node', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          flowNodeId: 'StartEvent_1',
+          active: 5,
+          incidents: 2,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(
+      () => useTotalRunningInstancesVisibleForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBe(7); // filteredActive + incidents
+  });
+
+  it('should fetch total visible running instances for multiple flow nodes', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          flowNodeId: 'StartEvent_1',
+          active: 5,
+          incidents: 2,
+          completed: 0,
+          canceled: 0,
+        },
+        {
+          flowNodeId: 'Activity_0qtp1k6',
+          active: 3,
+          incidents: 1,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    };
+
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(
+      () =>
+        useTotalRunningInstancesVisibleForFlowNodes([
+          'StartEvent_1',
+          'Activity_0qtp1k6',
+        ]),
+      {wrapper: Wrapper},
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toStrictEqual({
+      Activity_0qtp1k6: 4,
+      StartEvent_1: 7,
+    }); // [filteredActive + incidents for node1, node2]
+  });
+
+  it('should handle empty data', async () => {
+    mockFetchFlownodeInstancesStatistics().withSuccess({items: []});
+
+    const {result} = renderHook(
+      () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBe(0);
+  });
+
+  it('should handle server error', async () => {
+    mockFetchFlownodeInstancesStatistics().withServerError();
+
+    const {result} = renderHook(
+      () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('failed-response');
+  });
+
+  it('should handle network error', async () => {
+    mockFetchFlownodeInstancesStatistics().withNetworkError();
+
+    const {result} = renderHook(
+      () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('network-error');
+  });
+
+  it('should handle loading state', async () => {
+    const {result} = renderHook(
+      () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
+      {wrapper: Wrapper},
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
+import {getStatisticsByFlowNode} from 'modules/utils/statistics/flownodeInstances';
+
+const totalRunningInstancesForFlowNodeParser =
+  (flowNodeId?: string) =>
+  (response: GetProcessInstanceStatisticsResponseBody) => {
+    if (!flowNodeId) return 0;
+    return (
+      (getStatisticsByFlowNode(response.items)[flowNodeId]?.active ?? 0) +
+      (getStatisticsByFlowNode(response.items)[flowNodeId]?.incidents ?? 0)
+    );
+  };
+
+const totalRunningInstancesForFlowNodesParser =
+  (flowNodeIds: string[]) =>
+  (response: GetProcessInstanceStatisticsResponseBody) => {
+    const statistics = getStatisticsByFlowNode(response.items);
+
+    return flowNodeIds.reduce<Record<string, number>>((acc, flowNodeId) => {
+      const active = statistics[flowNodeId]?.active ?? 0;
+      const incidents = statistics[flowNodeId]?.incidents ?? 0;
+      acc[flowNodeId] = active + incidents;
+      return acc;
+    }, {});
+  };
+
+const totalRunningInstancesVisibleForFlowNodeParser =
+  (flowNodeId?: string) =>
+  (response: GetProcessInstanceStatisticsResponseBody) => {
+    if (!flowNodeId) return 0;
+    return (
+      (getStatisticsByFlowNode(response.items)[flowNodeId]?.filteredActive ??
+        0) +
+      (getStatisticsByFlowNode(response.items)[flowNodeId]?.incidents ?? 0)
+    );
+  };
+
+const totalRunningInstancesVisibleForFlowNodesParser =
+  (flowNodeIds: string[]) =>
+  (response: GetProcessInstanceStatisticsResponseBody) => {
+    const statistics = getStatisticsByFlowNode(response.items);
+
+    return flowNodeIds.reduce<Record<string, number>>((acc, flowNodeId) => {
+      const active = statistics[flowNodeId]?.filteredActive ?? 0;
+      const incidents = statistics[flowNodeId]?.incidents ?? 0;
+      acc[flowNodeId] = active + incidents;
+      return acc;
+    }, {});
+  };
+
+const useTotalRunningInstancesForFlowNode = (flowNodeId?: string) => {
+  return useFlownodeInstancesStatistics(
+    totalRunningInstancesForFlowNodeParser(flowNodeId),
+  );
+};
+
+const useTotalRunningInstancesForFlowNodes = (flowNodeIds: string[]) => {
+  return useFlownodeInstancesStatistics(
+    totalRunningInstancesForFlowNodesParser(flowNodeIds),
+  );
+};
+
+const useTotalRunningInstancesVisibleForFlowNode = (flowNodeId: string) => {
+  return useFlownodeInstancesStatistics(
+    totalRunningInstancesVisibleForFlowNodeParser(flowNodeId),
+  );
+};
+
+const useTotalRunningInstancesVisibleForFlowNodes = (flowNodeIds: string[]) => {
+  return useFlownodeInstancesStatistics(
+    totalRunningInstancesVisibleForFlowNodesParser(flowNodeIds),
+  );
+};
+
+export {
+  useTotalRunningInstancesForFlowNode,
+  useTotalRunningInstancesForFlowNodes,
+  useTotalRunningInstancesVisibleForFlowNode,
+  useTotalRunningInstancesVisibleForFlowNodes,
+};

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -6,14 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/*
- * DEPRECATED: The `flowNodeSelectionStore` is being deprecated and replaced with
- * utility functions and hooks in `flowNodeSelection.ts` as part of the Operate v2 migration.
- *
- * Please avoid adding new functionality to this store and migrate existing logic
- * to the new utils and hooks where possible.
- */
-
 import {IReactionDisposer, makeAutoObservable, when, reaction} from 'mobx';
 import {FlowNodeInstance} from './flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -154,6 +146,13 @@ class FlowNodeSelection {
     );
   }
 
+  /*
+   * DEPRECATED: The `flowNodeSelectionStore.selectedRunningInstanceCount` is being deprecated and replaced with
+   * utility functions and hooks in `flowNodeSelection.ts` as part of the Operate v2 migration.
+   *
+   * Please avoid using / adding new functionality to this, and migrate existing logic
+   * to the new utils and hooks where possible.
+   */
   get selectedRunningInstanceCount() {
     const currentSelection = this.state.selection;
     if (currentSelection === null) {

--- a/operate/client/yarn.lock
+++ b/operate/client/yarn.lock
@@ -12402,7 +12402,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12498,7 +12507,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13934,7 +13950,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13947,6 +13963,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Description

This PR adds queries necessary for TopPanel migration. The existing store logic have been partly migrated into smaller query hooks. To be hooks-compliant, I had to refactor some stores logic for example `totalRunningInstancesForFlowNodeParser`. The queries will later be used by the TopPanel component in #30409

## Related issues

related to #30263
