### PR TITLE
[Backport stable/8.3] Revert "ci: specify permissions for release workflow"

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -29,10 +29,6 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  contents: write
-  actions: write
-
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}


### PR DESCRIPTION
# Description
Backport of #30420 to `stable/8.3`.

relates to camunda/camunda#30411