### PR TITLE
refactor: normalize user group membership

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -14,9 +14,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.GroupState;
+import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -35,6 +37,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
       "Expected to delete group with ID '%s', but a group with this ID does not exist.";
   private final GroupState groupState;
   private final AuthorizationState authorizationState;
+  private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -50,6 +53,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
       final CommandDistributionBehavior commandDistributionBehavior) {
     groupState = processingState.getGroupState();
     authorizationState = processingState.getAuthorizationState();
+    membershipState = processingState.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -119,21 +123,18 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
 
   private void removeAssignedEntities(final GroupRecord record) {
     final var groupId = record.getGroupId();
-    groupState
-        .getEntitiesByType(groupId)
-        .forEach(
-            (entityType, entityKeys) -> {
-              entityKeys.forEach(
-                  entityKey -> {
-                    final var entityRecord =
-                        new GroupRecord()
-                            .setGroupId(groupId)
-                            .setEntityKey(entityKey)
-                            .setEntityType(entityType);
-                    stateWriter.appendFollowUpEvent(
-                        record.getGroupKey(), GroupIntent.ENTITY_REMOVED, entityRecord);
-                  });
-            });
+    membershipState.forEachMember(
+        RelationType.GROUP,
+        groupId,
+        (entityType, entityId) -> {
+          stateWriter.appendFollowUpEvent(
+              record.getGroupKey(),
+              GroupIntent.ENTITY_REMOVED,
+              new GroupRecord()
+                  .setGroupId(groupId)
+                  .setEntityType(entityType)
+                  .setEntityKey(Long.parseLong(entityId)));
+        });
   }
 
   private void deleteAuthorizations(final GroupRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -45,9 +45,7 @@ public class GroupProcessors {
         ValueType.GROUP,
         GroupIntent.ADD_ENTITY,
         new GroupAddEntityProcessor(
-            processingState.getGroupState(),
-            processingState.getUserState(),
-            processingState.getMappingState(),
+            processingState,
             authCheckBehavior,
             keyGenerator,
             writers,
@@ -56,9 +54,7 @@ public class GroupProcessors {
         ValueType.GROUP,
         GroupIntent.REMOVE_ENTITY,
         new GroupRemoveEntityProcessor(
-            processingState.getGroupState(),
-            processingState.getUserState(),
-            processingState.getMappingState(),
+            processingState,
             authCheckBehavior,
             keyGenerator,
             writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -14,9 +14,12 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingState;
+import io.camunda.zeebe.engine.state.immutable.MembershipState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -33,6 +36,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
   private final GroupState groupState;
   private final UserState userState;
   private final MappingState mappingState;
+  private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -41,16 +45,15 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
   private final CommandDistributionBehavior commandDistributionBehavior;
 
   public GroupRemoveEntityProcessor(
-      final GroupState groupState,
-      final UserState userState,
-      final MappingState mappingState,
+      final ProcessingState processingState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
-    this.groupState = groupState;
-    this.userState = userState;
-    this.mappingState = mappingState;
+    groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
+    mappingState = processingState.getMappingState();
+    membershipState = processingState.getMembershipState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -110,19 +113,28 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
   @Override
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
+    final var groupId = record.getGroupId();
 
-    groupState
-        .getEntityType(record.getGroupId(), record.getEntityKey())
-        .ifPresentOrElse(
-            entityType ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue()),
-            () -> {
-              final var errorMessage =
-                  ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(
-                      record.getEntityKey(), record.getGroupKey());
-              rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-            });
+    final var isAssigned =
+        switch (record.getEntityType()) {
+          case USER ->
+              membershipState.hasRelation(
+                  EntityType.USER,
+                  // TODO: Use entity id instead of key
+                  Long.toString(record.getEntityKey()),
+                  RelationType.GROUP,
+                  groupId);
+          default -> groupState.getEntityType(groupId, record.getEntityKey()).isPresent();
+        };
+
+    if (isAssigned) {
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue());
+    } else {
+      final var errorMessage =
+          ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityKey(), record.getGroupKey());
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+    }
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -8,23 +8,25 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
 
   private final MutableGroupState groupState;
-  private final MutableUserState userState;
   private final MutableMappingState mappingState;
+  private final MutableMembershipState membershipState;
 
   public GroupEntityAddedApplier(final MutableProcessingState processingState) {
     groupState = processingState.getGroupState();
-    userState = processingState.getUserState();
     mappingState = processingState.getMappingState();
+    membershipState = processingState.getMembershipState();
   }
 
   @Override
@@ -32,16 +34,21 @@ public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, G
     // TODO: refactor this with https://github.com/camunda/camunda/issues/30092 and
     // https://github.com/camunda/camunda/issues/30091
     final var groupKey = Long.parseLong(value.getGroupId());
-    groupState.addEntity(value);
 
     final var entityKey = value.getEntityKey();
     final var entityType = value.getEntityType();
     switch (entityType) {
       case USER ->
-          userState
-              .getUser(entityKey)
-              .ifPresent(user -> userState.addGroup(user.getUsername(), groupKey));
-      case MAPPING -> mappingState.addGroup(entityKey, groupKey);
+          membershipState.insertRelation(
+              EntityType.USER,
+              // TODO: Use entity id instead of key
+              Long.toString(entityKey),
+              RelationType.GROUP,
+              value.getGroupId());
+      case MAPPING -> {
+        groupState.addEntity(value);
+        mappingState.addGroup(entityKey, groupKey);
+      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
@@ -199,5 +199,6 @@ public final class DbMembershipState implements MutableMembershipState {
 
   public enum RelationType {
     ROLE,
+    GROUP,
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -21,8 +21,4 @@ public interface MutableUserState extends UserState {
   void addTenantId(final String username, final String tenantId);
 
   void removeTenant(final String username, final String tenantId);
-
-  void addGroup(final String username, final long groupKey);
-
-  void removeGroup(final String username, final long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -86,24 +86,6 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void addGroup(final String username, final long groupKey) {
-    this.username.wrapString(username);
-    final var persistedUser = usersColumnFamily.get(this.username);
-    persistedUser.addGroupKey(groupKey);
-    usersColumnFamily.update(this.username, persistedUser);
-  }
-
-  @Override
-  public void removeGroup(final String username, final long groupKey) {
-    this.username.wrapString(username);
-    final var persistedUser = usersColumnFamily.get(this.username);
-    final List<Long> groupKeys = persistedUser.getGroupKeysList();
-    groupKeys.remove(groupKey);
-    persistedUser.setGroupKeysList(groupKeys);
-    usersColumnFamily.update(this.username, persistedUser);
-  }
-
-  @Override
   public Optional<PersistedUser> getUser(final String username) {
     this.username.wrapString(username);
     final var persistedUser = usersColumnFamily.get(this.username);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -25,12 +24,10 @@ public class PersistedUser extends UnpackedObject implements DbValue {
       new ObjectProperty<>("user", new UserRecord());
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>("tenantIds", StringValue::new);
-  private final ArrayProperty<LongValue> groupKeysProp =
-      new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedUser() {
-    super(3);
-    declareProperty(userProp).declareProperty(tenantIdsProp).declareProperty(groupKeysProp);
+    super(2);
+    declareProperty(userProp).declareProperty(tenantIdsProp);
   }
 
   public PersistedUser copy() {
@@ -82,23 +79,6 @@ public class PersistedUser extends UnpackedObject implements DbValue {
 
   public PersistedUser addTenantId(final String tenantId) {
     tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
-    return this;
-  }
-
-  public List<Long> getGroupKeysList() {
-    return StreamSupport.stream(groupKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
-        .collect(Collectors.toList());
-  }
-
-  public PersistedUser setGroupKeysList(final List<Long> groupKeys) {
-    groupKeysProp.reset();
-    groupKeys.forEach(groupKey -> groupKeysProp.add().setValue(groupKey));
-    return this;
-  }
-
-  public PersistedUser addGroupKey(final long groupKey) {
-    groupKeysProp.add().setValue(groupKey);
     return this;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -48,7 +47,6 @@ public class DeleteUserTest {
     assertThat(deletedUser).isNotNull().hasFieldOrPropertyWithValue("userKey", userRecord.getKey());
   }
 
-  @Ignore("https://github.com/camunda/camunda/issues/30091")
   @Test
   public void shouldCleanupMembership() {
     final var username = UUID.randomUUID().toString();
@@ -91,7 +89,7 @@ public class DeleteUserTest {
     // then
     Assertions.assertThat(
             RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
-                .withGroupKey(Long.parseLong(groupId))
+                .withGroupId(groupId)
                 .withEntityKey(userRecord.getKey())
                 .exists())
         .isTrue();


### PR DESCRIPTION
Similar to https://github.com/camunda/camunda/pull/30451, this removes group membership from the user entity and group state and uses the generalized membership state instead.

closes #30453
