### PR TITLE
[Backport stable/8.7] fix: StagedCache should only cache configured intents

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -93,17 +93,25 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
 
     @Override
     public void add(final Intent intent, final long key) {
+      if (!caches.containsKey(intent)) {
+        return;
+      }
       stagedKeys(intent).add(key);
     }
 
     @Override
     public boolean contains(final Intent intent, final long key) {
-      return stagedKeys(intent).contains(key)
-          || (caches.containsKey(intent) && caches.get(intent).contains(key));
+      if (!caches.containsKey(intent)) {
+        return false;
+      }
+      return stagedKeys(intent).contains(key) || caches.get(intent).contains(key);
     }
 
     @Override
     public void remove(final Intent intent, final long key) {
+      if (!caches.containsKey(intent)) {
+        return;
+      }
       stagedKeys(intent).remove(key);
     }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -128,6 +129,19 @@ final class BoundedScheduledCommandCacheTest {
 
   @Nested
   final class StagedTest {
+    @RegressionTest("https://github.com/camunda/camunda/pull/30560")
+    void shouldOnlyStageKeysForConfiguredCachedIntents() {
+      // given
+      final var cache = BoundedScheduledCommandCache.ofIntent(NOOP_METRICS, TimerIntent.TRIGGER);
+      final var staged = cache.stage();
+
+      // when
+      staged.add(JobIntent.TIME_OUT, 1);
+
+      // then
+      assertThat(staged.contains(JobIntent.TIME_OUT, 1)).isFalse();
+    }
+
     @Test
     void shouldNotContainStagedKeys() {
       // given


### PR DESCRIPTION
# Description
Backport of #30560 to `stable/8.7`.

relates to #30536