### PR TITLE
fix: allow variables with null values in test cases

### DIFF
--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -117,7 +117,7 @@ public class VariableAssertTest {
     }
 
     @Test
-    void shouldPassIfHasVariableHasNullValue() {
+    void shouldPassIfHasVariableNamesIncludesNullValues() {
       // given
       final Variable variableA = newVariable("a", null);
       final Variable variableB = newVariable("b", null);
@@ -227,7 +227,7 @@ public class VariableAssertTest {
     }
 
     @Test
-    void shouldHasVariableWithNullValue() {
+    void shouldPassIfHasVariableContainsNullValues() {
       // given
       final Variable variableWithNull = newVariable("a", null);
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -117,6 +117,22 @@ public class VariableAssertTest {
     }
 
     @Test
+    void shouldPassIfHasVariableHasNullValue() {
+      // given
+      final Variable variableA = newVariable("a", null);
+      final Variable variableB = newVariable("b", null);
+
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
+    }
+
+    @Test
     void shouldWaitUntilHasVariableNames() {
       // given
       final Variable variableA = newVariable("a", "1");
@@ -208,6 +224,21 @@ public class VariableAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 1);
 
       verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldHasVariableWithNullValue() {
+      // given
+      final Variable variableWithNull = newVariable("a", null);
+
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableWithNull));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", null);
     }
 
     @Test
@@ -324,6 +355,27 @@ public class VariableAssertTest {
       final Map<String, Object> expectedVariables = new HashMap<>();
       expectedVariables.put("a", expectedValue);
       expectedVariables.put("b", 100);
+      CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
+    }
+
+    @Test
+    void shouldPassIfHasVariablesContainsNullValues() {
+      // given
+      final Variable variableA = newVariable("a", "1");
+      final Variable nullVariableB = newVariable("b", null);
+      final Variable nullVariableC = newVariable("c", null);
+
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, nullVariableB, nullVariableC));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 1);
+      expectedVariables.put("b", null);
+      expectedVariables.put("c", null);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
     }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -142,7 +142,7 @@ public class CamundaProcessResultCollectorTest {
   }
 
   @Test
-  void shouldReturnProcessInstanceVariablesWithNullValues() {
+  void shouldPassIfProcessInstanceVariablesContainsNullValues() {
     // given
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Collections.singletonList(PROCESS_INSTANCE_1));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -142,6 +142,31 @@ public class CamundaProcessResultCollectorTest {
   }
 
   @Test
+  void shouldReturnProcessInstanceVariablesWithNullValues() {
+    // given
+    when(camundaDataSource.findProcessInstances())
+        .thenReturn(Collections.singletonList(PROCESS_INSTANCE_1));
+
+    when(camundaDataSource.findVariablesByProcessInstanceKey(
+            PROCESS_INSTANCE_1.getProcessInstanceKey()))
+        .thenReturn(
+            Arrays.asList(
+                VariableBuilder.newVariable("var-1", "1").build(),
+                VariableBuilder.newVariable("var-2", null).build(),
+                VariableBuilder.newVariable("var-3", null).build()));
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result.getProcessInstanceTestResults().get(0).getVariables())
+        .hasSize(3)
+        .containsEntry("var-1", "1")
+        .containsEntry("var-2", null)
+        .containsEntry("var-3", null);
+  }
+
+  @Test
   void shouldReturnOpenIncidents() {
     // given
     when(camundaDataSource.findProcessInstances())


### PR DESCRIPTION
## Description

VariableAssertJ and CamundaTestResultCollector both fail when Camunda Variables have null values. The reason for this is that the `Collectors.toMap` collector doesn't allow null value mappings. It's possible to create a workaround, but this runs the (hopefully minor) risk of silently overwriting existing key values in the test environment. See more in this Stack Overflow answer which was used as the basis for this fix: https://stackoverflow.com/a/24634007
