### PR TITLE
ci: make GHA best practices linter extensible to more files

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -4,14 +4,12 @@ package main
 # aligned with the inclusion criteria and best practices:
 # See https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci
 
-unified_ci_workflow_names = ["CI", "Tasklist Frontend Jobs", "Zeebe CI"]
-
 # The `input` variable is a data structure that contains a YAML file's contents
 # as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_timeoutminutes(input.jobs)) > 0
 
@@ -20,8 +18,8 @@ deny[msg] {
 }
 
 warn[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
 
@@ -30,8 +28,8 @@ warn[msg] {
 }
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_cihealth(input.jobs)) > 0
 
@@ -40,8 +38,8 @@ deny[msg] {
 }
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_permissions(input.jobs)) > 0
 

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/camunda-helm-integration.yml"
   workflow_dispatch:
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   helm-deploy:
     name: Helm chart Integration Tests
@@ -83,3 +86,13 @@ jobs:
                 }
               ]
             }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ defaults:
 
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+  GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
   detect-changes:

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/statistics-daily.yml'
   workflow_dispatch: {}
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   flaky-tests:
     runs-on: ubuntu-latest
@@ -105,3 +108,13 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: "${{ steps.message.outputs.MESSAGE }}"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -3,6 +3,9 @@ name: Tasklist Frontend Jobs
 on:
   workflow_call: {}
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   fe-type-check:
     name: Type check

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -12,6 +12,7 @@ defaults:
 
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+  GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
   smoke-tests:


### PR DESCRIPTION
## Description

The `conftest` rules from https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria (which are mostly generally useful) to check GHA workflow YAML files for compliance are currently using a hard-coded list of workflow names to check.

This PR drops that hard-coded list and instead checks all GHA workflow YAML files that declare a dummy environment variable (is not actually used at runtime, just as a flag for `contftest` to identify workflows "opting-in" to the linter) on the workflow level:

```yaml
name: My cool GHA workflow

env:
  GHA_BEST_PRACTICES_LINTER: enabled

jobs: {}
```

The GHA workflow YAMLs sadly don't allow for unused/unknown keys so we have to exploit any existing key on the workflow level for our purpose.
This allows us to opt-in more GHA workflow YAML files into the linting checks and gradually improve quality.

This PR also does that by making the `.github/workflows/statistics-daily.yml` and the `.github/workflows/camunda-helm-integration.yml` part of the checks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
