### PR TITLE
refactor: add slack reporter to nightly test runs

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -17,15 +17,6 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Set Slack Reporter Flag
-        id: set-slack-reporter
-        run: |
-          if [[ "${{ matrix.branch }}" == "stable/8.7" || "${{ matrix.branch }}" == "main" ]]; then
-            echo "INCLUDE_SLACK_REPORTER=true" >> $GITHUB_ENV
-          else
-            echo "INCLUDE_SLACK_REPORTER=false" >> $GITHUB_ENV
-          fi
-
       - name: Start Tasklist and Operate
         run: |
           DATABASE=elasticsearch docker compose up -d tasklist operate
@@ -126,7 +117,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8089"
-          INCLUDE_SLACK_REPORTER: ${{ env.INCLUDE_SLACK_REPORTER }}
+          INCLUDE_SLACK_REPORTER: true
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.CORE_DOMAIN_SLACK_BOT_TOKEN }}
           VERSION: ${{ matrix.branch }}
         run: npm run test -- --project=chromium

--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -17,6 +17,15 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - name: Set Slack Reporter Flag
+        id: set-slack-reporter
+        run: |
+          if [[ "${{ matrix.branch }}" == "stable/8.7" || "${{ matrix.branch }}" == "main" ]]; then
+            echo "INCLUDE_SLACK_REPORTER=true" >> $GITHUB_ENV
+          else
+            echo "INCLUDE_SLACK_REPORTER=false" >> $GITHUB_ENV
+          fi
+
       - name: Start Tasklist and Operate
         run: |
           DATABASE=elasticsearch docker compose up -d tasklist operate
@@ -94,6 +103,7 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
             secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
+            secret/data/github.com/organizations/camunda CORE_DOMAIN_SLACK_BOT_TOKEN;
 
       - name: Install Playwright Browsers
         shell: bash
@@ -116,6 +126,9 @@ jobs:
           CAMUNDA_BASIC_AUTH_USERNAME: "demo"
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8089"
+          INCLUDE_SLACK_REPORTER: ${{ env.INCLUDE_SLACK_REPORTER }}
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.CORE_DOMAIN_SLACK_BOT_TOKEN }}
+          VERSION: ${{ matrix.branch }}
         run: npm run test -- --project=chromium
         working-directory: qa/core-application-e2e-test-suite
 

--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -140,7 +140,7 @@ jobs:
             --project 'Core Application' \
             --username $TESTRAIL_USERNAME \
             --key $TESTRAIL_KEY \
-            parse_junit --title "On Demand Core Application Test Run Results-  ${{ github.event.inputs.branch }}" \
+            parse_junit --title "On Demand Core Application Test Run Results -  ${{ github.event.inputs.branch }}" \
             --close-run \
             -f $JUNIT_RESULTS_FILE
 

--- a/qa/core-application-e2e-test-suite/playwright.config.ts
+++ b/qa/core-application-e2e-test-suite/playwright.config.ts
@@ -21,11 +21,13 @@ const useReportersWithSlack: any[] = [
   [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
-      slackWebHookUrl: process.env.SLACK_WEBHOOK_URL!,
+      slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
+      channels: ['core-application-e2e-test-results'],
       sendResults: 'always',
+      showInThread: true,
       meta: [
         {
-          key: 'Nightly Test Results for Mono Repo - 8.8',
+          key: `Nightly Test Results for Mono Repo - ${process.env.VERSION}`,
           value: `<https://github.com/camunda/camunda/actions/runs/${process.env.GITHUB_RUN_ID}|📊>`,
         },
       ],


### PR DESCRIPTION
## Description  

This PR adds a Slack integration app that publishes nightly test run results for versions 8.7 and 8.8 to the `core-application-e2e-test-results` channel.  

## Checklist  

<!--- Please delete options that are not relevant. Boxes should be checked by the reviewer. -->  
- [ ] For CI changes:  
  - [ ] Structural/foundational changes signed off by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)  
  - [ ] Modifications in [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)  
  - [ ] Enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)  

## Related issues  

Closes #  
