### PR TITLE
perf: minor msgpack improvements

### DIFF
--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
@@ -240,7 +240,7 @@ public final class MsgPackReader {
    *
    * @return the value
    */
-  public strictfp double readFloat() {
+  public double readFloat() {
     final byte headerByte = buffer.getByte(offset);
     ++offset;
     final double value;
@@ -265,29 +265,16 @@ public final class MsgPackReader {
     final byte headerByte = buffer.getByte(offset);
     ++offset;
 
-    final boolean theBool;
-
-    switch (headerByte) {
-      case TRUE:
-        theBool = true;
-        break;
-
-      case FALSE:
-        theBool = false;
-        break;
-
-      default:
-        throw exceptionOnUnknownHeader("boolean", headerByte);
-    }
-
-    return theBool;
+    return switch (headerByte) {
+      case TRUE -> true;
+      case FALSE -> false;
+      default -> throw exceptionOnUnknownHeader("boolean", headerByte);
+    };
   }
 
   public MsgPackToken readToken() {
     final byte b = buffer.getByte(offset);
     final MsgPackFormat format = MsgPackFormat.valueOf(b);
-
-    final int currentOffset = offset;
 
     switch (format.type) {
       case INTEGER:

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackReader.java
@@ -333,8 +333,6 @@ public final class MsgPackReader {
             String.format("Unknown token format '%s'", format.getType().name()));
     }
 
-    token.setTotalLength(offset - currentOffset);
-
     return token;
   }
 

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackToken.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackToken.java
@@ -49,14 +49,8 @@ public final class MsgPackToken {
   public void setValue(final DirectBuffer buffer, final int offset, final int length) {
     if (length == 0) {
       valueBuffer.wrap(0, 0);
-    } else if (offset + length <= buffer.capacity()) {
-      valueBuffer.wrap(buffer, offset, length);
     } else {
-      final int result = offset + length;
-      throw new MsgpackReaderException(
-          String.format(
-              "Reading %d bytes past buffer capacity(%d) in range [%d:%d]",
-              result - buffer.capacity(), buffer.capacity(), offset, result));
+      valueBuffer.wrap(buffer, offset, length);
     }
   }
 

--- a/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackToken.java
+++ b/zeebe/msgpack-core/src/main/java/io/camunda/zeebe/msgpack/spec/MsgPackToken.java
@@ -14,7 +14,6 @@ public final class MsgPackToken {
   public static final MsgPackToken NIL = new MsgPackToken();
 
   private MsgPackType type = MsgPackType.NIL;
-  private int totalLength;
 
   // string
   private final UnsafeBuffer valueBuffer = new UnsafeBuffer(0, 0);
@@ -30,14 +29,6 @@ public final class MsgPackToken {
 
   // float32/float64
   private double floatValue;
-
-  public int getTotalLength() {
-    return totalLength;
-  }
-
-  public void setTotalLength(final int totalLength) {
-    this.totalLength = totalLength;
-  }
 
   public int getSize() {
     return size;

--- a/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackReadingBoundaryCheckingExceptionTest.java
+++ b/zeebe/msgpack-core/src/test/java/io/camunda/zeebe/msgpack/spec/MsgPackReadingBoundaryCheckingExceptionTest.java
@@ -42,6 +42,9 @@ public final class MsgPackReadingBoundaryCheckingExceptionTest {
   public Consumer<MsgPackReader> codeUnderTest;
 
   @Parameter(2)
+  public Class<? extends Throwable> exceptionClass;
+
+  @Parameter(3)
   public String exceptionMessage;
 
   protected MsgPackReader reader;
@@ -52,22 +55,26 @@ public final class MsgPackReadingBoundaryCheckingExceptionTest {
         new Object[][] {
           {
             new byte[] {(byte) ARRAY32, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff},
-            codeUnderTest((r) -> r.readArrayHeader()),
+            codeUnderTest(MsgPackReader::readArrayHeader),
+            MsgpackReaderException.class,
             NEGATIVE_BUF_SIZE_EXCEPTION_MSG
           },
           {
             new byte[] {(byte) BIN32, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff},
-            codeUnderTest((r) -> r.readBinaryLength()),
+            codeUnderTest(MsgPackReader::readBinaryLength),
+            MsgpackReaderException.class,
             NEGATIVE_BUF_SIZE_EXCEPTION_MSG
           },
           {
             new byte[] {(byte) MAP32, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff},
-            codeUnderTest((r) -> r.readMapHeader()),
+            codeUnderTest(MsgPackReader::readMapHeader),
+            MsgpackReaderException.class,
             NEGATIVE_BUF_SIZE_EXCEPTION_MSG
           },
           {
             new byte[] {(byte) STR32, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff},
-            codeUnderTest((r) -> r.readStringLength()),
+            codeUnderTest(MsgPackReader::readStringLength),
+            MsgpackReaderException.class,
             NEGATIVE_BUF_SIZE_EXCEPTION_MSG
           },
           {
@@ -82,13 +89,15 @@ public final class MsgPackReadingBoundaryCheckingExceptionTest {
               (byte) 0xff,
               (byte) 0xff
             },
-            codeUnderTest((r) -> r.readInteger()),
+            codeUnderTest(MsgPackReader::readInteger),
+            MsgpackReaderException.class,
             NEGATIVE_BUF_SIZE_EXCEPTION_MSG
           },
           {
             new byte[] {(byte) FIXSTR_PREFIX | (byte) 0x01},
-            codeUnderTest((r) -> r.readToken()),
-            "Reading 1 bytes past buffer capacity(1) in range [1:2]"
+            codeUnderTest(MsgPackReader::readToken),
+            IllegalArgumentException.class,
+            "offset=1 length=1 not valid for capacity=1"
           },
         });
   }
@@ -105,7 +114,7 @@ public final class MsgPackReadingBoundaryCheckingExceptionTest {
     reader.wrap(negativeTestingBuf, 0, negativeTestingBuf.capacity());
 
     // then
-    exception.expect(MsgpackReaderException.class);
+    exception.expect(exceptionClass);
     exception.expectMessage(exceptionMessage);
 
     // when

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -16,10 +16,6 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 public class UnpackedObject extends ObjectValue implements Recyclable, BufferReader, BufferWriter {
-
-  protected final MsgPackReader reader = new MsgPackReader();
-  protected final MsgPackWriter writer = new MsgPackWriter();
-
   /**
    * Creates a new UnpackedObject
    *
@@ -37,6 +33,7 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
   @Override
   public void wrap(final DirectBuffer buff, final int offset, final int length) {
     reset();
+    final var reader = new MsgPackReader();
     reader.wrap(buff, offset, length);
     try {
       read(reader);
@@ -59,6 +56,7 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
 
   @Override
   public void write(final MutableDirectBuffer buffer, final int offset) {
+    final var writer = new MsgPackWriter();
     writer.wrap(buffer, offset);
     write(writer);
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -16,6 +16,10 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 public class UnpackedObject extends ObjectValue implements Recyclable, BufferReader, BufferWriter {
+
+  private MsgPackReader reader;
+  private MsgPackWriter writer;
+
   /**
    * Creates a new UnpackedObject
    *
@@ -33,7 +37,9 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
   @Override
   public void wrap(final DirectBuffer buff, final int offset, final int length) {
     reset();
-    final var reader = new MsgPackReader();
+    if (reader == null) {
+      reader = new MsgPackReader();
+    }
     reader.wrap(buff, offset, length);
     try {
       read(reader);
@@ -56,7 +62,9 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
 
   @Override
   public void write(final MutableDirectBuffer buffer, final int offset) {
-    final var writer = new MsgPackWriter();
+    if (writer == null) {
+      writer = new MsgPackWriter();
+    }
     writer.wrap(buffer, offset);
     write(writer);
   }


### PR DESCRIPTION
The main change is that `UnpackedObject` now creates readers/writers on demand. The idea is that creating these objects on the fly is cheaper than pre-allocating them and holding on to two extra references in each `UnpackedObject`.

Other improvements:
- General code cleanup
- Removed duplicated bounds checks