### PR TITLE
Revert "ci: specify permissions for release workflow"

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -29,10 +29,6 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  contents: write
-  actions: write
-
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}


### PR DESCRIPTION
Reverts camunda/camunda#30411

We encountered the following error releasing `8.8.0-alpha3`. It's not clear which other permissions we might be missing, and the merge cycle is too long to try them all out.

> [Invalid workflow file: .github/workflows/dispatch-release-8-8.yaml#L661](https://github.com/camunda/camunda/actions/runs/14192103303/workflow)
> The workflow is not valid. camunda/camunda/.github/workflows/camunda-platform-release.yml@b1849b246529d656963a7016f675e6d17931347f (Line: 661, Col: 3): Error calling workflow 'camunda/camunda/.github/workflows/zeebe-snyk.yml@b1849b246529d656963a7016f675e6d17931347f'. The nested job 'scan' is requesting 'security-events: write', but is only allowed 'security-events: none'.