### PR TITLE
ci: run daily statistics job early

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -3,7 +3,7 @@ name: Statistics Daily
 
 on:
   schedule:
-    - cron: '0 8 * * 2-5'  # Tuesdays to Fridays, to keep it actionable
+    - cron: '0 6 * * 2-5'  # Tuesdays to Fridays, to keep it actionable
   pull_request:
     paths:
       - '.github/workflows/statistics-daily.yml'


### PR DESCRIPTION
## Description

With daylight saving time change in Germany, the current time is 10 AM local Berlin which is later in the day than it needs to (the job looks at the data of the previous day until midnight).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
