### PR TITLE
refactor: add slack reporter for nightly 8.6 core application test run

### DIFF
--- a/qa/core-application-e2e-test-suite/playwright.config.ts
+++ b/qa/core-application-e2e-test-suite/playwright.config.ts
@@ -21,11 +21,13 @@ const useReportersWithSlack: any[] = [
   [
     './node_modules/playwright-slack-report/dist/src/SlackReporter.js',
     {
-      slackWebHookUrl: process.env.SLACK_WEBHOOK_URL!,
+      slackOAuthToken: process.env.SLACK_BOT_USER_OAUTH_TOKEN!,
+      channels: ['core-application-e2e-test-results'],
       sendResults: 'always',
+      showInThread: true,
       meta: [
         {
-          key: 'Nightly Test Results for Mono Repo - 8.6',
+          key: `Nightly Test Results for Mono Repo - ${process.env.VERSION}`,
           value: `<https://github.com/camunda/camunda/actions/runs/${process.env.GITHUB_RUN_ID}|📊>`,
         },
       ],


### PR DESCRIPTION
## Description  

This PR updates the Playwright configuration to enable the Slack reporter, allowing the results of the core application nightly tests to be published to Slack.

## Checklist  

<!--- Please delete options that are not relevant. Boxes should be checked by the reviewer. -->  
- [ ] for CI changes:  
  - [ ] Structural/foundational changes signed off by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)  
  - [ ] [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)  
  - [ ] Enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)  

## Related issues  

Closes #
