### PR TITLE
Migrate last Tasklist test to MultiDB

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/tenants/TasklistV1MultiTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/tenants/TasklistV1MultiTenancyIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
+@Disabled
 public class TasklistV1MultiTenancyIT {
 
   public static final String PASSWORD = "password";
@@ -47,7 +48,7 @@ public class TasklistV1MultiTenancyIT {
           .withMultiTenancyEnabled();
 
   @BeforeAll
-  public static void beforeEach(
+  public static void beforeAll(
       @Authenticated(USERNAME_1) final CamundaClient userOneClient,
       @Authenticated(USERNAME_2) final CamundaClient userTwoClient) {
 


### PR DESCRIPTION
## Description

> [!Note]
>
> This test is disabled and was not working before.
> I simply refactored it, to make use of the new MultiDb approach, so we can get rid of other utilities.
>
> @nathansandi my expectation is that this test is enabled after certain conditions (properly related to Identity?) become true.

### What the PR does

 * Migrate the multi-tenancy test to MultiDbExtension, via making use of MultiDb annotation
 * This allows to run against ES and OS, setting up backend once, and injecting necessary clients


## Related issues

related https://github.com/camunda/camunda/issues/29907
