### PR TITLE
Assign user to role (API)

### DIFF
--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -117,12 +117,11 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
     return sendBrokerRequest(new BrokerRoleDeleteRequest(roleId));
   }
 
-  public CompletableFuture<?> addMember(
-      final String roleId, final EntityType entityType, final String entityId) {
+  public CompletableFuture<?> addMember(final AddEntityToRoleRequest request) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createAddRequest()
-            .setRoleId(roleId)
-            .setEntity(entityType, entityId));
+            .setRoleId(request.roleId())
+            .setEntity(request.entityType(), request.entityId()));
   }
 
   public CompletableFuture<?> removeMember(
@@ -136,4 +135,6 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   public record CreateRoleRequest(String roleId, String name, String description) {}
 
   public record UpdateRoleRequest(String roleId, String name, String description) {}
+
+  public record AddEntityToRoleRequest(String roleId, String entityId, EntityType entityType) {}
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -118,19 +118,19 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public CompletableFuture<?> addMember(
-      final Long roleKey, final EntityType entityType, final long entityKey) {
+      final String roleId, final EntityType entityType, final String entityId) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createAddRequest()
-            .setRoleKey(roleKey)
-            .setEntity(entityType, entityKey));
+            .setRoleId(roleId)
+            .setEntity(entityType, entityId));
   }
 
   public CompletableFuture<?> removeMember(
       final Long roleKey, final EntityType entityType, final long entityKey) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createRemoveRequest()
-            .setRoleKey(roleKey)
-            .setEntity(entityType, entityKey));
+            .setRoleId(String.valueOf(roleKey))
+            .setEntity(entityType, String.valueOf(entityKey)));
   }
 
   public record CreateRoleRequest(String roleId, String name, String description) {}

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.RoleServices.AddEntityToRoleRequest;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.security.SecurityContextProvider;
@@ -152,7 +153,7 @@ public class RoleServicesTest {
     final var entityId = "entityId";
 
     // when
-    services.addMember(roleId, EntityType.USER, entityId);
+    services.addMember(new AddEntityToRoleRequest(roleId, entityId, EntityType.USER));
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -148,19 +148,19 @@ public class RoleServicesTest {
   @Test
   public void shouldAddUserToRole() {
     // given
-    final var roleKey = 100L;
-    final var entityKey = 42;
+    final var roleId = "roleId";
+    final var entityId = "entityId";
 
     // when
-    services.addMember(roleKey, EntityType.USER, entityKey);
+    services.addMember(roleId, EntityType.USER, entityId);
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(RoleIntent.ADD_ENTITY);
     assertThat(request.getValueType()).isEqualTo(ValueType.ROLE);
     final RoleRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getRoleKey()).isEqualTo(roleKey);
-    assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
+    assertThat(brokerRequestValue.getRoleId()).isEqualTo(roleId);
+    assertThat(brokerRequestValue.getEntityId()).isEqualTo(entityId);
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(EntityType.USER);
   }
 
@@ -178,8 +178,8 @@ public class RoleServicesTest {
     assertThat(request.getIntent()).isEqualTo(RoleIntent.REMOVE_ENTITY);
     assertThat(request.getValueType()).isEqualTo(ValueType.ROLE);
     final RoleRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getRoleKey()).isEqualTo(roleKey);
-    assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
+    assertThat(brokerRequestValue.getRoleId()).isEqualTo(String.valueOf(roleKey));
+    assertThat(brokerRequestValue.getEntityId()).isEqualTo(String.valueOf(entityKey));
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(EntityType.USER);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2311,6 +2311,51 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /roles/{roleId}/users/{username}:
+    put:
+      tags:
+        - Role
+      operationId: addUserToRole
+      summary: Assign a user to a role (Work-in-Progress)
+      description: |
+        Assigns a user to a role.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: roleId
+          in: path
+          required: true
+          description: The role ID.
+          schema:
+            type: string
+        - name: username
+          in: path
+          required: true
+          description: The user username.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The user was assigned successfully to the role.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role or user with the given ID or username was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: The user with the given ID is already assigned to the role.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /roles/search:
     post:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -65,6 +65,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
+import io.camunda.service.RoleServices.AddEntityToRoleRequest;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.TenantServices.TenantDTO;
@@ -122,6 +123,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.Part;
@@ -322,6 +324,13 @@ public class RequestMapper {
                 roleCreateRequest.getRoleId(),
                 roleCreateRequest.getName(),
                 roleCreateRequest.getDescription()));
