### PR TITLE
feat: set setStrictEarlyShutdown(true) in Backup executor to close the executor when shutdown

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -70,6 +70,7 @@ public class BackupConfig {
     executor.setMaxPoolSize(8);
     executor.setKeepAliveSeconds(60);
     executor.setThreadNamePrefix("webapps_backup_");
+    executor.setStrictEarlyShutdown(true);
     executor.setQueueCapacity(4096);
     executor.initialize();
     return executor;


### PR DESCRIPTION
## Description
Setting `    executor.setStrictEarlyShutdown(true);`, by default is false.
Executor are not closed immediately and tasks can be submitted to them even after the Spring context `close()` method has been called. 
This is probably done to allow components that need the thread pool to shutdown to do so.  I don't think we need such behaviour for this thread pool so it's ok to set it to true.

> Specify whether to initiate an early shutdown signal on context close, disposing all idle threads and rejecting further task submissions.
> By default, existing tasks will be allowed to complete within the coordinated lifecycle stop phase in any case. This setting just controls whether an explicit ThreadPoolExecutor. shutdown() call will be triggered on context close, rejecting task submissions after that point.
> As of 6.1.4, the default is "false", leniently allowing for late tasks to arrive after context close, still participating in the lifecycle stop phase. Note that this differs from setAcceptTasksAfterContextClose which completely bypasses the coordinated lifecycle stop phase, with no explicit waiting for the completion of existing tasks at all.
> Switch this to "true" for a strict early shutdown signal analogous to the 6.1-established default behavior of ThreadPoolTaskScheduler. Note that the related flags setAcceptTasksAfterContextClose and setWaitForTasksToCompleteOnShutdown will override this setting, leading to a late shutdown without a coordinated lifecycle stop phase.
> Since:
> 6.1.4
> See Also:
> initiateShutdown()
> 
## Related issues

closes #28464
