### PR TITLE
[renovate] Avoid version update for Maven packages detected as parent

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -147,6 +147,14 @@
       "enabled": false
     },
     {
+      "description": "Exclude Maven packages detected as parent root",
+      "matchManagers": ["maven"],
+      "matchDepTypes": [
+        "parent-root"
+      ],
+      "enabled": false
+    }
+    {
       "matchPackageNames": ["mcr.microsoft.com/playwright"],
       "additionalBranchPrefix": "fe-"
     },


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Renovate was trying to update a parent dependency from the project https://github.com/camunda/camunda/pull/30628 and https://github.com/camunda/camunda/pull/30629
To prevent that, adding a package rule as documented in https://docs.renovatebot.com/presets-workarounds/#workaroundsdisablemavenparentroot

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
