### PR TITLE
CI: Improve Java UT execution time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,30 +177,60 @@ jobs:
 
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [detect-changes]
-    runs-on: gcp-perf-core-16-default
-    timeout-minutes: 30
+    name: "[UT] ${{ matrix.name }}"
+    needs: [ detect-changes ]
+    timeout-minutes: 25
     permissions: {}  # GITHUB_TOKEN unused in this job
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [ general, zeebe, client ]
+        include:
+          - group: general
+            name: "General Unit Tests"
+            # Here we exclude all modules that are separated in extra jobs below
+            # Example: '[-+]<groupId>:artifactId' -> '-' excludes
+            maven-modules: "'-:zeebe-workflow-engine','-:zeebe-broker','-:camunda-process-test-java','-:zeebe-gateway-rest','-:camunda-client-java','-:zeebe-elasticsearch-exporter','-:zeebe-opensearch-exporter','-:camunda-exporter','-:zeebe-atomix-cluster','-:zeebe-cluster-config'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: gcp-perf-core-16-default
+          - group: zeebe
+            name: "Zeebe Big Unit Tests"
+            maven-modules: "':zeebe-workflow-engine',':zeebe-broker',':zeebe-atomix-cluster',':zeebe-cluster-config'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: gcp-perf-core-16-default
+          - group: client
+            name: "Camunda API Big Unit Tests"
+            maven-modules: "':camunda-process-test-java',':zeebe-gateway-rest',':camunda-client-java',':zeebe-elasticsearch-exporter',':zeebe-opensearch-exporter',':camunda-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+            runs-on: gcp-perf-core-16-default
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
+          maven-cache-key-modifier: it-${{ matrix.group }}
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild
+          maven-extra-args: -T1C -Dquickly
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
         run: >
-          ./mvnw -T2 -B --no-snapshot-updates
+          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
+          -D forkCount=${{ matrix.maven-test-fork-count }}
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
@@ -213,12 +243,13 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "unit tests"
+          name: "[UT] ${{ matrix.name }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          job_name: "unit-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -226,6 +257,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
 
   elasticsearch-integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
-          maven-cache-key-modifier: it-${{ matrix.group }}
+          maven-cache-key-modifier: ut-${{ matrix.group }}
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "unit-tests/${{ matrix.group }}"
+          job_name: "java-unit-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[UT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 25
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     strategy:


### PR DESCRIPTION
## Description

As mentioned here https://github.com/camunda/camunda/pull/30426#issuecomment-2769292986 the Java unit tests are currently our limiting factor in having a quicker pipeline, faster merge, faster feedback cycle, etc. 

The job itself takes on main ~15 minutes

![2025-04-02_13-36](https://github.com/user-attachments/assets/0f9fb2a6-b4f1-4768-a9b1-6f56084b2608)

Right now the java unit test job is running ALL java unit tests from the complete mono-repo. This is indeed a bit sub-optimal.

First, I tried several things, to reduce the execution time, like playing around with fork count, etc. I reduced the build time with using the `quickly` flag. As checks are done in a separate job.

At the end, I went with a similar approach as with the integration tests and created a matrix of jobs for unit-tests. Based on analysis of main and execution times, I separated some "bigger" modules into own jobs.

![2025-04-02_12-49](https://github.com/user-attachments/assets/cb96766a-dff0-41b0-978f-00226568d45f)

For example, the broker and engine tests, have been moved into an own job.



With the change we were able to split up the unit tests, and bring down the execution time from ~15 minutes to under 10 minutes for the general unit-tests, which runs the wider chunk of tests. This is below the integration tests.

![2025-04-02_13-35_2](https://github.com/user-attachments/assets/0d0b4006-1c40-465c-b0b7-702b017f8aa3)
![2025-04-02_13-35_1](https://github.com/user-attachments/assets/9005daed-2fa2-405c-b5c8-ee157439e7ed)


> [!Important]
>
> I think this is just the beginning of potential improvements. This can be seen as building the base/foundation, and with that we can iterate on. For example we could validate whether we still need such bug nodes, or we can reduce the size of them to safe costs.
> For example: we could further split jobs, and use github hosted runners.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

