### PR TITLE
Continue flow after completing the creating listener

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -49,7 +49,12 @@ public final class UserTaskCommandProcessors {
         new EnumMap<>(
             Map.of(
                 UserTaskIntent.CREATE,
-                new UserTaskCreateProcessor(),
+                new UserTaskCreateProcessor(
+                    processingState,
+                    writers,
+                    authCheckBehavior,
+                    bpmnBehaviors.userTaskBehavior(),
+                    bpmnBehaviors.jobBehavior()),
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -68,14 +68,16 @@ public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
-    final var initialAssignee = userTaskState.findInitialAssignee(userTaskKey);
 
-    if (initialAssignee.isPresent()) {
-      // clean up the changed attributes because we have already finished the creation,
-      // and are now starting a new transition to assigning
-      userTaskRecord.resetChangedAttributes();
-      assignUserTask(userTaskRecord, initialAssignee.get());
-    }
+    userTaskState
+        .findInitialAssignee(userTaskKey)
+        .ifPresent(
+            initialAssignee -> {
+              // clean up the changed attributes because we have already finished the creation,
+              // and are now starting a new transition to assigning
+              userTaskRecord.resetChangedAttributes();
+              assignUserTask(userTaskRecord, initialAssignee);
+            });
   }
 
   private void assignUserTask(final UserTaskRecord userTaskRecord, final String assignee) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -68,13 +68,13 @@ public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
-    final var intermediateAssignee = userTaskState.getIntermediateAssignee(userTaskKey);
+    final var initialAssignee = userTaskState.findInitialAssignee(userTaskKey);
 
-    if (intermediateAssignee != null) {
+    if (initialAssignee.isPresent()) {
       // clean up the changed attributes because we have already finished the creation,
       // and are now starting a new transition to assigning
       userTaskRecord.resetChangedAttributes();
-      assignUserTask(userTaskRecord, intermediateAssignee);
+      assignUserTask(userTaskRecord, initialAssignee.get());
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -7,16 +7,99 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
 
 public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
+
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final UserTaskState userTaskState;
+  private final StateWriter stateWriter;
+  private final UserTaskCommandPreconditionChecker preconditionChecker;
+  private final BpmnJobBehavior jobBehavior;
+  private final BpmnUserTaskBehavior userTaskBehavior;
+
+  public UserTaskCreateProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final BpmnUserTaskBehavior userTaskBehavior,
+      final BpmnJobBehavior jobBehavior) {
+    elementInstanceState = state.getElementInstanceState();
+    processState = state.getProcessState();
+    userTaskState = state.getUserTaskState();
+    stateWriter = writers.state();
+    preconditionChecker =
+        new UserTaskCommandPreconditionChecker(
+            List.of(LifecycleState.CREATING),
+            "create",
+            state.getUserTaskState(),
+            authCheckBehavior);
+    this.userTaskBehavior = userTaskBehavior;
+    this.jobBehavior = jobBehavior;
+  }
+
+  @Override
+  public Either<Rejection, UserTaskRecord> validateCommand(
+      final TypedRecord<UserTaskRecord> command) {
+    return preconditionChecker.check(command);
+  }
 
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
-    throw new UnsupportedOperationException(
-        "UserTaskCreateProcessor.onFinalizeCommand is not yet implemented. "
-            + "It should be covered by: https://github.com/camunda/camunda/issues/29122");
+    final long userTaskKey = command.getKey();
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+    final var intermediateAssignee = userTaskState.getIntermediateAssignee(userTaskKey);
+
+    if (intermediateAssignee != null) {
+      // clean up the changed attributes because we have already finished the creation,
+      // and are now starting a new transition to assigning
+      userTaskRecord.resetChangedAttributes();
+      assignUserTask(userTaskRecord, intermediateAssignee);
+    }
+  }
+
+  private void assignUserTask(final UserTaskRecord userTaskRecord, final String assignee) {
+    userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
+
+    final var element =
+        processState.getFlowElement(
+            userTaskRecord.getProcessDefinitionKey(),
+            userTaskRecord.getTenantId(),
+            userTaskRecord.getElementIdBuffer(),
+            ExecutableUserTask.class);
+
+    final var elementInstance =
+        elementInstanceState.getInstance(userTaskRecord.getElementInstanceKey());
+
+    final var context = new BpmnElementContextImpl();
+    context.init(elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
+
+    element.getTaskListeners(ZeebeTaskListenerEventType.assigning).stream()
+        .findFirst()
+        .ifPresentOrElse(
+            listener ->
+                jobBehavior.createNewTaskListenerJob(
+                    context, userTaskRecord, listener, List.of(UserTaskRecord.ASSIGNEE)),
+            () -> userTaskBehavior.userTaskAssigned(userTaskRecord, assignee));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -242,12 +242,14 @@ public class TaskListenerBlockedTransitionTest {
                 t ->
                     t.zeebeAssignee(assignee)
                         .zeebeTaskListener(l -> l.creating().type(listenerType + "_creating"))
+                        .zeebeTaskListener(l -> l.creating().type(listenerType + "_creating_2"))
                         .zeebeTaskListener(l -> l.assigning().type(listenerType + "_assigning"))
                         .zeebeTaskListener(l -> l.assigning().type(listenerType + "_assigning_2"))
                         .zeebeTaskListener(
                             l -> l.assigning().type(listenerType + "_assigning_3"))));
 
-    helper.completeJobs(processInstanceKey, listenerType + "_creating");
+    helper.completeJobs(
+        processInstanceKey, listenerType + "_creating", listenerType + "_creating_2");
 
     // when
     helper.completeJobs(
@@ -279,7 +281,9 @@ public class TaskListenerBlockedTransitionTest {
         .containsExactly(
             // assignee should be present in the CREATING
             tuple(UserTaskIntent.CREATING, assignee, action, List.of()),
-            // creating task listener completion, assignee should NOT be present
+            // creating first task listener completion, assignee should NOT be present
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, StringUtils.EMPTY, action, List.of()),
+            // creating second task listener completion, assignee should NOT be present
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, StringUtils.EMPTY, action, List.of()),
             // assignee should NOT be present in the CREATED
             tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action, List.of()),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
@@ -180,7 +180,8 @@ public class TaskListenerDenialsTest {
     // given
     final long processInstanceKey =
         helper.createProcessInstance(
-            helper.createUserTaskWithTaskListenersAndAssignee(listenerType, "first_assignee"));
+            helper.createUserTaskWithTaskListenersAndAssignee(
+                ZeebeTaskListenerEventType.assigning, "first_assignee", listenerType));
 
     ENGINE
         .job()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
@@ -132,13 +132,19 @@ public class TaskListenerTaskHeadersTest {
     // when
     final long processInstanceKey =
         helper.createProcessInstance(
-            helper.createUserTaskWithTaskListenersAndAssignee(
-                ZeebeTaskListenerEventType.creating, assignee, listenerType));
+            helper.createProcessWithZeebeUserTask(
+                t ->
+                    t.zeebeAssignee(assignee)
+                        .zeebeTaskListener(l -> l.creating().type(listenerType))));
 
     // then
-    final var firstListenerJob = helper.activateJob(processInstanceKey, listenerType);
-    assertThat(firstListenerJob.getCustomHeaders())
-        .containsEntry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, assignee);
+    helper.assertActivatedJob(
+        processInstanceKey,
+        listenerType,
+        job ->
+            assertThat(job.getCustomHeaders())
+                .describedAs("Expect first listener job to receive assignee header.")
+                .containsEntry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "initial_assignee"));
     helper.completeJobs(processInstanceKey, listenerType);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTestHelper.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTestHelper.java
@@ -107,12 +107,17 @@ public class TaskListenerTestHelper {
   }
 
   BpmnModelInstance createUserTaskWithTaskListenersAndAssignee(
-      final String listenerType, final String assignee) {
+      final ZeebeTaskListenerEventType listenerType,
+      String assignee,
+      final String... listenerTypes) {
     return createProcessWithZeebeUserTask(
-        taskBuilder ->
-            taskBuilder
-                .zeebeAssignee(assignee)
-                .zeebeTaskListener(l -> l.assigning().type(listenerType)));
+        taskBuilder -> {
+          taskBuilder.zeebeAssignee(assignee);
+          Stream.of(listenerTypes)
+              .forEach(
+                  type -> taskBuilder.zeebeTaskListener(l -> l.eventType(listenerType).type(type)));
+          return taskBuilder;
+        });
   }
 
   BpmnModelInstance createProcessWithCompletingTaskListeners(final String... listenerTypes) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -737,4 +737,9 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setChangedAttributes(changedAttributes);
     return this;
   }
+
+  public UserTaskRecord resetChangedAttributes() {
+    changedAttributesProp.reset();
+    return this;
+  }
 }


### PR DESCRIPTION
## Description

After a `creating` listener job is completed, we must continue the flow of the process. 

In this PR: 

- Implementation of `UserTaskCreateProcessor`:
  - It does not do anything `onCommand` as it's only used on continue after a completed listener job, or after incident resolution on a listener job
  - To finalize it:
    - appends the `created` event
    - retrieves the initial `assignee` from state
    - assigns if it is present, and creates an `assigning` listener job if needed 
 - Additional tests:
   - Triggering `assigning` listeners after `creating` listeners with defined assignee
   - Should have access to `assignee` in `creating` listener when defined on model
   - Should not have access to `assignee` in `creating` listener when no defined on model

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29122 
