### PR TITLE
refactor: add remove items method to ArrayProperty + use it in batch operation state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PersistedBatchOperationChunk extends UnpackedObject implements DbValue {
 
@@ -55,14 +56,7 @@ public class PersistedBatchOperationChunk extends UnpackedObject implements DbVa
   }
 
   public PersistedBatchOperationChunk removeItemKeys(final Set<Long> itemKeys) {
-    final var newKeys =
-        itemKeysProp.stream().map(LongValue::getValue).filter(k -> !itemKeys.contains(k)).toList();
-
-    // This is needed since ArrayProperty does not support removing items
-    itemKeysProp.reset();
-    for (final var key : newKeys) {
-      itemKeysProp.add().setValue(key);
-    }
+    itemKeysProp.remove(itemKeys.stream().map(LongValue::new).collect(Collectors.toSet()));
 
     return this;
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.BaseValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -47,6 +48,15 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
   public T add(final int index) {
     try {
       return value.add(index);
+    } catch (final Exception e) {
+      throw new MsgpackPropertyException(getKey(), e);
+    }
+  }
+
+  @Override
+  public void remove(final Set<T> items) {
+    try {
+      value.remove(items);
     } catch (final Exception e) {
       throw new MsgpackPropertyException(getKey(), e);
     }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ArrayValue.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.agrona.collections.CollectionUtil;
 
@@ -126,5 +127,28 @@ public final class ArrayValue<T extends BaseValue> extends BaseValue
 
   public int size() {
     return items.size();
+  }
+
+  public void remove(final Set<T> values) {
+    shiftDown(values);
+  }
+
+  /**
+   * Removes the specified items from the list by shifting down the remaining elements.
+   *
+   * @param itemsToRemove the set of items to be removed from the list
+   */
+  private void shiftDown(final Set<T> itemsToRemove) {
+    int current = 0;
+    for (int src = 0; src < items.size(); ++src) {
+      // If the current item is not in the itemsToRemove set, copy it to the 'current' position
+      // Otherwise, we skip the item and DON'T increment current.
+      // With this we will drop it out later when we copy the next wanted item to current.
+      if (!itemsToRemove.contains(items.get(src))) {
+        items.set(current++, items.get(src));
+      }
+    }
+    // Clear the remaining items from the list
+    items.subList(current, items.size()).clear();
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
@@ -8,12 +8,15 @@
 package io.camunda.zeebe.msgpack.value;
 
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public interface ValueArray<T> extends Iterable<T>, RandomAccess {
   T add();
 
   T add(final int index);
+
+  void remove(final Set<T> values);
 
   Stream<T> stream();
 }

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -399,6 +400,58 @@ public final class ArrayValueTest {
 
     // then - fails because it's not flushed
     assertThat((Object) other).hasSameHashCodeAs(array);
+  }
+
+  @Test
+  void shouldRemoveSetOfItems() {
+    // given
+    final var array = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3, 4, 5);
+
+    // when
+    array.remove(Set.of(new IntegerValue(2), new IntegerValue(4)));
+
+    // then
+    assertIntValues(array, 1, 3, 5);
+  }
+
+  @Test
+  void shouldRemoveAllItems() {
+    // given
+    final var array = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3);
+
+    // when
+    array.remove(Set.of(new IntegerValue(1), new IntegerValue(2), new IntegerValue(3)));
+
+    // then
+    assertThat(array.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldNotRemoveAnyItemsIfSetIsEmpty() {
+    // given
+    final var array = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3);
+
+    // when
+    array.remove(Set.of());
+
+    // then
+    assertIntValues(array, 1, 2, 3);
+  }
+
+  @Test
+  void shouldHandleRemovingNonExistentItems() {
+    // given
+    final var array = new ArrayValue<>(IntegerValue::new);
+    addIntValues(array, 1, 2, 3);
+
+    // when
+    array.remove(Set.of(new IntegerValue(4), new IntegerValue(5)));
+
+    // then
+    assertIntValues(array, 1, 2, 3);
   }
 
   // Helpers


### PR DESCRIPTION
## Description

Introduce a new remove set of items method to ArrayProperty in order to to faster removal of items. 
Directly use this list in batch operations where we remove the chunk keys.

