### PR TITLE
feat: migrate MetadataPopover component to v2 REST API

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/Details/index.tsx
@@ -14,11 +14,12 @@ import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {Header} from '../Header';
 import {SummaryDataKey, SummaryDataValue} from '../styled';
 import {getExecutionDuration} from './getExecutionDuration';
 import {buildMetadata} from './buildMetadata';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 
 type Props = {
   metaData: MetaDataDto;
@@ -39,9 +40,15 @@ const NULL_METADATA = {
 
 const Details: React.FC<Props> = ({metaData, flowNodeId}) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const businessObject =
-    processInstanceDetailsDiagramStore.businessObjects[flowNodeId];
+
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {data} = useProcessInstanceXml({
+    processDefinitionKey,
+  });
+  const businessObject = data?.businessObjects[flowNodeId];
+
   const flowNodeName = businessObject?.name || flowNodeId;
+
   const {instanceMetadata, incident} = metaData;
   const {
     flowNodeInstanceId,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/calledDecisions.test.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {screen, waitFor} from 'modules/testing-library';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {labels, renderPopover} from './mocks';
+import {
+  calledDecisionMetadata,
+  calledFailedDecisionMetadata,
+  calledInstanceMetadata,
+  calledUnevaluatedDecisionMetadata,
+  CALL_ACTIVITY_FLOW_NODE_ID,
+  PROCESS_INSTANCE_ID,
+} from 'modules/mocks/metadata';
+import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
+import {createInstance, mockCallActivityProcessXML} from 'modules/testUtils';
+
+const MOCK_EXECUTION_DATE = '21 seconds';
+
+jest.mock('date-fns', () => ({
+  ...jest.requireActual('date-fns'),
+  formatDistanceToNowStrict: () => MOCK_EXECUTION_DATE,
+}));
+
+describe('MetadataPopover', () => {
+  beforeEach(() => {
+    flowNodeMetaDataStore.init();
+    flowNodeSelectionStore.init();
+  });
+
+  it('should render meta data for completed flow node', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
+    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+    flowNodeSelectionStore.selectFlowNode({
+      flowNodeId: CALL_ACTIVITY_FLOW_NODE_ID,
+    });
+
+    renderPopover();
+
+    expect(
+      await screen.findByText(labels.flowNodeInstanceKey),
+    ).toBeInTheDocument();
+    expect(screen.getByText(labels.executionDuration)).toBeInTheDocument();
+    expect(
+      await screen.findByText(labels.calledProcessInstance),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: labels.showMoreMetadata}),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        calledInstanceMetadata.instanceMetadata!.flowNodeInstanceId,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Less than 1 second')).toBeInTheDocument();
+    expect(screen.getByTestId('called-process-instance')).toHaveTextContent(
+      `Called Process - ${
+        calledInstanceMetadata.instanceMetadata!.calledProcessInstanceId
+      }`,
+    );
+  });
+
+  it('should render completed decision', async () => {
+    jest.useFakeTimers();
+    const {instanceMetadata} = calledDecisionMetadata;
+
+    mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
+    mockFetchFlowNodeMetadata().withSuccess(calledDecisionMetadata);
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'COMPLETED',
+      }),
+    );
+
+    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
+
+    const {user} = renderPopover();
+
+    expect(
+      await screen.findByText(labels.calledDecisionInstance),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {name: labels.incident}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(labels.rootCauseDecisionInstance),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByText(
+        `${instanceMetadata!.calledDecisionDefinitionName} - ${
+          instanceMetadata!.calledDecisionInstanceId
+        }`,
+      ),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent(
+        `/decisions/${instanceMetadata!.calledDecisionInstanceId}`,
+      ),
+    );
+
+    jest.clearAllTimers();
+    jest.useFakeTimers();
+  });
+
+  it('should render failed decision', async () => {
+    jest.useFakeTimers();
+
+    const {instanceMetadata} = calledFailedDecisionMetadata;
+    const {rootCauseDecision} = calledFailedDecisionMetadata!.incident!;
+
+    mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
+    mockFetchFlowNodeMetadata().withSuccess(calledFailedDecisionMetadata);
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'INCIDENT',
+      }),
+    );
+
+    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
+
+    const {user} = renderPopover();
+
+    expect(
+      await screen.findByText(labels.calledDecisionInstance),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: labels.incident}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${instanceMetadata!.calledDecisionDefinitionName} - ${
+          instanceMetadata!.calledDecisionInstanceId
+        }`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(labels.rootCauseDecisionInstance),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(labels.rootCauseProcessInstance),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByText(
+        `${rootCauseDecision!.decisionName!} - ${
+          rootCauseDecision!.instanceId
+        }`,
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent(
+        `/decisions/${rootCauseDecision!.instanceId}`,
+      ),
+    );
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('should render unevaluated decision', async () => {
+    const {instanceMetadata} = calledUnevaluatedDecisionMetadata;
+
+    mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
+    mockFetchFlowNodeMetadata().withSuccess(calledUnevaluatedDecisionMetadata);
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+
+    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
+
+    renderPopover();
+
+    expect(
+      await screen.findByText(labels.calledDecisionInstance),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(instanceMetadata.calledDecisionDefinitionName),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(labels.incident)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(labels.rootCauseDecisionInstance),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -6,25 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, waitFor} from 'modules/testing-library';
+import {screen} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import {MetadataPopover} from '.';
-import {
-  createInstance,
-  mockCallActivityProcessXML,
-  mockProcessXML,
-} from 'modules/testUtils';
+import {createInstance} from 'modules/testUtils';
 import {mockIncidents} from 'modules/mocks/incidents';
-import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {incidentsStore} from 'modules/stores/incidents';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {
-  calledDecisionMetadata,
-  calledFailedDecisionMetadata,
   calledInstanceMetadata,
-  calledUnevaluatedDecisionMetadata,
   incidentFlowNodeMetaData,
   multiInstanceCallActivityMetadata,
   multiInstancesMetadata,
@@ -37,14 +27,9 @@ import {
   retriesLeftFlowNodeMetaData,
   singleInstanceMetadata,
 } from 'modules/mocks/metadata';
-import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
-import {LocationLog} from 'modules/utils/LocationLog';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {useEffect} from 'react';
-import {Paths} from 'modules/Routes';
-import {ProcessInstance} from 'modules/testUtils/pages/ProcessInstance';
+import {labels, renderPopover} from './mocks';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -53,52 +38,17 @@ jest.mock('date-fns', () => ({
   formatDistanceToNowStrict: () => MOCK_EXECUTION_DATE,
 }));
 
-const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  useEffect(() => {
-    return () => {
-      flowNodeMetaDataStore.reset();
-      flowNodeSelectionStore.reset();
-      processInstanceDetailsStore.reset();
-      incidentsStore.reset();
-      processInstanceDetailsDiagramStore.reset();
-    };
-  }, []);
-
-  return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route path={Paths.processInstance()} element={children} />
-        <Route path={Paths.decisionInstance()} element={<></>} />
-      </Routes>
-      <LocationLog />
-    </MemoryRouter>
-  );
-};
-
-const renderPopover = () => {
-  const {container} = render(<svg />);
-
-  return render(
-    <MetadataPopover selectedFlowNodeRef={container.querySelector('svg')} />,
-    {
-      wrapper: Wrapper,
-    },
-  );
-};
-
-const {
-  metadataPopover: {labels},
-} = new ProcessInstance();
+jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
+  useProcessDefinitionXml: () => ({data: {businessObjects: {}}}),
+}));
 
 describe('MetadataPopover', () => {
   beforeEach(() => {
     flowNodeMetaDataStore.init();
     flowNodeSelectionStore.init();
-    processInstanceDetailsDiagramStore.init();
   });
 
   it('should not show unrelated data', async () => {
-    mockFetchProcessXML().withSuccess(mockProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -141,7 +91,6 @@ describe('MetadataPopover', () => {
   });
 
   it('should render meta data for incident flow node', async () => {
-    mockFetchProcessXML().withSuccess(mockProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
 
@@ -195,46 +144,7 @@ describe('MetadataPopover', () => {
     );
   });
 
-  it('should render meta data for completed flow node', async () => {
-    mockFetchProcessXML().withSuccess(mockCallActivityProcessXML);
-    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: PROCESS_INSTANCE_ID,
-        state: 'ACTIVE',
-      }),
-    );
-    flowNodeSelectionStore.selectFlowNode({
-      flowNodeId: CALL_ACTIVITY_FLOW_NODE_ID,
-    });
-
-    renderPopover();
-
-    expect(
-      await screen.findByText(labels.flowNodeInstanceKey),
-    ).toBeInTheDocument();
-    expect(screen.getByText(labels.executionDuration)).toBeInTheDocument();
-    expect(screen.getByText(labels.calledProcessInstance)).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: labels.showMoreMetadata}),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(
-        calledInstanceMetadata.instanceMetadata!.flowNodeInstanceId,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Less than 1 second')).toBeInTheDocument();
-    expect(screen.getByTestId('called-process-instance')).toHaveTextContent(
-      `Called Process - ${
-        calledInstanceMetadata.instanceMetadata!.calledProcessInstanceId
-      }`,
-    );
-  });
-
   it('should render meta data modal', async () => {
-    mockFetchProcessXML().withSuccess(mockCallActivityProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -304,7 +214,6 @@ describe('MetadataPopover', () => {
   });
 
   it('should render metadata for multi instance flow nodes', async () => {
-    mockFetchProcessXML().withSuccess(mockProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(multiInstancesMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -337,7 +246,6 @@ describe('MetadataPopover', () => {
   });
 
   it('should not render called instances for multi instance call activities', async () => {
-    mockFetchProcessXML().withSuccess(mockProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(multiInstanceCallActivityMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -363,7 +271,6 @@ describe('MetadataPopover', () => {
   it('should not render root cause instance link when instance is root', async () => {
     const {rootCauseInstance} = rootIncidentFlowNodeMetaData.incident;
 
-    mockFetchProcessXML().withSuccess(mockProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(rootIncidentFlowNodeMetaData);
 
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
@@ -391,143 +298,10 @@ describe('MetadataPopover', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should render completed decision', async () => {
-    jest.useFakeTimers();
-    const {instanceMetadata} = calledDecisionMetadata;
-
-    mockFetchProcessXML().withSuccess(metadataDemoProcess);
-    mockFetchFlowNodeMetadata().withSuccess(calledDecisionMetadata);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: PROCESS_INSTANCE_ID,
-        state: 'COMPLETED',
-      }),
-    );
-
-    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
-
-    const {user} = renderPopover();
-
-    expect(
-      await screen.findByText(labels.calledDecisionInstance),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('heading', {name: labels.incident}),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(labels.rootCauseDecisionInstance),
-    ).not.toBeInTheDocument();
-
-    await user.click(
-      screen.getByText(
-        `${instanceMetadata!.calledDecisionDefinitionName} - ${
-          instanceMetadata!.calledDecisionInstanceId
-        }`,
-      ),
-    );
-
-    await waitFor(() =>
-      expect(screen.getByTestId('pathname')).toHaveTextContent(
-        `/decisions/${instanceMetadata!.calledDecisionInstanceId}`,
-      ),
-    );
-
-    jest.clearAllTimers();
-    jest.useFakeTimers();
-  });
-
-  it('should render failed decision', async () => {
-    jest.useFakeTimers();
-
-    const {instanceMetadata} = calledFailedDecisionMetadata;
-    const {rootCauseDecision} = calledFailedDecisionMetadata!.incident!;
-
-    mockFetchProcessXML().withSuccess(metadataDemoProcess);
-    mockFetchFlowNodeMetadata().withSuccess(calledFailedDecisionMetadata);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: PROCESS_INSTANCE_ID,
-        state: 'INCIDENT',
-      }),
-    );
-
-    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
-
-    const {user} = renderPopover();
-
-    expect(
-      await screen.findByText(labels.calledDecisionInstance),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {name: labels.incident}),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        `${instanceMetadata!.calledDecisionDefinitionName} - ${
-          instanceMetadata!.calledDecisionInstanceId
-        }`,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(labels.rootCauseDecisionInstance),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(labels.rootCauseProcessInstance),
-    ).not.toBeInTheDocument();
-
-    await user.click(
-      screen.getByText(
-        `${rootCauseDecision!.decisionName!} - ${
-          rootCauseDecision!.instanceId
-        }`,
-      ),
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('pathname')).toHaveTextContent(
-        `/decisions/${rootCauseDecision!.instanceId}`,
-      ),
-    );
-
-    jest.clearAllTimers();
-    jest.useRealTimers();
-  });
-
-  it('should render unevaluated decision', async () => {
-    const {instanceMetadata} = calledUnevaluatedDecisionMetadata;
-
-    mockFetchProcessXML().withSuccess(metadataDemoProcess);
-    mockFetchFlowNodeMetadata().withSuccess(calledUnevaluatedDecisionMetadata);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: PROCESS_INSTANCE_ID,
-        state: 'ACTIVE',
-      }),
-    );
-
-    flowNodeSelectionStore.selectFlowNode({flowNodeId: 'BusinessRuleTask'});
-
-    renderPopover();
-
-    expect(
-      await screen.findByText(labels.calledDecisionInstance),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(instanceMetadata.calledDecisionDefinitionName),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(labels.incident)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(labels.rootCauseDecisionInstance),
-    ).not.toBeInTheDocument();
-  });
-
   it('should render link to tasklist', async () => {
     const tasklistUrl = 'https://tasklist:8080';
     window.clientConfig = {tasklistUrl};
 
-    mockFetchProcessXML().withSuccess(metadataDemoProcess);
     mockFetchFlowNodeMetadata().withSuccess(userTaskFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
@@ -547,7 +321,6 @@ describe('MetadataPopover', () => {
   });
 
   it('should render retries left', async () => {
-    mockFetchProcessXML().withSuccess(metadataDemoProcess);
     mockFetchFlowNodeMetadata().withSuccess(retriesLeftFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.test.tsx
@@ -29,6 +29,7 @@ import {
 } from 'modules/mocks/metadata';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {labels, renderPopover} from './mocks';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
@@ -38,14 +39,11 @@ jest.mock('date-fns', () => ({
   formatDistanceToNowStrict: () => MOCK_EXECUTION_DATE,
 }));
 
-jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
-  useProcessDefinitionXml: () => ({data: {businessObjects: {}}}),
-}));
-
 describe('MetadataPopover', () => {
   beforeEach(() => {
     flowNodeMetaDataStore.init();
     flowNodeSelectionStore.init();
+    mockFetchProcessDefinitionXml().withSuccess('');
   });
 
   it('should not show unrelated data', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/mocks.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Paths} from 'modules/Routes';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {incidentsStore} from 'modules/stores/incidents';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {LocationLog} from 'modules/utils/LocationLog';
+import {useEffect} from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {MetadataPopover} from '.';
+import {ProcessInstance} from 'modules/testUtils/pages/ProcessInstance';
+import {render} from 'modules/testing-library';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+  useEffect(() => {
+    return () => {
+      flowNodeMetaDataStore.reset();
+      flowNodeSelectionStore.reset();
+      processInstanceDetailsStore.reset();
+      incidentsStore.reset();
+    };
+  }, []);
+
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+            <Route path={Paths.decisionInstance()} element={<></>} />
+          </Routes>
+          <LocationLog />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
+};
+
+const renderPopover = () => {
+  const {container} = render(<svg />);
+
+  return render(
+    <MetadataPopover selectedFlowNodeRef={container.querySelector('svg')} />,
+    {
+      wrapper: Wrapper,
+    },
+  );
+};
+
+const {
+  metadataPopover: {labels},
+} = new ProcessInstance();
+
+export {labels, renderPopover};

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -56,6 +56,10 @@ jest.mock('react-transition-group', () => {
   };
 });
 
+jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
+  useProcessDefinitionXml: () => ({}),
+}));
+
 type Props = {
   children?: React.ReactNode;
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -36,6 +36,10 @@ import {open} from 'modules/mocks/diagrams';
 import {mockNestedSubprocess} from 'modules/mocks/mockNestedSubprocess';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {Paths} from 'modules/Routes';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 jest.mock('react-transition-group', () => {
   const FakeTransition = jest.fn(({children}) => children);
@@ -56,21 +60,21 @@ jest.mock('react-transition-group', () => {
   };
 });
 
-jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
-  useProcessDefinitionXml: () => ({}),
-}));
-
 type Props = {
   children?: React.ReactNode;
 };
 
 const Wrapper: React.FC<Props> = ({children}) => {
   return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route path={Paths.processInstance()} element={children} />
-      </Routes>
-    </MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 
@@ -87,6 +91,9 @@ describe('TopPanel', () => {
 
   beforeEach(() => {
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
 
     mockFetchProcessInstance().withSuccess(
       createInstance({id: 'instance_id', state: 'INCIDENT'}),

--- a/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
@@ -28,6 +28,10 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 
 jest.unmock('modules/utils/date/formatDate');
 
+jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
+  useProcessDefinitionXml: () => ({}),
+}));
+
 describe('Filters', () => {
   beforeEach(async () => {
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);

--- a/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/multiTenancy.test.tsx
@@ -28,10 +28,6 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 
 jest.unmock('modules/utils/date/formatDate');
 
-jest.mock('modules/queries/processDefinitions/useProcessDefinitionXml', () => ({
-  useProcessDefinitionXml: () => ({}),
-}));
-
 describe('Filters', () => {
   beforeEach(async () => {
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
@@ -133,7 +129,7 @@ describe('Filters', () => {
     });
 
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
-
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     await selectTenant({user, option: 'All tenants'});
     expect(screen.getByRole('combobox', {name: /tenant/i})).toHaveTextContent(
       /all tenants/i,


### PR DESCRIPTION
## Description

This PR is part of https://github.com/camunda/camunda/issues/30591 with the goal to replace processInstanceDetailsDiagramStore by Tanstack query.

#### MetadataPopover/Details component
- remove dependency to processInstanceDetailsDiagramStore
- add query to v2 XML API

#### Misc

- Adjust tests
- Mock useProcessDefinitionXml in ListView test

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591
