### PR TITLE
fix: remove un-needed artifact upload from the nightly test run

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -141,9 +141,3 @@ jobs:
             parse_junit --title "Nightly Core Application Run Test Results - $BRANCH_NAME - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
             -f $JUNIT_RESULTS_FILE
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: Core Application E2E Test Result
-          path: qa/core-application-e2e-test-suite/html-report
-          retention-days: 10


### PR DESCRIPTION
## Description  
The nightly tests were failing due to issues with artifact upload. In this PR, the artifact upload step has been removed, as the results are already being published to TestRail and Slack.

## Checklist  

<!--- Please delete options that are not relevant. Boxes should be checked by the reviewer. -->  
- [ ] for CI changes:  
  - [ ] Structural/foundational changes signed off by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)  
  - [ ] [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)  
  - [ ] Enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)  

## Related issues  

Closes #
