### PR TITLE
Display helpful log messages in CPT

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
@@ -34,22 +34,14 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CamundaManagementClient {
-  private static final Logger LOG = LoggerFactory.getLogger(CamundaManagementClient.class);
 
   private static final String CLOCK_ENDPOINT = "/actuator/clock";
   private static final String CLOCK_ADD_ENDPOINT = "/actuator/clock/add";
 
   private static final String TOPOLOGY_ENDPOINT = "/v2/topology";
   private static final String CLUSTER_PURGE_ENDPOINT = "/actuator/cluster/purge";
-
-  private static final String CLUSTER_PURGE_FAILURE_MESSAGE_HINT =
-      "This could indicate that the client"
-          + " is unable to initiate a cluster purge. Please double-check that the containerRuntime"
-          + " has started and the containers are healthy.";
 
   private final ObjectMapper objectMapper =
       new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -126,12 +118,11 @@ public class CamundaManagementClient {
           .atMost(timeout)
           .until(() -> isPurgeComplete(startPurgeResponse.getChangeId()));
 
-      LOG.info("The cluster has been purged.");
     } catch (final ConditionTimeoutException e) {
-      LOG.warn(
-          "Failed to purge the cluster, timeout expired. " + CLUSTER_PURGE_FAILURE_MESSAGE_HINT);
+      throw new RuntimeException("Failed to purge the cluster, timeout expired.", e);
+
     } catch (final Exception e) {
-      LOG.warn("Failed to purge the cluster. " + CLUSTER_PURGE_FAILURE_MESSAGE_HINT, e);
+      throw new RuntimeException("Failed to purge the cluster.", e);
     }
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.impl.testresult;
 
-import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.search.enums.FlowNodeInstanceState;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.FlowNodeInstance;
@@ -26,13 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CamundaProcessTestResultCollector {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(CamundaProcessTestResultCollector.class);
 
   private final CamundaDataSource dataSource;
 
@@ -43,15 +37,11 @@ public class CamundaProcessTestResultCollector {
   public ProcessTestResult collect() {
     final ProcessTestResult result = new ProcessTestResult();
 
-    try {
-      final List<ProcessInstanceResult> processInstanceResults =
-          dataSource.findProcessInstances().stream()
-              .map(this::collectProcessInstanceResult)
-              .collect(Collectors.toList());
-      result.setProcessInstanceTestResults(processInstanceResults);
-    } catch (final ClientException e) {
-      LOG.warn("Failed to collect the process instance results.", e);
-    }
+    final List<ProcessInstanceResult> processInstanceResults =
+        dataSource.findProcessInstances().stream()
+            .map(this::collectProcessInstanceResult)
+            .collect(Collectors.toList());
+    result.setProcessInstanceTestResults(processInstanceResults);
 
     return result;
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -18,10 +18,8 @@ package io.camunda.process.test.impl.testresult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
@@ -65,19 +63,6 @@ public class CamundaProcessResultCollectorTest {
   void shouldReturnEmptyResult() {
     // given
     when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
-
-    // when
-    final ProcessTestResult result = resultCollector.collect();
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getProcessInstanceTestResults()).isEmpty();
-  }
-
-  @Test
-  void shouldReturnEmptyResultIfDataSourceThrowsException() {
-    // given
-    doThrow(new ClientException("expected failure")).when(camundaDataSource).findProcessInstances();
 
     // when
     final ProcessTestResult result = resultCollector.collect();

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -99,6 +99,11 @@
       <artifactId>httpcore5</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!--  test scope  -->
 
     <dependency>


### PR DESCRIPTION
## Description

The CamundaProcessTest Extensions (Java and Spring versions) don't have enough transparency. This makes it doubly surprising whenever an exception is thrown and the user is left wondering why and where a cluster purge was initiated, for example. We want to expose these details and be more transparent to the user while also reducing some verbosity in case an exception occurred or the containerRuntime couldn't be started.

This PR aims to:

- Fail-fast whenever the containerRuntime is null (cpt-java), most likely because the extension is used with a non-static field.
- Log whenever the cluster is being purged (and an initial log statement describing the test environment)
- Ignore errors from both the cluster purge and the testResultCollector. These are logged and the exceptions then skipped so that test execution can continue.
