### PR TITLE
feat: add pause resume cancel endpoints for batch operations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3782,6 +3782,123 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /batch-operations/{batchOperationKey}/cancel:
+    put:
+      tags:
+        - Batch operation
+      operationId: cancelBatchOperation
+      summary: Cancel Batch operation
+      description: Cancels a running batch operation.
+      parameters:
+        - name: batchOperationKey
+          in: path
+          required: true
+          description: |
+            The key of the batch operation.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              nullable: true
+        required: false
+      responses:
+        "202":
+          description: The batch operation cancel request was accepted.
+          content: { }
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The batch operation was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /batch-operations/{batchOperationKey}/pause:
+    put:
+      tags:
+        - Batch operation
+      operationId: pauseBatchOperation
+      summary: Pause Batch operation
+      description: Pauses a running batch operation.
+      parameters:
+        - name: batchOperationKey
+          in: path
+          required: true
+          description: |
+            The key of the batch operation.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              nullable: true
+        required: false
+      responses:
+        "202":
+          description: The batch operation pause request was accepted.
+          content: { }
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The batch operation was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /batch-operations/{batchOperationKey}/resume:
+    put:
+      tags:
+        - Batch operation
+      operationId: resumeBatchOperation
+      summary: Resume Batch operation
+      description: Resumes a paused batch operation.
+      parameters:
+        - name: batchOperationKey
+          in: path
+          required: true
+          description: |
+            The key of the batch operation.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              nullable: true
+        required: false
+      responses:
+        "202":
+          description: The batch operation resume request was accepted.
+          content: { }
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The batch operation was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
 components:
   schemas:
     TenantCreateRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -484,7 +484,7 @@ public final class ResponseMapper {
         new BatchOperationCreatedResult()
             .batchOperationKey(KeyUtil.keyToString(brokerResponse.getBatchOperationKey()))
             .batchOperationType(brokerResponse.getBatchOperationType().toString());
-    return new ResponseEntity<>(response, HttpStatus.CREATED);
+    return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
   }
 
   public static ResponseEntity<Object> toSignalBroadcastResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,6 +72,36 @@ public class BatchOperationController {
       @RequestBody(required = false) final BatchOperationSearchQuery query) {
     return SearchQueryRequestMapper.toBatchOperationQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  @CamundaPutMapping(path = "/{key}/cancel")
+  public ResponseEntity<Object> cancelBatchOperation(@PathVariable final long key) {
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
+            () ->
+                batchOperationServices
+                    .withAuthentication(RequestMapper.getAuthentication())
+                    .cancel(key))
+        .join();
+  }
+
+  @CamundaPutMapping(path = "/{key}/pause")
+  public ResponseEntity<Object> pauseBatchOperation(@PathVariable final long key) {
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
+            () ->
+                batchOperationServices
+                    .withAuthentication(RequestMapper.getAuthentication())
+                    .pause(key))
+        .join();
+  }
+
+  @CamundaPutMapping(path = "/{key}/resume")
+  public ResponseEntity<Object> resumeBatchOperation(@PathVariable final long key) {
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
+            () ->
+                batchOperationServices
+                    .withAuthentication(RequestMapper.getAuthentication())
+                    .resume(key))
+        .join();
   }
 
   private ResponseEntity<BatchOperationSearchQueryResult> search(final BatchOperationQuery query) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.gateway.protocol.rest.BatchOperationSearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -104,6 +105,48 @@ class BatchOperationControllerTest extends RestControllerTest {
             }],
             "page":{"totalItems":1,"firstSortValues":[],"lastSortValues":[]}
            }""");
+  }
+
+  @Test
+  void shouldCancelBatchOperation() {
+    final var batchOperationKey = 1L;
+    when(batchOperationServices.cancel(batchOperationKey))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    webClient
+        .put()
+        .uri("/v2/batch-operations/{key}/cancel", batchOperationKey)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+  }
+
+  @Test
+  void shouldPauseBatchOperation() {
+    final var batchOperationKey = 1L;
+    when(batchOperationServices.pause(batchOperationKey))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    webClient
+        .put()
+        .uri("/v2/batch-operations/{key}/pause", batchOperationKey)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+  }
+
+  @Test
+  void shouldResumeBatchOperation() {
+    final var batchOperationKey = 1L;
+    when(batchOperationServices.resume(batchOperationKey))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    webClient
+        .put()
+        .uri("/v2/batch-operations/{key}/resume", batchOperationKey)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1326,7 +1326,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isCreated()
+        .isAccepted()
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerCancelBatchOperationRequest
+    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+
+  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+
+  public BrokerCancelBatchOperationRequest() {
+    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.CANCEL);
+  }
+
+  public BrokerCancelBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
+    requestDto.setBatchOperationKey(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public BatchOperationExecutionRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerPauseBatchOperationRequest
+    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+
+  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+
+  public BrokerPauseBatchOperationRequest() {
+    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.PAUSE);
+  }
+
+  public BrokerPauseBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
+    requestDto.setBatchOperationKey(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public BatchOperationExecutionRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerResumeBatchOperationRequest
+    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+
+  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+
+  public BrokerResumeBatchOperationRequest() {
+    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.RESUME);
+  }
+
+  public BrokerResumeBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
+    requestDto.setBatchOperationKey(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public BatchOperationExecutionRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds three new endpoints to BatchOperationController to cancel, pause and resume a batch operation. 
-> Since the new endpoints just sends a broker request, the actual operation is async, that's why just "accepted" was chosen as HttpStatus.

New BrokerRequests have also been added and the BatchOperationService has been extended.

## Related issues

closes #29712
