### PR TITLE
fix: pass text counter fields only to textArea

### DIFF
--- a/identity/client/src/components/form/TextField.tsx
+++ b/identity/client/src/components/form/TextField.tsx
@@ -12,16 +12,25 @@ import useTranslate from "src/utility/localization";
 type TextInputProps = {
   type?: "text" | "email";
   cols?: never;
+  counterMode?: never;
+  enableCounter?: never;
+  maxCount?: never;
 };
 
 type TextAreaProps = {
   type?: never;
   cols: number;
+  counterMode?: "character" | "word";
+  enableCounter?: boolean;
+  maxCount?: number;
 };
 
 type PasswordInputProps = {
   type: "password";
   cols?: never;
+  counterMode?: never;
+  enableCounter?: never;
+  maxCount?: never;
 };
 
 export type TextFieldProps = {
@@ -35,9 +44,6 @@ export type TextFieldProps = {
   onBlur?: () => void;
   readOnly?: boolean;
   onChange?: (newValue: string) => void;
-  maxCount?: number;
-  enableCounter?: boolean;
-  counterMode?: "character" | "word";
 } & (TextInputProps | TextAreaProps | PasswordInputProps);
 
 const TextField: FC<TextFieldProps> = ({
@@ -73,16 +79,20 @@ const TextField: FC<TextFieldProps> = ({
     invalidText: errors?.map((e) => t(e)).join(" "),
     onBlur: onBlur,
     readOnly: readOnly,
-    maxCount: maxCount,
-    enableCounter: enableCounter,
-    counterMode: counterMode,
     ...(autoFocus && { "data-modal-primary-focus": true }),
   };
 
   if (type === "password") {
     return <PasswordInput {...commonProps} />;
   } else if (cols && cols > 1) {
-    return <TextArea {...commonProps} />;
+    return (
+      <TextArea
+        {...commonProps}
+        enableCounter={enableCounter}
+        counterMode={counterMode}
+        maxCount={maxCount}
+      />
+    );
   } else {
     return <TextInput {...commonProps} type={type} />;
   }


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
I noticed that we keep getting errors on the console regarding invalid enableCounter/counterMode properties. i adjust the code to fix this issue by only passing those fields to the textarea instead of all types of input fields.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
