### PR TITLE
[Backport stable/8.4] try to not overwrite committed data when quorum of nodes experienced data loss

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.DeterministicSingleThreadContext;
 import java.time.Duration;
 import java.util.List;
@@ -33,7 +34,7 @@ final class PriorityElectionTimerTest {
 
   private final Logger log = LoggerFactory.getLogger(PriorityElectionTimerTest.class);
   private final DeterministicSingleThreadContext threadContext =
-      new DeterministicSingleThreadContext(new DeterministicScheduler());
+      new DeterministicSingleThreadContext(new DeterministicScheduler(), MemberId.from(""));
 
   @AfterEach
   void afterEach() {

--- a/atomix/cluster/src/test/resources/log4j2-test.xml
+++ b/atomix/cluster/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name} %X{actor-scheduler}] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
# Description
Backport of #30290 to `stable/8.4`.

relates to #30057