### PR TITLE
feat: cancel batch operation in engine

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
@@ -19,5 +19,6 @@ public enum BatchOperationItemState {
   ACTIVE,
   COMPLETED,
   FAILED,
+  CANCELED,
   UNKNOWN_ENUM_VALUE;
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -110,6 +110,9 @@ public class BatchOperationWriter {
     updateCompleted(
         batchOperationKey,
         new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.CANCELED, endDate));
+
+    updateItemsWithStatus(
+        batchOperationKey, BatchOperationItemStatus.ACTIVE, BatchOperationItemStatus.CANCELED);
   }
 
   public void paused(final long batchOperationKey) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -66,6 +66,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -117,6 +118,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationExecution = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationExecutionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
@@ -452,6 +453,26 @@ public class RecordFixtures {
         .withValue(
             ImmutableBatchOperationExecutionRecordValue.builder()
                 .from((ImmutableBatchOperationExecutionRecordValue) recordValueRecord.getValue())
+                .withBatchOperationKey(batchOperationKey)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getBatchOperationLifecycleCanceledRecord(
+      final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(BatchOperationIntent.CANCELED)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableBatchOperationLifecycleManagementRecordValue.builder()
+                .from(
+                    (ImmutableBatchOperationLifecycleManagementRecordValue)
+                        recordValueRecord.getValue())
                 .withBatchOperationKey(batchOperationKey)
                 .build())
         .build();

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -36,6 +36,7 @@ public record BatchOperationEntity(
   public enum BatchOperationItemStatus {
     ACTIVE,
     COMPLETED,
+    CANCELED,
     FAILED
   }
 }

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPauseBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerResumeBatchOperationRequest;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -71,7 +71,8 @@ public final class BatchOperationServices
     return batchOperationSearchClient.getBatchOperationItems(key);
   }
 
-  public CompletableFuture<BatchOperationExecutionRecord> cancel(final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> cancel(
+      final long batchKey) {
     LOGGER.debug("Cancelling batch operation with key '{}'", batchKey);
 
     final var brokerRequest =
@@ -80,7 +81,8 @@ public final class BatchOperationServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationExecutionRecord> pause(final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> pause(
+      final long batchKey) {
     LOGGER.debug("Pausing batch operation with key '{}'", batchKey);
 
     final var brokerRequest = new BrokerPauseBatchOperationRequest().setBatchOperationKey(batchKey);
@@ -88,7 +90,8 @@ public final class BatchOperationServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationExecutionRecord> resume(final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> resume(
+      final long batchKey) {
     LOGGER.debug("Resuming batch operation with key '{}'", batchKey);
 
     final var brokerRequest =

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPauseBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerResumeBatchOperationRequest;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -71,8 +71,7 @@ public final class BatchOperationServices
     return batchOperationSearchClient.getBatchOperationItems(key);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> cancel(
-      final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> cancel(final long batchKey) {
     LOGGER.debug("Cancelling batch operation with key '{}'", batchKey);
 
     final var brokerRequest =
@@ -81,8 +80,7 @@ public final class BatchOperationServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> pause(
-      final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> pause(final long batchKey) {
     LOGGER.debug("Pausing batch operation with key '{}'", batchKey);
 
     final var brokerRequest = new BrokerPauseBatchOperationRequest().setBatchOperationKey(batchKey);
@@ -90,8 +88,7 @@ public final class BatchOperationServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementManagementRecord> resume(
-      final long batchKey) {
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> resume(final long batchKey) {
     LOGGER.debug("Resuming batch operation with key '{}'", batchKey);
 
     final var brokerRequest =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -67,6 +67,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -120,6 +121,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -92,6 +93,9 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.RESOURCE, ResourceRecord::new);
     RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
+    RECORDS_BY_TYPE.put(
+        ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+        BatchOperationLifecycleManagementManagementRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -95,7 +95,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
     RECORDS_BY_TYPE.put(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
-        BatchOperationLifecycleManagementManagementRecord::new);
+        BatchOperationLifecycleManagementRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
 public final class BatchOperationCancelProcessor
-    implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementManagementRecord> {
+    implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementRecord> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationCancelProcessor.class);
 
@@ -57,7 +57,7 @@ public final class BatchOperationCancelProcessor
 
   @Override
   public void processNewCommand(
-      final TypedRecord<BatchOperationLifecycleManagementManagementRecord> command) {
+      final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var recordValue = command.getValue();
     final var batchOperationKey = recordValue.getBatchOperationKey();
     final var cancelKey = keyGenerator.nextKey();
@@ -86,7 +86,7 @@ public final class BatchOperationCancelProcessor
 
   @Override
   public void processDistributedCommand(
-      final TypedRecord<BatchOperationLifecycleManagementManagementRecord> command) {
+      final TypedRecord<BatchOperationLifecycleManagementRecord> command) {
     final var recordValue = command.getValue();
     final var batchOperationKey = recordValue.getBatchOperationKey();
 
@@ -107,7 +107,7 @@ public final class BatchOperationCancelProcessor
   }
 
   private void cancelBatchOperationEvent(
-      final Long cancelKey, final BatchOperationLifecycleManagementManagementRecord recordValue) {
+      final Long cancelKey, final BatchOperationLifecycleManagementRecord recordValue) {
     stateWriter.appendFollowUpEvent(cancelKey, BatchOperationIntent.CANCELED, recordValue);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExcludeAuthorizationCheck
+public final class BatchOperationCancelProcessor
+    implements DistributedTypedRecordProcessor<BatchOperationLifecycleManagementManagementRecord> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationCancelProcessor.class);
+
+  private static final String MESSAGE_PREFIX =
+      "Expected to cancel a batch operation with key '%d', but ";
+  private static final String BATCH_OPERATION_NOT_FOUND_MESSAGE =
+      MESSAGE_PREFIX + "no such batch operation was found";
+
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final BatchOperationState batchOperationState;
+  private final KeyGenerator keyGenerator;
+
+  public BatchOperationCancelProcessor(
+      final Writers writers,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    batchOperationState = processingState.getBatchOperationState();
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void processNewCommand(
+      final TypedRecord<BatchOperationLifecycleManagementManagementRecord> command) {
+    final var recordValue = command.getValue();
+    final var batchOperationKey = recordValue.getBatchOperationKey();
+    final var cancelKey = keyGenerator.nextKey();
+    LOGGER.debug(
+        "Processing new command to cancel a batch operation with key '{}': {}",
+        batchOperationKey,
+        recordValue);
+
+    final var batchOperation = batchOperationState.get(batchOperationKey);
+    if (batchOperation.isPresent() && batchOperation.get().canCancel()) {
+      cancelBatchOperationEvent(cancelKey, recordValue);
+      responseWriter.writeEventOnCommand(
+          cancelKey, BatchOperationIntent.CANCELED, command.getValue(), command);
+      commandDistributionBehavior.withKey(cancelKey).unordered().distribute(command);
+    } else {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
+      responseWriter.writeRejectionOnCommand(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
+    }
+  }
+
+  @Override
+  public void processDistributedCommand(
+      final TypedRecord<BatchOperationLifecycleManagementManagementRecord> command) {
+    final var recordValue = command.getValue();
+    final var batchOperationKey = recordValue.getBatchOperationKey();
+
+    final var batchOperation = batchOperationState.get(batchOperationKey);
+    if (batchOperation.isEmpty()) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.NOT_FOUND, "Batch operation does not exist!");
+      commandDistributionBehavior.acknowledgeCommand(command);
+      return;
+    }
+
+    LOGGER.debug(
+        "Processing distributed command to cancel a batch operation with key '{}': {}",
+        batchOperationKey,
+        recordValue);
+    cancelBatchOperationEvent(batchOperationKey, recordValue);
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void cancelBatchOperationEvent(
+      final Long cancelKey, final BatchOperationLifecycleManagementManagementRecord recordValue) {
+    stateWriter.appendFollowUpEvent(cancelKey, BatchOperationIntent.CANCELED, recordValue);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -178,6 +178,12 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
     Object[] searchValues = null;
     while (true) {
+      // Check if the batch operation is still present, could be canceled in the meantime
+      if (!batchOperationState.exists(batchOperation.getKey())) {
+        LOG.warn(
+            "Batch operation {} is no longer active, stopping query.", batchOperation.getKey());
+        break;
+      }
 
       final var page =
           SearchQueryPageBuilders.page().size(QUERY_SIZE).searchAfter(searchValues).build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -53,6 +53,11 @@ public final class BatchOperationSetupProcessors {
             ValueType.BATCH_OPERATION_EXECUTION,
             BatchOperationExecutionIntent.EXECUTE,
             new BatchOperationExecuteProcessor(writers, processingState, partitionId))
+        .onCommand(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            BatchOperationIntent.CANCEL,
+            new BatchOperationCancelProcessor(
+                writers, commandDistributionBehavior, processingState, keyGenerator))
         .withListener(
             new BatchOperationExecutionScheduler(
                 scheduledTaskStateFactory, searchClientsProxy, Duration.ofMillis(1000)));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCanceledApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCanceledApplier.java
@@ -9,12 +9,11 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 
 public class BatchOperationCanceledApplier
-    implements TypedEventApplier<
-        BatchOperationIntent, BatchOperationLifecycleManagementManagementRecord> {
+    implements TypedEventApplier<BatchOperationIntent, BatchOperationLifecycleManagementRecord> {
 
   private final MutableBatchOperationState batchOperationState;
 
@@ -24,7 +23,7 @@ public class BatchOperationCanceledApplier
 
   @Override
   public void applyState(
-      final long cancelKey, final BatchOperationLifecycleManagementManagementRecord value) {
+      final long cancelKey, final BatchOperationLifecycleManagementRecord value) {
     batchOperationState.cancel(value.getBatchOperationKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCanceledApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCanceledApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+
+public class BatchOperationCanceledApplier
+    implements TypedEventApplier<
+        BatchOperationIntent, BatchOperationLifecycleManagementManagementRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationCanceledApplier(final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(
+      final long cancelKey, final BatchOperationLifecycleManagementManagementRecord value) {
+    batchOperationState.cancel(value.getBatchOperationKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -604,7 +604,9 @@ public final class EventAppliers implements EventApplier {
         BatchOperationExecutionIntent.EXECUTING,
         new BatchOperationExecutingApplier(state.getBatchOperationState()));
     register(BatchOperationExecutionIntent.EXECUTED, NOOP_EVENT_APPLIER);
-
+    register(
+        BatchOperationIntent.CANCELED,
+        new BatchOperationCanceledApplier(state.getBatchOperationState()));
     register(
         BatchOperationExecutionIntent.COMPLETED,
         new BatchOperationCompletedApplier(state.getBatchOperationState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -155,10 +155,15 @@ public class DbBatchOperationState implements MutableBatchOperationState {
   }
 
   @Override
+  public void cancel(final long batchOperationKey) {
+    LOGGER.trace("Cancel batch operation with key {}", batchOperationKey);
+    deleteBatchOperation(batchOperationKey);
+  }
+
+  @Override
   public void complete(final long batchOperationKey) {
     LOGGER.trace("Completing batch operation with key {}", batchOperationKey);
-    batchKey.wrapLong(batchOperationKey);
-    batchOperationColumnFamily.deleteExisting(batchKey);
+    deleteBatchOperation(batchOperationKey);
   }
 
   @Override
@@ -197,6 +202,11 @@ public class DbBatchOperationState implements MutableBatchOperationState {
     final var chunkKeys = chunk.getItemKeys();
 
     return chunkKeys.stream().limit(batchSize).toList();
+  }
+
+  private void deleteBatchOperation(final long batchOperationKey) {
+    batchKey.wrapLong(batchOperationKey);
+    batchOperationColumnFamily.deleteExisting(batchKey);
   }
 
   private PersistedBatchOperationChunk createNewChunk(final PersistedBatchOperation batch) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -48,6 +48,12 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
+  public boolean canCancel() {
+    return getStatus() == BatchOperationStatus.CREATED
+        || getStatus() == BatchOperationStatus.STARTED
+        || getStatus() == BatchOperationStatus.PAUSED;
+  }
+
   public long getKey() {
     return keyProp.getValue();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -91,13 +91,6 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
-  /**
-   * Deserializes the entity filter to the given class.
-   *
-   * @param clazz of the entity filter
-   * @return the deserialized entity filter
-   * @throws EntityFilterDeserializeException if any error occurs during deserialization
-   */
   public <T> T getEntityFilter(final Class<T> clazz) {
     return MsgPackConverter.convertToObject(entityFilterProp.getValue(), clazz);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 
 public interface BatchOperationState {
 
+  boolean exists(long batchKey);
+
   Optional<PersistedBatchOperation> get(final long batchKey);
 
   void foreachPendingBatchOperation(BatchOperationVisitor visitor);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -28,5 +28,7 @@ public interface MutableBatchOperationState extends BatchOperationState {
 
   void removeItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 
+  void cancel(final long batchKey);
+
   void complete(final long batchOperationKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.mockito.Mockito;
+
+abstract class AbstractBatchOperationTest {
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  protected final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
+
+  protected long createNewProcessInstanceCancellationBatchOperation(final Set<Long> itemKeys) {
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
+            .total(itemKeys.size())
+            .build();
+    Mockito.when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
+        .thenReturn(result);
+
+    final var filterBuffer =
+        convertToBuffer(
+            new ProcessInstanceFilter.Builder().processInstanceKeys(1L, 3L, 8L).build());
+
+    return engine
+        .batchOperation()
+        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+        .withFilter(filterBuffer)
+        .create()
+        .getValue()
+        .getBatchOperationKey();
+  }
+
+  protected static UnsafeBuffer convertToBuffer(final Object object) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
+  }
+
+  protected ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
+    final var entity = mock(ProcessInstanceEntity.class);
+    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
+    return entity;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -8,42 +8,24 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
-import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public final class CreateBatchOperationTest {
-
-  @Rule
-  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
-      new RecordingExporterTestWatcher();
-
-  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
-  private final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
-
-  @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
+public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
 
   @Test
   public void shouldRejectWithoutFilter() {
@@ -134,15 +116,5 @@ public final class CreateBatchOperationTest {
             RecordingExporter.batchOperationChunkRecords().withBatchOperationKey(batchOperationKey))
         .extracting(Record::getIntent)
         .containsSequence(BatchOperationChunkIntent.CREATE, BatchOperationChunkIntent.CREATED);
-  }
-
-  private static UnsafeBuffer convertToBuffer(final Object object) {
-    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
-  }
-
-  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
@@ -8,42 +8,15 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.search.entities.ProcessInstanceEntity;
-import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.search.query.ProcessInstanceQuery;
-import io.camunda.search.query.SearchQueryResult;
-import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.value.BatchOperationType;
-import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-public final class ExecuteBatchOperationTest {
-
-  @Rule
-  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
-      new RecordingExporterTestWatcher();
-
-  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
-  private final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
-
-  @Rule
-  public final EngineRule engine =
-      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
+public final class ExecuteBatchOperationTest extends AbstractBatchOperationTest {
 
   @Test
   public void shouldExecuteBatchOperationForProcessInstanceCancellation() {
@@ -86,9 +59,9 @@ public final class ExecuteBatchOperationTest {
     // when
     engine
         .batchOperation()
-        .newExecution(BatchOperationType.PROCESS_CANCELLATION)
+        .newExecution()
         .withBatchOperationKey(batchOperationKey)
-        .createCanceled();
+        .executeWithoutExpectation();
 
     // then
     assertThat(
@@ -97,38 +70,5 @@ public final class ExecuteBatchOperationTest {
         .extracting(Record::getIntent)
         .doesNotContain(
             BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
-  }
-
-  private long createNewProcessInstanceCancellationBatchOperation(final Set<Long> itemKeys) {
-    final var result =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(
-                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
-            .total(itemKeys.size())
-            .build();
-    Mockito.when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
-        .thenReturn(result);
-
-    final var filterBuffer =
-        convertToBuffer(
-            new ProcessInstanceFilter.Builder().processInstanceKeys(1L, 3L, 8L).build());
-
-    return engine
-        .batchOperation()
-        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
-        .withFilter(filterBuffer)
-        .create()
-        .getValue()
-        .getBatchOperationKey();
-  }
-
-  private static UnsafeBuffer convertToBuffer(final Object object) {
-    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
-  }
-
-  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Set;
+import org.junit.Test;
+
+public final class LifecycleBatchOperationTest extends AbstractBatchOperationTest {
+
+  @Test
+  public void shouldCancelBatchOperationForProcessInstanceCancellation() {
+    // given
+    final var processInstanceKeys = Set.of(1L, 2L, 3L);
+    final var batchOperationKey =
+        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+
+    // when we cancel the batch operation
+    engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).cancel();
+
+    // then we have a canceled event
+    assertThat(
+            RecordingExporter.batchOperationLifecycleRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationIntent.CANCELED);
+
+    // and no follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .doesNotContain(BatchOperationExecutionIntent.EXECUTE);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -329,6 +329,23 @@ public class BatchOperationStateTest {
     assertThat(state.get(batchOperationKey)).isEmpty();
   }
 
+  @Test
+  void canceledBatchShouldBeRemoved() {
+    // given
+    final var batchOperationKey = 1L;
+    final var batchRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    state.create(batchOperationKey, batchRecord);
+
+    // when
+    state.cancel(batchOperationKey);
+
+    // then
+    assertThat(state.get(batchOperationKey)).isEmpty();
+  }
+
   private static UnsafeBuffer convertToBuffer(final Object object) {
     return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -344,6 +344,7 @@ public class BatchOperationStateTest {
 
     // then
     assertThat(state.get(batchOperationKey)).isEmpty();
+    assertThat(state.getNextItemKeys(batchOperationKey, 20)).isEmpty();
   }
 
   private static UnsafeBuffer convertToBuffer(final Object object) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -232,14 +232,12 @@ public final class BatchOperationClient {
                     .getFirst();
 
     private final CommandWriter writer;
-    private final BatchOperationLifecycleManagementManagementRecord
-        batchOperationLifecycleManagementRecord;
+    private final BatchOperationLifecycleManagementRecord batchOperationLifecycleManagementRecord;
     private final int partition = DEFAULT_PARTITION;
 
     public BatchOperationLifecycleClient(final CommandWriter writer) {
       this.writer = writer;
-      batchOperationLifecycleManagementRecord =
-          new BatchOperationLifecycleManagementManagementRecord();
+      batchOperationLifecycleManagementRecord = new BatchOperationLifecycleManagementRecord();
     }
 
     public BatchOperationLifecycleClient withBatchOperationKey(final long batchOperationKey) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -211,6 +211,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean batchOperationCreation = false;
     public boolean batchOperationChunk = false;
     public boolean batchOperationExecution = false;
+    public boolean batchOperationLifecycleManagement = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -66,6 +66,7 @@ final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -118,7 +119,8 @@ final class TestSupport {
             ValueType.RESOURCE,
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_CHUNK,
-            ValueType.BATCH_OPERATION_EXECUTION);
+            ValueType.BATCH_OPERATION_EXECUTION,
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -201,6 +201,7 @@ public class OpensearchExporterConfiguration {
     public boolean batchOperationCreation = false;
     public boolean batchOperationChunk = false;
     public boolean batchOperationExecution = false;
+    public boolean batchOperationLifecycleManagement = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -67,6 +67,7 @@ final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -119,7 +120,8 @@ final class TestSupport {
             ValueType.RESOURCE,
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_CHUNK,
-            ValueType.BATCH_OPERATION_EXECUTION);
+            ValueType.BATCH_OPERATION_EXECUTION,
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.exporter.rdbms.handlers.BatchOperationChunkExportHandler;
 import io.camunda.exporter.rdbms.handlers.BatchOperationCompletedExportHandler;
 import io.camunda.exporter.rdbms.handlers.BatchOperationCreatedExportHandler;
+import io.camunda.exporter.rdbms.handlers.BatchOperationLifecycleManagementExportHandler;
 import io.camunda.exporter.rdbms.handlers.DecisionDefinitionExportHandler;
 import io.camunda.exporter.rdbms.handlers.DecisionInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.DecisionRequirementsExportHandler;
@@ -214,6 +215,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.BATCH_OPERATION_EXECUTION,
         new BatchOperationCompletedExportHandler(rdbmsWriter.getBatchOperationWriter()));
+    builder.withHandler(
+        ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+        new BatchOperationLifecycleManagementExportHandler(rdbmsWriter.getBatchOperationWriter()));
 
     // Handlers per batch operation to track status
     builder.withHandler(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationLifecycleManagementExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationLifecycleManagementExportHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.Set;
+
+public class BatchOperationLifecycleManagementExportHandler
+    implements RdbmsExportHandler<BatchOperationLifecycleManagementRecordValue> {
+
+  private static final Set<Intent> EXPORTABLE_INTENTS = Set.of(BatchOperationIntent.CANCELED);
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public BatchOperationLifecycleManagementExportHandler(
+      final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<BatchOperationLifecycleManagementRecordValue> record) {
+    return record.getValueType() == ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT
+        && EXPORTABLE_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public void export(final Record<BatchOperationLifecycleManagementRecordValue> record) {
+    final var value = record.getValue();
+    final var batchOperationKey = value.getBatchOperationKey();
+    if (record.getIntent().equals(BatchOperationIntent.CANCELED)) {
+      batchOperationWriter.cancel(
+          batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));
+    }
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7990,6 +7990,7 @@ components:
           enum:
             - ACTIVE
             - COMPLETED
+            - CANCELED
             - FAILED
   responses:
     InternalServerError:

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
@@ -8,16 +8,16 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerCancelBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementRecord> {
 
-  BatchOperationLifecycleManagementManagementRecord requestDto =
-      new BatchOperationLifecycleManagementManagementRecord();
+  BatchOperationLifecycleManagementRecord requestDto =
+      new BatchOperationLifecycleManagementRecord();
 
   public BrokerCancelBatchOperationRequest() {
     super(ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.CANCEL);
@@ -29,15 +29,14 @@ public class BrokerCancelBatchOperationRequest
   }
 
   @Override
-  public BatchOperationLifecycleManagementManagementRecord getRequestWriter() {
+  public BatchOperationLifecycleManagementRecord getRequestWriter() {
     return requestDto;
   }
 
   @Override
-  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
-      final DirectBuffer buffer) {
-    final BatchOperationLifecycleManagementManagementRecord responseDto =
-        new BatchOperationLifecycleManagementManagementRecord();
+  protected BatchOperationLifecycleManagementRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementRecord responseDto =
+        new BatchOperationLifecycleManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCancelBatchOperationRequest.java
@@ -8,18 +8,19 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerCancelBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
 
-  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+  BatchOperationLifecycleManagementManagementRecord requestDto =
+      new BatchOperationLifecycleManagementManagementRecord();
 
   public BrokerCancelBatchOperationRequest() {
-    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.CANCEL);
+    super(ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.CANCEL);
   }
 
   public BrokerCancelBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
@@ -28,13 +29,15 @@ public class BrokerCancelBatchOperationRequest
   }
 
   @Override
-  public BatchOperationExecutionRecord getRequestWriter() {
+  public BatchOperationLifecycleManagementManagementRecord getRequestWriter() {
     return requestDto;
   }
 
   @Override
-  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
-    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
+      final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementManagementRecord responseDto =
+        new BatchOperationLifecycleManagementManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
@@ -9,17 +9,18 @@ package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerPauseBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
 
   BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
 
   public BrokerPauseBatchOperationRequest() {
-    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.PAUSE);
+    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationIntent.PAUSE);
   }
 
   public BrokerPauseBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
@@ -33,8 +34,10 @@ public class BrokerPauseBatchOperationRequest
   }
 
   @Override
-  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
-    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
+      final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementManagementRecord responseDto =
+        new BatchOperationLifecycleManagementManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPauseBatchOperationRequest.java
@@ -9,13 +9,13 @@ package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerPauseBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementRecord> {
 
   BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
 
@@ -34,10 +34,9 @@ public class BrokerPauseBatchOperationRequest
   }
 
   @Override
-  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
-      final DirectBuffer buffer) {
-    final BatchOperationLifecycleManagementManagementRecord responseDto =
-        new BatchOperationLifecycleManagementManagementRecord();
+  protected BatchOperationLifecycleManagementRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementRecord responseDto =
+        new BatchOperationLifecycleManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
@@ -8,16 +8,16 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerResumeBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementRecord> {
 
-  BatchOperationLifecycleManagementManagementRecord requestDto =
-      new BatchOperationLifecycleManagementManagementRecord();
+  BatchOperationLifecycleManagementRecord requestDto =
+      new BatchOperationLifecycleManagementRecord();
 
   public BrokerResumeBatchOperationRequest() {
     super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationIntent.RESUME);
@@ -29,15 +29,14 @@ public class BrokerResumeBatchOperationRequest
   }
 
   @Override
-  public BatchOperationLifecycleManagementManagementRecord getRequestWriter() {
+  public BatchOperationLifecycleManagementRecord getRequestWriter() {
     return requestDto;
   }
 
   @Override
-  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
-      final DirectBuffer buffer) {
-    final BatchOperationLifecycleManagementManagementRecord responseDto =
-        new BatchOperationLifecycleManagementManagementRecord();
+  protected BatchOperationLifecycleManagementRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementRecord responseDto =
+        new BatchOperationLifecycleManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeBatchOperationRequest.java
@@ -8,18 +8,19 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import org.agrona.DirectBuffer;
 
 public class BrokerResumeBatchOperationRequest
-    extends BrokerExecuteCommand<BatchOperationExecutionRecord> {
+    extends BrokerExecuteCommand<BatchOperationLifecycleManagementManagementRecord> {
 
-  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+  BatchOperationLifecycleManagementManagementRecord requestDto =
+      new BatchOperationLifecycleManagementManagementRecord();
 
   public BrokerResumeBatchOperationRequest() {
-    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.RESUME);
+    super(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationIntent.RESUME);
   }
 
   public BrokerResumeBatchOperationRequest setBatchOperationKey(final long batchOperationKey) {
@@ -28,13 +29,15 @@ public class BrokerResumeBatchOperationRequest
   }
 
   @Override
-  public BatchOperationExecutionRecord getRequestWriter() {
+  public BatchOperationLifecycleManagementManagementRecord getRequestWriter() {
     return requestDto;
   }
 
   @Override
-  protected BatchOperationExecutionRecord toResponseDto(final DirectBuffer buffer) {
-    final BatchOperationExecutionRecord responseDto = new BatchOperationExecutionRecord();
+  protected BatchOperationLifecycleManagementManagementRecord toResponseDto(
+      final DirectBuffer buffer) {
+    final BatchOperationLifecycleManagementManagementRecord responseDto =
+        new BatchOperationLifecycleManagementManagementRecord();
     responseDto.wrap(buffer);
     return responseDto;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -53,6 +53,7 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   }
 
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
+    setBatchOperationKey(record.getBatchOperationKey());
     setItemKeys(record.getItemKeys());
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementManagementRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementManagementRecord.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+
+public final class BatchOperationLifecycleManagementManagementRecord extends UnifiedRecordValue
+    implements BatchOperationLifecycleManagementRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+
+  public BatchOperationLifecycleManagementManagementRecord() {
+    super(1);
+    declareProperty(batchOperationKeyProp);
+  }
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationLifecycleManagementManagementRecord setBatchOperationKey(
+      final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  public BatchOperationLifecycleManagementManagementRecord wrap(
+      final BatchOperationLifecycleManagementManagementRecord record) {
+    setBatchOperationKey(record.getBatchOperationKey());
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
@@ -11,14 +11,14 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 
-public final class BatchOperationLifecycleManagementManagementRecord extends UnifiedRecordValue
+public final class BatchOperationLifecycleManagementRecord extends UnifiedRecordValue
     implements BatchOperationLifecycleManagementRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
 
-  public BatchOperationLifecycleManagementManagementRecord() {
+  public BatchOperationLifecycleManagementRecord() {
     super(1);
     declareProperty(batchOperationKeyProp);
   }
@@ -28,15 +28,15 @@ public final class BatchOperationLifecycleManagementManagementRecord extends Uni
     return batchOperationKeyProp.getValue();
   }
 
-  public BatchOperationLifecycleManagementManagementRecord setBatchOperationKey(
+  public BatchOperationLifecycleManagementRecord setBatchOperationKey(
       final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
     return this;
   }
 
-  public BatchOperationLifecycleManagementManagementRecord wrap(
-      final BatchOperationLifecycleManagementManagementRecord record) {
+  public BatchOperationLifecycleManagementRecord wrap(
+      final BatchOperationLifecycleManagementRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -60,7 +60,9 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.REDISTRIBUTION, RedistributionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
-    RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_LIFECYCLE, BatchOperationLifecycleRecord::new);
+    RECORDS_BY_TYPE.put(
+        ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+        BatchOperationLifecycleManagementManagementRecord::new);
   }
 
   /*

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -62,7 +62,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
     RECORDS_BY_TYPE.put(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
-        BatchOperationLifecycleManagementManagementRecord::new);
+        BatchOperationLifecycleManagementRecord::new);
   }
 
   /*

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -59,6 +60,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.REDISTRIBUTION, RedistributionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_LIFECYCLE, BatchOperationLifecycleRecord::new);
   }
 
   /*

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -71,6 +71,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -290,6 +291,10 @@ public final class ValueTypeMapping {
         ValueType.BATCH_OPERATION_EXECUTION,
         new Mapping<>(
             BatchOperationExecutionRecordValue.class, BatchOperationExecutionIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+        new Mapping<>(
+            BatchOperationLifecycleManagementRecordValue.class, BatchOperationIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
@@ -19,17 +19,7 @@ public enum BatchOperationExecutionIntent implements Intent {
   EXECUTE((short) 0),
   EXECUTING((short) 1),
   EXECUTED((short) 2),
-
-  COMPLETED((short) 3),
-
-  CANCEL((short) 4),
-  //  CANCELED((short) 5),
-
-  PAUSE((short) 6),
-  //  PAUSED((short) 7),
-
-  RESUME((short) 8);
-  //  RESUMED((short) 9),
+  COMPLETED((short) 3);
 
   private final short value;
 
@@ -51,12 +41,6 @@ public enum BatchOperationExecutionIntent implements Intent {
         return EXECUTED;
       case 3:
         return COMPLETED;
-      case 4:
-        return CANCEL;
-      case 6:
-        return PAUSE;
-      case 8:
-        return RESUME;
 
       default:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
@@ -21,7 +21,13 @@ public enum BatchOperationIntent implements Intent {
   START((short) 2),
   STARTED((short) 3),
   FAIL((short) 4),
-  FAILED((short) 5);
+  FAILED((short) 5),
+  CANCEL((short) 6),
+  CANCELED((short) 7),
+  PAUSE((short) 8),
+  // PAUSED((short) 9),
+  RESUME((short) 10);
+  // RESUMED((short) 11);
 
   private final short value;
 
@@ -47,6 +53,14 @@ public enum BatchOperationIntent implements Intent {
         return FAIL;
       case 5:
         return FAILED;
+      case 6:
+        return CANCEL;
+      case 7:
+        return CANCELED;
+      case 8:
+        return PAUSE;
+      case 10:
+        return RESUME;
 
       default:
         return Intent.UNKNOWN;
@@ -64,6 +78,7 @@ public enum BatchOperationIntent implements Intent {
       case CREATED:
       case STARTED:
       case FAILED:
+      case CANCELED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -190,6 +190,8 @@ public interface Intent {
         return BatchOperationExecutionIntent.from(intent);
       case BATCH_OPERATION_CHUNK:
         return BatchOperationChunkIntent.from(intent);
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
+        return BatchOperationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -295,6 +297,8 @@ public interface Intent {
         return BatchOperationExecutionIntent.valueOf(intent);
       case BATCH_OPERATION_CHUNK:
         return BatchOperationChunkIntent.valueOf(intent);
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
+        return BatchOperationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationLifecycleManagementRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationLifecycleManagementRecordValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/** Will be used by lifecycle operations like cancel, pause and resume of batch operations. */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationLifecycleManagementRecordValue.Builder.class)
+public interface BatchOperationLifecycleManagementRecordValue
+    extends BatchOperationRelated, RecordValue {}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -69,6 +69,7 @@
       <validValue name="BATCH_OPERATION_EXECUTION">51</validValue>
       <validValue name="BATCH_OPERATION_CHUNK">52</validValue>
       <validValue name="AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION">53</validValue>
+      <validValue name="BATCH_OPERATION_LIFECYCLE_MANAGEMENT">54</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -129,7 +129,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkRecord.class);
     registry.put(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
-        BatchOperationLifecycleManagementManagementRecord.class);
+        BatchOperationLifecycleManagementRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementManagementRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -126,6 +127,9 @@ public final class TypedEventRegistry {
     registry.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord.class);
     registry.put(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionRecord.class);
     registry.put(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkRecord.class);
+    registry.put(
+        ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+        BatchOperationLifecycleManagementManagementRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationLifecycleRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationLifecycleRecordStream.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import java.util.stream.Stream;
+
+public class BatchOperationLifecycleRecordStream
+    extends ExporterRecordStream<
+        BatchOperationLifecycleManagementRecordValue, BatchOperationLifecycleRecordStream> {
+
+  public BatchOperationLifecycleRecordStream(
+      final Stream<Record<BatchOperationLifecycleManagementRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected BatchOperationLifecycleRecordStream supply(
+      final Stream<Record<BatchOperationLifecycleManagementRecordValue>> wrappedStream) {
+    return new BatchOperationLifecycleRecordStream(wrappedStream);
+  }
+
+  public BatchOperationLifecycleRecordStream withBatchOperationKey(final long batchOperationKey) {
+    return valueFilter(v -> v.getBatchOperationKey() == batchOperationKey);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -578,6 +579,18 @@ public final class RecordingExporter implements Exporter {
   public static BatchOperationExecutionRecordStream batchOperationExecutionRecords(
       final BatchOperationIntent intent) {
     return batchOperationExecutionRecords().withIntent(intent);
+  }
+
+  public static BatchOperationLifecycleRecordStream batchOperationLifecycleRecords() {
+    return new BatchOperationLifecycleRecordStream(
+        records(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            BatchOperationLifecycleManagementRecordValue.class));
+  }
+
+  public static BatchOperationLifecycleRecordStream batchOperationLifecycleRecords(
+      final BatchOperationIntent intent) {
+    return batchOperationLifecycleRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

* Adds new processor and applier in order to process the newly introduced batch operation cancel intent
* Extends RDBMS Exporter and DB to store if a batch operation get's canceled
  * Since it could be, that there are still items which got not processed until the cancel occurs, we now also set a CANCELED state to batch operation items. 

## Related issues

closes #29888
