### PR TITLE
[Backport stable/8.7] Small optimization in BufferUtil: do not allocate an empty string if buffer is empty

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -59,18 +59,11 @@ public final class BufferUtil {
 
   /** byte-by-byte comparison of two buffers */
   public static boolean contentsEqual(final DirectBuffer buffer1, final DirectBuffer buffer2) {
-
-    if (buffer1.capacity() == buffer2.capacity()) {
-      boolean equal = true;
-
-      for (int i = 0; i < buffer1.capacity() && equal; i++) {
-        equal &= buffer1.getByte(i) == buffer2.getByte(i);
-      }
-
-      return equal;
-    } else {
-      return false;
+    boolean equal = buffer1.capacity() == buffer2.capacity();
+    for (int i = 0; equal && i < buffer1.capacity(); i++) {
+      equal = buffer1.getByte(i) == buffer2.getByte(i);
     }
+    return equal;
   }
 
   public static DirectBuffer createCopy(final BufferWriter writer) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/buffer/BufferUtil.java
@@ -31,6 +31,9 @@ public final class BufferUtil {
 
   public static String bufferAsString(
       final DirectBuffer buffer, final int offset, final int length) {
+    if (length == 0) {
+      return "";
+    }
     final byte[] bytes = new byte[length];
 
     buffer.getBytes(offset, bytes);


### PR DESCRIPTION
# Description
Backport of #30460 to `stable/8.7`.

relates to 