### PR TITLE
deps: upgrade springboot to 3.4.4 for stable/8.6

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/WorkingDirectoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/WorkingDirectoryConfiguration.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -23,6 +24,7 @@ import org.springframework.core.env.Profiles;
 public record WorkingDirectoryConfiguration(Environment environment) {
 
   @Bean
+  @ConditionalOnMissingBean
   public WorkingDirectory workingDirectory() {
     final Path workingDirectory;
 

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -27,24 +27,36 @@ management.server.ssl.enabled=false
 spring.web.resources.add-mappings=false
 # General management configuration; disable all endpoints by default but exposes all enabled ones
 # via web. Endpoints should be enabled individually based on the target application
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=none
 management.endpoints.web.exposure.include=*
 # Health configuration; disable default health indicators. As it's unclear how to do this globally,
 # only the ones which currently would get enabled are explicitly disabled.
-management.endpoint.health.enabled=true
+management.endpoint.health.access=unrestricted
 management.endpoint.health.show-details=always
 management.health.defaults.enabled=false
 # Configure Prometheus as the default enabled backend, for scraping
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=unrestricted
 management.prometheus.metrics.export.enabled=true
 # Disable the OpenTelemetry backend by default; can be enabled on demand by users
 management.otlp.metrics.export.enabled=false
 # Allow runtime configuration of log levels
-management.endpoint.loggers.enabled=true
+management.endpoint.loggers.access=unrestricted
 # Allow viewing the config properties, but sanitize their outputs
-management.endpoint.configprops.enabled=true
+management.endpoint.configprops.access=unrestricted
 management.endpoint.configprops.show-values=always
-management.endpoint.info.enabled=true
+management.endpoint.info.access=unrestricted
+# since springboot 3.4, we need to explicitly enable the custom actuator endpoints, as they are globally disabled by default
+management.endpoint.backups.access=unrestricted
+management.endpoint.banning.access=unrestricted
+management.endpoint.clock.access=unrestricted
+management.endpoint.cluster.access=unrestricted
+management.endpoint.exporters.access=unrestricted
+management.endpoint.exporting.access=unrestricted
+management.endpoint.flowControl.access=unrestricted
+management.endpoint.jobstreams.access=unrestricted
+management.endpoint.partitions.access=unrestricted
+management.endpoint.rebalance.access=unrestricted
+management.endpoint.usage-metrics.access=unrestricted
 # Define keywords to sanitize in applicable endpoints; this will be applied to the configprops,
 # beans, and if enabled, the environment endpoint as well
 management.sanitize.keywords=user,pass,secret,accessKey,accountKey,connectionString

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.6</version.protobuf>
     <version.protobuf-common>2.44.0</version.protobuf-common>
-    <version.micrometer>1.13.6</version.micrometer>
+    <version.micrometer>1.14.5</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.16</version.scala>
@@ -97,9 +97,9 @@
     <version.feel-scala>1.18.1</version.feel-scala>
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.1</version.rest-assured>
-    <version.spring>6.1.14</version.spring>
+    <version.spring>6.2.5</version.spring>
     <version.spring-security>6.4.4</version.spring-security>
-    <version.spring-boot>3.3.9</version.spring-boot>
+    <version.spring-boot>3.4.4</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/MemoryHealthIndicatorProperties.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/MemoryHealthIndicatorProperties.java
@@ -9,11 +9,9 @@ package io.camunda.zeebe.util.health;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Component;
 
 /** External configuration properties for {@link MemoryHealthIndicator}. */
 @ConfigurationProperties(prefix = "management.health.memory")
-@Component
 @Primary
 public class MemoryHealthIndicatorProperties {
 
@@ -24,7 +22,7 @@ public class MemoryHealthIndicatorProperties {
     return threshold;
   }
 
-  public void setThreshold(double threshold) {
+  public void setThreshold(final double threshold) {
     if (threshold <= 0 || threshold >= 1) {
       throw new IllegalArgumentException("Threshold must be a value in the interval ]0,1[");
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Bumping SpringBoot to 3.4 as OSS support of 3.3 will end in June 2025. This includes:
- bumping Spring core to 6.2
- bumping micrometer to 1.14
- explicitly enabling the custom actuator endpoints, as they are globally disabled by default

List of actuator endpoints that are exposed in 8.6
```json
{
  "_links": {
    "self": {
      "href": "http://localhost:9600/actuator",
      "templated": false
    },
    "partitions-operation": {
      "href": "http://localhost:9600/actuator/partitions/{operation}",
      "templated": true
    },
    "partitions": {
      "href": "http://localhost:9600/actuator/partitions",
      "templated": false
    },
    "jobstreams-type": {
      "href": "http://localhost:9600/actuator/jobstreams/{type}",
      "templated": true
    },
    "jobstreams": {
      "href": "http://localhost:9600/actuator/jobstreams",
      "templated": false
    },
    "banning-processInstanceKey": {
      "href": "http://localhost:9600/actuator/banning/{processInstanceKey}",
      "templated": true
    },
    "backups": {
      "href": "http://localhost:9600/actuator/backups",
      "templated": false
    },
    "backups-id": {
      "href": "http://localhost:9600/actuator/backups/{id}",
      "templated": true
    },
    "clock": {
      "href": "http://localhost:9600/actuator/clock",
      "templated": false
    },
    "clock-operationKey": {
      "href": "http://localhost:9600/actuator/clock/{operationKey}",
      "templated": true
    },
    "rebalance": {
      "href": "http://localhost:9600/actuator/rebalance",
      "templated": false
    },
    "prometheus": {
      "href": "http://localhost:9600/actuator/prometheus",
      "templated": false
    },
    "health": {
      "href": "http://localhost:9600/actuator/health",
      "templated": false
    },
    "health-path": {
      "href": "http://localhost:9600/actuator/health/{*path}",
      "templated": true
    },
    "info": {
      "href": "http://localhost:9600/actuator/info",
      "templated": false
    },
    "configprops": {
      "href": "http://localhost:9600/actuator/configprops",
      "templated": false
    },
    "configprops-prefix": {
      "href": "http://localhost:9600/actuator/configprops/{prefix}",
      "templated": true
    },
    "loggers": {
      "href": "http://localhost:9600/actuator/loggers",
      "templated": false
    },
    "loggers-name": {
      "href": "http://localhost:9600/actuator/loggers/{name}",
      "templated": true
    },
    "usage-metrics": {
      "href": "http://localhost:9600/actuator/usage-metrics",
      "templated": false
    },
    "cluster": {
      "href": "http://localhost:9600/actuator/cluster",
      "templated": false
    },
    "flowcontrol": {
      "href": "http://localhost:9600/actuator/flowControl",
      "templated": false
    },
    "exporting": {
      "href": "http://localhost:9600/actuator/exporting",
      "templated": false
    },
    "exporters": {
      "href": "http://localhost:9600/actuator/exporters",
      "templated": false
    }
  }
}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/28554
