### PR TITLE
reconstruct deployments without reiterating multiple times on the same elements

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -142,7 +142,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
     if (resource != null) {
       return resource;
     }
-    return findNextResource(null, reconstructionProgress.next());
+    return findNextResource(null, nextProgress(reconstructionProgress));
   }
 
   private ProcessResource findProcessResource(final ProcessIdentifier identifier) {
@@ -334,6 +334,14 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
             });
       }
     }
+  }
+
+  public static ReconstructionProgress nextProgress(final ReconstructionProgress progress) {
+    return switch (progress) {
+      case PROCESS -> ReconstructionProgress.FORM;
+      case FORM -> ReconstructionProgress.DECISION_REQUIREMENTS;
+      case DECISION_REQUIREMENTS, DONE -> ReconstructionProgress.DONE;
+    };
   }
 
   static ResourceIdentifier fromDeploymentRecord(final DeploymentRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -493,16 +493,18 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
       }
     }
 
-    record Done() implements ProgressState {
+    final class Done implements ProgressState {
 
       private static final Done DONE = new Done();
+
+      private Done() {}
 
       @Override
       public Resource resource() {
         return null;
       }
 
-      public static ProgressState done() {
+      static ProgressState done() {
         return DONE;
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -122,27 +122,32 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
   // If all the resources have been searched then it returns null.
   private Resource findNextResource(
       final ResourceIdentifier identifier, final ReconstructionProgress reconstructionProgress) {
-    if (identifier == null & reconstructionProgress == ReconstructionProgress.DONE) {
+    if (reconstructionProgress == ReconstructionProgress.DONE) {
       return null;
     }
-    final var resource =
-        switch (identifier) {
-          case null ->
-              switch (reconstructionProgress) {
-                case PROCESS -> findProcessResource(null);
-                case FORM -> findFormResource(null);
-                case DECISION_REQUIREMENTS -> findDecisionRequirementsResource(null);
-                case DONE -> null;
-              };
-          case final ProcessIdentifier processIdentifier -> findProcessResource(processIdentifier);
-          case final FormIdentifier form -> findFormResource(form);
-          case final DecisionRequirementsIdentifier decisionRequirementsIdentifier ->
-              findDecisionRequirementsResource(decisionRequirementsIdentifier);
-        };
+    final var resource = findResource(identifier, reconstructionProgress);
     if (resource != null) {
       return resource;
+    } else {
+      return findNextResource(null, nextProgress(reconstructionProgress));
     }
-    return findNextResource(null, nextProgress(reconstructionProgress));
+  }
+
+  private Resource findResource(
+      final ResourceIdentifier identifier, final ReconstructionProgress reconstructionProgress) {
+    return switch (identifier) {
+      case null ->
+          switch (reconstructionProgress) {
+            case PROCESS -> findProcessResource(null);
+            case FORM -> findFormResource(null);
+            case DECISION_REQUIREMENTS -> findDecisionRequirementsResource(null);
+            case DONE -> null;
+          };
+      case final ProcessIdentifier processIdentifier -> findProcessResource(processIdentifier);
+      case final FormIdentifier form -> findFormResource(form);
+      case final DecisionRequirementsIdentifier decisionRequirementsIdentifier ->
+          findDecisionRequirementsResource(decisionRequirementsIdentifier);
+    };
   }
 
   private ProcessResource findProcessResource(final ProcessIdentifier identifier) {
@@ -392,11 +397,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
 
       @Override
       public ResourceIdentifier identifier() {
-        return process != null ? processIdentifier() : null;
-      }
-
-      public ProcessIdentifier processIdentifier() {
-        return new ProcessIdentifier(tenantId(), key());
+        return process != null ? new ProcessIdentifier(tenantId(), key()) : null;
       }
     }
 
@@ -419,11 +420,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
 
       @Override
       public ResourceIdentifier identifier() {
-        return form != null ? formIdentifier() : null;
-      }
-
-      public FormIdentifier formIdentifier() {
-        return new FormIdentifier(tenantId(), form.getFormKey());
+        return form != null ? new FormIdentifier(tenantId(), form.getFormKey()) : null;
       }
     }
 
@@ -449,11 +446,9 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
 
       @Override
       public ResourceIdentifier identifier() {
-        return decisionRequirements != null ? decisionRequirementsIdentifier() : null;
-      }
-
-      DecisionRequirementsIdentifier decisionRequirementsIdentifier() {
-        return new DecisionRequirementsIdentifier(tenantId(), key());
+        return decisionRequirements != null
+            ? new DecisionRequirementsIdentifier(tenantId(), key())
+            : null;
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -208,7 +208,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
           // decisions are associated with a deployment key instead.
           final long deploymentKey =
               decisions.stream()
-                  .map(PersistedDecision::getDeploymentKey)
+                  .mapToLong(PersistedDecision::getDeploymentKey)
                   .filter(key -> key != NO_DEPLOYMENT_KEY)
                   .findAny()
                   .orElse(NO_DEPLOYMENT_KEY);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
@@ -47,8 +47,6 @@ public final class DeploymentReconstructionStarter implements StreamProcessorLif
     // start to add more state to the command or make the command non-idempotent unless you also
     // find a way to prevent that this initial command is written more than once.
 
-    // We need to set the tenantId to "", otherwise its default is "<default>" which breaks
-    // searching iteratively in RocksDB
     taskResultBuilder.appendCommandRecord(
         DeploymentIntent.RECONSTRUCT, DeploymentRecord.emptyCommandForReconstruction());
     return taskResultBuilder.build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
@@ -46,7 +46,11 @@ public final class DeploymentReconstructionStarter implements StreamProcessorLif
     // This is fine as long as the command is idempotent and does not contain any state. Do not
     // start to add more state to the command or make the command non-idempotent unless you also
     // find a way to prevent that this initial command is written more than once.
-    taskResultBuilder.appendCommandRecord(DeploymentIntent.RECONSTRUCT, new DeploymentRecord());
+
+    // We need to set the tenantId to "", otherwise its default is "<default>" which breaks
+    // searching iteratively in RocksDB
+    taskResultBuilder.appendCommandRecord(
+        DeploymentIntent.RECONSTRUCT, DeploymentRecord.emptyCommandForReconstruction());
     return taskResultBuilder.build();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -107,7 +107,8 @@ public interface DecisionState {
   /** Completely clears all caches. */
   void clearCache();
 
-  record DecisionRequirementsIdentifier(String tenantId, long decisionRequirementsKey) {}
+  record DecisionRequirementsIdentifier(String tenantId, long decisionRequirementsKey)
+      implements ResourceIdentifier {}
 
   interface PersistedDecisionRequirementsVisitor {
     boolean visit(PersistedDecisionRequirements decisionRequirements);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -73,7 +73,7 @@ public interface FormState {
 
   void clearCache();
 
-  record FormIdentifier(String tenantId, long key) {}
+  record FormIdentifier(String tenantId, long key) implements ResourceIdentifier {}
 
   interface PersistedFormVisitor {
     boolean visit(final PersistedForm form);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -74,7 +74,8 @@ public interface ProcessState {
    */
   void forEachProcess(ProcessIdentifier previousProcess, PersistedProcessVisitor visitor);
 
-  record ProcessIdentifier(String tenantId, long processDefinitionKey) {}
+  record ProcessIdentifier(String tenantId, long processDefinitionKey)
+      implements ResourceIdentifier {}
 
   interface PersistedProcessVisitor {
     boolean visit(PersistedProcess process);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceIdentifier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceIdentifier.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.engine.state.immutable.DecisionState.DecisionRequirementsIdentifier;
+import io.camunda.zeebe.engine.state.immutable.FormState.FormIdentifier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState.ProcessIdentifier;
+
+public sealed interface ResourceIdentifier
+    permits ProcessIdentifier, FormIdentifier, DecisionRequirementsIdentifier {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -611,6 +611,8 @@ final class DeploymentReconstructProcessorTest {
     // when
     // let's run again the processor to make it reach progressState = Done
     processor.processRecord(getCommandAt(eventIndex++));
+    final var typedRecord = resultBuilder.getFollowupRecords().get(eventIndex++);
+    assertThat(typedRecord.getIntent()).isEqualTo(DeploymentIntent.RECONSTRUCTED_ALL);
   }
 
   private TypedRecord<DeploymentRecord> getCommandAt(final int index) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord.ReconstructionProgress;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.Record;
@@ -36,6 +37,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.function.Consumer;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -620,5 +622,19 @@ final class DeploymentReconstructProcessorTest {
     when(command.getIntent()).thenReturn(record.getIntent());
     when(command.getRecordType()).thenReturn(record.getRecordType());
     return command;
+  }
+
+  @Nested
+  class ReconstructionProgressTest {
+    @Test
+    void shouldHaveDoneAsTerminalState() {
+      var progress = ReconstructionProgress.PROCESS;
+      for (int i = 0; i < 3; i++) {
+        progress = DeploymentReconstructProcessor.nextProgress(progress);
+      }
+      assertThat(progress).isEqualTo(ReconstructionProgress.DONE);
+      assertThat(DeploymentReconstructProcessor.nextProgress(progress))
+          .isEqualTo(ReconstructionProgress.DONE);
+    }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -75,6 +75,11 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .declareProperty(reconstructionKeyProp);
   }
 
+  /**
+   * Create an empty DeploymentRecord that can be used as a starting point for reconstructing
+   * deployments: The tenantId must be set to "", otherwise its default is "<default>" which breaks
+   * /* searching iteratively in RocksDB
+   */
   public static DeploymentRecord emptyCommandForReconstruction() {
     return new DeploymentRecord().setTenantId("");
   }
@@ -197,6 +202,31 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     return this;
   }
 
+  /**
+   * @return the current ReconstructionProgress
+   */
+  @JsonIgnore
+  public ReconstructionProgress getReconstructionProgress() {
+    return reconstructionProp.getValue();
+  }
+
+  public void setReconstructionProgress(final ReconstructionProgress progress) {
+    reconstructionProp.setValue(progress);
+  }
+
+  /**
+   * @return the last key whose Deployment was reconstructed
+   */
+  @JsonIgnore
+  public long getReconstructionKey() {
+    return reconstructionKeyProp.getValue();
+  }
+
+  public DeploymentRecord setReconstructionKey(final long deploymentKey) {
+    reconstructionKeyProp.setValue(deploymentKey);
+    return this;
+  }
+
   public void resetResources() {
     resourcesProp.reset();
   }
@@ -241,23 +271,6 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
             .allMatch(DecisionRequirementsMetadataValue::isDuplicate)
         && formMetadata().stream().allMatch(FormMetadataValue::isDuplicate)
         && resourceMetadata().stream().allMatch(ResourceMetadataValue::isDuplicate);
-  }
-
-  public ReconstructionProgress getReconstructionProgress() {
-    return reconstructionProp.getValue();
-  }
-
-  public void setReconstructionProgress(final ReconstructionProgress progress) {
-    reconstructionProp.setValue(progress);
-  }
-
-  public long getReconstructionKey() {
-    return reconstructionKeyProp.getValue();
-  }
-
-  public DeploymentRecord setReconstructionKey(final long deploymentKey) {
-    reconstructionKeyProp.setValue(deploymentKey);
-    return this;
   }
 
   public enum ReconstructionProgress {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -278,13 +278,5 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     FORM,
     DECISION_REQUIREMENTS,
     DONE;
-
-    public ReconstructionProgress next() {
-      return switch (this) {
-        case PROCESS -> FORM;
-        case FORM -> DECISION_REQUIREMENTS;
-        case DECISION_REQUIREMENTS, DONE -> DONE;
-      };
-    }
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -278,5 +278,13 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     FORM,
     DECISION_REQUIREMENTS,
     DONE;
+
+    public ReconstructionProgress next() {
+      return switch (this) {
+        case PROCESS -> FORM;
+        case FORM -> DECISION_REQUIREMENTS;
+        case DECISION_REQUIREMENTS, DONE -> DONE;
+      };
+    }
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord.ReconstructionProgress;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -190,6 +191,7 @@ final class JsonSerializableToJsonTest {
                   .setResourceName(wrapString(resourceName))
                   .setVersion(processVersion)
                   .setChecksum(checksum);
+              record.setReconstructionProgress(ReconstructionProgress.DECISION_REQUIREMENTS);
 
               final int key = 1234;
               final int position = 4321;
@@ -242,7 +244,9 @@ final class JsonSerializableToJsonTest {
             "decisionRequirementsMetadata": [],
             "formMetadata": [],
             "tenantId": "<default>",
-            "deploymentKey": -1
+            "deploymentKey": -1,
+            "reconstructionKey": -1,
+            "reconstructionProgress": "DECISION_REQUIREMENTS"
           }
         }
         """
@@ -288,7 +292,9 @@ final class JsonSerializableToJsonTest {
               "decisionsMetadata": [],
               "formMetadata": [],
               "tenantId": "<default>",
-              "deploymentKey": -1
+              "deploymentKey":-1,
+              "reconstructionKey": -1,
+              "reconstructionProgress": "PROCESS"
           }
         }
         """
@@ -360,6 +366,10 @@ final class JsonSerializableToJsonTest {
                   .setDeploymentKey(deploymentKey)
                   .setDuplicate(true)
                   .setVersionTag(versionTag);
+              record
+                  .setTenantId("tenant-23")
+                  .setReconstructionKey(123)
+                  .setReconstructionProgress(ReconstructionProgress.FORM);
               return record;
             },
         """
@@ -424,8 +434,10 @@ final class JsonSerializableToJsonTest {
             }
           ],
           "resourceMetadata":[],
-          "tenantId": "<default>",
-          "deploymentKey": 1234
+          "tenantId": "tenant-23",
+          "deploymentKey": 1234,
+          "reconstructionKey": 123,
+          "reconstructionProgress": "FORM"
         }
         """
       },
@@ -461,7 +473,9 @@ final class JsonSerializableToJsonTest {
           "formMetadata": [],
           "resourceMetadata":[],
           "tenantId": "<default>",
-          "deploymentKey": -1
+          "deploymentKey": -1,
+          "reconstructionKey": -1,
+          "reconstructionProgress": "PROCESS"
         }
         """
       },
@@ -2310,7 +2324,9 @@ final class JsonSerializableToJsonTest {
             "formMetadata": [],
             "resourceMetadata":[],
             "tenantId": "<default>",
-            "deploymentKey": -1
+            "deploymentKey": -1,
+            "reconstructionKey": -1,
+            "reconstructionProgress": "PROCESS"
           }
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -244,9 +244,7 @@ final class JsonSerializableToJsonTest {
             "decisionRequirementsMetadata": [],
             "formMetadata": [],
             "tenantId": "<default>",
-            "deploymentKey": -1,
-            "reconstructionKey": -1,
-            "reconstructionProgress": "DECISION_REQUIREMENTS"
+            "deploymentKey": -1
           }
         }
         """
@@ -292,9 +290,7 @@ final class JsonSerializableToJsonTest {
               "decisionsMetadata": [],
               "formMetadata": [],
               "tenantId": "<default>",
-              "deploymentKey":-1,
-              "reconstructionKey": -1,
-              "reconstructionProgress": "PROCESS"
+              "deploymentKey":-1
           }
         }
         """
@@ -435,9 +431,7 @@ final class JsonSerializableToJsonTest {
           ],
           "resourceMetadata":[],
           "tenantId": "tenant-23",
-          "deploymentKey": 1234,
-          "reconstructionKey": 123,
-          "reconstructionProgress": "FORM"
+          "deploymentKey": 1234
         }
         """
       },
@@ -473,9 +467,7 @@ final class JsonSerializableToJsonTest {
           "formMetadata": [],
           "resourceMetadata":[],
           "tenantId": "<default>",
-          "deploymentKey": -1,
-          "reconstructionKey": -1,
-          "reconstructionProgress": "PROCESS"
+          "deploymentKey": -1
         }
         """
       },
@@ -2324,9 +2316,7 @@ final class JsonSerializableToJsonTest {
             "formMetadata": [],
             "resourceMetadata":[],
             "tenantId": "<default>",
-            "deploymentKey": -1,
-            "reconstructionKey": -1,
-            "reconstructionProgress": "PROCESS"
+            "deploymentKey": -1
           }
         }
         """


### PR DESCRIPTION
## Description
To avoid rescanning every resource every time, the last resources that
was searched for saved in the next command that the Processor will process.
The same `DeploymentRecord` is also used as a command: a lot of fields are not used and I had to add a new field to identify which type of `Resource` is going to be processed next.
From the `DeploymentRecord` class we are reusing the fields:
- `tenantId,` which has a default of "<default>", which must be overwritten with ""

Two fields are added:
- `reconstructionKey`: which keeps a reference of the last key of the resource that was reconstructed
- `reconstructionProgress`: enum that keep track of which resource type the key was referring to

These fields are not exported to json to the old ElasticsearchExporter/OpensearchExporter.

To reduce potential bugs because of the different default in tenantId, a factory method has been added to `DeploymentRecord`.

The cleanest solution would have been to use a different record as a command, that would have required much more work and most of the codebase follow this pattern

Depends on #30433 (test cases will fail when that PR is merged)
## Related issues

closes #25493 
