### PR TITLE
test: reenable schema integrity tests for optimize

### DIFF
--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -60,7 +60,6 @@ jobs:
 
   es-schema-integrity-test:
     name: Elasticsearch Schema Integrity Test
-    if: false
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:
@@ -132,7 +131,6 @@ jobs:
 
   os-schema-integrity-test:
     name: OpenSearch Schema Integrity Test
-    if: false
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -14,9 +14,6 @@
   <properties>
     <old.database.port>9250</old.database.port>
     <new.database.port>9200</new.database.port>
-    <!-- In order to allow the build to keep working, we need to specify an already released -->
-    <!-- previous version-->
-    <temporary.previous.version>8.6.0</temporary.previous.version>
   </properties>
 
   <!-- this is necessary. Dependency:analyze error suppressed -->
@@ -188,7 +185,7 @@
           <redirectTestOutputToFile>false</redirectTestOutputToFile>
           <failIfNoTests>true</failIfNoTests>
           <systemPropertyVariables>
-            <previousVersion>${temporary.previous.version}</previousVersion>
+            <previousVersion>${project.previousVersion}</previousVersion>
             <currentVersion>${project.version}</currentVersion>
             <buildDirectory>${project.build.directory}</buildDirectory>
             <oldDatabasePort>${old.database.port}</oldDatabasePort>
@@ -217,14 +214,14 @@
                 <artifactItem>
                   <groupId>io.camunda.optimize</groupId>
                   <artifactId>camunda-optimize</artifactId>
-                  <version>${temporary.previous.version}</version>
+                  <version>${project.previousVersion}</version>
                   <type>tar.gz</type>
                   <classifier>production</classifier>
                   <!-- we want to use environment variables as present in the internal service-config -->
                   <!-- thus excluding the default environment-config -->
                   <excludes>**/environment-config.yaml</excludes>
                   <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.directory}/${temporary.previous.version}</outputDirectory>
+                  <outputDirectory>${project.build.directory}/${project.previousVersion}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>io.camunda.optimize</groupId>


### PR DESCRIPTION
related to 27314

## Description

<!-- Describe the goal and purpose of this PR. -->

We disabled the Schema integrity tests in [this PR](https://github.com/camunda/camunda/pull/27257/files). Now 8.7 release is complete, we can reenable the upgrade tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27314
