### PR TITLE
fix: exclude number of replicas check out of Tasklist healthcheck

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
@@ -23,6 +23,8 @@ public interface IndexSchemaValidator {
 
   void validateIndexVersions();
 
+  boolean isValidNumberOfReplicas();
+
   Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexMappings() throws IOException;
 
   Set<String> olderVersionsForIndex(final IndexDescriptor indexDescriptor);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -40,7 +40,8 @@ public class SchemaStartup {
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isCreateSchema()
               : tasklistProperties.getElasticsearch().isCreateSchema();
-      if (createSchema && !schemaValidator.schemaExists()) {
+      if (createSchema
+          && !(schemaValidator.schemaExists() && schemaValidator.isValidNumberOfReplicas())) {
         LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
         schemaManager.createSchema();
         LOGGER.info("SchemaStartup: update index mappings.");

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -94,7 +94,7 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
 
     tasklistProperties.getElasticsearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.schemaExists()).isFalse();
+    assertThat(indexSchemaValidator.isValidNumberOfReplicas()).isFalse();
 
     schemaManager.createSchema();
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -91,7 +91,7 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
 
     tasklistProperties.getOpenSearch().setNumberOfReplicas(modifiedNumberOfReplicas);
 
-    assertThat(indexSchemaValidator.schemaExists()).isFalse();
+    assertThat(indexSchemaValidator.isValidNumberOfReplicas()).isFalse();
 
     schemaManager.createSchema();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Exclude number of replicas check out Tasklist healthcheck
This is to solve the readiness probe of Tasklist detecting mismatch between the actual replica count and the one configured in Tasklist properties
This is expected until we complete the implementation of https://github.com/camunda/camunda/issues/26890
The replica count should not be part of the health check anyway and it is only required for schema startup

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30275 
