### PR TITLE
fix: change hide limit for entity list pagination from 25 to 15

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -104,7 +104,7 @@ type EntityListProps<D extends EntityData> = {
 };
 
 const MAX_ICON_ACTIONS = 2;
-const PAGINATION_HIDE_LIMIT = 25;
+const PAGINATION_HIDE_LIMIT = 15;
 const PAGINATION_MAX_PAGE_SIZE = 15;
 const MAX_DISPLAY_CELL_LENGTH = 20;
 


### PR DESCRIPTION
## Description

Change hide limit for entity list pagination from 25 to 15 to avoid hiding elements 16 to 25 and instead showing the second page when the list is over 15 elements.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30369
