### PR TITLE
deps: bump 8.8 to alpha3

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha2
+CAMUNDA_VERSION=8.8.0-alpha3
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0-alpha2
+CONNECTORS_VERSION=8.8.0-alpha3
 # version of docker compose artifact (used for --docker option)
-COMPOSE_TAG=alpha
-COMPOSE_EXTRACTED_FOLDER=docker-compose-alpha
+COMPOSE_TAG=8.7
+COMPOSE_EXTRACTED_FOLDER=docker-compose-8.7


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

bump versions for 8.8-alpha3 release.

p.s. docker compose still points to 8.7 as we have no 8.8 release yet.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
