### PR TITLE
feat: Migrate ProcessInstance component to v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.test.tsx
@@ -21,7 +21,6 @@ import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails
 import {sequenceFlowsStore} from 'modules/stores/sequenceFlows';
 import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
-import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {Paths} from 'modules/Routes';
 import {singleInstanceMetadata} from 'modules/mocks/metadata';
@@ -50,7 +49,6 @@ const clearPollingStates = () => {
   processInstanceDetailsStore.isPollRequestRunning = false;
   incidentsStore.isPollRequestRunning = false;
   flowNodeInstanceStore.isPollRequestRunning = false;
-  processInstanceDetailsStatisticsStore.isPollRequestRunning = false;
 };
 
 const triggerVisibilityChange = (visibility: 'hidden' | 'visible') => {
@@ -351,11 +349,6 @@ describe('ProcessInstance', () => {
       'pollInstances',
     );
 
-    const handlePollingProcessInstanceDetailStatisticsSpy = jest.spyOn(
-      processInstanceDetailsStatisticsStore,
-      'handlePolling',
-    );
-
     render(<ProcessInstance />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
@@ -368,9 +361,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
     jest.runOnlyPendingTimers();
@@ -379,9 +369,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(variablesStore.state.status).toBe('fetched');
@@ -401,9 +388,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     clearPollingStates();
     mockRequests();
@@ -415,9 +399,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     mockRequests();
 
@@ -434,9 +415,6 @@ describe('ProcessInstance', () => {
       expect(handlePollingInstanceDetailsSpy).toHaveBeenCalledTimes(3);
       expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(3);
       expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(3);
-      expect(
-        handlePollingProcessInstanceDetailStatisticsSpy,
-      ).toHaveBeenCalledTimes(3);
     });
 
     await waitForPollingsToBeComplete();
@@ -473,11 +451,6 @@ describe('ProcessInstance', () => {
       'pollInstances',
     );
 
-    const handlePollingProcessInstanceDetailStatisticsSpy = jest.spyOn(
-      processInstanceDetailsStatisticsStore,
-      'handlePolling',
-    );
-
     render(<ProcessInstance />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
@@ -490,9 +463,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
     jest.runOnlyPendingTimers();
@@ -502,9 +472,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     triggerVisibilityChange('visible');
 
@@ -514,9 +481,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     mockRequests();
     jest.runOnlyPendingTimers();
@@ -526,9 +490,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(2);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(2);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(2);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(2);
 
     await waitForPollingsToBeComplete();
 
@@ -567,11 +528,6 @@ describe('ProcessInstance', () => {
       'pollInstances',
     );
 
-    const handlePollingProcessInstanceDetailStatisticsSpy = jest.spyOn(
-      processInstanceDetailsStatisticsStore,
-      'handlePolling',
-    );
-
     render(<ProcessInstance />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
@@ -584,9 +540,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     triggerVisibilityChange('hidden');
     triggerVisibilityChange('visible');
@@ -600,9 +553,6 @@ describe('ProcessInstance', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     jest.clearAllTimers();
     jest.useRealTimers();

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -19,7 +19,6 @@ import {reaction, when} from 'mobx';
 import {variablesStore} from 'modules/stores/variables';
 import {sequenceFlowsStore} from 'modules/stores/sequenceFlows';
 import {incidentsStore} from 'modules/stores/incidents';
-import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {instanceHistoryModificationStore} from 'modules/stores/instanceHistoryModification';
 import {Locations} from 'modules/Routes';
@@ -27,8 +26,7 @@ import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstance
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
 import {ProcessInstanceHeader} from '../ProcessInstanceHeader';
-import {TopPanel} from '../TopPanel';
-import {TopPanel as TopPanelV2} from '../TopPanel/v2';
+import {TopPanel} from '../TopPanel/v2';
 import {BottomPanel, ModificationFooter, Buttons} from '../styled';
 import {FlowNodeInstanceLog} from '../FlowNodeInstanceLog';
 import {Button, Modal} from '@carbon/react';
@@ -42,7 +40,6 @@ import {Forbidden} from 'modules/components/Forbidden';
 import {notificationsStore} from 'modules/stores/notifications';
 import {Frame} from 'modules/components/Frame';
 import {processInstanceListenersStore} from 'modules/stores/processInstanceListeners';
-import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 const startPolling = (processInstanceId: ProcessInstanceEntity['id']) => {
   variablesStore.startPolling(processInstanceId, {runImmediately: true});
@@ -54,9 +51,6 @@ const startPolling = (processInstanceId: ProcessInstanceEntity['id']) => {
     runImmediately: true,
   });
   flowNodeInstanceStore.startPolling({runImmediately: true});
-  processInstanceDetailsStatisticsStore.startPolling(processInstanceId, {
-    runImmediately: true,
-  });
 };
 
 const stopPolling = () => {
@@ -65,7 +59,6 @@ const stopPolling = () => {
   processInstanceDetailsStore.stopPolling();
   incidentsStore.stopPolling();
   flowNodeInstanceStore.stopPolling();
-  processInstanceDetailsStatisticsStore.stopPolling();
 };
 
 const ProcessInstance: React.FC = observer(() => {
@@ -140,7 +133,6 @@ const ProcessInstance: React.FC = observer(() => {
         },
       });
       flowNodeInstanceStore.init();
-      processInstanceDetailsStatisticsStore.init(processInstanceId);
       processInstanceDetailsDiagramStore.init();
       flowNodeSelectionStore.init();
     }
@@ -150,7 +142,6 @@ const ProcessInstance: React.FC = observer(() => {
     return () => {
       instanceHistoryModificationStore.reset();
       processInstanceDetailsStore.reset();
-      processInstanceDetailsStatisticsStore.reset();
       flowNodeInstanceStore.reset();
       processInstanceDetailsDiagramStore.reset();
       flowNodeTimeStampStore.reset();
@@ -217,13 +208,7 @@ const ProcessInstance: React.FC = observer(() => {
             ) : undefined
           }
           header={<ProcessInstanceHeader />}
-          topPanel={
-            IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED ? (
-              <TopPanelV2 />
-            ) : (
-              <TopPanel />
-            )
-          }
+          topPanel={<TopPanel />}
           bottomPanel={
             <BottomPanel $shouldExpandPanel={isListenerTabSelected}>
               <FlowNodeInstanceLog />

--- a/operate/client/src/App/ProcessInstance/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/mocks.tsx
@@ -42,6 +42,8 @@ import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcess} from 'modules/mocks/api/processes/fetchProcess';
 import {mockProcess} from '../ProcessInstanceHeader/index.setup';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {QueryClientProvider} from '@tanstack/react-query';
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('4294980768');
 
@@ -108,22 +110,24 @@ function getWrapper(options?: {
     }, []);
 
     return (
-      <HistoryRouter
-        history={createMemoryHistory({
-          initialEntries: [initialPath],
-        })}
-        basename={contextPath ?? ''}
-      >
-        <Routes>
-          <Route path={Paths.processInstance()} element={children} />
-          <Route path={Paths.processes()} element={<>instances page</>} />
-          <Route path={Paths.dashboard()} element={<>dashboard page</>} />
-        </Routes>
-        {selectableFlowNode && (
-          <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
-        )}
-        <LocationLog />
-      </HistoryRouter>
+      <QueryClientProvider client={getMockQueryClient()}>
+        <HistoryRouter
+          history={createMemoryHistory({
+            initialEntries: [initialPath],
+          })}
+          basename={contextPath ?? ''}
+        >
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+            <Route path={Paths.processes()} element={<>instances page</>} />
+            <Route path={Paths.dashboard()} element={<>dashboard page</>} />
+          </Routes>
+          {selectableFlowNode && (
+            <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
+          )}
+          <LocationLog />
+        </HistoryRouter>
+      </QueryClientProvider>
     );
   };
 

--- a/operate/client/src/App/ProcessInstance/v2/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/modifications.test.tsx
@@ -21,7 +21,6 @@ import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails
 import {sequenceFlowsStore} from 'modules/stores/sequenceFlows';
 import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
-import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 
 import {Paths} from 'modules/Routes';
@@ -37,7 +36,6 @@ const clearPollingStates = () => {
   processInstanceDetailsStore.isPollRequestRunning = false;
   incidentsStore.isPollRequestRunning = false;
   flowNodeInstanceStore.isPollRequestRunning = false;
-  processInstanceDetailsStatisticsStore.isPollRequestRunning = false;
 };
 
 jest.mock('modules/utils/bpmn');
@@ -244,11 +242,6 @@ describe('ProcessInstance - modification mode', () => {
       'pollInstances',
     );
 
-    const handlePollingProcessInstanceDetailStatisticsSpy = jest.spyOn(
-      processInstanceDetailsStatisticsStore,
-      'handlePolling',
-    );
-
     const {user} = render(<ProcessInstance />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
@@ -265,9 +258,6 @@ describe('ProcessInstance - modification mode', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(0);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(0);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(0);
 
     clearPollingStates();
     jest.runOnlyPendingTimers();
@@ -276,9 +266,6 @@ describe('ProcessInstance - modification mode', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(variablesStore.state.status).toBe('fetched');
@@ -302,9 +289,6 @@ describe('ProcessInstance - modification mode', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     clearPollingStates();
     mockRequests();
@@ -316,9 +300,6 @@ describe('ProcessInstance - modification mode', () => {
     expect(handlePollingIncidentsSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(1);
     expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(1);
-    expect(
-      handlePollingProcessInstanceDetailStatisticsSpy,
-    ).toHaveBeenCalledTimes(1);
 
     mockRequests();
     await user.click(screen.getByTestId('discard-all-button'));
@@ -336,9 +317,6 @@ describe('ProcessInstance - modification mode', () => {
       expect(handlePollingInstanceDetailsSpy).toHaveBeenCalledTimes(3);
       expect(handlePollingFlowNodeInstanceSpy).toHaveBeenCalledTimes(3);
       expect(handlePollingVariablesSpy).toHaveBeenCalledTimes(3);
-      expect(
-        handlePollingProcessInstanceDetailStatisticsSpy,
-      ).toHaveBeenCalledTimes(3);
     });
 
     await waitForPollingsToBeComplete();

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -28,6 +28,7 @@ import {createBrowserHistory} from 'history';
 import {ThemeSwitcher} from 'modules/components/ThemeSwitcher';
 import {ForbiddenPage} from 'modules/components/ForbiddenPage';
 import {ReactQueryProvider} from 'modules/react-query/ReactQueryProvider';
+import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 const CarbonLogin = loadable(() => import('./Login/index'), {
   resolveComponent: (components) => components.Login,
@@ -51,6 +52,13 @@ const CarbonProcesses = loadable(() => import('./Processes/index'), {
 
 const CarbonProcessInstance = loadable(
   () => import('./ProcessInstance/index'),
+  {
+    resolveComponent: (components) => components.ProcessInstance,
+  },
+);
+
+const CarbonProcessInstanceV2 = loadable(
+  () => import('./ProcessInstance/v2/index'),
   {
     resolveComponent: (components) => components.ProcessInstance,
   },
@@ -101,7 +109,13 @@ const App: React.FC = () => {
               <Route path={Paths.processes()} element={<CarbonProcesses />} />
               <Route
                 path={Paths.processInstance()}
-                element={<CarbonProcessInstance />}
+                element={
+                  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED ? (
+                    <CarbonProcessInstanceV2 />
+                  ) : (
+                    <CarbonProcessInstance />
+                  )
+                }
               />
               <Route path={Paths.decisions()} element={<CarbonDecisions />} />
               <Route


### PR DESCRIPTION
## Description

In this PR, I'm migrating `ProcessInstance` component away from `processInstanceDetailsStatisticsStore` :
- I've removed statistics fetching and polling (all the child components that rely on the polling will be migrated in later PRs)
- Updated the tests
- Added the v2 feature flag in the parent component

## Related issues

closes #30264
