### PR TITLE
fix: resolve issues with OIDC setups

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -342,6 +342,13 @@ public class WebSecurityConfig {
         throws Exception {
       return httpSecurity
           .securityMatcher(WEBAPP_PATHS.toArray(new String[0]))
+          .authorizeHttpRequests(
+              (authorizeHttpRequests) ->
+                  authorizeHttpRequests
+                      .requestMatchers(UNPROTECTED_PATHS.toArray(String[]::new))
+                      .permitAll()
+                      .anyRequest()
+                      .authenticated())
           .headers(WebSecurityConfig::setupStrictTransportSecurity)
           .exceptionHandling(
               (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))

--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -43,7 +43,7 @@ export function logout(): Promise<void> {
   })
     .then((response: Response) => {
       if (response.status < 400) {
-        window.location.href = `${LOGIN_PATH}?next=${window.location.pathname}`;
+        window.location.href = `${getBaseUrl()}/`;
       }
     })
     .catch((e) => {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When the security chains were fixed in https://github.com/camunda/camunda/commit/aaf32b69cb7f7428e0dce6e58df9bea6b6b32e9e it highlighted that actually we had been operating under the assumption things were working (but now we understand they were working for the wrong reason).

When running in OIDC mode webapp paths were open allowing all the UI to load, meaning that when the Identity UI loaded it would get past the first step (load the page request) but then fail at the `/authentication/me` API call due to not having any authentication. This 401 would cause the Identity UI to redirect to the unprotected `/login` page and show the basic login page instead of triggering the oauth flows.

In this PR I make a small change to require authentication on the webapp paths in general, and also update the post logout path to head back to the base url.