### PR TITLE
feat: migrate InputOutputMappings component to V2 API

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/InputOutputMappings/index.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {observer} from 'mobx-react';
 import {getMappings} from 'modules/bpmn-js/utils/getInputOutputMappings';
@@ -15,6 +14,8 @@ import {IOMappingInfoBanner} from './IOMappingInfoBanner';
 import {useState} from 'react';
 import {getStateLocally} from 'modules/utils/localStorage';
 import {StructuredList} from 'modules/components/StructuredList';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const INFORMATION_TEXT = {
   Input:
@@ -37,8 +38,9 @@ const InputOutputMappings: React.FC<Props> = observer(({type}) => {
     return null;
   }
 
-  const businessObject =
-    processInstanceDetailsDiagramStore.businessObjects[flowNodeId];
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {data} = useProcessInstanceXml({processDefinitionKey});
+  const businessObject = data?.businessObjects[flowNodeId];
 
   const mappings =
     businessObject === undefined ? [] : getMappings(businessObject, type);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -34,6 +34,7 @@ import {Paths} from 'modules/Routes';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 
 jest.mock('modules/stores/processInstanceListeners', () => ({
   processInstanceListenersStore: {
@@ -125,10 +126,7 @@ describe('New Variable Modifications', () => {
       },
     ]);
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([createVariable()]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -35,6 +35,16 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
 
+jest.mock('modules/stores/processInstanceListeners', () => ({
+  processInstanceListenersStore: {
+    state: {},
+    listenersFailureCount: 0,
+    reset: () => {},
+    fetchListeners: () => {},
+    setListenerTabVisibility: () => {},
+  },
+}));
+
 const editNameFromTextfieldAndBlur = async (user: UserEvent, value: string) => {
   const [nameField] = screen.getAllByTestId('new-variable-name');
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -31,6 +31,9 @@ import {singleInstanceMetadata} from 'modules/mocks/metadata';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
 import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
 
 const editNameFromTextfieldAndBlur = async (user: UserEvent, value: string) => {
   const [nameField] = screen.getAllByTestId('new-variable-name');
@@ -83,11 +86,13 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   }, []);
 
   return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route path={Paths.processInstance()} element={children} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 };
 
@@ -110,6 +115,10 @@ describe('New Variable Modifications', () => {
       },
     ]);
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([createVariable()]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -55,6 +55,16 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/stores/processInstanceListeners', () => ({
+  processInstanceListenersStore: {
+    state: {},
+    listenersFailureCount: 0,
+    reset: () => {},
+    fetchListeners: () => {},
+    setListenerTabVisibility: () => {},
+  },
+}));
+
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => {
     return () => {

--- a/operate/client/src/App/ProcessInstance/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/index.test.tsx
@@ -44,25 +44,6 @@ jest.mock('modules/stores/notifications', () => ({
 
 jest.mock('modules/utils/bpmn');
 
-jest.mock('modules/stores/processInstanceListeners', () => ({
-  processInstanceListenersStore: {
-    state: {},
-    listenersFailureCount: 0,
-    reset: () => {},
-    fetchListeners: () => {},
-    setListenerTabVisibility: () => {},
-  },
-}));
-
-jest.mock(
-  'modules/queries/processDefinitions/useProcessInstanceXml.ts',
-  () => ({
-    useProcessInstanceXml: jest.fn(() => ({
-      data: undefined,
-    })),
-  }),
-);
-
 const clearPollingStates = () => {
   variablesStore.isPollRequestRunning = false;
   sequenceFlowsStore.isPollRequestRunning = false;

--- a/operate/client/src/App/ProcessInstance/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/index.test.tsx
@@ -44,6 +44,15 @@ jest.mock('modules/stores/notifications', () => ({
 
 jest.mock('modules/utils/bpmn');
 
+jest.mock(
+  'modules/queries/processDefinitions/useProcessInstanceXml.ts',
+  () => ({
+    useProcessInstanceXml: jest.fn(() => ({
+      data: undefined,
+    })),
+  }),
+);
+
 const clearPollingStates = () => {
   variablesStore.isPollRequestRunning = false;
   sequenceFlowsStore.isPollRequestRunning = false;

--- a/operate/client/src/App/ProcessInstance/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/index.test.tsx
@@ -44,6 +44,16 @@ jest.mock('modules/stores/notifications', () => ({
 
 jest.mock('modules/utils/bpmn');
 
+jest.mock('modules/stores/processInstanceListeners', () => ({
+  processInstanceListenersStore: {
+    state: {},
+    listenersFailureCount: 0,
+    reset: () => {},
+    fetchListeners: () => {},
+    setListenerTabVisibility: () => {},
+  },
+}));
+
 jest.mock(
   'modules/queries/processDefinitions/useProcessInstanceXml.ts',
   () => ({

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -43,6 +43,7 @@ import {notificationsStore} from 'modules/stores/notifications';
 import {Frame} from 'modules/components/Frame';
 import {processInstanceListenersStore} from 'modules/stores/processInstanceListeners';
 import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const startPolling = (processInstanceId: ProcessInstanceEntity['id']) => {
   variablesStore.startPolling(processInstanceId, {runImmediately: true});
@@ -173,6 +174,10 @@ const ProcessInstance: React.FC = observer(() => {
   }, []);
 
   const {
+    state: {processInstance},
+  } = processInstanceDetailsStore;
+
+  const {
     isModificationModeEnabled,
     state: {modifications, status: modificationStatus},
   } = modificationsStore;
@@ -193,7 +198,7 @@ const ProcessInstance: React.FC = observer(() => {
   }
 
   return (
-    <>
+    <ProcessDefinitionKeyContext.Provider value={processInstance?.processId}>
       <VisuallyHiddenH1>
         {`Operate Process Instance${
           isModificationModeEnabled ? ' - Modification Mode' : ''
@@ -327,7 +332,7 @@ const ProcessInstance: React.FC = observer(() => {
           </p>
         </Modal>
       )}
-    </>
+    </ProcessDefinitionKeyContext.Provider>
   );
 });
 

--- a/operate/client/src/App/ProcessInstance/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/mocks.tsx
@@ -47,6 +47,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('4294980768');
 
@@ -75,10 +76,7 @@ const mockRequests = (contextPath: string = '') => {
     count: 2,
   });
   mockFetchProcess(contextPath).withSuccess(mockProcess);
-  mockFetchProcessInstanceListeners(contextPath).withSuccess({
-    listeners: [],
-    totalCount: 0,
-  });
+  mockFetchProcessInstanceListeners(contextPath).withSuccess(noListeners);
 };
 
 type FlowNodeSelectorProps = {

--- a/operate/client/src/App/ProcessInstance/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/mocks.tsx
@@ -42,6 +42,11 @@ import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcess} from 'modules/mocks/api/processes/fetchProcess';
 import {mockProcess} from './ProcessInstanceHeader/index.setup';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('4294980768');
 
@@ -50,6 +55,7 @@ const mockRequests = (contextPath: string = '') => {
     testData.fetch.onPageLoad.processInstanceWithIncident,
   );
   mockFetchProcessXML(contextPath).withSuccess('');
+  mockFetchProcessDefinitionXml({contextPath}).withSuccess('');
   mockFetchSequenceFlows(contextPath).withSuccess(mockSequenceFlows);
   mockFetchFlowNodeInstances(contextPath).withSuccess(
     processInstancesMock.level1,
@@ -69,6 +75,10 @@ const mockRequests = (contextPath: string = '') => {
     count: 2,
   });
   mockFetchProcess(contextPath).withSuccess(mockProcess);
+  mockFetchProcessInstanceListeners(contextPath).withSuccess({
+    listeners: [],
+    totalCount: 0,
+  });
 };
 
 type FlowNodeSelectorProps = {
@@ -108,22 +118,26 @@ function getWrapper(options?: {
     }, []);
 
     return (
-      <HistoryRouter
-        history={createMemoryHistory({
-          initialEntries: [initialPath],
-        })}
-        basename={contextPath ?? ''}
-      >
-        <Routes>
-          <Route path={Paths.processInstance()} element={children} />
-          <Route path={Paths.processes()} element={<>instances page</>} />
-          <Route path={Paths.dashboard()} element={<>dashboard page</>} />
-        </Routes>
-        {selectableFlowNode && (
-          <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
-        )}
-        <LocationLog />
-      </HistoryRouter>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <HistoryRouter
+            history={createMemoryHistory({
+              initialEntries: [initialPath],
+            })}
+            basename={contextPath ?? ''}
+          >
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+              <Route path={Paths.processes()} element={<>instances page</>} />
+              <Route path={Paths.dashboard()} element={<>dashboard page</>} />
+            </Routes>
+            {selectableFlowNode && (
+              <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
+            )}
+            <LocationLog />
+          </HistoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 

--- a/operate/client/src/App/ProcessInstance/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/modifications.test.tsx
@@ -44,6 +44,14 @@ jest.mock('modules/utils/bpmn');
 jest.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: jest.fn()},
 }));
+jest.mock(
+  'modules/queries/processDefinitions/useProcessInstanceXml.ts',
+  () => ({
+    useProcessInstanceXml: jest.fn(() => ({
+      data: undefined,
+    })),
+  }),
+);
 
 describe('ProcessInstance - modification mode', () => {
   beforeEach(() => {

--- a/operate/client/src/App/ProcessInstance/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/modifications.test.tsx
@@ -44,6 +44,15 @@ jest.mock('modules/utils/bpmn');
 jest.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: jest.fn()},
 }));
+jest.mock('modules/stores/processInstanceListeners', () => ({
+  processInstanceListenersStore: {
+    state: {},
+    listenersFailureCount: 0,
+    reset: () => {},
+    fetchListeners: () => {},
+    setListenerTabVisibility: () => {},
+  },
+}));
 jest.mock(
   'modules/queries/processDefinitions/useProcessInstanceXml.ts',
   () => ({

--- a/operate/client/src/App/ProcessInstance/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/modifications.test.tsx
@@ -31,6 +31,7 @@ import {mockModify} from 'modules/mocks/api/processInstances/modify';
 import {getWrapper, mockRequests, waitForPollingsToBeComplete} from './mocks';
 import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 
 const clearPollingStates = () => {
   variablesStore.isPollRequestRunning = false;
@@ -181,19 +182,13 @@ describe('ProcessInstance - modification mode', () => {
       }),
     );
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     await user.click(screen.getByRole('button', {name: 'Select flow node'}));
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(
@@ -202,10 +197,7 @@ describe('ProcessInstance - modification mode', () => {
       }),
     );
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(screen.getByTestId('apply-modifications-button'));
@@ -388,19 +380,13 @@ describe('ProcessInstance - modification mode', () => {
       screen.getByText('Process Instance Modification Mode'),
     ).toBeInTheDocument();
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     await user.click(screen.getByRole('button', {name: 'Select flow node'}));
 
-    mockFetchProcessInstanceListeners().withSuccess({
-      listeners: [],
-      totalCount: 0,
-    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(

--- a/operate/client/src/App/ProcessInstance/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/modifications.test.tsx
@@ -30,6 +30,7 @@ import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetc
 import {mockModify} from 'modules/mocks/api/processInstances/modify';
 import {getWrapper, mockRequests, waitForPollingsToBeComplete} from './mocks';
 import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
 
 const clearPollingStates = () => {
   variablesStore.isPollRequestRunning = false;
@@ -44,23 +45,6 @@ jest.mock('modules/utils/bpmn');
 jest.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: jest.fn()},
 }));
-jest.mock('modules/stores/processInstanceListeners', () => ({
-  processInstanceListenersStore: {
-    state: {},
-    listenersFailureCount: 0,
-    reset: () => {},
-    fetchListeners: () => {},
-    setListenerTabVisibility: () => {},
-  },
-}));
-jest.mock(
-  'modules/queries/processDefinitions/useProcessInstanceXml.ts',
-  () => ({
-    useProcessInstanceXml: jest.fn(() => ({
-      data: undefined,
-    })),
-  }),
-);
 
 describe('ProcessInstance - modification mode', () => {
   beforeEach(() => {
@@ -197,11 +181,19 @@ describe('ProcessInstance - modification mode', () => {
       }),
     );
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     await user.click(screen.getByRole('button', {name: 'Select flow node'}));
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(
@@ -210,6 +202,10 @@ describe('ProcessInstance - modification mode', () => {
       }),
     );
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(screen.getByTestId('apply-modifications-button'));
@@ -392,11 +388,19 @@ describe('ProcessInstance - modification mode', () => {
       screen.getByText('Process Instance Modification Mode'),
     ).toBeInTheDocument();
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     await user.click(screen.getByRole('button', {name: 'Select flow node'}));
 
+    mockFetchProcessInstanceListeners().withSuccess({
+      listeners: [],
+      totalCount: 0,
+    });
     mockFetchVariables().withSuccess([createVariable()]);
 
     await user.click(

--- a/operate/client/src/modules/mocks/mockProcessInstanceListeners.ts
+++ b/operate/client/src/modules/mocks/mockProcessInstanceListeners.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const noListeners = {listeners: [], totalCount: 0};
+
+export {noListeners};

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
@@ -60,6 +60,7 @@ function useProcessDefinitionXml<T extends ParsedXmlData = ParsedXmlData>({
           }
         : skipToken,
     select,
+    staleTime: Infinity,
   });
 }
 

--- a/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  ParsedXmlData,
+  useProcessDefinitionXml,
+} from './useProcessDefinitionXml';
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {isFlowNode} from 'modules/utils/flowNodes';
+
+type ExtendedParsedXmlData = ParsedXmlData & {
+  businessObjects: {[key: string]: BusinessObject};
+};
+
+function processInstanceXmlParser({
+  xml,
+  diagramModel,
+  selectableFlowNodes,
+}: ParsedXmlData) {
+  const businessObjects = Object.entries(diagramModel.elementsById).reduce(
+    (flowNodes, [flowNodeId, businessObject]) => {
+      if (isFlowNode(businessObject)) {
+        return {...flowNodes, [flowNodeId]: businessObject};
+      } else {
+        return flowNodes;
+      }
+    },
+    {},
+  );
+
+  return {
+    xml,
+    diagramModel,
+    selectableFlowNodes,
+    businessObjects,
+  };
+}
+
+function useProcessInstanceXml({
+  processDefinitionKey,
+}: {
+  processDefinitionKey?: string;
+}) {
+  return useProcessDefinitionXml<ExtendedParsedXmlData>({
+    processDefinitionKey,
+    select: processInstanceXmlParser,
+    enabled: !!processDefinitionKey,
+  });
+}
+
+export {useProcessInstanceXml};


### PR DESCRIPTION
## Description

This PR is part of https://github.com/camunda/camunda/issues/30591 with the goal to replace processInstanceDetailsDiagramStore by Tanstack query.

#### InputOutputMappings component
- remove dependency to processInstanceDetailsDiagramStore
- add query to v2 XML API

#### Misc
- Adjust tests 
- Set staleTime for process defnition xml to infinity, because the XML for a given process definition key is static and will never change. This avoids unnecessary re-fetches
- mock processInstanceListenersStore in test that are not related to listeners to avoid console warnings

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591