+  }
+
+  public static Either<ProblemDetail, AddEntityToRoleRequest> toRoleAddEntityRequest(
+      final String roleId, final String entityId, final EntityType entityType) {
+    return getResult(
+        RoleRequestValidator.validateAddEntityRequest(roleId, entityId, entityType),
+        () -> new AddEntityToRoleRequest(roleId, entityId, entityType));
   }
 
   public static Either<ProblemDetail, CreateGroupRequest> toGroupCreateRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -106,7 +106,7 @@ public class RoleController {
   @CamundaPutMapping(
       path = "/{roleId}/users/{username}",
       consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addRole(
+  public CompletableFuture<ResponseEntity<Object>> addUserToRole(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -106,10 +105,10 @@ public class RoleController {
 
   @CamundaPutMapping(
       path = "/{roleId}/users/{username}",
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+      consumes = {})
   public CompletableFuture<ResponseEntity<Object>> addRole(
       @PathVariable final String roleId, @PathVariable final String username) {
-    return RequestMapper.executeServiceMethodWithNoContentResult(
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
             roleServices
                 .withAuthentication(RequestMapper.getAuthentication())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -105,15 +105,15 @@ public class RoleController {
   }
 
   @CamundaPutMapping(
-      path = "/{userKey}/roles/{roleKey}",
+      path = "/{roleId}/users/{username}",
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> addRole(
-      @PathVariable final long userKey, @PathVariable final long roleKey) {
+      @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             roleServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(roleKey, EntityType.USER, userKey));
+                .addMember(roleId, EntityType.USER, username));
   }
 
   private ResponseEntity<RoleSearchQueryResult> search(final RoleQuery query) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -25,7 +25,9 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -100,6 +102,18 @@ public class RoleController {
       @RequestBody(required = false) final RoleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  @CamundaPutMapping(
+      path = "/{userKey}/roles/{roleKey}",
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> addRole(
+      @PathVariable final long userKey, @PathVariable final long roleKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            roleServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .addMember(roleKey, EntityType.USER, userKey));
   }
 
   private ResponseEntity<RoleSearchQueryResult> search(final RoleQuery query) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import io.camunda.search.query.RoleQuery;
 import io.camunda.service.RoleServices;
+import io.camunda.service.RoleServices.AddEntityToRoleRequest;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
@@ -103,18 +104,6 @@ public class RoleController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @CamundaPutMapping(
-      path = "/{roleId}/users/{username}",
-      consumes = {})
-  public CompletableFuture<ResponseEntity<Object>> addUserToRole(
-      @PathVariable final String roleId, @PathVariable final String username) {
-    return RequestMapper.executeServiceMethodWithAcceptedResult(
-        () ->
-            roleServices
-                .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(roleId, EntityType.USER, username));
-  }
-
   private ResponseEntity<RoleSearchQueryResult> search(final RoleQuery query) {
     try {
       final var result =
@@ -123,5 +112,21 @@ public class RoleController {
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
     }
+  }
+
+  @CamundaPutMapping(
+      path = "/{roleId}/users/{username}",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> addUserToRole(
+      @PathVariable final String roleId, @PathVariable final String username) {
+    return RequestMapper.toRoleAddEntityRequest(roleId, username, EntityType.USER)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addEntityToRole);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> addEntityToRole(
+      final AddEntityToRoleRequest request) {
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
+        () ->
+            roleServices.withAuthentication(RequestMapper.getAuthentication()).addMember(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -28,7 +28,6 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -79,18 +78,6 @@ public class UserController {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userServices.withAuthentication(RequestMapper.getAuthentication()).updateUser(request));
-  }
-
-  @CamundaPutMapping(
-      path = "/{userKey}/roles/{roleKey}",
-      consumes = MediaType.APPLICATION_JSON_VALUE)
-  public CompletableFuture<ResponseEntity<Object>> addRole(
-      @PathVariable final long userKey, @PathVariable final long roleKey) {
-    return RequestMapper.executeServiceMethodWithNoContentResult(
-        () ->
-            roleServices
-                .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(roleKey, EntityType.USER, userKey));
   }
 
   @CamundaDeleteMapping(path = "/{userKey}/roles/{roleKey}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
@@ -17,6 +17,7 @@ import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.http.ProblemDetail;
@@ -30,13 +31,35 @@ public final class RoleRequestValidator {
     }
   }
 
-  public static void validateRoleId(final String id, final List<String> violations) {
+  private static void validateId(
+      final String id, final String propertyName, final List<String> violations) {
     if (id == null || id.isBlank()) {
-      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("roleId"));
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(propertyName));
     } else if (id.length() > MAX_LENGTH) {
-      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("roleId", MAX_LENGTH));
+      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(propertyName, MAX_LENGTH));
     } else if (!ID_PATTERN.matcher(id).matches()) {
-      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("roleId", ID_REGEX));
+      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(propertyName, ID_REGEX));
+    }
+  }
+
+  public static void validateRoleId(final String id, final List<String> violations) {
+    validateId(id, "roleId", violations);
+  }
+
+  public static void validateEntityId(
+      final String entityId, final EntityType entityType, final List<String> violations) {
+    switch (entityType) {
+      case USER:
+        validateId(entityId, "username", violations);
+        break;
+      case GROUP:
+        validateId(entityId, "groupId", violations);
+        break;
+      case MAPPING:
+        validateId(entityId, "mappingId", violations);
+        break;
+      default:
+        validateId(entityId, "entityId", violations);
     }
   }
 
@@ -60,6 +83,15 @@ public final class RoleRequestValidator {
         violations -> {
           validateRoleId(request.getRoleId(), violations);
           validateRoleName(request.getName(), violations);
+        });
+  }
+
+  public static Optional<ProblemDetail> validateAddEntityRequest(
+      final String roleId, final String entityId, final EntityType entityType) {
+    return validate(
+        violations -> {
+          validateRoleId(roleId, violations);
+          validateEntityId(entityId, entityType, violations);
         });
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.RoleServices;
+import io.camunda.service.RoleServices.AddEntityToRoleRequest;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.UpdateRoleRequest;
 import io.camunda.service.exception.CamundaBrokerException;
@@ -400,8 +401,8 @@ public class RoleControllerTest extends RestControllerTest {
     final var roleId = "roleId";
     final var username = "username";
 
-    when(roleServices.addMember(roleId, EntityType.USER, username))
-        .thenReturn(CompletableFuture.completedFuture(null));
+    final var request = new AddEntityToRoleRequest(roleId, username, EntityType.USER);
+    when(roleServices.addMember(request)).thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     webClient
@@ -413,7 +414,7 @@ public class RoleControllerTest extends RestControllerTest {
         .isAccepted();
 
     // then
-    verify(roleServices, times(1)).addMember(roleId, EntityType.USER, username);
+    verify(roleServices, times(1)).addMember(request);
   }
 
   @Test
@@ -422,7 +423,8 @@ public class RoleControllerTest extends RestControllerTest {
     final var roleId = "roleId";
     final var username = "username";
     final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
-    when(roleServices.addMember(roleId, EntityType.USER, username))
+    final var request = new AddEntityToRoleRequest(roleId, username, EntityType.USER);
+    when(roleServices.addMember(request))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
@@ -439,7 +441,7 @@ public class RoleControllerTest extends RestControllerTest {
         .isNotFound();
 
     // then
-    verify(roleServices, times(1)).addMember(roleId, EntityType.USER, username);
+    verify(roleServices, times(1)).addMember(request);
   }
 
   @Test
@@ -448,7 +450,8 @@ public class RoleControllerTest extends RestControllerTest {
     final String roleId = "roleId";
     final String username = "username";
     final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
-    when(roleServices.addMember(roleId, EntityType.USER, username))
+    final var request = new AddEntityToRoleRequest(roleId, username, EntityType.USER);
+    when(roleServices.addMember(request))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
@@ -465,6 +468,6 @@ public class RoleControllerTest extends RestControllerTest {
         .isNotFound();
 
     // then
-    verify(roleServices, times(1)).addMember(roleId, EntityType.USER, username);
+    verify(roleServices, times(1)).addMember(request);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -470,4 +470,64 @@ public class RoleControllerTest extends RestControllerTest {
     // then
     verify(roleServices, times(1)).addMember(request);
   }
+
+  @Test
+  void shouldReturnErrorForProvidingInvalidUsername() {
+    // given
+    final String roleId = "roleId";
+    final String username = "username!";
+    final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
+
+    // when
+    webClient
+        .put()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
+                "instance": "%s"
+              }"""
+                .formatted(IdentifierPatterns.ID_PATTERN, path));
+    verifyNoInteractions(roleServices);
+  }
+
+  @Test
+  void shouldReturnErrorForProvidingInvalidRoleId() {
+    // given
+    final String roleId = "roleId!";
+    final String username = "username";
+    final var path = "%s/%s/users/%s".formatted(ROLE_BASE_URL, roleId, username);
+
+    // when
+    webClient
+        .put()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "The provided roleId contains illegal characters. It must match the pattern '%s'.",
+                "instance": "%s"
+              }"""
+                .formatted(IdentifierPatterns.ID_PATTERN, path));
+    verifyNoInteractions(roleServices);
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRoleEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRoleEntityRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -19,6 +20,7 @@ public final class BrokerRoleEntityRequest extends BrokerExecuteCommand<RoleReco
 
   private BrokerRoleEntityRequest(final RoleIntent intent) {
     super(ValueType.ROLE, intent);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
   public static BrokerRoleEntityRequest createAddRequest() {
@@ -29,18 +31,18 @@ public final class BrokerRoleEntityRequest extends BrokerExecuteCommand<RoleReco
     return new BrokerRoleEntityRequest(RoleIntent.REMOVE_ENTITY);
   }
 
-  public BrokerRoleEntityRequest setRoleKey(final long roleKey) {
-    roleDto.setRoleKey(roleKey);
+  public BrokerRoleEntityRequest setRoleId(final String roleId) {
+    roleDto.setRoleId(roleId);
     return this;
   }
 
-  public BrokerRoleEntityRequest setEntity(final EntityType entityType, final long entityKey) {
+  public BrokerRoleEntityRequest setEntity(final EntityType entityType, final String entityId) {
     if (entityType != EntityType.USER && entityType != EntityType.MAPPING) {
       throw new IllegalArgumentException(
           "For now, roles can only be granted to users and mappings");
     }
     roleDto.setEntityType(entityType);
-    roleDto.setEntityKey(entityKey);
+    roleDto.setEntityId(entityId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -22,17 +22,20 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   private final StringProperty roleIdProp = new StringProperty("roleId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
+  // TODO remove entityKeyProp https://github.com/camunda/camunda/issues/30116
   private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
+  private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public RoleRecord() {
-    super(6);
+    super(7);
     declareProperty(roleKeyProp)
         .declareProperty(roleIdProp)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
         .declareProperty(entityKeyProp)
+        .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
 
@@ -79,6 +82,16 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   @Override
   public long getEntityKey() {
     return entityKeyProp.getValue();
+  }
+
+  @Override
+  public String getEntityId() {
+    return BufferUtil.bufferAsString(entityIdProp.getValue());
+  }
+
+  public RoleRecord setEntityId(final String entityId) {
+    entityIdProp.setValue(entityId);
+    return this;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2831,6 +2831,7 @@ final class JsonSerializableToJsonTest {
                     .setName("role")
                     .setDescription("description")
                     .setEntityKey(2L)
+                    .setEntityId("entityId")
                     .setEntityType(EntityType.USER),
         """
         {
@@ -2839,6 +2840,7 @@ final class JsonSerializableToJsonTest {
           "name": "role",
           "description": "description",
           "entityKey": 2,
+          "entityId": "entityId",
           "entityType": "USER"
         }
         """
@@ -2856,6 +2858,7 @@ final class JsonSerializableToJsonTest {
           "name": "",
           "description": "",
           "entityKey": -1,
+          "entityId": "",
           "entityType": "UNSPECIFIED"
         }
         """
@@ -3053,6 +3056,7 @@ final class JsonSerializableToJsonTest {
                             .setName("roleName")
                             .setDescription("description")
                             .setEntityKey(2)
+                            .setEntityId("entityId")
                             .setEntityType(EntityType.USER))
                     .addUser(
                         new UserRecord()
@@ -3092,6 +3096,7 @@ final class JsonSerializableToJsonTest {
           "name": "roleName",
           "description": "description",
           "entityKey": 2,
+          "entityId": "entityId",
           "entityType": "USER"
         },
         "users": [
@@ -3151,6 +3156,7 @@ final class JsonSerializableToJsonTest {
               "name": "",
               "description": "",
               "entityKey": -1,
+              "entityId": "",
               "entityType": "UNSPECIFIED"
           },
           "users": [],

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
@@ -38,6 +38,9 @@ public interface RoleRecordValue extends RecordValue {
   /** The key of a user/mapping to assign/remove from a role. */
   long getEntityKey();
 
+  /** The id of an entity to assign/remove from a role. */
+  String getEntityId();
+
   /** The type of the entity to assign/remove from a role. */
   EntityType getEntityType();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Moves the endpoint to add a user to a role from the `UserController` to the `RoleController` with this the url is fixed to be `/roles/<roleId>/users/<username>`. This matches with groups and tenants.
It'll now work with ids instead of keys. I've also added a few missing test cases and the missing api spec.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30031 

Based upon #30114 