### PR TITLE
Fix: batch operation memory safety issue with scheduled task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -47,9 +47,6 @@ public final class BatchOperationSetupProcessors {
             new BatchOperationExecuteProcessor(writers, processingState, partitionId))
         .withListener(
             new BatchOperationExecutionScheduler(
-                scheduledTaskStateFactory,
-                searchClientsProxy,
-                keyGenerator,
-                Duration.ofMillis(1000)));
+                scheduledTaskStateFactory, searchClientsProxy, Duration.ofMillis(1000)));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
@@ -45,7 +44,6 @@ public class BatchOperationExecutionSchedulerTest {
 
   @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
   @Mock private SearchClientsProxy searchClientsProxy;
-  @Mock private KeyGenerator keyGenerator;
   @Mock private TaskResultBuilder taskResultBuilder;
   @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
   @Mock private ProcessingScheduleService scheduleService;
@@ -76,7 +74,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, searchClientsProxy, keyGenerator, Duration.ofSeconds(1));
+            scheduledTaskStateFactory, searchClientsProxy, Duration.ofSeconds(1));
   }
 
   @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -19,19 +19,15 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     implements BatchOperationChunkRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
-  public static final String PROP_CHUNK_KEY = "chunkKey";
   public static final String PROP_ITEM_KEY_LIST = "itemKeys";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
-  private final LongProperty chunkKeyProp = new LongProperty(PROP_CHUNK_KEY);
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
 
   public BatchOperationChunkRecord() {
-    super(3);
-    declareProperty(batchOperationKeyProp)
-        .declareProperty(chunkKeyProp)
-        .declareProperty(itemKeysProp);
+    super(2);
+    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
   }
 
   @Override
@@ -56,19 +52,8 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     return this;
   }
 
-  @Override
-  public Long getChunkKey() {
-    return chunkKeyProp.getValue();
-  }
-
-  public BatchOperationChunkRecord setChunkKey(final Long key) {
-    chunkKeyProp.setValue(key);
-    return this;
-  }
-
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setItemKeys(record.getItemKeys());
-    setChunkKey(record.getChunkKey());
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -28,9 +28,4 @@ public interface BatchOperationChunkRecordValue extends BatchOperationRelated, R
    * @return subset of item keys for the batch operation
    */
   Set<Long> getItemKeys();
-
-  /**
-   * @return the key of this chunk of entity keys
-   */
-  Long getChunkKey();
 }


### PR DESCRIPTION
## Description

Removes the usage of keyGenerator in the BatchOperationExecutionScheduler since this can cause memory safety issue and is not allowed. Instead we now just use the batch operation key for all follow up commands. We don't need own keys at this place.

See also here https://camunda.slack.com/archives/C05DH1F5TAR/p1743605166704629

## Related issues
closes #30536
