### PR TITLE
Set assignee on the creating event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -37,7 +37,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +125,7 @@ public final class BpmnUserTaskBehavior {
         new UserTaskRecord()
             .setVariables(DocumentValue.EMPTY_DOCUMENT)
             .setUserTaskKey(userTaskKey)
-            .setAssignee(StringUtils.EMPTY)
+            .setAssignee(userTaskProperties.getAssignee())
             .setCandidateGroupsList(userTaskProperties.getCandidateGroups())
             .setCandidateUsersList(userTaskProperties.getCandidateUsers())
             .setDueDate(userTaskProperties.getDueDate())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -444,6 +444,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.CREATING, new UserTaskCreatingApplier(state));
     register(UserTaskIntent.CREATING, 2, new UserTaskCreatingV2Applier(state));
     register(UserTaskIntent.CREATED, new UserTaskCreatedApplier(state));
+    register(UserTaskIntent.CREATED, 2, new UserTaskCreatedV2Applier(state));
     register(UserTaskIntent.CANCELING, 1, new UserTaskCancelingV1Applier(state));
     register(UserTaskIntent.CANCELING, 2, new UserTaskCancelingV2Applier(state));
     register(UserTaskIntent.CANCELED, new UserTaskCanceledApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -442,6 +442,7 @@ public final class EventAppliers implements EventApplier {
 
   private void registerUserTaskAppliers(final MutableProcessingState state) {
     register(UserTaskIntent.CREATING, new UserTaskCreatingApplier(state));
+    register(UserTaskIntent.CREATING, 2, new UserTaskCreatingV2Applier(state));
     register(UserTaskIntent.CREATED, new UserTaskCreatedApplier(state));
     register(UserTaskIntent.CANCELING, 1, new UserTaskCancelingV1Applier(state));
     register(UserTaskIntent.CANCELING, 2, new UserTaskCancelingV2Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -38,6 +38,7 @@ public final class UserTaskAssignedV2Applier
     // Clear operational data related to the current assign(claim) transition
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
+    userTaskState.deleteIntermediateAssignee(key);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -38,7 +38,7 @@ public final class UserTaskAssignedV2Applier
     // Clear operational data related to the current assign(claim) transition
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
-    userTaskState.deleteIntermediateAssignee(key);
+    userTaskState.deleteInitialAssignee(key);
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
@@ -33,7 +33,7 @@ public class UserTaskAssignmentDeniedApplier
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
-    userTaskState.deleteIntermediateAssignee(key);
+    userTaskState.deleteInitialAssignee(key);
 
     final long elementInstanceKey = value.getElementInstanceKey();
     final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
@@ -33,6 +33,7 @@ public class UserTaskAssignmentDeniedApplier
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
+    userTaskState.deleteIntermediateAssignee(key);
 
     final long elementInstanceKey = value.getElementInstanceKey();
     final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -37,6 +37,6 @@ public final class UserTaskCancelingV2Applier
 
     // Persist new data related to "canceling" user task transition
     userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
-    userTaskState.deleteIntermediateAssignee(key);
+    userTaskState.deleteInitialAssignee(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -37,5 +37,6 @@ public final class UserTaskCancelingV2Applier
 
     // Persist new data related to "canceling" user task transition
     userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
+    userTaskState.deleteIntermediateAssignee(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2Applier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskCreatedV2Applier implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCreatedV2Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    // Ensure we store any corrections
+    final UserTaskRecord userTask = userTaskState.getUserTask(key);
+    userTask.wrapChangedAttributes(value, false);
+    userTaskState.update(userTask);
+
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+
+    // Clear operational data related to the current transition
+    userTaskState.deleteIntermediateState(key);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
@@ -32,7 +32,7 @@ public class UserTaskCreatingV2Applier
     final var valueWithoutAssignee = value.copy().unsetAssignee();
     userTaskState.create(valueWithoutAssignee);
     userTaskState.storeIntermediateState(valueWithoutAssignee, LifecycleState.CREATING);
-    userTaskState.storeIntermediateAssignee(key, value.getAssignee());
+    userTaskState.storeInitialAssignee(key, value.getAssignee());
 
     final long elementInstanceKey = value.getElementInstanceKey();
     if (elementInstanceKey > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskCreatingV2Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCreatingV2Applier(final MutableProcessingState processingState) {
+    elementInstanceState = processingState.getElementInstanceState();
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    final var valueWithoutAssignee = value.copy().unsetAssignee();
+    userTaskState.create(valueWithoutAssignee);
+    userTaskState.storeIntermediateState(valueWithoutAssignee, LifecycleState.CREATING);
+    userTaskState.storeIntermediateAssignee(key, value.getAssignee());
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    if (elementInstanceKey > 0) {
+      final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+      if (elementInstance != null) {
+        elementInstance.setUserTaskKey(key);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -26,7 +26,7 @@ public interface UserTaskState {
   Optional<UserTaskTransitionTriggerRequestMetadata> findRecordRequestMetadata(
       final long userTaskKey);
 
-  String getInitialAssignee(long key);
+  Optional<String> findInitialAssignee(long key);
 
   enum LifecycleState {
     NOT_FOUND((byte) 0),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -26,6 +26,8 @@ public interface UserTaskState {
   Optional<UserTaskTransitionTriggerRequestMetadata> findRecordRequestMetadata(
       final long userTaskKey);
 
+  String getIntermediateAssignee(long key);
+
   enum LifecycleState {
     NOT_FOUND((byte) 0),
     CREATING((byte) 1),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -26,7 +26,7 @@ public interface UserTaskState {
   Optional<UserTaskTransitionTriggerRequestMetadata> findRecordRequestMetadata(
       final long userTaskKey);
 
-  String getIntermediateAssignee(long key);
+  String getInitialAssignee(long key);
 
   enum LifecycleState {
     NOT_FOUND((byte) 0),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
@@ -235,9 +235,9 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
-  public String getInitialAssignee(final long key) {
+  public Optional<String> findInitialAssignee(final long key) {
     userTaskKey.wrapLong(key);
     final var initialAssignee = userTasksInitialAssigneeColumnFamily.get(userTaskKey);
-    return initialAssignee == null ? null : initialAssignee.toString();
+    return initialAssignee == null ? Optional.empty() : Optional.of(initialAssignee.toString());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
@@ -56,7 +56,7 @@ public class DbUserTaskState implements MutableUserTaskState {
   private final ColumnFamily<DbLong, UserTaskTransitionTriggerRequestMetadata>
       userTasksTransitionTriggerRequestMetadataColumnFamily;
 
-  private final DbString intermediateAssignee = new DbString();
+  private final DbString initialAssignee = new DbString();
   private final ColumnFamily<DbLong, DbString> userTasksInitialAssigneeColumnFamily;
 
   public DbUserTaskState(
@@ -92,7 +92,7 @@ public class DbUserTaskState implements MutableUserTaskState {
             ZbColumnFamilies.USER_TASK_INITIAL_ASSIGNEE,
             transactionContext,
             userTaskKey,
-            intermediateAssignee);
+            initialAssignee);
   }
 
   @Override
@@ -182,8 +182,8 @@ public class DbUserTaskState implements MutableUserTaskState {
   public void storeInitialAssignee(final long key, final String assignee) {
     if (!StringUtils.isEmpty(assignee)) {
       userTaskKey.wrapLong(key);
-      intermediateAssignee.wrapString(assignee);
-      userTasksInitialAssigneeColumnFamily.insert(userTaskKey, intermediateAssignee);
+      initialAssignee.wrapString(assignee);
+      userTasksInitialAssigneeColumnFamily.insert(userTaskKey, initialAssignee);
     }
   }
 
@@ -235,9 +235,9 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
-  public String getIntermediateAssignee(final long key) {
+  public String getInitialAssignee(final long key) {
     userTaskKey.wrapLong(key);
-    final var intermediateAssignee = userTasksInitialAssigneeColumnFamily.get(userTaskKey);
-    return intermediateAssignee == null ? null : intermediateAssignee.toString();
+    final var initialAssignee = userTasksInitialAssigneeColumnFamily.get(userTaskKey);
+    return initialAssignee == null ? null : initialAssignee.toString();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
@@ -57,7 +57,7 @@ public class DbUserTaskState implements MutableUserTaskState {
       userTasksTransitionTriggerRequestMetadataColumnFamily;
 
   private final DbString intermediateAssignee = new DbString();
-  private final ColumnFamily<DbLong, DbString> userTasksIntermediateAssigneeColumnFamily;
+  private final ColumnFamily<DbLong, DbString> userTasksInitialAssigneeColumnFamily;
 
   public DbUserTaskState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -87,9 +87,9 @@ public class DbUserTaskState implements MutableUserTaskState {
             userTaskKey,
             userTaskTransitionTriggerRequestMetadata);
 
-    userTasksIntermediateAssigneeColumnFamily =
+    userTasksInitialAssigneeColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.USER_TASK_INTERMEDIATE_ASSIGNEE,
+            ZbColumnFamilies.USER_TASK_INITIAL_ASSIGNEE,
             transactionContext,
             userTaskKey,
             intermediateAssignee);
@@ -179,18 +179,18 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
-  public void storeIntermediateAssignee(final long key, final String assignee) {
+  public void storeInitialAssignee(final long key, final String assignee) {
     if (!StringUtils.isEmpty(assignee)) {
       userTaskKey.wrapLong(key);
       intermediateAssignee.wrapString(assignee);
-      userTasksIntermediateAssigneeColumnFamily.insert(userTaskKey, intermediateAssignee);
+      userTasksInitialAssigneeColumnFamily.insert(userTaskKey, intermediateAssignee);
     }
   }
 
   @Override
-  public void deleteIntermediateAssignee(final long key) {
+  public void deleteInitialAssignee(final long key) {
     userTaskKey.wrapLong(key);
-    userTasksIntermediateAssigneeColumnFamily.deleteIfExists(userTaskKey);
+    userTasksInitialAssigneeColumnFamily.deleteIfExists(userTaskKey);
   }
 
   @Override
@@ -237,7 +237,7 @@ public class DbUserTaskState implements MutableUserTaskState {
   @Override
   public String getIntermediateAssignee(final long key) {
     userTaskKey.wrapLong(key);
-    final var intermediateAssignee = userTasksIntermediateAssigneeColumnFamily.get(userTaskKey);
+    final var intermediateAssignee = userTasksInitialAssigneeColumnFamily.get(userTaskKey);
     return intermediateAssignee == null ? null : intermediateAssignee.toString();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -36,7 +36,7 @@ public interface MutableUserTaskState extends UserTaskState {
 
   void deleteRecordRequestMetadata(final long userTaskKey);
 
-  void storeIntermediateAssignee(final long key, String assignee);
+  void storeInitialAssignee(final long key, String assignee);
 
-  void deleteIntermediateAssignee(final long userTaskKey);
+  void deleteInitialAssignee(final long userTaskKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -36,7 +36,7 @@ public interface MutableUserTaskState extends UserTaskState {
 
   void deleteRecordRequestMetadata(final long userTaskKey);
 
-  void storeInitialAssignee(final long key, String assignee);
+  void storeInitialAssignee(final long userTaskKey, String assignee);
 
   void deleteInitialAssignee(final long userTaskKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -35,4 +35,8 @@ public interface MutableUserTaskState extends UserTaskState {
       final long userTaskKey, final UserTaskTransitionTriggerRequestMetadata recordRequestMetadata);
 
   void deleteRecordRequestMetadata(final long userTaskKey);
+
+  void storeIntermediateAssignee(final long key, String assignee);
+
+  void deleteIntermediateAssignee(final long userTaskKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -704,7 +704,7 @@ public class TaskListenerBlockedTransitionTest {
             r -> r.getValue().getAction(),
             r -> r.getValue().getChangedAttributes())
         .containsExactly(
-            tuple(UserTaskIntent.CREATING, StringUtils.EMPTY, action, List.of()),
+            tuple(UserTaskIntent.CREATING, assignee, action, List.of()),
             tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action, List.of()),
             tuple(UserTaskIntent.ASSIGNING, assignee, action, List.of(UserTaskRecord.ASSIGNEE)),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action, List.of()),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
@@ -203,7 +203,7 @@ public class TaskListenerDenialsTest {
         .describedAs(
             "Verify that the assignee changes. The assignment of the second assignee should be rejected.")
         .containsSequence(
-            tuple(UserTaskIntent.CREATING, ""),
+            tuple(UserTaskIntent.CREATING, "first_assignee"),
             tuple(UserTaskIntent.CREATED, ""),
             tuple(UserTaskIntent.ASSIGNING, "first_assignee"),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "first_assignee"),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -123,7 +123,7 @@ public final class AssignUserTaskTest {
             r -> r.getValue().getAction(),
             r -> r.getValue().getChangedAttributes())
         .containsExactly(
-            tuple(UserTaskIntent.CREATING, StringUtils.EMPTY, action, List.of()),
+            tuple(UserTaskIntent.CREATING, assignee, action, List.of()),
             tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action, List.of()),
             // The `assignee` property isn't yet available during the `CREATED` event
             // as it becomes effective only during the assignment phase.
@@ -260,7 +260,7 @@ public final class AssignUserTaskTest {
             r -> r.getValue().getAction(),
             r -> r.getValue().getChangedAttributes())
         .containsExactly(
-            tuple(UserTaskIntent.CREATING, "", "", List.of()),
+            tuple(UserTaskIntent.CREATING, initialAssignee, "", List.of()),
             tuple(UserTaskIntent.CREATED, "", "", List.of()),
             // The `assignee` property isn't yet available during the `CREATING/CREATED` events
             // as it becomes effective only during the assignment phase.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
@@ -56,8 +56,9 @@ public class UserTaskAssignedV2ApplierTest {
 
     // assignee is present in the creating event
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
-    testSetup.applyEventToState(
-        userTaskKey, UserTaskIntent.CREATED, userTaskRecord.unsetAssignee());
+    final UserTaskRecord recordWithoutAssignee = userTaskRecord.unsetAssignee();
+    // but we clear the assignee for created event
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
 
     // when
@@ -84,8 +85,9 @@ public class UserTaskAssignedV2ApplierTest {
 
     // assignee is present in the creating event
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
-    testSetup.applyEventToState(
-        userTaskKey, UserTaskIntent.CREATED, userTaskRecord.unsetAssignee());
+    // but we clear the assignee for created event
+    final UserTaskRecord recordWithoutAssignee = userTaskRecord.unsetAssignee();
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
 
     assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord().getAssignee())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
@@ -94,7 +94,7 @@ public class UserTaskAssignedV2ApplierTest {
         .describedAs("Expect intermediate user task to be stored without assignee")
         .isEmpty();
 
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be present")
         .isEqualTo(initialAssignee);
 
@@ -106,7 +106,7 @@ public class UserTaskAssignedV2ApplierTest {
         .describedAs("Expect that intermediate state to be cleaned up")
         .isNull();
 
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be cleaned up")
         .isNull();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskAssignedV2ApplierTest {
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskAssignedV2Applier userTaskAssignedV2Applier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private AppliersTestSetupHelper testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskAssignedV2Applier = new UserTaskAssignedV2Applier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new AppliersTestSetupHelper(processingState);
+  }
+
+  @Test
+  public void shouldTransitionUserTaskLifecycleToCreatedOnApply() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final String assignee = "initial_assignee";
+
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee(assignee)
+            .setElementInstanceKey(elementInstanceKey);
+
+    // assignee is present in the creating event
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+    testSetup.applyEventToState(
+        userTaskKey, UserTaskIntent.CREATED, userTaskRecord.unsetAssignee());
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+
+    // when
+    userTaskAssignedV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to transition to CREATED state")
+        .isEqualTo(LifecycleState.CREATED);
+  }
+
+  @Test
+  public void shouldClearIntermediateStateAndAssigneeWhenUserTaskAssigned() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final String initialAssignee = "initial_assignee";
+
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee(initialAssignee)
+            .setElementInstanceKey(elementInstanceKey);
+
+    // assignee is present in the creating event
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+    testSetup.applyEventToState(
+        userTaskKey, UserTaskIntent.CREATED, userTaskRecord.unsetAssignee());
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+
+    assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord().getAssignee())
+        .describedAs("Expect intermediate user task to be stored without assignee")
+        .isEmpty();
+
+    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+        .describedAs("Expect intermediate assignee to be present")
+        .isEqualTo(initialAssignee);
+
+    // when
+    userTaskAssignedV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getIntermediateState(userTaskKey))
+        .describedAs("Expect that intermediate state to be cleaned up")
+        .isNull();
+
+    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+        .describedAs("Expect intermediate assignee to be cleaned up")
+        .isNull();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2ApplierTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,9 +95,9 @@ public class UserTaskAssignedV2ApplierTest {
         .describedAs("Expect intermediate user task to be stored without assignee")
         .isEmpty();
 
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to be present")
-        .isEqualTo(initialAssignee);
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to be present")
+        .isEqualTo(Optional.of(initialAssignee));
 
     // when
     userTaskAssignedV2Applier.applyState(userTaskKey, userTaskRecord);
@@ -106,8 +107,8 @@ public class UserTaskAssignedV2ApplierTest {
         .describedAs("Expect that intermediate state to be cleaned up")
         .isNull();
 
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to be cleaned up")
-        .isNull();
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to be cleaned up")
+        .isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -94,9 +94,9 @@ public class UserTaskAssignmentDeniedApplierTest {
 
     // assignee is present in the creating event
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, given);
-
-    // created event is written without assignee
-    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, given.unsetAssignee());
+    // but we clear the assignee for created event
+    final UserTaskRecord recordWithoutAssignee = given.unsetAssignee();
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, given);
 
     Assertions.assertThat(userTaskState.getIntermediateAssignee(userTaskKey))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -85,7 +85,7 @@ public class UserTaskAssignmentDeniedApplierTest {
   }
 
   @Test
-  public void shouldCleanUpIntermediateAssigneeIfAssignmentDeniedByTaskListener() {
+  public void shouldCleanUpInitialAssigneeIfAssignmentDeniedByTaskListener() {
     // given
     final long userTaskKey = new Random().nextLong();
     final var initialAssignee = "initial";
@@ -99,7 +99,7 @@ public class UserTaskAssignmentDeniedApplierTest {
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, given);
 
-    Assertions.assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    Assertions.assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect that intermediate assignee is stored")
         .isEqualTo(initialAssignee);
 
@@ -107,7 +107,7 @@ public class UserTaskAssignmentDeniedApplierTest {
     userTaskAssignmentDeniedApplierApplier.applyState(userTaskKey, given);
 
     // then
-    Assertions.assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    Assertions.assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect that intermediate assignee is not present anymore")
         .isNull();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Optional;
 import java.util.Random;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,16 +100,16 @@ public class UserTaskAssignmentDeniedApplierTest {
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.ASSIGNING, given);
 
-    Assertions.assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect that intermediate assignee is stored")
-        .isEqualTo(initialAssignee);
+    Assertions.assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect that initial assignee is stored")
+        .isEqualTo(Optional.of(initialAssignee));
 
     // when
     userTaskAssignmentDeniedApplierApplier.applyState(userTaskKey, given);
 
     // then
-    Assertions.assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect that intermediate assignee is not present anymore")
-        .isNull();
+    Assertions.assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect that initial assignee is not present anymore")
+        .isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -226,16 +227,16 @@ public class UserTaskCancelingV2ApplierTest {
     final UserTaskRecord recordWithoutAssignee = userTaskRecord.unsetAssignee();
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
 
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to be present")
-        .isEqualTo(initialAssignee);
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to be present")
+        .isEqualTo(Optional.of(initialAssignee));
 
     // when
     userTaskCancelingApplier.applyState(userTaskKey, userTaskRecord);
 
     // then
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to be cleaned up")
-        .isNull();
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to be cleaned up")
+        .isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
@@ -207,7 +207,7 @@ public class UserTaskCancelingV2ApplierTest {
   }
 
   @Test
-  public void shouldClearIntermediateAssigneeOnUserTaskCancelingTransition() {
+  public void shouldClearInitialAssigneeOnUserTaskCancelingTransition() {
     // given
     final long userTaskKey = new Random().nextLong();
     final long elementInstanceKey = new Random().nextLong();
@@ -226,7 +226,7 @@ public class UserTaskCancelingV2ApplierTest {
     final UserTaskRecord recordWithoutAssignee = userTaskRecord.unsetAssignee();
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
 
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be present")
         .isEqualTo(initialAssignee);
 
@@ -234,7 +234,7 @@ public class UserTaskCancelingV2ApplierTest {
     userTaskCancelingApplier.applyState(userTaskKey, userTaskRecord);
 
     // then
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be cleaned up")
         .isNull();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
@@ -220,9 +220,11 @@ public class UserTaskCancelingV2ApplierTest {
             .setElementInstanceKey(elementInstanceKey);
 
     // simulate user task creation
+    // assignee is present in the creating event
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
-    testSetup.applyEventToState(
-        userTaskKey, UserTaskIntent.CREATED, userTaskRecord.unsetAssignee());
+    // but we clear the assignee for created event
+    final UserTaskRecord recordWithoutAssignee = userTaskRecord.unsetAssignee();
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, recordWithoutAssignee);
 
     assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be present")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.msgpack.value.StringValue.EMPTY_STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskCreatedV2ApplierTest {
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskCreatedV2Applier userTaskCreatedV2Applier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private AppliersTestSetupHelper testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskCreatedV2Applier = new UserTaskCreatedV2Applier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new AppliersTestSetupHelper(processingState);
+  }
+
+  @Test
+  void shouldTransitionUserTaskLifecycleToCreatedOnApply() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    // simulate a user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+
+    // verify initial state
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to be in CREATING state before applying CREATED")
+        .isEqualTo(LifecycleState.CREATING);
+
+    // when
+    userTaskCreatedV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to transition to CREATED state")
+        .isEqualTo(LifecycleState.CREATED);
+  }
+
+  @Test
+  public void shouldCleanIntermediateStateButNotAssigneeWhenUserTaskCreated() {
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final String initialAssignee = "initial_assignee";
+
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee(initialAssignee)
+            .setElementInstanceKey(elementInstanceKey);
+
+    // simulate a user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+
+    // when
+    userTaskCreatedV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getIntermediateState(userTaskKey))
+        .describedAs("Expect that intermediate state is cleared")
+        .isNull();
+
+    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+        .describedAs("Expect that intermediate state is cleared")
+        .isEqualTo(initialAssignee);
+  }
+
+  @Test
+  public void shouldUpdateUserTaskWithCorrectionsWhenUserTaskCreated() {
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    // user task record with assignee set
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee("initial_assignee")
+            .setElementInstanceKey(elementInstanceKey);
+
+    // simulate a user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+
+    // simulate corrections
+    testSetup.applyEventToState(
+        userTaskKey,
+        UserTaskIntent.CORRECTED,
+        userTaskRecord
+            .setCandidateGroupsList(List.of("overwritten"))
+            .setCandidateUsersList(List.of("overwritten"))
+            .setDueDate("overwritten")
+            .setFollowUpDate("overwritten")
+            .setPriority(99)
+            .setCandidateGroupsChanged()
+            .setCandidateUsersChanged()
+            .setDueDateChanged()
+            .setFollowUpDateChanged()
+            .setPriorityChanged());
+
+    // when
+    userTaskCreatedV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    Assertions.assertThat(userTaskState.getUserTask(userTaskKey))
+        .describedAs(
+            "Expect that user task was updated and ensure corrections were stored. "
+                + "Expect that the changed attributes are not persisted. "
+                + "Expect that user task has not yet been assigned.")
+        .hasAssignee(EMPTY_STRING)
+        .hasCandidateUsersList(List.of("overwritten"))
+        .hasCandidateGroupsList(List.of("overwritten"))
+        .hasDueDate("overwritten")
+        .hasFollowUpDate("overwritten")
+        .hasPriority(99)
+        .hasNoChangedAttributes();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -93,7 +93,7 @@ public class UserTaskCreatedV2ApplierTest {
         .describedAs("Expect that intermediate state is cleared")
         .isNull();
 
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect that intermediate assignee is not cleared")
         .isEqualTo(initialAssignee);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -119,14 +119,14 @@ public class UserTaskCreatedV2ApplierTest {
         UserTaskIntent.CORRECTED,
         userTaskRecord
             .setCandidateGroupsList(List.of("overwritten"))
-            .setCandidateUsersList(List.of("overwritten"))
-            .setDueDate("overwritten")
-            .setFollowUpDate("overwritten")
-            .setPriority(99)
             .setCandidateGroupsChanged()
+            .setCandidateUsersList(List.of("overwritten"))
             .setCandidateUsersChanged()
+            .setDueDate("overwritten")
             .setDueDateChanged()
+            .setFollowUpDate("overwritten")
             .setFollowUpDateChanged()
+            .setPriority(99)
             .setPriorityChanged());
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ public class UserTaskCreatedV2ApplierTest {
 
     assertThat(userTaskState.findInitialAssignee(userTaskKey))
         .describedAs("Expect that intermediate assignee is not cleared")
-        .isEqualTo(initialAssignee);
+        .isEqualTo(Optional.of(initialAssignee));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -93,7 +93,7 @@ public class UserTaskCreatedV2ApplierTest {
         .describedAs("Expect that intermediate state is cleared")
         .isNull();
 
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
         .describedAs("Expect that intermediate assignee is not cleared")
         .isEqualTo(initialAssignee);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedV2ApplierTest.java
@@ -94,7 +94,7 @@ public class UserTaskCreatedV2ApplierTest {
         .isNull();
 
     assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
-        .describedAs("Expect that intermediate state is cleared")
+        .describedAs("Expect that intermediate assignee is not cleared")
         .isEqualTo(initialAssignee);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.msgpack.value.StringValue.EMPTY_STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskCreatingV2ApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskCreatingV2Applier userTaskCreatingV2Applier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  @BeforeEach
+  public void setup() {
+    userTaskCreatingV2Applier = new UserTaskCreatingV2Applier(processingState);
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Test
+  void shouldTransitionUserTaskLifecycleToCreatingOnApply() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    // when
+    userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to transition to CREATING state")
+        .isEqualTo(LifecycleState.CREATING);
+  }
+
+  @Test
+  public void shouldStoreIntermediateStateAndAssigneeWhenCreatingUserTask() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final String initialAssignee = "initial_assignee";
+
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee(initialAssignee)
+            .setElementInstanceKey(elementInstanceKey);
+
+    // when
+    userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    // ensure the intermediate state is present without an assignee
+    Assertions.assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord())
+        .describedAs("Expect that intermediate is present and has no assignee")
+        .hasAssignee(EMPTY_STRING);
+
+    // ensure the intermediate assignee is stored
+    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+        .describedAs("Expect intermediate assignee to be present")
+        .isEqualTo(initialAssignee);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
-import static io.camunda.zeebe.msgpack.value.StringValue.EMPTY_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
@@ -15,7 +14,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
-import io.camunda.zeebe.protocol.record.Assertions;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,9 +73,9 @@ public class UserTaskCreatingV2ApplierTest {
 
     // then
     // ensure the intermediate state is present without an assignee
-    Assertions.assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord())
-        .describedAs("Expect that intermediate is present and has no assignee")
-        .hasAssignee(EMPTY_STRING);
+    assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord().getAssignee())
+        .describedAs("Expect that intermediate state to be present")
+        .isEmpty();
 
     // ensure the intermediate assignee is stored
     assertThat(userTaskState.getIntermediateAssignee(userTaskKey))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -78,7 +78,7 @@ public class UserTaskCreatingV2ApplierTest {
         .isEmpty();
 
     // ensure the intermediate assignee is stored
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to be present")
         .isEqualTo(initialAssignee);
   }
@@ -103,7 +103,7 @@ public class UserTaskCreatingV2ApplierTest {
         .isEmpty();
 
     // ensure the intermediate assignee is not present
-    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+    assertThat(userTaskState.getInitialAssignee(userTaskKey))
         .describedAs("Expect intermediate assignee to not be present")
         .isNull();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import java.util.Optional;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,9 +79,9 @@ public class UserTaskCreatingV2ApplierTest {
         .isEmpty();
 
     // ensure the intermediate assignee is stored
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to be present")
-        .isEqualTo(initialAssignee);
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to be present")
+        .isEqualTo(Optional.of(initialAssignee));
   }
 
   @Test
@@ -103,8 +104,8 @@ public class UserTaskCreatingV2ApplierTest {
         .isEmpty();
 
     // ensure the intermediate assignee is not present
-    assertThat(userTaskState.getInitialAssignee(userTaskKey))
-        .describedAs("Expect intermediate assignee to not be present")
-        .isNull();
+    assertThat(userTaskState.findInitialAssignee(userTaskKey))
+        .describedAs("Expect initial assignee to not be present")
+        .isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -82,4 +82,28 @@ public class UserTaskCreatingV2ApplierTest {
         .describedAs("Expect intermediate assignee to be present")
         .isEqualTo(initialAssignee);
   }
+
+  @Test
+  public void shouldStoreIntermediateStateAndNoAssigneeWhenCreatingUserTaskWithoutAssignee() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    // when
+    userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    // ensure the intermediate state is present without an assignee
+    assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord().getAssignee())
+        .describedAs("Expect that intermediate state to be present")
+        .isEmpty();
+
+    // ensure the intermediate assignee is not present
+    assertThat(userTaskState.getIntermediateAssignee(userTaskKey))
+        .describedAs("Expect intermediate assignee to not be present")
+        .isNull();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -56,7 +56,7 @@ public class UserTaskCreatingV2ApplierTest {
   }
 
   @Test
-  public void shouldStoreIntermediateStateAndAssigneeWhenCreatingUserTask() {
+  public void shouldStoreIntermediateStateAndInitialAssigneeWhenCreatingUserTask() {
     // given
     final long userTaskKey = new Random().nextLong();
     final long elementInstanceKey = new Random().nextLong();
@@ -84,7 +84,8 @@ public class UserTaskCreatingV2ApplierTest {
   }
 
   @Test
-  public void shouldStoreIntermediateStateAndNoAssigneeWhenCreatingUserTaskWithoutAssignee() {
+  public void
+      shouldStoreIntermediateStateAndNoInitialAssigneeWhenCreatingUserTaskWithoutAssignee() {
     // given
     final long userTaskKey = new Random().nextLong();
     final long elementInstanceKey = new Random().nextLong();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -239,7 +239,7 @@ public enum ZbColumnFamilies implements EnumValue {
   RELATIONS_BY_ENTITY(124),
   ENTITIES_BY_RELATION(125),
 
-  USER_TASK_INTERMEDIATE_ASSIGNEE(126);
+  USER_TASK_INITIAL_ASSIGNEE(126);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -237,7 +237,9 @@ public enum ZbColumnFamilies implements EnumValue {
   VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY(123),
 
   RELATIONS_BY_ENTITY(124),
-  ENTITIES_BY_RELATION(125);
+  ENTITIES_BY_RELATION(125),
+
+  USER_TASK_INTERMEDIATE_ASSIGNEE(126);
 
   private final int value;
 


### PR DESCRIPTION
## Description

In order to pass the initial `assignee` from the user task creation through the `creating` listeners to the `assigning` event, we need to store it in `USER_TASK_INITIAL_ASSIGNEE ` for later usage.

As we can only store data in state when we write it in events, the decision was made to add it to the `creating` event. To avoid the user task actually being created with an `assignee`, the assignee should not be present in the `created` event.

In this PR:

- setting `assignee` from user task properties in `BpmnUserTaskBehavior`
- storing `assignee` as the initial assignee in the `creating` applier (v2 applier was added as we are storing new data)
- adding a new column family in `DbUserTaskState`
- ensuring that the actual user task in the `creating` applier is stored without an `assignee`
- storing the intermediate state of the `creating` user task
- cleaning up the intermediate state in the `created` applier (we should NOT clean up the initial assignee here)
- updating the user task on the `created` applier to ensure we store any corrections
- cleaning up the initial `assignee` in `assignment_denied`, `assigned`, and `canceling` appliers

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29121 
