### PR TITLE
feat: implement simple mapping configuration for username

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.util.List;
 
 public record AuthenticationContext(
+    String username,
     List<RoleEntity> roles,
     List<String> authorizedApplications,
     List<TenantDTO> tenants,

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -188,7 +188,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
           password,
           email,
           authorities,
-          new AuthenticationContext(roles, authorizedApplications, tenants, groups),
+          new AuthenticationContext(username, roles, authorizedApplications, tenants, groups),
           salesPlanType,
           c8Links,
           canLogout);

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -43,10 +43,10 @@ public class OidcCamundaUserService implements CamundaUserService {
             user -> {
               final AuthenticationContext auth = user.getAuthenticationContext();
               return new CamundaUserDTO(
-                  user.getUserInfo().getSubject(),
+                  auth.username(),
                   null,
                   user.getDisplayName(),
-                  user.getName(),
+                  auth.username(),
                   user.getEmail(),
                   auth.authorizedApplications(),
                   auth.tenants(),

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -104,6 +104,7 @@ public class CamundaOidcUserServiceTest {
     assertThat(camundaUser.getMappingKeys()).isEqualTo(Set.of(5L, 7L));
     assertThat(camundaUser.getMappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
+    assertThat(authenticationContext.username()).isEqualTo("test|foo@camunda.test");
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.groups()).isEmpty();
     assertThat(authenticationContext.tenants()).isEmpty();

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -59,6 +59,11 @@ public class CamundaOidcUserServiceTest {
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
+
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
+
     camundaOidcUserService =
         new CamundaOidcUserService(
             mappingServices,
@@ -67,10 +72,6 @@ public class CamundaOidcUserServiceTest {
             groupServices,
             authorizationServices,
             securityConfiguration);
-
-    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
-    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
-    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -14,6 +14,9 @@ import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
@@ -49,13 +52,25 @@ public class CamundaOidcUserServiceTest {
   @Mock private RoleServices roleServices;
   @Mock private GroupServices groupServices;
   @Mock private AuthorizationServices authorizationServices;
+  @Mock private SecurityConfiguration securityConfiguration;
+  @Mock private AuthenticationConfiguration authenticationConfiguration;
+  @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
     camundaOidcUserService =
         new CamundaOidcUserService(
-            mappingServices, tenantServices, roleServices, groupServices, authorizationServices);
+            mappingServices,
+            tenantServices,
+            roleServices,
+            groupServices,
+            authorizationServices,
+            securityConfiguration);
+
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -74,6 +74,7 @@ public class CamundaUserDetailsServiceTest {
     assertThat(user.getUsername()).isEqualTo(TEST_USER_ID);
     assertThat(user.getPassword()).isEqualTo("password1");
     assertThat(user.getEmail()).isEqualTo("email@tested");
+    assertThat(user.getAuthenticationContext().username()).isEqualTo(TEST_USER_ID);
     assertThat(user.getAuthenticationContext().authorizedApplications())
         .containsExactlyInAnyOrder("operate", "identity");
     assertThat(user.getAuthenticationContext().roles()).isEqualTo(List.of(adminRole));

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
@@ -59,6 +59,7 @@ public class PermissionsServiceTest {
     when(camundaUser.getAuthenticationContext())
         .thenReturn(
             new AuthenticationContext(
+                "test",
                 List.of(new RoleEntity(roleKey, "roleName")),
                 List.of(),
                 List.of(new TenantDTO(123L, tenantId, "tenantName", "")),

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -21,6 +21,7 @@ public class OidcAuthenticationConfiguration {
   private String jwkSetUri;
   private String authorizationUri;
   private Set<String> audiences;
+  private String usernameClaim = "sub";
 
   public String getIssuerUri() {
     return issuerUri;
@@ -92,5 +93,13 @@ public class OidcAuthenticationConfiguration {
 
   public void setAudiences(final Set<String> audiences) {
     this.audiences = audiences;
+  }
+
+  public String getUsernameClaim() {
+    return usernameClaim;
+  }
+
+  public void setUsernameClaim(final String usernameClaim) {
+    this.usernameClaim = usernameClaim;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -92,11 +92,21 @@ public final class AuthorizationCheckBehavior {
     }
 
     final var username = getUsername(request);
+
+    // TODO: remove this check when username retrieval is supported in JWT modes
     if (username.isPresent()) {
-      return isUserAuthorized(request, username.get());
-    } else {
-      return isMappingAuthorized(request);
+      final var userAuthorized = isUserAuthorized(request, username.get());
+      if (userAuthorized.isRight()) {
+        return userAuthorized;
+      }
     }
+
+    final var mappingAuthorized = isMappingAuthorized(request);
+    if (mappingAuthorized.isLeft()) {
+      return Either.left(mappingAuthorized.getLeft());
+    }
+
+    return Either.right(null);
   }
 
   /**

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -499,7 +499,7 @@ public final class EndpointManager {
     }
 
     // retrieve the username from the context and add it to the authorization if present
-    final String username = Context.current().call(AuthenticationHandler.BasicAuth.USERNAME::get);
+    final String username = Context.current().call(AuthenticationHandler.USERNAME::get);
     if (username != null) {
       claims.put(Authorization.AUTHORIZED_USERNAME, username);
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -407,7 +407,9 @@ public final class Gateway implements CloseableSilently {
       final var handler =
           switch (securityConfiguration.getAuthentication().getMethod()) {
             case BASIC -> new AuthenticationHandler.BasicAuth(userServices, passwordEncoder);
-            case OIDC -> new AuthenticationHandler.Oidc(jwtDecoder);
+            case OIDC ->
+                new AuthenticationHandler.Oidc(
+                    jwtDecoder, securityConfiguration.getAuthentication().getOidc());
           };
       interceptors.add(new AuthenticationInterceptor(handler));
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -106,7 +106,9 @@ public final class StubbedGateway {
                 ServerInterceptors.intercept(
                     gatewayGrpcService,
                     new AuthenticationInterceptor(
-                        new AuthenticationHandler.Oidc(new FakeJwtDecoder()))));
+                        new AuthenticationHandler.Oidc(
+                            new FakeJwtDecoder(),
+                            securityConfiguration.getAuthentication().getOidc()))));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
+import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -19,7 +20,6 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.BasicAuth;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
 import io.grpc.Context;
@@ -169,7 +169,8 @@ public class AuthenticationInterceptorTest {
         Map.of(
             "role", "admin",
             "foo", "bar",
-            "baz", "qux");
+            "baz", "qux",
+            "username", "test-user");
     when(jwt.getClaims()).thenReturn(claims);
 
     // Configure the JwtDecoder to return our mock JWT
@@ -205,7 +206,8 @@ public class AuthenticationInterceptorTest {
         Map.of(
             "role", "admin",
             "foo", "bar",
-            "baz", "qux");
+            "baz", "qux",
+            "username", "test-user");
     when(jwt.getClaims()).thenReturn(claims);
 
     // Configure the JwtDecoder to return our mock JWT
@@ -223,6 +225,7 @@ public class AuthenticationInterceptorTest {
             (call, headers) -> {
               // then
               assertUserClaims().containsKey("role").containsKey("foo").containsKey("baz");
+              assertUserKey().isEqualTo("test-user");
               call.close(Status.OK, headers);
               return null;
             });
@@ -254,7 +257,7 @@ public class AuthenticationInterceptorTest {
             metadata,
             (call, headers) -> {
               // then
-              assertUserClaims().containsEntry(Authorization.AUTHORIZED_USERNAME, "test-user");
+              assertUserKey().isEqualTo("test-user");
               call.close(Status.OK, headers);
               return null;
             });
@@ -291,7 +294,7 @@ public class AuthenticationInterceptorTest {
 
   private static StringAssert assertUserKey() {
     try {
-      return (StringAssert) assertThat(Context.current().call(() -> BasicAuth.USERNAME.get()));
+      return (StringAssert) assertThat(Context.current().call(() -> USERNAME.get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve user key from context", e);
     }

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -264,6 +264,17 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -39,7 +39,6 @@ import static io.camunda.zeebe.gateway.rest.validator.UserValidator.validateUser
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.entity.CamundaPrincipal;
-import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.filter.AdHocSubprocessActivityFilter;
@@ -590,21 +589,16 @@ public class RequestMapper {
     if (requestAuthentication != null) {
       if (requestAuthentication.getPrincipal()
           instanceof final CamundaPrincipal authenticatedPrincipal) {
+        final var authenticationContext = authenticatedPrincipal.getAuthenticationContext();
 
         authenticatedRoleKeys.addAll(
-            authenticatedPrincipal.getAuthenticationContext().roles().stream()
-                .map(RoleEntity::roleKey)
-                .toList());
+            authenticationContext.roles().stream().map(RoleEntity::roleKey).toList());
 
         authenticatedTenantIds.addAll(
-            authenticatedPrincipal.getAuthenticationContext().tenants().stream()
-                .map(TenantDTO::tenantId)
-                .toList());
+            authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());
 
-        if (authenticatedPrincipal instanceof final CamundaUser user) {
-          authenticatedUsername = user.getUsername();
-          claims.put(Authorization.AUTHORIZED_USERNAME, authenticatedUsername);
-        }
+        authenticatedUsername = authenticationContext.username();
+        claims.put(Authorization.AUTHORIZED_USERNAME, authenticationContext.username());
       }
 
       if (requestAuthentication instanceof final JwtAuthenticationToken jwtAuthenticationToken) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -74,13 +74,6 @@ class RequestMapperTest {
 
     // then
     assertThat(authenticatedUsername).isEqualTo(usernameValue);
-
-    final var claims = RequestMapper.getAuthentication().claims();
-    assertNotNull(claims);
-    assertThat(claims).containsKey("authorized_username");
-    assertThat(claims).containsKey(USER_TOKEN_CLAIM_PREFIX + "aud");
-    assertThat(claims.get("authorized_username")).isEqualTo("test-user");
-    assertThat(claims.get(USER_TOKEN_CLAIM_PREFIX + "aud")).isEqualTo("aud1");
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -13,9 +13,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import io.camunda.authentication.entity.AuthenticationContext;
+import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.zeebe.auth.Authorization;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +28,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.context.request.RequestAttributes;
@@ -57,6 +64,20 @@ class RequestMapperTest {
 
   @Test
   void tokenContainsExtraClaimsWithOidcAuth() {
+    // given
+    final String usernameClaim = "sub";
+    final String usernameValue = "test-user";
+    setOidcAuthenticationInContext(usernameClaim, usernameValue);
+
+    // when
+    final var authenticatedUsername = RequestMapper.getAuthentication().authenticatedUsername();
+
+    // then
+    assertThat(authenticatedUsername).isEqualTo(usernameValue);
+  }
+
+  @Test
+  void tokenContainsExtraClaimsWithJwtAuth() {
 
     // given
     final String sub1 = "sub1";
@@ -90,6 +111,32 @@ class RequestMapperTest {
             Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
     final JwtAuthenticationToken jwtAuthenticationToken = new JwtAuthenticationToken(jwt);
     SecurityContextHolder.getContext().setAuthentication(jwtAuthenticationToken);
+  }
+
+  private void setOidcAuthenticationInContext(
+      final String usernameClaim, final String usernameValue) {
+    final String tokenValue = "{}";
+    final Instant tokenIssuedAt = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    final Instant tokenExpiresAt = tokenIssuedAt.plus(1, ChronoUnit.DAYS);
+
+    final var oauth2Authentication =
+        new OAuth2AuthenticationToken(
+            new CamundaOidcUser(
+                new DefaultOidcUser(
+                    Collections.emptyList(),
+                    new OidcIdToken(
+                        tokenValue,
+                        tokenIssuedAt,
+                        tokenExpiresAt,
+                        Map.of(usernameClaim, usernameValue))),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                new AuthenticationContext(
+                    usernameValue, List.of(), List.of(), List.of(), List.of())),
+            List.of(),
+            "oidc");
+
+    SecurityContextHolder.getContext().setAuthentication(oauth2Authentication);
   }
 
   private void setUsernamePasswordAuthenticationInContext(final String username) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces the configuration of the simple mapping username claim for OIDC scenarios, with this I also make sure that the username is set on the requests that are sent to the broker for both REST and GRPC.

I opted to default the username claim to `sub` as this in theory is a safe default and by spec is always present on the authentication token.

## Related issues

closes https://github.com/camunda/camunda/issues/30326, closes https://github.com/camunda/camunda/issues/30329, closes https://github.com/camunda/camunda/issues/30332
