### PR TITLE
fix: consolidated-auth profile Swager UI path authorization

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -93,7 +93,7 @@ public class WebSecurityConfig {
           // swagger-ui endpoint
           "/swagger-ui/**",
           "/v3/api-docs/**",
-          "/camunda-api-docs/**",
+          "/rest-api.yaml",
           // deprecated Tasklist v1 Public Endpoints
           "/new/**",
           "/favicon.ico");


### PR DESCRIPTION
## Description

Replace `/camunda-api-docs `to `/rest-api.yaml` on authorised paths for consolidated-auth profile. 

This update is only for the specific case of `consolidated-auth`
