### PR TITLE
feat: add hooks for TopPanel

### DIFF
--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useEffect} from 'react';
+import {renderHook} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {useModificationsByFlowNode} from './modifications';
+import {modificationsStore} from 'modules/stores/modifications';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+
+describe('modifications hooks', () => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    useEffect(() => {
+      return () => {
+        processInstanceDetailsDiagramStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useModificationsByFlowNode', () => {
+    it('should return modifications by flow node', () => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {id: 'node1', name: 'node1'},
+          affectedTokenCount: 5,
+          visibleAffectedTokenCount: 3,
+          scopeId: 'scope1',
+          parentScopeIds: {},
+        },
+      });
+
+      const {result} = renderHook(() => useModificationsByFlowNode(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual({
+        node1: {
+          newTokens: 5,
+          cancelledTokens: 0,
+          cancelledChildTokens: 0,
+          visibleCancelledTokens: 0,
+          areAllTokensCanceled: false,
+        },
+      });
+    });
+
+    it('should handle CANCEL_TOKEN operations', () => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'CANCEL_TOKEN',
+          flowNode: {id: 'node1', name: 'node1'},
+          affectedTokenCount: 5,
+          visibleAffectedTokenCount: 3,
+        },
+      });
+
+      const {result} = renderHook(() => useModificationsByFlowNode(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual({
+        node1: {
+          newTokens: 0,
+          cancelledTokens: 5,
+          cancelledChildTokens: 0,
+          visibleCancelledTokens: 3,
+          areAllTokensCanceled: false,
+        },
+      });
+    });
+
+    it('should handle MOVE_TOKEN operations', () => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'MOVE_TOKEN',
+          flowNode: {id: 'node1', name: 'node1'},
+          targetFlowNode: {id: 'node2', name: 'node2'},
+          affectedTokenCount: 5,
+          visibleAffectedTokenCount: 3,
+          scopeIds: [],
+          parentScopeIds: {},
+        },
+      });
+
+      const {result} = renderHook(() => useModificationsByFlowNode(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual({
+        node1: {
+          newTokens: 0,
+          cancelledTokens: 5,
+          cancelledChildTokens: 0,
+          visibleCancelledTokens: 3,
+          areAllTokensCanceled: false,
+        },
+        node2: {
+          newTokens: 5,
+          cancelledTokens: 0,
+          cancelledChildTokens: 0,
+          visibleCancelledTokens: 0,
+          areAllTokensCanceled: false,
+        },
+      });
+    });
+  });
+});

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getFlowElementIds} from 'modules/bpmn-js/utils/getFlowElementIds';
+import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
+import {
+  useTotalRunningInstancesForFlowNodes,
+  useTotalRunningInstancesVisibleForFlowNodes,
+} from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
+import {
+  EMPTY_MODIFICATION,
+  modificationsStore,
+} from 'modules/stores/modifications';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {useMemo} from 'react';
+
+const useModificationsByFlowNode = () => {
+  const flowNodeIds = modificationsStore.flowNodeModifications.map(
+    (modification) => modification.flowNode.id,
+  );
+  const {data: flowNodeDataArray} =
+    useTotalRunningInstancesForFlowNodes(flowNodeIds);
+  const flowNodeData = useMemo(() => {
+    return flowNodeIds.reduce(
+      (acc, id, index) => {
+        acc[id] = flowNodeDataArray?.[index] ?? 0;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+  }, [flowNodeIds, flowNodeDataArray]);
+
+  const elementIds = useMemo(() => {
+    return flowNodeIds.flatMap((flowNodeId) =>
+      getFlowElementIds(
+        processInstanceDetailsDiagramStore.businessObjects[flowNodeId],
+      ),
+    );
+  }, [flowNodeIds]);
+
+  const {data: elementCancelledTokens} =
+    useTotalRunningInstancesForFlowNodes(elementIds);
+  const {data: elementVisibleCancelledTokens} =
+    useTotalRunningInstancesVisibleForFlowNodes(elementIds);
+
+  const elementData = useMemo(() => {
+    return elementIds.reduce(
+      (acc, id, index) => {
+        acc[id] = {
+          cancelledTokens: elementCancelledTokens?.[index] ?? 0,
+          visibleCancelledTokens: elementVisibleCancelledTokens?.[index] ?? 0,
+        };
+        return acc;
+      },
+      {} as Record<
+        string,
+        {cancelledTokens: number; visibleCancelledTokens: number}
+      >,
+    );
+  }, [elementIds, elementCancelledTokens, elementVisibleCancelledTokens]);
+
+  return modificationsStore.flowNodeModifications.reduce<{
+    [key: string]: {
+      newTokens: number;
+      cancelledTokens: number;
+      cancelledChildTokens: number;
+      visibleCancelledTokens: number;
+      areAllTokensCanceled: boolean;
+    };
+  }>((modificationsByFlowNode, payload) => {
+    const {flowNode, operation, affectedTokenCount, visibleAffectedTokenCount} =
+      payload;
+
+    const sourceFlowNode = modificationsByFlowNode[flowNode.id] ?? {
+      ...EMPTY_MODIFICATION,
+    };
+
+    const totalRunningInstancesCount = flowNodeData[flowNode.id] ?? 0;
+
+    if (operation === 'ADD_TOKEN') {
+      sourceFlowNode.newTokens += affectedTokenCount;
+      modificationsByFlowNode[flowNode.id] = sourceFlowNode;
+      return modificationsByFlowNode;
+    }
+
+    if (sourceFlowNode.areAllTokensCanceled) {
+      return modificationsByFlowNode;
+    }
+
+    if (payload.flowNodeInstanceKey === undefined) {
+      sourceFlowNode.cancelledTokens = affectedTokenCount;
+      sourceFlowNode.visibleCancelledTokens = visibleAffectedTokenCount;
+    } else {
+      sourceFlowNode.cancelledTokens += affectedTokenCount;
+      sourceFlowNode.visibleCancelledTokens += visibleAffectedTokenCount;
+    }
+
+    sourceFlowNode.areAllTokensCanceled =
+      sourceFlowNode.cancelledTokens === totalRunningInstancesCount;
+
+    if (operation === 'MOVE_TOKEN') {
+      const targetFlowNode = modificationsByFlowNode[
+        payload.targetFlowNode.id
+      ] ?? {
+        ...EMPTY_MODIFICATION,
+      };
+
+      targetFlowNode.newTokens += isMultiInstance(
+        processInstanceDetailsDiagramStore.businessObjects[flowNode.id],
+      )
+        ? 1
+        : affectedTokenCount;
+
+      modificationsByFlowNode[payload.targetFlowNode.id] = targetFlowNode;
+    }
+
+    if (operation === 'CANCEL_TOKEN') {
+      if (sourceFlowNode.areAllTokensCanceled) {
+        // set cancel token counts for child elements if flow node has any
+        const elementIds = getFlowElementIds(
+          processInstanceDetailsDiagramStore.businessObjects[flowNode.id],
+        );
+
+        let affectedChildTokenCount = 0;
+        elementIds.forEach((elementId) => {
+          const childFlowNode = modificationsByFlowNode[elementId] ?? {
+            ...EMPTY_MODIFICATION,
+          };
+
+          const {cancelledTokens, visibleCancelledTokens} =
+            elementData[elementId] || {};
+
+          if (cancelledTokens) {
+            childFlowNode.cancelledTokens = cancelledTokens;
+          }
+          if (visibleCancelledTokens) {
+            childFlowNode.visibleCancelledTokens = visibleCancelledTokens;
+          }
+
+          childFlowNode.areAllTokensCanceled = true;
+
+          affectedChildTokenCount += childFlowNode.visibleCancelledTokens;
+
+          modificationsByFlowNode[elementId] = childFlowNode;
+        });
+
+        sourceFlowNode.cancelledChildTokens = affectedChildTokenCount;
+      }
+    }
+
+    modificationsByFlowNode[flowNode.id] = sourceFlowNode;
+    return modificationsByFlowNode;
+  }, {});
+};
+
+export {useModificationsByFlowNode};

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.test.tsx
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useEffect} from 'react';
+import {renderHook} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {
+  useFlowNodes,
+  useAppendableFlowNodes,
+  useCancellableFlowNodes,
+  useModifiableFlowNodes,
+} from './processInstanceDetailsDiagram';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {modificationsStore} from 'modules/stores/modifications';
+import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+
+jest.mock('modules/stores/modifications', () => ({
+  modificationsStore: {
+    state: {
+      status: 'idle',
+      sourceFlowNodeIdForMoveOperation: null,
+    },
+  },
+}));
+
+jest.mock('modules/bpmn-js/utils/isMoveModificationTarget', () => ({
+  isMoveModificationTarget: jest.fn(() => true),
+}));
+
+describe('processInstanceDetailsDiagram hooks', () => {
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    useEffect(() => {
+      processInstanceDetailsDiagramStore.reset();
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
+    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+
+    jest
+      .spyOn(
+        require('modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics'),
+        'useFlownodeInstancesStatistics',
+      )
+      .mockReturnValue({
+        data: {
+          items: [
+            {flowNodeId: 'StartEvent_1', active: 5, incidents: 0},
+            {flowNodeId: 'Activity_0qtp1k6', active: 0, incidents: 1},
+          ],
+        },
+      });
+  });
+
+  describe('useFlowNodes', () => {
+    it('should return flow nodes with their states', () => {
+      const {result} = renderHook(() => useFlowNodes(), {wrapper: Wrapper});
+
+      expect(result.current).toEqual([
+        {
+          id: 'StartEvent_1',
+          isCancellable: true,
+          hasMultipleScopes: false,
+          isMoveModificationTarget: true,
+        },
+        {
+          id: 'Activity_0qtp1k6',
+          isCancellable: true,
+          hasMultipleScopes: false,
+          isMoveModificationTarget: true,
+        },
+        {
+          id: 'Event_0bonl61',
+          isCancellable: false,
+          hasMultipleScopes: false,
+          isMoveModificationTarget: true,
+        },
+      ]);
+    });
+  });
+
+  describe('useAppendableFlowNodes', () => {
+    it('should return appendable flow nodes', () => {
+      (isMoveModificationTarget as jest.Mock).mockImplementation(
+        (flowNode) => flowNode.id === 'StartEvent_1',
+      );
+
+      const {result} = renderHook(() => useAppendableFlowNodes(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual(['StartEvent_1']);
+    });
+  });
+
+  describe('useCancellableFlowNodes', () => {
+    it('should return cancellable flow nodes', () => {
+      const {result} = renderHook(() => useCancellableFlowNodes(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual(['StartEvent_1', 'Activity_0qtp1k6']);
+    });
+  });
+
+  describe('useModifiableFlowNodes', () => {
+    it('should return filtered modifiable flow nodes when status is moving-token', () => {
+      modificationsStore.state.status = 'moving-token';
+      modificationsStore.state.sourceFlowNodeIdForMoveOperation =
+        'Activity_0qtp1k6';
+
+      const {result} = renderHook(() => useModifiableFlowNodes(), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current).toEqual(['StartEvent_1']);
+    });
+  });
+});

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -57,7 +57,7 @@ const useModifiableFlowNodes = () => {
   const cancellableFlowNodes = useCancellableFlowNodes();
 
   if (modificationsStore.state.status === 'moving-token') {
-    return processInstanceDetailsDiagramStore.appendableFlowNodes.filter(
+    return appendableFlowNodes.filter(
       (flowNodeId) =>
         flowNodeId !==
         modificationsStore.state.sourceFlowNodeIdForMoveOperation,

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
+import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
+import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
+import {modificationsStore} from 'modules/stores/modifications';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+
+const useFlowNodes = () => {
+  const {data: statistics} = useFlownodeInstancesStatistics();
+  return Object.values(processInstanceDetailsDiagramStore.businessObjects).map(
+    (flowNode) => {
+      const flowNodeState = statistics?.items.find(
+        ({flowNodeId}) => flowNodeId === flowNode.id,
+      );
+
+      return {
+        id: flowNode.id,
+        isCancellable:
+          flowNodeState !== undefined &&
+          (flowNodeState.active > 0 || flowNodeState.incidents > 0),
+        isMoveModificationTarget: isMoveModificationTarget(flowNode),
+        hasMultipleScopes: processInstanceDetailsDiagramStore.hasMultipleScopes(
+          flowNode.$parent,
+        ),
+      };
+    },
+  );
+};
+
+const useAppendableFlowNodes = () => {
+  return useFlowNodes()
+    .filter(
+      (flowNode) =>
+        flowNode.isMoveModificationTarget &&
+        ((IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED &&
+          modificationsStore.state.status !== 'moving-token') ||
+          !flowNode.hasMultipleScopes),
+    )
+    .map(({id}) => id);
+};
+
+const useCancellableFlowNodes = () => {
+  return useFlowNodes()
+    .filter((flowNode) => flowNode.isCancellable)
+    .map(({id}) => id);
+};
+
+const useModifiableFlowNodes = () => {
+  const appendableFlowNodes = useAppendableFlowNodes();
+  const cancellableFlowNodes = useCancellableFlowNodes();
+
+  if (modificationsStore.state.status === 'moving-token') {
+    return processInstanceDetailsDiagramStore.appendableFlowNodes.filter(
+      (flowNodeId) =>
+        flowNodeId !==
+        modificationsStore.state.sourceFlowNodeIdForMoveOperation,
+    );
+  } else {
+    return Array.from(
+      new Set([...appendableFlowNodes, ...cancellableFlowNodes]),
+    );
+  }
+};
+
+export {
+  useFlowNodes,
+  useAppendableFlowNodes,
+  useCancellableFlowNodes,
+  useModifiableFlowNodes,
+};

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -109,52 +109,6 @@ const mockEndpoints = [
       );
     },
   ),
-  rest.get(
-    '/v2/process-instances/:processInstanceKey/statistics/flownode-instances',
-    async (req: RestRequest<any>, res, ctx) => {
-      return res(
-        ctx.json({
-          items: [
-            {
-              flowNodeId: 'Gateway_15jzrqe',
-              active: 0,
-              canceled: 0,
-              incidents: 1,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'exclusiveGateway',
-              active: 0,
-              canceled: 0,
-              incidents: 0,
-              completed: 1,
-            },
-            {
-              flowNodeId: 'alwaysFailingTask',
-              active: 1,
-              canceled: 0,
-              incidents: 0,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'messageCatchEvent',
-              active: 0,
-              canceled: 0,
-              incidents: 1,
-              completed: 0,
-            },
-            {
-              flowNodeId: 'upperTask',
-              active: 1,
-              canceled: 0,
-              incidents: 0,
-              completed: 0,
-            },
-          ],
-        }),
-      );
-    },
-  ),
 ];
 
 const handlers: RequestHandler[] = [...mockEndpoints];

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -109,6 +109,52 @@ const mockEndpoints = [
       );
     },
   ),
+  rest.get(
+    '/v2/process-instances/:processInstanceKey/statistics/flownode-instances',
+    async (req: RestRequest<any>, res, ctx) => {
+      return res(
+        ctx.json({
+          items: [
+            {
+              flowNodeId: 'Gateway_15jzrqe',
+              active: 0,
+              canceled: 0,
+              incidents: 1,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'exclusiveGateway',
+              active: 0,
+              canceled: 0,
+              incidents: 0,
+              completed: 1,
+            },
+            {
+              flowNodeId: 'alwaysFailingTask',
+              active: 1,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'messageCatchEvent',
+              active: 0,
+              canceled: 0,
+              incidents: 1,
+              completed: 0,
+            },
+            {
+              flowNodeId: 'upperTask',
+              active: 1,
+              canceled: 0,
+              incidents: 0,
+              completed: 0,
+            },
+          ],
+        }),
+      );
+    },
+  ),
 ];
 
 const handlers: RequestHandler[] = [...mockEndpoints];

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -878,3 +878,4 @@ class Modifications {
 
 export type {FlowNodeModification};
 export const modificationsStore = new Modifications();
+export {EMPTY_MODIFICATION};


### PR DESCRIPTION
## Description

This PR is introducing some hooks needed for the TopPanel component migration. The `modification` hook is very similar to the modification's store method. The same was done for processInstanceDetailsDiagram's store. The hooks introduced here will later be used in #30409

## Related issues

related to #30263
