### PR TITLE
[Backport stable/8.7] fix: allow variables with null values in test cases

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -21,10 +21,11 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.process.test.impl.client.VariableDto;
+import com.fasterxml.jackson.databind.node.NullNode;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -175,10 +176,18 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   private Map<String, String> getProcessInstanceVariables(final long processInstanceKey)
       throws IOException {
     return dataSource.getVariablesByProcessInstanceKey(processInstanceKey).stream()
-        .collect(Collectors.toMap(VariableDto::getName, VariableDto::getValue));
+        // We're deliberately switching from the Collectors.toMap collector to a custom
+        // implementation because it's allowed to have Camunda Variables with null values
+        // However, the toMap collector does not allow null values and would throw an exception.
+        // See this Stack Overflow issue for more context: https://stackoverflow.com/a/24634007
+        .collect(HashMap::new, (m, v) -> m.put(v.getName(), v.getValue()), HashMap::putAll);
   }
 
   private JsonNode readJson(final String value) {
+    if (value == null) {
+      return NullNode.getInstance();
+    }
+
     try {
       return jsonMapper.readValue(value, JsonNode.class);
     } catch (final JsonProcessingException e) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -119,6 +119,22 @@ public class VariableAssertTest {
     }
 
     @Test
+    void shouldPassIfHasVariableNamesIncludesNullValues() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", null);
+      final VariableDto variableB = newVariable("b", null);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
+    }
+
+    @Test
     void shouldWaitUntilHasVariableNames() throws IOException {
       // given
       final VariableDto variableA = newVariable("a", "1");
@@ -211,6 +227,21 @@ public class VariableAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 1);
 
       verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldPassIfHasVariableContainsNullValues() throws IOException {
+      // given
+      final VariableDto variableWithNull = newVariable("a", null);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableWithNull));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", null);
     }
 
     @Test
@@ -328,6 +359,27 @@ public class VariableAssertTest {
       final Map<String, Object> expectedVariables = new HashMap<>();
       expectedVariables.put("a", expectedValue);
       expectedVariables.put("b", 100);
+      CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
+    }
+
+    @Test
+    void shouldPassIfHasVariablesContainsNullValues() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto nullVariableB = newVariable("b", null);
+      final VariableDto nullVariableC = newVariable("c", null);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, nullVariableB, nullVariableC));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 1);
+      expectedVariables.put("b", null);
+      expectedVariables.put("c", null);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
     }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -131,6 +131,29 @@ public class CamundaProcessResultCollectorTest {
   }
 
   @Test
+  void shouldReturnProcessInstanceVariablesWithNullValues() throws IOException {
+    // given
+    final ProcessInstanceDto processInstance1 = newProcessInstance(1L, "process-a");
+    when(camundaDataSource.findProcessInstances())
+        .thenReturn(Collections.singletonList(processInstance1));
+
+    when(camundaDataSource.getVariablesByProcessInstanceKey(processInstance1.getKey()))
+        .thenReturn(
+            Arrays.asList(
+                newVariable("var-1", "1"), newVariable("var-2", null), newVariable("var-3", null)));
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result.getProcessInstanceTestResults().get(0).getVariables())
+        .hasSize(3)
+        .containsEntry("var-1", "1")
+        .containsEntry("var-2", null)
+        .containsEntry("var-3", null);
+  }
+
+  @Test
   void shouldReturnOpenIncidents() throws IOException {
     // given
     final ProcessInstanceDto processInstance1 = newProcessInstance(1L, "process-a");


### PR DESCRIPTION
# Description
Backport of #30572 to `stable/8.7`.

relates to 