### PR TITLE
[Backport stable/8.6] try to not overwrite committed data when quorum of nodes experienced data loss

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -584,8 +584,8 @@ public class PassiveRole extends InactiveRole {
     // Append the entries to the log.
     appendEntries(request, future);
 
-    // If a snapshot replication was ongoing, reset it. Otherwise SnapshotReplicationListeners will
-    // wait for ever for the snapshot to be received.
+    // If a snapshot replication was ongoing, reset it. Otherwise, SnapshotReplicationListeners will
+    // wait forever for the snapshot to be received.
     abortPendingSnapshots();
     return future;
   }
@@ -758,7 +758,7 @@ public class PassiveRole extends InactiveRole {
     }
 
     // Set the first commit index.
-    raft.setFirstCommitIndex(request.commitIndex());
+    raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
 
     // Update the context commit and global indices.
     final long previousCommitIndex = raft.setCommitIndex(commitIndex);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Uses a DeterministicScheduler and controllable messaging layer to get a deterministic execution
@@ -222,7 +223,7 @@ public final class ControllableRaftContexts {
             memberId,
             m ->
                 (DeterministicSingleThreadContext)
-                    DeterministicSingleThreadContext.createContext());
+                    DeterministicSingleThreadContext.createContext(memberId));
   }
 
   private RaftStorage createStorage(
@@ -382,12 +383,17 @@ public final class ControllableRaftContexts {
   }
 
   public void restart(final MemberId memberId) {
-    raftServers.get(memberId).close();
+    final var raftcontext = raftServers.get(memberId);
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      raftServers.get(memberId).close();
+    }
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    newContext.getCluster().bootstrap(raftServers.keySet());
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      newContext.getCluster().bootstrap(raftServers.keySet());
+    }
   }
 
   // This is a different from other operations, as it restarts the node and force operations on
@@ -396,7 +402,9 @@ public final class ControllableRaftContexts {
   // of one node at a time.
   public void restartWithDataLoss(final MemberId memberId) {
     LOG.info("Shutting down member {}", memberId.id());
-    raftServers.get(memberId).close();
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      raftServers.get(memberId).close();
+    }
     deterministicExecutors.remove(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
     final var nodeBeforeRestart = raftServers.remove(memberId);
@@ -415,7 +423,9 @@ public final class ControllableRaftContexts {
       throw new UncheckedIOException(e);
     }
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    newContext.getCluster().bootstrap(raftServers.keySet());
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      newContext.getCluster().bootstrap(raftServers.keySet());
+    }
 
     raftServers.put(memberId, newContext);
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RaftCorruptedDataTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RaftCorruptedDataTest.class);
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  @DisplayName(
+      "When nodes with corrupted data forms a quorum, the remaining one should not delete its files")
+  public void upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption() throws Exception {
+    // given
+    // nodes 0, 1 experience corruption: all data is lost
+    final var servers = raftRule.getServers().toArray(RaftServer[]::new);
+    // name == memberId since the name is not specified
+    final var node0 = MemberId.from(servers[0].name());
+    final var node1 = MemberId.from(servers[1].name());
+    final var node2 = MemberId.from(servers[2].name());
+
+    raftRule.appendEntries(2000);
+    raftRule.appendEntries(1);
+    Awaitility.await("commitIndex is > 0 on all nodes")
+        .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
+
+    final var commitIndex = servers[2].getContext().getCommitIndex();
+
+    for (final RaftServer server : servers) {
+      raftRule.shutdownServer(server);
+    }
+
+    raftRule.triggerDataLossOnNode(node0.id());
+    raftRule.triggerDataLossOnNode(node1.id());
+
+    // after shutdown the servers must be created from scratch with the same server name.
+    final var server0 = raftRule.createServer(node0);
+    final var server1 = raftRule.createServer(node1);
+
+    // bootstrap the nodes with data loss
+    CompletableFuture.allOf(
+            server0.bootstrap(node0, node1, node2), server1.bootstrap(node0, node1, node2))
+        .join();
+
+    // wait for the two corrupted nodes to form quorum
+    Awaitility.await("corrupted nodes form a quorum")
+        .until(() -> server0.isLeader() || server1.isLeader());
+    raftRule.appendEntries(1000);
+    raftRule.takeCompactingSnapshot(server0, 500, 1);
+    raftRule.takeCompactingSnapshot(server1, 500, 1);
+
+    // when
+    // the node with up-to-date log joins the cluster
+    final var server2 = raftRule.createServer(node2);
+
+    // then
+    // trigger bootstrap async
+    server2.bootstrap(node0, node1, node2);
+
+    raftRule.appendEntries(1);
+
+    // node does not become follower - goes to inactive as it detects that it has longer log
+    Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole() == Role.INACTIVE);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.DeterministicSingleThreadContext;
 import java.time.Duration;
 import java.util.List;
@@ -33,7 +34,7 @@ final class PriorityElectionTimerTest {
 
   private final Logger log = LoggerFactory.getLogger(PriorityElectionTimerTest.class);
   private final DeterministicSingleThreadContext threadContext =
-      new DeterministicSingleThreadContext(new DeterministicScheduler());
+      new DeterministicSingleThreadContext(new DeterministicScheduler(), MemberId.from(""));
 
   @AfterEach
   void afterEach() {

--- a/zeebe/atomix/cluster/src/test/resources/log4j2-test.xml
+++ b/zeebe/atomix/cluster/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name} %X{actor-scheduler}] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
# Description
Backport of #30290 to `stable/8.6`.

relates to #30057