### PR TITLE
feat: added partitionId filter to processInstanceFilter

### DIFF
--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -131,6 +131,9 @@
       </if>
       )
     </if>
+    <if test="filter.partitionId != null">
+      AND pi.PARTITION_ID = #{filter.partitionId}
+    </if>
 
     <!-- date filters -->
     <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
@@ -33,7 +33,8 @@ public final class ProcessInstanceFixtures extends CommonFixtures {
             .startDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .endDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .version(RANDOM.nextInt(10000))
-            .tenantId("tenant-" + RANDOM.nextInt(10000));
+            .tenantId("tenant-" + RANDOM.nextInt(10000))
+            .partitionId(RANDOM.nextInt(10000));
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -240,7 +240,8 @@ public class ProcessInstanceIT {
                     .endDate(NOW)
                     .parentProcessInstanceKey(-1L)
                     .parentElementInstanceKey(-1L)
-                    .version(1)));
+                    .version(1)
+                    .partitionId(123456)));
 
     final var searchResult =
         processInstanceReader.search(
@@ -253,7 +254,8 @@ public class ProcessInstanceIT {
                                     .processDefinitionKeys(1337L)
                                     .states(ProcessInstanceState.ACTIVE.name())
                                     .parentProcessInstanceKeys(-1L)
-                                    .parentFlowNodeInstanceKeys(-1L))
+                                    .parentFlowNodeInstanceKeys(-1L)
+                                    .partitionId(123456))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(5))));
 
@@ -328,13 +330,22 @@ public class ProcessInstanceIT {
         ProcessDefinitionFixtures.createAndSaveProcessDefinition(rdbmsWriter, b -> b);
     final var pi1 =
         createAndSaveRandomProcessInstance(
-            rdbmsWriter, b -> b.processDefinitionKey(processDefinition.processDefinitionKey()));
+            rdbmsWriter,
+            b ->
+                b.processDefinitionKey(processDefinition.processDefinitionKey())
+                    .partitionId(PARTITION_ID));
     final var pi2 =
         createAndSaveRandomProcessInstance(
-            rdbmsWriter, b -> b.processDefinitionKey(processDefinition.processDefinitionKey()));
+            rdbmsWriter,
+            b ->
+                b.processDefinitionKey(processDefinition.processDefinitionKey())
+                    .partitionId(PARTITION_ID));
     final var pi3 =
         createAndSaveRandomProcessInstance(
-            rdbmsWriter, b -> b.processDefinitionKey(processDefinition.processDefinitionKey()));
+            rdbmsWriter,
+            b ->
+                b.processDefinitionKey(processDefinition.processDefinitionKey())
+                    .partitionId(PARTITION_ID));
 
     // set cleanup dates
     rdbmsWriter.getProcessInstanceWriter().scheduleForHistoryCleanup(pi1.processInstanceKey(), NOW);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.*;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PARTITION_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITIES_JOIN_RELATION;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_STATE;
@@ -107,6 +108,10 @@ public final class ProcessInstanceFilterTransformer
     if (filter.flowNodeIdOperations() != null && !filter.flowNodeIdOperations().isEmpty()) {
       final var flowNodeInstanceQuery = getFlowNodeInstanceQuery(filter, queries);
       queries.add(flowNodeInstanceQuery);
+    }
+
+    if (filter.partitionId() != null) {
+      queries.add(term(PARTITION_ID, filter.partitionId()));
     }
 
     return and(queries);

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -39,7 +39,8 @@ public record ProcessInstanceFilter(
     List<Operation<String>> flowNodeIdOperations,
     Boolean hasFlowNodeInstanceIncident,
     List<Operation<String>> flowNodeInstanceStateOperations,
-    List<Integer> incidentErrorHashCodes)
+    List<Integer> incidentErrorHashCodes,
+    Integer partitionId)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -58,7 +59,8 @@ public record ProcessInstanceFilter(
         .hasIncident(hasIncident)
         .tenantIdOperations(tenantIdOperations)
         .variables(variableFilters)
-        .batchOperationIdOperations(batchOperationIdOperations);
+        .batchOperationIdOperations(batchOperationIdOperations)
+        .partitionId(partitionId);
   }
 
   public static final class Builder implements ObjectBuilder<ProcessInstanceFilter> {
@@ -84,6 +86,7 @@ public record ProcessInstanceFilter(
     private Boolean hasFlowNodeInstanceIncident;
     private List<Operation<String>> flowNodeInstanceStateOperations;
     private List<Integer> incidentErrorHashCodes;
+    private Integer partitionId;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
       processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
@@ -358,6 +361,11 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder partitionId(final Integer value) {
+      partitionId = value;
+      return this;
+    }
+
     @Override
     public ProcessInstanceFilter build() {
       return new ProcessInstanceFilter(
@@ -382,7 +390,8 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
           hasFlowNodeInstanceIncident,
           Objects.requireNonNullElse(flowNodeInstanceStateOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()));
+          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()),
+          partitionId);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -164,6 +164,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     updateFields.put(ListViewTemplate.PROCESS_VERSION, entity.getProcessVersion());
     updateFields.put(ListViewTemplate.PROCESS_KEY, entity.getProcessDefinitionKey());
     updateFields.put(ListViewTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
+    updateFields.put(PARTITION_ID, entity.getPartitionId());
     updateFields.put(POSITION, entity.getPosition());
     if (entity.getState() != null) {
       updateFields.put(ListViewTemplate.STATE, entity.getState());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PARTITION_ID;
 import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSITION;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -160,6 +161,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setProcessVersionTag("versionTag")
             .setProcessDefinitionKey(444L)
             .setBpmnProcessId("bpmnProcessId")
+            .setPartitionId(12)
             .setPosition(123L)
             .setStartDate(OffsetDateTime.now())
             .setEndDate(OffsetDateTime.now())
@@ -177,6 +179,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
     expectedUpdateFields.put(ListViewTemplate.START_DATE, inputEntity.getStartDate());
     expectedUpdateFields.put(ListViewTemplate.END_DATE, inputEntity.getEndDate());
+    expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
     // when
@@ -196,6 +199,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setProcessVersion(2)
             .setProcessDefinitionKey(444L)
             .setBpmnProcessId("bpmnProcessId")
+            .setPartitionId(12)
             .setPosition(123L)
             .setState(ProcessInstanceState.ACTIVE);
     final BatchRequest mockRequest = mock(BatchRequest.class);
@@ -206,6 +210,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.PROCESS_KEY, 444L);
     expectedUpdateFields.put(ListViewTemplate.BPMN_PROCESS_ID, "bpmnProcessId");
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
+    expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
     // when


### PR DESCRIPTION
## Description

The batchOperation scheduler needs to fetch processInstanceKeys by it's own partitionId. This PR implements a partitionId filter to the ProcessInstanceFilter on search-domain level. Since it is only used internally, it is:
- not populated to `CamundaClient` or REST-API
- implemented as simple Integer filter and not with a full list of `Operation` objects

In the camunda-exporter, the partitionId was extracted from the record but not persisted in the ES/OS document. This was also fixed in this PR.

closes #30662
