### PR TITLE
[Backport stable/8.3] ci: specify permissions for release workflow

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -29,6 +29,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: write
+  actions: write
+
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}


### PR DESCRIPTION
# Description
Backport of #30411 to `stable/8.3`.

relates to camunda/camunda#28522