### PR TITLE
fix: update operate port in core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/config/docker-compose.yml
+++ b/qa/core-application-e2e-test-suite/config/docker-compose.yml
@@ -77,9 +77,8 @@ services:
     container_name: operate-${DATABASE}
     image: camunda/operate:8.6.12
     ports:
-      - 8088:8081
+      - 8081:8080
     environment:
-      - SERVER_PORT=8081
       - SPRING_PROFILES_ACTIVE=dev,auth
     depends_on:
       - ${DATABASE}


### PR DESCRIPTION
## Description  
Operate was started on port 8088, but when the workflows started, they were trying to reach port 8081, marking it as unhealthy. So, I changed the ports here to use 8081.  

## Checklist  

<!--- Please delete options that are not relevant. Reviewers should check the appropriate boxes. -->  
- [ ] For CI changes:  
  - [ ] Structural/foundational changes approved by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)  
  - [ ] Modifications to [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)  
  - [ ] Enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)  

## Related issues  

Closes #  