### PR TITLE
[CPT] Assert that a process instance completed the given elements in order

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -107,6 +107,34 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasCompletedElements(ElementSelector... elementSelectors);
 
   /**
+   * Verifies that the given BPMN elements are completed in order. Elements that do not match any of
+   * the given element IDs are ignored.
+   *
+   * <p>The verification fails if at least one of the elements is not completed, or the order is not
+   * correct.
+   *
+   * <p>The assertion waits until all elements are left.
+   *
+   * @param elementIds the BPMN element IDs
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCompletedElementsInOrder(String... elementIds);
+
+  /**
+   * Verifies that the given BPMN elements are completed in order. Elements that do not match any of
+   * the given element selectors are ignored.
+   *
+   * <p>The verification fails if at least one of the elements is not completed, or the order is not
+   * correct.
+   *
+   * <p>The assertion waits until all elements are left.
+   *
+   * @param elementSelectors the selectors for the BPMN elements
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCompletedElementsInOrder(ElementSelector... elementSelectors);
+
+  /**
    * Verifies that the given BPMN elements are terminated. The verification fails if at least one
    * element is active, completed, or not entered.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -131,6 +131,21 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasCompletedElementsInOrder(final String... elementIds) {
+    elementAssertj.hasCompletedElementsInOrder(
+        getProcessInstanceKey(), toElementSelectors(elementIds));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCompletedElementsInOrder(
+      final ElementSelector... elementSelectors) {
+    elementAssertj.hasCompletedElementsInOrder(
+        getProcessInstanceKey(), Arrays.asList(elementSelectors));
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasTerminatedElements(final String... elementIds) {
     elementAssertj.hasTerminatedElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;


### PR DESCRIPTION
## Description

Adds `assertThat(processInstance).hasCompletedElementsInOrder("A", "B", "C");` to assert that a process instance completed the given elements in order.

## Related issues

closes #23191
