### PR TITLE
feat: set a default retention policy name

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/RetentionConfiguration.java
@@ -8,9 +8,12 @@
 package io.camunda.search.schema.config;
 
 public class RetentionConfiguration {
+
+  private static final String DEFAULT_RETENTION_MINIMUM_AGE = "30d";
+  private static final String DEFAULT_RETENTION_POLICY_NAME = "camunda-history-retention-policy";
   private boolean enabled = false;
-  private String minimumAge = "30d";
-  private String policyName;
+  private String minimumAge = DEFAULT_RETENTION_MINIMUM_AGE;
+  private String policyName = DEFAULT_RETENTION_POLICY_NAME;
 
   public boolean isEnabled() {
     return enabled;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in [Slack](https://camunda.slack.com/archives/C06F0GLJNFM/p1743670960190279?thread_ts=1742994971.649189&cid=C06F0GLJNFM), currently Operate (`operate_delete_archived_indices`) and Tasklist (`tasklist_delete_archived_indices`) have hardcoded retention policy name, while in the new configuration we don't have any default value for it in the configuration.
To avoid the need to define it in the operator and other places, we can define a default value (`camunda-history-retention-policy`) with the possibility to override it if needed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
