### PR TITLE
refactor: update slack bot secret

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda TESTRAIL_QA_EMAIL;
             secret/data/github.com/organizations/camunda TESTRAIL_QA_PSW;
-            secret/data/github.com/organizations/camunda CORE_DOMAIN_SLACK_BOT_TOKEN;
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
       - name: Install Playwright Browsers
         shell: bash
@@ -118,7 +118,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8089"
           INCLUDE_SLACK_REPORTER: true
-          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.CORE_DOMAIN_SLACK_BOT_TOKEN }}
+          SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           VERSION: ${{ matrix.branch }}
         run: npm run test -- --project=chromium
         working-directory: qa/core-application-e2e-test-suite


### PR DESCRIPTION
## Description
As Infra team [requested](https://camunda.slack.com/archives/C5AHF1D8T/p1744020582639199?thread_ts=1743682250.666369&cid=C5AHF1D8T) to change the path of the slack bot secret to align with other Monorepo secrets, In this PR below is updated:
`path: products/camunda/ci/github-actions`
`key: SLACK_CORE_DOMAIN_BOT_TOKEN`
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
