### PR TITLE
refactor: group should use entityId instead of entityKey

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -91,7 +91,7 @@ public class CamundaOidcUserService extends OidcUserService {
             tenantServices.getTenantsByMemberIds(mappingIds).stream()
                 .map(TenantDTO::fromEntity)
                 .toList(),
-            groupServices.getGroupsByMemberKeys(mappingKeys).stream()
+            groupServices.getGroupsByMemberIds(mappingIds).stream()
                 .map(GroupEntity::name)
                 .toList()));
   }

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1185,7 +1185,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * camundaClient
    *  .newUnassignUserFromGroupCommand(123L)
-   *  .userKey(456L)
+   *  .username(username)
    *  .send();
    * </pre>
    *

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
@@ -22,9 +22,9 @@ public interface AssignUserToGroupCommandStep1 extends FinalCommandStep<AssignUs
   /**
    * Sets the user key for the assignment.
    *
-   * @param userKey the key of the user
+   * @param username the username of the user
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  AssignUserToGroupCommandStep1 userKey(long userKey);
+  AssignUserToGroupCommandStep1 username(String username);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
@@ -21,11 +21,11 @@ public interface UnassignUserFromGroupCommandStep1
     extends FinalCommandStep<UnassignUserFromGroupResponse> {
 
   /**
-   * Sets the user key for the unassignment.
+   * Sets the user username for the unassignment.
    *
-   * @param userKey the key of the user
+   * @param username the username of the user
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  UnassignUserFromGroupCommandStep1 userKey(long userKey);
+  UnassignUserFromGroupCommandStep1 username(String username);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
@@ -30,7 +30,7 @@ public class AssignUserToGroupCommandImpl implements AssignUserToGroupCommandSte
   private final long groupKey;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private long userKey;
+  private String username;
 
   public AssignUserToGroupCommandImpl(final long groupKey, final HttpClient httpClient) {
     this.groupKey = groupKey;
@@ -39,9 +39,9 @@ public class AssignUserToGroupCommandImpl implements AssignUserToGroupCommandSte
   }
 
   @Override
-  public AssignUserToGroupCommandStep1 userKey(final long userKey) {
-    ArgumentUtil.ensureNotNull("userKey", userKey);
-    this.userKey = userKey;
+  public AssignUserToGroupCommandStep1 username(final String username) {
+    ArgumentUtil.ensureNotNull("username", username);
+    this.username = username;
     return this;
   }
 
@@ -53,10 +53,10 @@ public class AssignUserToGroupCommandImpl implements AssignUserToGroupCommandSte
 
   @Override
   public CamundaFuture<AssignUserToGroupResponse> send() {
-    ArgumentUtil.ensureNotNull("userKey", userKey);
+    ArgumentUtil.ensureNotNull("username", username);
     final HttpCamundaFuture<AssignUserToGroupResponse> result = new HttpCamundaFuture<>();
     httpClient.put(
-        "/groups/" + groupKey + "/users/" + userKey, null, httpRequestConfig.build(), result);
+        "/groups/" + groupKey + "/users/" + username, null, httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
@@ -30,7 +30,7 @@ public class UnassignUserFromGroupCommandImpl implements UnassignUserFromGroupCo
   private final long groupKey;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private long userKey;
+  private String username;
 
   public UnassignUserFromGroupCommandImpl(final long groupKey, final HttpClient httpClient) {
     this.groupKey = groupKey;
@@ -39,9 +39,9 @@ public class UnassignUserFromGroupCommandImpl implements UnassignUserFromGroupCo
   }
 
   @Override
-  public UnassignUserFromGroupCommandStep1 userKey(final long userKey) {
-    ArgumentUtil.ensureNotNull("userKey", userKey);
-    this.userKey = userKey;
+  public UnassignUserFromGroupCommandStep1 username(final String username) {
+    ArgumentUtil.ensureNotNull("username", username);
+    this.username = username;
     return this;
   }
 
@@ -54,10 +54,10 @@ public class UnassignUserFromGroupCommandImpl implements UnassignUserFromGroupCo
 
   @Override
   public CamundaFuture<UnassignUserFromGroupResponse> send() {
-    ArgumentUtil.ensureNotNull("userKey", userKey);
+    ArgumentUtil.ensureNotNull("username", username);
     final HttpCamundaFuture<UnassignUserFromGroupResponse> result = new HttpCamundaFuture<>();
     httpClient.delete(
-        "/groups/" + groupKey + "/users/" + userKey, httpRequestConfig.build(), result);
+        "/groups/" + groupKey + "/users/" + username, httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -440,7 +440,7 @@
       <column name="GROUP_KEY" type="BIGINT" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_KEY" type="BIGINT" >
+      <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
@@ -52,6 +52,6 @@ public class GroupReader extends AbstractEntityReader<GroupEntity> {
     return new GroupEntity(
         model.groupKey(),
         model.name(),
-        model.members().stream().map(GroupMemberDbModel::entityKey).collect(Collectors.toSet()));
+        model.members().stream().map(GroupMemberDbModel::entityId).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupMemberDbModel.java
@@ -9,13 +9,13 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record GroupMemberDbModel(Long groupKey, Long entityKey, String entityType) {
+public record GroupMemberDbModel(Long groupKey, String entityId, String entityType) {
 
   // create builder implementing ObjectBuilder
   public static class Builder implements ObjectBuilder<GroupMemberDbModel> {
 
     private Long groupKey;
-    private Long entityKey;
+    private String entityId;
     private String entityType;
 
     public Builder groupKey(final Long groupKey) {
@@ -23,8 +23,8 @@ public record GroupMemberDbModel(Long groupKey, Long entityKey, String entityTyp
       return this;
     }
 
-    public Builder entityKey(final Long entityKey) {
-      this.entityKey = entityKey;
+    public Builder entityId(final String entityId) {
+      this.entityId = entityId;
       return this;
     }
 
@@ -35,7 +35,7 @@ public record GroupMemberDbModel(Long groupKey, Long entityKey, String entityTyp
 
     @Override
     public GroupMemberDbModel build() {
-      return new GroupMemberDbModel(groupKey, entityKey, entityType);
+      return new GroupMemberDbModel(groupKey, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -23,7 +23,7 @@
     g.GROUP_KEY,
     g.NAME,
     gm.GROUP_KEY AS MEMBER_GROUP_KEY,
-    gm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
+    gm.ENTITY_ID AS MEMBER_ENTITY_ID,
     gm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}GROUPS g
     LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_KEY = gm.GROUP_KEY
@@ -47,7 +47,7 @@
       javaType="java.util.List">
       <constructor>
         <idArg column="MEMBER_GROUP_KEY" javaType="java.lang.Long"/>
-        <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_ENTITY_ID" javaType="java.lang.String"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>
     </collection>
@@ -80,8 +80,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}GROUP_MEMBER (GROUP_KEY, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{groupKey}, #{entityKey}, #{entityType})
+    INSERT INTO ${prefix}GROUP_MEMBER (GROUP_KEY, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{groupKey}, #{entityId}, #{entityType})
   </insert>
 
   <delete
@@ -91,7 +91,7 @@
     DELETE
     FROM ${prefix}GROUP_MEMBER
     WHERE GROUP_KEY = #{groupKey}
-      AND ENTITY_KEY = #{entityKey}
+      AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -468,20 +468,20 @@ class RdbmsExporterIT {
     assertThat(group.get().name()).isEqualTo(groupRecordValue.getName());
 
     // when
-    exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_ADDED, 1337L));
+    exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_ADDED, "entityId"));
 
     // then
     final var updatedGroup =
         rdbmsService.getGroupReader().findOne(groupRecord.getKey()).orElseThrow();
-    assertThat(updatedGroup.assignedMemberKeys()).containsExactly(1337L);
+    assertThat(updatedGroup.assignedMemberIds()).containsExactly("entityId");
 
     // when
-    exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_REMOVED, 1337L));
+    exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_REMOVED, "entityId"));
 
     // then
     final var deletedGroup =
         rdbmsService.getGroupReader().findOne(groupRecord.getKey()).orElseThrow();
-    assertThat(deletedGroup.assignedMemberKeys()).isEmpty();
+    assertThat(deletedGroup.assignedMemberIds()).isEmpty();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -340,7 +340,7 @@ public class RecordFixtures {
   }
 
   protected static ImmutableRecord<RecordValue> getGroupRecord(
-      final Long groupKey, final GroupIntent intent, final Long entityKey) {
+      final Long groupKey, final GroupIntent intent, final String entityId) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.GROUP);
     return ImmutableRecord.builder()
         .from(recordValueRecord)
@@ -352,8 +352,8 @@ public class RecordFixtures {
             ImmutableGroupRecordValue.builder()
                 .from((GroupRecordValue) recordValueRecord.getValue())
                 .withGroupKey(groupKey)
-                .withEntityKey(entityKey != null ? entityKey : 0)
-                .withEntityType(entityKey != null ? EntityType.USER : null)
+                .withEntityId(entityId)
+                .withEntityType(entityId != null ? EntityType.USER : null)
                 .build())
         .build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GroupEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GroupEntityTransformer.java
@@ -18,8 +18,8 @@ public class GroupEntityTransformer
   @Override
   public GroupEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.GroupEntity value) {
-    final Set<Long> memberSet =
-        value.getMemberKey() == null ? Set.of() : Set.of(value.getMemberKey());
+    final Set<String> memberSet =
+        value.getMemberId() == null ? Set.of() : Set.of(value.getMemberId());
     return new GroupEntity(value.getKey(), value.getName(), memberSet);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -9,11 +9,11 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.KEY;
-import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_KEY;
+import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -34,12 +34,12 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
         term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()),
         filter.groupKey() == null ? null : term(KEY, filter.groupKey()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberKeys() == null
+        filter.memberIds() == null
             ? null
-            : filter.memberKeys().isEmpty()
+            : filter.memberIds().isEmpty()
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(MEMBER_KEY, filter.memberKeys())));
+                    stringTerms(MEMBER_ID, filter.memberIds())));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
@@ -11,4 +11,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record GroupEntity(Long groupKey, String name, Set<Long> assignedMemberKeys) {}
+public record GroupEntity(Long groupKey, String name, Set<String> assignedMemberIds) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -10,12 +10,12 @@ package io.camunda.search.filter;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 
-public record GroupFilter(Long groupKey, String name, Set<Long> memberKeys) implements FilterBase {
+public record GroupFilter(Long groupKey, String name, Set<String> memberIds) implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
     private Long groupKey;
     private String name;
-    private Set<Long> memberKeys;
+    private Set<String> memberIds;
 
     public Builder groupKey(final Long value) {
       groupKey = value;
@@ -27,18 +27,18 @@ public record GroupFilter(Long groupKey, String name, Set<Long> memberKeys) impl
       return this;
     }
 
-    public Builder memberKey(final Long value) {
-      return memberKeys(Set.of(value));
+    public Builder memberId(final String value) {
+      return memberIds(Set.of(value));
     }
 
-    public Builder memberKeys(final Set<Long> value) {
-      memberKeys = value;
+    public Builder memberIds(final Set<String> value) {
+      memberIds = value;
       return this;
     }
 
     @Override
     public GroupFilter build() {
-      return new GroupFilter(groupKey, name, memberKeys);
+      return new GroupFilter(groupKey, name, memberIds);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -99,16 +99,16 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
                     CamundaSearchException.Reason.NOT_FOUND));
   }
 
-  public List<GroupEntity> getGroupsByUserKey(final long userKey) {
-    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberKey(userKey)).build())
+  public List<GroupEntity> getGroupsByUsername(final String username) {
+    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberId(username)).build())
         .items()
         .stream()
         .toList();
   }
 
-  public List<GroupEntity> getGroupsByMemberKeys(final Set<Long> memberKeys) {
+  public List<GroupEntity> getGroupsByMemberIds(final Set<String> memberIds) {
     return findAll(
-        SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberKeys(memberKeys)).build());
+        SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberIds(memberIds)).build());
   }
 
   public Optional<GroupEntity> findGroup(final Long groupKey) {

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -202,7 +202,7 @@ public class GroupServiceTest {
     assertThat(request.getKey()).isEqualTo(groupKey);
     final GroupRecord record = request.getRequestWriter();
     assertThat(record).hasGroupKey(groupKey);
-    assertThat(record).hasEntityKey(Long.parseLong(memberId));
+    assertThat(record).hasEntityId(memberId);
     assertThat(record).hasEntityType(EntityType.USER);
   }
 
@@ -226,7 +226,7 @@ public class GroupServiceTest {
     assertThat(request.getKey()).isEqualTo(groupKey);
     final GroupRecord record = request.getRequestWriter();
     assertThat(record).hasGroupKey(groupKey);
-    assertThat(record).hasEntityKey(memberKey);
+    assertThat(record).hasEntityId(username);
     assertThat(record).hasEntityType(EntityType.USER);
   }
 

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -125,7 +125,7 @@ public class GroupServiceTest {
   }
 
   @Test
-  public void shouldReturnListOfGroupsForGetByUserKey() {
+  public void shouldReturnListOfGroupsForGetByUsername() {
     // given
     final var group1 = mock(GroupEntity.class);
     final var group2 = mock(GroupEntity.class);
@@ -134,7 +134,7 @@ public class GroupServiceTest {
     when(client.searchGroups(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getGroupsByUserKey(1L);
+    final var searchQueryResult = services.getGroupsByUsername("username");
 
     // then
     assertThat(searchQueryResult).contains(group1, group2);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
@@ -18,7 +18,7 @@ public class GroupIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "group";
   public static final String INDEX_VERSION = "8.8.0";
   public static final String KEY = "key";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String MEMBER_ID = "memberId";
   public static final String NAME = "name";
   public static final String JOIN = "join";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -13,7 +13,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
   private Long key;
   private String name;
-  private Long memberKey;
+  private String memberId;
 
   private EntityJoinRelation<Long> join;
 
@@ -35,12 +35,12 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public Long getMemberKey() {
-    return memberKey;
+  public String getMemberId() {
+    return memberId;
   }
 
-  public GroupEntity setMemberKey(final Long memberKey) {
-    this.memberKey = memberKey;
+  public GroupEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
     return this;
   }
 
@@ -53,7 +53,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public static String getChildKey(final long groupKey, final long memberKey) {
-    return String.format("%d-%d", groupKey, memberKey);
+  public static String getChildKey(final long groupKey, final String memberKey) {
+    return String.format("%d-%s", groupKey, memberKey);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-group.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
   private static final String ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE =
-      "Expected to add entity with key '%s' to group with ID '%s', but the entity is already assigned to this group.";
+      "Expected to add entity with ID '%s' to group with ID '%s', but the entity is already assigned to this group.";
 
   private final GroupState groupState;
   private final UserState userState;
@@ -86,12 +86,12 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
       return;
     }
 
-    final var entityKey = record.getEntityKey();
+    final var entityId = record.getEntityId();
     final var entityType = record.getEntityType();
-    if (!isEntityPresent(entityKey, entityType)) {
+    if (!isEntityPresent(entityId, entityType)) {
       final var errorMessage =
-          "Expected to add an entity with key '%s' and type '%s' to group with ID '%s', but the entity does not exist."
-              .formatted(entityKey, entityType, groupId);
+          "Expected to add an entity with ID '%s' and type '%s' to group with ID '%s', but the entity does not exist."
+              .formatted(entityId, entityType, groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
@@ -100,7 +100,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     if (isEntityAssigned(record)) {
       final var errorMessage =
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(
-              record.getEntityKey(), record.getGroupId());
+              record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
@@ -122,7 +122,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     if (isEntityAssigned(record)) {
       final var errorMessage =
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(
-              record.getEntityKey(), record.getGroupId());
+              record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
     } else {
       stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.ENTITY_ADDED, record);
@@ -131,15 +131,15 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
+  private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case EntityType.USER -> userState.getUser(entityKey).isPresent();
-      case EntityType.MAPPING -> mappingState.get(entityKey).isPresent();
+      case EntityType.USER -> userState.getUser(entityId).isPresent();
+      case EntityType.MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };
   }
 
   private boolean isEntityAssigned(final GroupRecord record) {
-    return groupState.getEntityType(record.getGroupId(), record.getEntityKey()).isPresent();
+    return groupState.getEntityType(record.getGroupId(), record.getEntityId()).isPresent();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -128,7 +128,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
                     final var entityRecord =
                         new GroupRecord()
                             .setGroupKey(groupKey)
-                            .setEntityKey(entityKey)
+                            .setEntityId(entityKey)
                             .setEntityType(entityType);
                     stateWriter.appendFollowUpEvent(
                         groupKey, GroupIntent.ENTITY_REMOVED, entityRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
   private static final String ENTITY_NOT_ASSIGNED_ERROR_MESSAGE =
-      "Expected to remove entity with key '%s' from group with key '%s', but the entity is not assigned to this group.";
+      "Expected to remove entity with ID '%s' from group with key '%s', but the entity is not assigned to this group.";
   private final GroupState groupState;
   private final UserState userState;
   private final MappingState mappingState;
@@ -84,12 +84,12 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
       return;
     }
 
-    final var entityKey = record.getEntityKey();
+    final var entityId = record.getEntityId();
     final var entityType = record.getEntityType();
-    if (!isEntityPresent(entityKey, entityType)) {
+    if (!isEntityPresent(entityId, entityType)) {
       final var errorMessage =
-          "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity does not exist."
-              .formatted(entityKey, entityType, groupKey);
+          "Expected to remove an entity with ID '%s' and type '%s' from group with key '%s', but the entity does not exist."
+              .formatted(entityId, entityType, groupKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
@@ -110,7 +110,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     final var record = command.getValue();
 
     groupState
-        .getEntityType(record.getGroupId(), record.getEntityKey())
+        .getEntityType(record.getGroupId(), record.getEntityId())
         .ifPresentOrElse(
             entityType ->
                 stateWriter.appendFollowUpEvent(
@@ -118,17 +118,17 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
             () -> {
               final var errorMessage =
                   ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(
-                      record.getEntityKey(), record.getGroupKey());
+                      record.getEntityId(), record.getGroupKey());
               rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
             });
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
+  private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER -> userState.getUser(entityKey).isPresent();
-      case MAPPING -> mappingState.get(entityKey).isPresent();
+      case USER -> userState.getUser(entityId).isPresent();
+      case MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -149,7 +149,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
           GroupIntent.ENTITY_REMOVED,
           new GroupRecord()
               .setGroupKey(groupKey)
-              .setEntityKey(mappingKey)
+              .setEntityId(mappingKey)
               .setEntityType(EntityType.MAPPING));
     }
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -149,7 +149,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
           GroupIntent.ENTITY_REMOVED,
           new GroupRecord()
               .setGroupKey(groupKey)
-              .setEntityId(mappingKey)
+              .setEntityId(mapping.getMappingId())
               .setEntityType(EntityType.MAPPING));
     }
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -167,7 +167,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
           GroupIntent.ENTITY_REMOVED,
           new GroupRecord()
               .setGroupKey(groupKey)
-              .setEntityId(userKey)
+              .setEntityId(user.getUsername())
               .setEntityType(EntityType.USER));
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -167,7 +167,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
           GroupIntent.ENTITY_REMOVED,
           new GroupRecord()
               .setGroupKey(groupKey)
-              .setEntityKey(userKey)
+              .setEntityId(userKey)
               .setEntityType(EntityType.USER));
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -33,19 +33,19 @@ public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, G
     final var groupKey = Long.parseLong(value.getGroupId());
     groupState.addEntity(value);
 
-    final var entityKey = value.getEntityKey();
+    final var entityId = value.getEntityId();
     final var entityType = value.getEntityType();
     switch (entityType) {
       case USER ->
           userState
-              .getUser(entityKey)
+              .getUser(entityId)
               .ifPresent(user -> userState.addGroup(user.getUsername(), groupKey));
-      case MAPPING -> mappingState.addGroup(entityKey, groupKey);
+      case MAPPING -> mappingState.addGroup(entityId, groupKey);
       default ->
           throw new IllegalStateException(
               String.format(
-                  "Expected to add entity '%d' to group '%d', but entities of type '%s' cannot be added to groups.",
-                  entityKey, groupKey, entityType));
+                  "Expected to add entity '%s' to group '%d', but entities of type '%s' cannot be added to groups.",
+                  entityId, groupKey, entityType));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
@@ -29,25 +29,25 @@ public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent,
 
   @Override
   public void applyState(final long key, final GroupRecord value) {
-    final var entityKey = value.getEntityKey();
+    final var entityId = value.getEntityId();
     final var entityType = value.getEntityType();
 
     // get the record key from the GroupRecord, as the key argument
     // may belong to the distribution command
     final var groupKey = value.getGroupKey();
-    groupState.removeEntity(groupKey, entityKey);
+    groupState.removeEntity(groupKey, entityId);
 
     switch (entityType) {
       case USER ->
           userState
-              .getUser(entityKey)
+              .getUser(entityId)
               .ifPresent(user -> userState.removeGroup(user.getUsername(), key));
-      case MAPPING -> mappingState.removeGroup(entityKey, key);
+      case MAPPING -> mappingState.removeGroup(entityId, key);
       default ->
           throw new IllegalStateException(
               String.format(
-                  "Expected to remove entity '%d' from group '%d', but entities of type '%s' cannot be removed from groups.",
-                  entityKey, groupKey, entityType));
+                  "Expected to remove entity '%s' from group '%d', but entities of type '%s' cannot be removed from groups.",
+                  entityId, groupKey, entityType));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -139,9 +139,9 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void addGroup(final long mappingKey, final long groupKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+  public void addGroup(final String mappingId, final long groupKey) {
+    this.mappingId.wrapString(mappingId);
+    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
     if (fkClaim != null) {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);
@@ -179,9 +179,9 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void removeGroup(final long mappingKey, final long groupKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+  public void removeGroup(final String mappingId, final long groupKey) {
+    this.mappingId.wrapString(mappingId);
+    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
     if (fkClaim != null) {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -21,7 +21,7 @@ public interface GroupState {
 
   Optional<PersistedGroup> get(String groupId);
 
-  Optional<EntityType> getEntityType(String groupId, long entityKey);
+  Optional<EntityType> getEntityType(String groupId, String entityId);
 
-  Map<EntityType, List<Long>> getEntitiesByType(long groupKey);
+  Map<EntityType, List<String>> getEntitiesByType(long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -18,7 +18,7 @@ public interface MutableGroupState extends GroupState {
 
   void addEntity(final GroupRecord group);
 
-  void removeEntity(final long groupKey, final long entityKey);
+  void removeEntity(final long groupKey, final String entityId);
 
   void delete(final String groupId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -20,13 +20,13 @@ public interface MutableMappingState extends MappingState {
 
   void addTenant(final String mappingId, final String tenantId);
 
-  void addGroup(final long mappingKey, final long groupKey);
+  void addGroup(final String mappingId, final long groupKey);
 
   void removeRole(final long mappingKey, final long roleKey);
 
   void removeTenant(final long mappingKey, final String tenantId);
 
-  void removeGroup(final long mappingKey, final long groupKey);
+  void removeGroup(final String mappingId, final long groupKey);
 
   void delete(final String id);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -525,7 +525,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
             .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
-            .setEntityKey(entityKey)
+            .setEntityId(entityKey)
             .setEntityType(entityType);
     groupCreatedApplier.applyState(groupKey, group);
     groupEntityAddedApplier.applyState(groupKey, group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -121,7 +121,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
         user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var groupKey = createGroup(user.getUsername(), EntityType.USER);
     final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommand(user.getUsername());
 
@@ -174,7 +174,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
         resourceType,
         permissionType,
         resourceId);
-    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
+    final var groupKey = createGroup(mapping.getMappingId(), EntityType.MAPPING);
     final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
@@ -238,7 +238,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   void shouldGetUserAuthorizedTenantIdsThroughGroup() {
     // given
     final var user = createUser();
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var groupKey = createGroup(user.getUsername(), EntityType.USER);
     final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommand(user.getUsername());
@@ -263,7 +263,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mapping = createMapping(claimName, claimValue);
-    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
+    final var groupKey = createGroup(mapping.getMappingId(), EntityType.MAPPING);
     final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommandWithMapping(claimName, claimValue);
@@ -516,7 +516,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     }
   }
 
-  private long createGroup(final long entityKey, final EntityType entityType) {
+  private long createGroup(final String entityId, final EntityType entityType) {
     final var groupKey = random.nextLong();
     final var groupId = String.valueOf(groupKey);
     final var group =
@@ -525,7 +525,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
             .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
-            .setEntityId(entityKey)
+            .setEntityId(entityId)
             .setEntityType(entityType);
     groupCreatedApplier.applyState(groupKey, group);
     groupEntityAddedApplier.applyState(groupKey, group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -224,7 +224,7 @@ final class AuthorizationCheckBehaviorTest {
   public void shouldBeAuthorizedWhenGroupHasPermissions() {
     // given
     final var user = createUser();
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var groupKey = createGroup(user.getUsername(), EntityType.USER);
     final var groupId = String.valueOf(groupKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -245,7 +245,7 @@ final class AuthorizationCheckBehaviorTest {
   void shouldGetResourceIdentifiersWhenGroupHasPermissions() {
     // given
     final var user = createUser();
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var groupKey = createGroup(user.getUsername(), EntityType.USER);
     final var groupId = String.valueOf(groupKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -320,8 +320,8 @@ final class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue).getMappingKey();
-    final var groupKey = createGroup(mappingKey, EntityType.MAPPING);
+    final var mappingId = createMapping(claimName, claimValue).getMappingId();
+    final var groupKey = createGroup(mappingId, EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -548,8 +548,7 @@ final class AuthorizationCheckBehaviorTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mapping = createMapping(claimName, claimValue);
-    final var mappingKey = mapping.getMappingKey();
-    final var groupKey = createGroup(mappingKey, EntityType.MAPPING);
+    final var groupKey = createGroup(mapping.getMappingId(), EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -607,7 +606,7 @@ final class AuthorizationCheckBehaviorTest {
     return roleKey;
   }
 
-  private long createGroup(final long entityKey, final EntityType entityType) {
+  private long createGroup(final String entityId, final EntityType entityType) {
     final var groupKey = random.nextLong();
     final var groupId = String.valueOf(groupKey);
     final var group =
@@ -616,7 +615,7 @@ final class AuthorizationCheckBehaviorTest {
             .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
-            .setEntityId(entityKey)
+            .setEntityId(entityId)
             .setEntityType(entityType);
     groupCreatedApplier.applyState(groupKey, group);
     groupEntityAddedApplier.applyState(groupKey, group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -616,7 +616,7 @@ final class AuthorizationCheckBehaviorTest {
             .setGroupId(groupId)
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
-            .setEntityKey(entityKey)
+            .setEntityId(entityKey)
             .setEntityType(entityType);
     groupCreatedApplier.applyState(groupKey, group);
     groupEntityAddedApplier.applyState(groupKey, group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -303,7 +303,7 @@ public class CommandDistributionIdempotencyTest {
                   return ENGINE
                       .group()
                       .addEntity(groupId)
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                 }),
@@ -323,14 +323,14 @@ public class CommandDistributionIdempotencyTest {
                   ENGINE
                       .group()
                       .addEntity(groupId)
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                   return ENGINE
                       .group()
                       .removeEntity(groupKey)
                       .withGroupId(groupId)
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .remove();
                 }),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -41,20 +41,24 @@ public class AddEntityGroupMultiPartitionTest {
   @Test
   public void shouldDistributeGroupAddEntityCommand() {
     // when
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     // TODO: refactor this with https://github.com/camunda/camunda/issues/30476
     final var groupId = "123";
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     assertThat(
             RecordingExporter.records()
@@ -105,20 +109,24 @@ public class AddEntityGroupMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     // TODO: refactor this with https://github.com/camunda/camunda/issues/30476
     final var groupId = "123";
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     // then
     assertThat(
@@ -135,22 +143,26 @@ public class AddEntityGroupMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptGroupCommandForPartition(partitionId, GroupIntent.CREATE);
     }
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
 
     // when
     final var name = UUID.randomUUID().toString();
     // TODO: refactor this with https://github.com/camunda/camunda/issues/30476
     final var groupId = "123";
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -98,15 +98,14 @@ public class GroupTest {
     // given
     // TODO: refactor this with https://github.com/camunda/camunda/issues/30476
     final var groupId = "123";
-    final var userKey =
+    final var createdUser =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(name).withGroupId(groupId).create().getValue().getGroupKey();
 
@@ -115,13 +114,15 @@ public class GroupTest {
         engine
             .group()
             .addEntity(groupId)
-            .withEntityKey(userKey)
+            .withEntityId(createdUser.getValue().getUsername())
             .withEntityType(EntityType.USER)
             .add()
             .getValue();
 
     // then
-    assertThat(updatedGroup).hasEntityKey(userKey).hasEntityType(EntityType.USER);
+    assertThat(updatedGroup)
+        .hasEntityId(createdUser.getValue().getUsername())
+        .hasEntityType(EntityType.USER);
   }
 
   @Test
@@ -152,7 +153,7 @@ public class GroupTest {
         engine
             .group()
             .addEntity(groupId)
-            .withEntityKey(1L)
+            .withEntityId("entityId")
             .withEntityType(EntityType.USER)
             .expectRejection()
             .add();
@@ -162,8 +163,8 @@ public class GroupTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add an entity with key '%s' and type '%s' to group with ID '%s', but the entity does not exist."
-                .formatted(1L, EntityType.USER, groupId));
+            "Expected to add an entity with ID '%s' and type '%s' to group with ID '%s', but the entity does not exist."
+                .formatted("entityId", EntityType.USER, groupId));
   }
 
   @Test
@@ -173,23 +174,27 @@ public class GroupTest {
     final var groupId = "123";
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(name).withGroupId(groupId).create();
-    final var userKey =
+    final var createdUser =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+            .create();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(createdUser.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     // when
     final var notPresentUpdateRecord =
         engine
             .group()
             .addEntity(groupId)
-            .withEntityKey(userKey)
+            .withEntityId(createdUser.getValue().getUsername())
             .withEntityType(EntityType.USER)
             .expectRejection()
             .add();
@@ -198,8 +203,8 @@ public class GroupTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
-            "Expected to add entity with key '%d' to group with ID '%s', but the entity is already assigned to this group."
-                .formatted(userKey, groupId));
+            "Expected to add entity with ID '%s' to group with ID '%s', but the entity is already assigned to this group."
+                .formatted(createdUser.getValue().getUsername(), groupId));
   }
 
   @Test
@@ -208,25 +213,29 @@ public class GroupTest {
     // given
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     // when
     final var groupWithRemovedEntity =
         engine
             .group()
             .removeEntity(groupKey)
-            .withEntityKey(userKey)
+            .withEntityId(user.getValue().getUsername())
             .withEntityType(EntityType.USER)
             .remove()
             .getValue();
@@ -234,7 +243,7 @@ public class GroupTest {
     // then
     assertThat(groupWithRemovedEntity)
         .hasGroupKey(groupKey)
-        .hasEntityKey(userKey)
+        .hasEntityId(user.getValue().getUsername())
         .hasEntityType(EntityType.USER);
   }
 
@@ -269,7 +278,7 @@ public class GroupTest {
         engine
             .group()
             .removeEntity(groupKey)
-            .withEntityKey(1L)
+            .withEntityId("entityId")
             .withEntityType(EntityType.USER)
             .expectRejection()
             .remove();
@@ -279,8 +288,8 @@ public class GroupTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity does not exist."
-                .formatted(1L, EntityType.USER, groupKey));
+            "Expected to remove an entity with ID '%s' and type '%s' from group with key '%s', but the entity does not exist."
+                .formatted("entityId", EntityType.USER, groupKey));
   }
 
   @Test
@@ -302,18 +311,22 @@ public class GroupTest {
     // given
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(name).withGroupId(groupId).create().getValue().getGroupKey();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
 
     // when
     final var deletedGroup =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -41,24 +41,28 @@ public class RemoveEntityGroupMultiPartitionTest {
   @Test
   public void shouldDistributeGroupRemoveEntityCommand() {
     // when
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
     engine
         .group()
         .removeEntity(groupKey)
-        .withEntityKey(userKey)
+        .withEntityId(user.getValue().getUsername())
         .withEntityType(EntityType.USER)
         .remove();
 
@@ -111,24 +115,28 @@ public class RemoveEntityGroupMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
     final var name = UUID.randomUUID().toString();
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
     engine
         .group()
         .removeEntity(groupKey)
-        .withEntityKey(userKey)
+        .withEntityId(user.getValue().getUsername())
         .withEntityType(EntityType.USER)
         .remove();
 
@@ -147,26 +155,30 @@ public class RemoveEntityGroupMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }
-    final var userKey =
+    final var user =
         engine
             .user()
             .newUser("foo")
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
-            .create()
-            .getKey();
+            .create();
 
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
     engine.group().newGroup(name).withGroupId(groupId).create();
-    engine.group().addEntity(groupId).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .addEntity(groupId)
+        .withEntityId(user.getValue().getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
     engine
         .group()
         .removeEntity(groupKey)
-        .withEntityKey(userKey)
+        .withEntityId(user.getValue().getUsername())
         .withEntityType(EntityType.USER)
         .remove();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -244,7 +244,7 @@ public class MappingTest {
     engine
         .group()
         .addEntity(groupId)
-        .withEntityKey(mappingRecord.getKey())
+        .withEntityId(mappingRecord.getValue().getMappingId())
         .withEntityType(EntityType.MAPPING)
         .add();
     engine
@@ -261,7 +261,7 @@ public class MappingTest {
     Assertions.assertThat(
             RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
                 .withGroupKey(groupKey)
-                .withEntityKey(mappingRecord.getKey())
+                .withEntityId(mappingRecord.getValue().getMappingId())
                 .exists())
         .isTrue();
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -67,7 +67,7 @@ public class DeleteUserTest {
     ENGINE
         .group()
         .addEntity(groupId)
-        .withEntityKey(userRecord.getKey())
+        .withEntityId(userRecord.getValue().getUsername())
         .withEntityType(EntityType.USER)
         .add();
     ENGINE
@@ -91,7 +91,7 @@ public class DeleteUserTest {
             RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
                 // TODO: refactor this with https://github.com/camunda/camunda/issues/30029
                 .withGroupKey(Long.parseLong(groupId))
-                .withEntityKey(userRecord.getKey())
+                .withEntityId(userRecord.getValue().getUsername())
                 .exists())
         .isTrue();
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -115,7 +115,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityKey).setEntityType(entityType);
 
     // when
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
@@ -144,7 +144,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityKey).setEntityType(entityType);
 
     // when
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
@@ -175,7 +175,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // when
@@ -205,7 +205,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityKey).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -100,6 +100,7 @@ public class GroupAppliersTest {
   void shouldAddUserEntityToGroup() {
     // given
     final var entityKey = 1L;
+    final var entityId = "entityId";
     final var userRecord =
         new UserRecord()
             .setUserKey(entityKey)
@@ -115,15 +116,15 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityId).setEntityType(entityType);
 
     // when
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // then
     final var entitiesByType = groupState.getEntitiesByType(groupKey);
-    assertThat(entitiesByType).containsOnly(Map.entry(entityType, List.of(entityKey)));
-    final var persistedUser = userState.getUser(entityKey).get();
+    assertThat(entitiesByType).containsOnly(Map.entry(entityType, List.of(entityId)));
+    final var persistedUser = userState.getUser(entityId).get();
     assertThat(persistedUser.getGroupKeysList()).containsExactly(groupKey);
   }
 
@@ -131,6 +132,7 @@ public class GroupAppliersTest {
   void shouldAddMappingEntityToGroup() {
     // given
     final var entityKey = 1L;
+    final var entityId = "entityId";
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(entityKey)
@@ -144,15 +146,15 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityId).setEntityType(entityType);
 
     // when
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // then
     final var entitiesByType = groupState.getEntitiesByType(groupKey);
-    assertThat(entitiesByType).containsOnly(Map.entry(entityType, List.of(entityKey)));
-    final var persistedMapping = mappingState.get(entityKey).get();
+    assertThat(entitiesByType).containsOnly(Map.entry(entityType, List.of(entityId)));
+    final var persistedMapping = mappingState.get(entityId).get();
     assertThat(persistedMapping.getGroupKeysList()).containsExactly(groupKey);
   }
 
@@ -175,7 +177,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId("username").setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // when
@@ -192,6 +194,7 @@ public class GroupAppliersTest {
   void shouldRemoveMappingEntityFromGroup() {
     // given
     final var entityKey = 1L;
+    final var entityId = "entityId";
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(entityKey)
@@ -205,7 +208,7 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(entityKey).setEntityType(entityType);
+    groupRecord.setEntityId(entityId).setEntityType(entityType);
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // when
@@ -214,7 +217,7 @@ public class GroupAppliersTest {
     // then
     final var entitiesByType = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByType).isEmpty();
-    final var persistedMapping = mappingState.get(entityKey).get();
+    final var persistedMapping = mappingState.get(entityId).get();
     assertThat(persistedMapping.getGroupKeysList()).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -100,7 +100,6 @@ public class GroupAppliersTest {
   void shouldAddUserEntityToGroup() {
     // given
     final var entityKey = 1L;
-    final var entityId = "entityId";
     final var userRecord =
         new UserRecord()
             .setUserKey(entityKey)
@@ -116,26 +115,26 @@ public class GroupAppliersTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(entityId).setEntityType(entityType);
+    groupRecord.setEntityId(userRecord.getUsername()).setEntityType(entityType);
 
     // when
     groupEntityAddedApplier.applyState(groupKey, groupRecord);
 
     // then
     final var entitiesByType = groupState.getEntitiesByType(groupKey);
-    assertThat(entitiesByType).containsOnly(Map.entry(entityType, List.of(entityId)));
-    final var persistedUser = userState.getUser(entityId).get();
+    assertThat(entitiesByType)
+        .containsOnly(Map.entry(entityType, List.of(userRecord.getUsername())));
+    final var persistedUser = userState.getUser(userRecord.getUsername()).get();
     assertThat(persistedUser.getGroupKeysList()).containsExactly(groupKey);
   }
 
   @Test
   void shouldAddMappingEntityToGroup() {
     // given
-    final var entityKey = 1L;
     final var entityId = "entityId";
     final var mappingRecord =
         new MappingRecord()
-            .setMappingKey(entityKey)
+            .setMappingId(entityId)
             .setClaimName("claimName")
             .setClaimValue("claimValue");
     mappingState.create(mappingRecord);
@@ -193,11 +192,10 @@ public class GroupAppliersTest {
   @Test
   void shouldRemoveMappingEntityFromGroup() {
     // given
-    final var entityKey = 1L;
     final var entityId = "entityId";
     final var mappingRecord =
         new MappingRecord()
-            .setMappingKey(entityKey)
+            .setMappingId(entityId)
             .setClaimName("claimName")
             .setClaimValue("claimValue");
     mappingState.create(mappingRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -161,7 +161,7 @@ public class MappingAppliersTest {
         new GroupRecord()
             .setGroupKey(groupKey)
             .setGroupId(groupId)
-            .setEntityKey(mappingKey)
+            .setEntityId(mappingKey)
             .setEntityType(EntityType.MAPPING);
     groupState.create(group);
     groupState.addEntity(group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -156,12 +156,12 @@ public class MappingAppliersTest {
     // create group
     final var groupId = "1";
     final var groupKey = Long.parseLong(groupId);
-    mappingState.addGroup(mappingKey, groupKey);
+    mappingState.addGroup(mappingId, groupKey);
     final var group =
         new GroupRecord()
             .setGroupKey(groupKey)
             .setGroupId(groupId)
-            .setEntityId(mappingKey)
+            .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     groupState.create(group);
     groupState.addEntity(group);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -94,7 +94,7 @@ public class GroupStateTest {
     // when
     final var userKey = 2L;
     final var userEntityType = EntityType.USER;
-    groupRecord.setEntityKey(userKey).setEntityType(userEntityType);
+    groupRecord.setEntityId(userKey).setEntityType(userEntityType);
     groupState.addEntity(groupRecord);
 
     // then
@@ -113,10 +113,10 @@ public class GroupStateTest {
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
     final var userKey = 2L;
-    groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
+    groupRecord.setEntityId(2L).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
     final var mappingKey = 3L;
-    groupRecord.setEntityKey(mappingKey).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(mappingKey).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when
@@ -138,10 +138,10 @@ public class GroupStateTest {
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
     final var userKey = 2L;
-    groupRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
+    groupRecord.setEntityId(userKey).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
     final var mappingKey = 3L;
-    groupRecord.setEntityKey(mappingKey).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(mappingKey).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when
@@ -161,9 +161,9 @@ public class GroupStateTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
+    groupRecord.setEntityId(2L).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
-    groupRecord.setEntityKey(3L).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(3L).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -92,13 +92,13 @@ public class GroupStateTest {
     groupState.create(groupRecord);
 
     // when
-    final var userKey = 2L;
+    final var username = "entityId";
     final var userEntityType = EntityType.USER;
-    groupRecord.setEntityId(userKey).setEntityType(userEntityType);
+    groupRecord.setEntityId(username).setEntityType(userEntityType);
     groupState.addEntity(groupRecord);
 
     // then
-    final var entityType = groupState.getEntityType(groupId, userKey);
+    final var entityType = groupState.getEntityType(groupId, username);
     assertThat(entityType.isPresent()).isTrue();
     assertThat(entityType.get()).isEqualTo(userEntityType);
   }
@@ -112,11 +112,11 @@ public class GroupStateTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    final var userKey = 2L;
-    groupRecord.setEntityId(2L).setEntityType(EntityType.USER);
+    final var firstEntityId = "username";
+    final var secondEntityId = "mappingId";
+    groupRecord.setEntityId(firstEntityId).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
-    final var mappingKey = 3L;
-    groupRecord.setEntityId(mappingKey).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(secondEntityId).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when
@@ -124,8 +124,8 @@ public class GroupStateTest {
 
     // then
     assertThat(entities)
-        .containsEntry(EntityType.USER, List.of(userKey))
-        .containsEntry(EntityType.MAPPING, List.of(mappingKey));
+        .containsEntry(EntityType.USER, List.of(firstEntityId))
+        .containsEntry(EntityType.MAPPING, List.of(secondEntityId));
   }
 
   @Test
@@ -137,19 +137,19 @@ public class GroupStateTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    final var userKey = 2L;
-    groupRecord.setEntityId(userKey).setEntityType(EntityType.USER);
+    final var firstEntityId = "username";
+    final var secondEntityId = "mappingId";
+    groupRecord.setEntityId(firstEntityId).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
-    final var mappingKey = 3L;
-    groupRecord.setEntityId(mappingKey).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(secondEntityId).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when
-    groupState.removeEntity(groupKey, userKey);
+    groupState.removeEntity(groupKey, firstEntityId);
 
     // then
     final var entityType = groupState.getEntitiesByType(groupKey);
-    assertThat(entityType).containsOnly(Map.entry(EntityType.MAPPING, List.of(mappingKey)));
+    assertThat(entityType).containsOnly(Map.entry(EntityType.MAPPING, List.of(secondEntityId)));
   }
 
   @Test
@@ -161,9 +161,11 @@ public class GroupStateTest {
     final var groupRecord =
         new GroupRecord().setGroupKey(groupKey).setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    groupRecord.setEntityId(2L).setEntityType(EntityType.USER);
+    final var firstEntityId = "username";
+    final var secondEntityId = "mappingId";
+    groupRecord.setEntityId(firstEntityId).setEntityType(EntityType.USER);
     groupState.addEntity(groupRecord);
-    groupRecord.setEntityId(3L).setEntityType(EntityType.MAPPING);
+    groupRecord.setEntityId(secondEntityId).setEntityType(EntityType.MAPPING);
     groupState.addEntity(groupRecord);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -157,7 +157,7 @@ public class GroupClient {
     }
 
     public GroupAddEntityClient withEntityKey(final long entityKey) {
-      groupRecord.setEntityKey(entityKey);
+      groupRecord.setEntityId(entityKey);
       return this;
     }
 
@@ -211,7 +211,7 @@ public class GroupClient {
     }
 
     public GroupRemoveEntityClient withEntityKey(final long entityKey) {
-      groupRecord.setEntityKey(entityKey);
+      groupRecord.setEntityId(entityKey);
       return this;
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -156,8 +156,8 @@ public class GroupClient {
       groupRecord.setGroupId(groupId);
     }
 
-    public GroupAddEntityClient withEntityKey(final long entityKey) {
-      groupRecord.setEntityId(entityKey);
+    public GroupAddEntityClient withEntityId(final String entityId) {
+      groupRecord.setEntityId(entityId);
       return this;
     }
 
@@ -210,8 +210,8 @@ public class GroupClient {
       return this;
     }
 
-    public GroupRemoveEntityClient withEntityKey(final long entityKey) {
-      groupRecord.setEntityId(entityKey);
+    public GroupRemoveEntityClient withEntityId(final String entityId) {
+      groupRecord.setEntityId(entityId);
       return this;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -44,7 +44,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityId()));
   }
 
   @Override
@@ -59,7 +59,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
     entity
         .setKey(value.getGroupKey())
         .setName(value.getName())
-        .setMemberKey(value.getEntityKey())
+        .setMemberId(value.getEntityId())
         .setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -44,7 +44,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityId()));
   }
 
   @Override
@@ -56,7 +56,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
-    entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
+    entity.setMemberId(value.getEntityId()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -61,7 +61,7 @@ public class GroupEntityAddedHandlerTest {
     // then
     final var value = groupRecord.getValue();
     assertThat(idList)
-        .containsExactly(GroupEntity.getChildKey(value.getGroupKey(), value.getEntityKey()));
+        .containsExactly(GroupEntity.getChildKey(value.getGroupKey(), value.getEntityId()));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class GroupEntityAddedHandlerTest {
     // given
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
     final GroupEntity inputEntity =
-        new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+        new GroupEntity().setId("111").setMemberId("memberId").setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -61,7 +61,7 @@ public class GroupEntityRemovedHandlerTest {
     // then
     final var value = groupRecord.getValue();
     assertThat(idList)
-        .containsExactly(GroupEntity.getChildKey(value.getGroupKey(), value.getEntityKey()));
+        .containsExactly(GroupEntity.getChildKey(value.getGroupKey(), value.getEntityId()));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class GroupEntityRemovedHandlerTest {
     // given
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
     final GroupEntity inputEntity =
-        new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+        new GroupEntity().setId("111").setMemberId("memberId").setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
@@ -54,14 +54,14 @@ public class GroupExportHandler implements RdbmsExportHandler<GroupRecordValue> 
           groupWriter.addMember(
               new GroupMemberDbModel.Builder()
                   .groupKey(value.getGroupKey())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       case GroupIntent.ENTITY_REMOVED ->
           groupWriter.removeMember(
               new GroupMemberDbModel.Builder()
                   .groupKey(value.getGroupKey())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for group record", record.getIntent());

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6108,9 +6108,9 @@ components:
         groupKey:
           type: string
           description: The group key.
-        assignedMemberKeys:
+        assignedMemberIds:
           type: array
-          description: The set of keys of members assigned to the group.
+          description: The set of IDs of members assigned to the group.
           items:
             type: string
     GroupSearchQuerySortRequest:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -58,7 +58,7 @@ public class GroupControllerTest extends RestControllerTest {
     when(groupServices.createGroup(createGroupRequest))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new GroupRecord().setEntityKey(1L).setName(groupName)));
+                new GroupRecord().setEntityId(1L).setName(groupName)));
 
     // when
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -58,7 +58,7 @@ public class GroupControllerTest extends RestControllerTest {
     when(groupServices.createGroup(createGroupRequest))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new GroupRecord().setEntityId(1L).setName(groupName)));
+                new GroupRecord().setEntityId("entityId").setName(groupName)));
 
     // when
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -44,17 +44,17 @@ public class GroupQueryControllerTest extends RestControllerTest {
           {
             "groupKey":"111",
             "name":"Group 1",
-            "assignedMemberKeys":[]
+            "assignedMemberIds":[]
           },
           {
             "groupKey":"222",
             "name":"Group 2",
-            "assignedMemberKeys":[]
+            "assignedMemberIds":[]
           },
           {
             "groupKey":"333",
             "name":"Group 3",
-            "assignedMemberKeys":[]
+            "assignedMemberIds":[]
           }
         ],
         "page":{

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupMemberRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupMemberRequest.java
@@ -35,7 +35,7 @@ public class BrokerGroupMemberRequest extends BrokerExecuteCommand<GroupRecord> 
 
   public BrokerGroupMemberRequest setMemberId(final String memberKey) {
     // TODO: remove this after https://github.com/camunda/camunda/issues/29902 is implemented
-    requestDto.setEntityKey(Long.parseLong(memberKey));
+    requestDto.setEntityId(Long.parseLong(memberKey));
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupMemberRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupMemberRequest.java
@@ -33,9 +33,8 @@ public class BrokerGroupMemberRequest extends BrokerExecuteCommand<GroupRecord> 
     return new BrokerGroupMemberRequest(groupId, GroupIntent.REMOVE_ENTITY);
   }
 
-  public BrokerGroupMemberRequest setMemberId(final String memberKey) {
-    // TODO: remove this after https://github.com/camunda/camunda/issues/29902 is implemented
-    requestDto.setEntityId(Long.parseLong(memberKey));
+  public BrokerGroupMemberRequest setMemberId(final String memberId) {
+    requestDto.setEntityId(memberId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -24,7 +24,7 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
   private final StringProperty groupId = new StringProperty("groupId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
-  private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
+  private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
@@ -34,7 +34,7 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
         .declareProperty(groupId)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
-        .declareProperty(entityKeyProp)
+        .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
 
@@ -79,13 +79,8 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
   }
 
   @Override
-  public long getEntityKey() {
-    return entityKeyProp.getValue();
-  }
-
-  public GroupRecord setEntityKey(final long entityKey) {
-    entityKeyProp.setValue(entityKey);
-    return this;
+  public String getEntityId() {
+    return BufferUtil.bufferAsString(entityIdProp.getValue());
   }
 
   @Override
@@ -95,6 +90,11 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
 
   public GroupRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
+    return this;
+  }
+
+  public GroupRecord setEntityId(final String entityId) {
+    entityIdProp.setValue(entityId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2972,7 +2972,7 @@ final class JsonSerializableToJsonTest {
                     .setGroupId("groupId")
                     .setName("group")
                     .setDescription("description")
-                    .setEntityKey(2L)
+                    .setEntityId(2L)
                     .setEntityType(EntityType.USER),
         """
       {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2972,7 +2972,7 @@ final class JsonSerializableToJsonTest {
                     .setGroupId("groupId")
                     .setName("group")
                     .setDescription("description")
-                    .setEntityId(2L)
+                    .setEntityId("entityId")
                     .setEntityType(EntityType.USER),
         """
       {
@@ -2980,7 +2980,7 @@ final class JsonSerializableToJsonTest {
         "groupId": "groupId",
         "name": "group",
         "description": "description",
-        "entityKey": 2,
+        "entityId": "entityId",
         "entityType": "USER"
       }
       """
@@ -2997,7 +2997,7 @@ final class JsonSerializableToJsonTest {
         "groupId": "",
         "name": "",
         "description": "",
-        "entityKey": -1,
+        "entityId": "",
         "entityType": "UNSPECIFIED"
       }
       """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GroupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/GroupRecordValue.java
@@ -35,8 +35,8 @@ public interface GroupRecordValue extends RecordValue {
   /** The description of the group. */
   String getDescription();
 
-  /** The key of a user/mapping to assign/remove from a group. */
-  long getEntityKey();
+  /** The id of an entity to assign/remove from a group. */
+  String getEntityId();
 
   /** The type of the entity to assign/remove from a group. */
   EntityType getEntityType();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -441,7 +441,7 @@ public final class ZeebeAssertHelper {
         RecordingExporter.groupRecords()
             .withIntent(GroupIntent.ENTITY_ADDED)
             .withGroupKey(groupKey)
-            .withEntityKey(userKey)
+            .withEntityId(userKey)
             .getFirst()
             .getValue();
 
@@ -450,12 +450,12 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertEntityUnassignedFromGroup(
-      final long groupKey, final long userKey, final Consumer<GroupRecordValue> consumer) {
+      final long groupKey, final String username, final Consumer<GroupRecordValue> consumer) {
     final GroupRecordValue groupRecordValue =
         RecordingExporter.groupRecords()
             .withIntent(GroupIntent.ENTITY_REMOVED)
             .withGroupKey(groupKey)
-            .withEntityKey(userKey)
+            .withEntityId(username)
             .getFirst()
             .getValue();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -436,12 +436,12 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertEntityAssignedToGroup(
-      final long groupKey, final long userKey, final Consumer<GroupRecordValue> consumer) {
+      final long groupKey, final String username, final Consumer<GroupRecordValue> consumer) {
     final GroupRecordValue groupRecordValue =
         RecordingExporter.groupRecords()
             .withIntent(GroupIntent.ENTITY_ADDED)
             .withGroupKey(groupKey)
-            .withEntityId(userKey)
+            .withEntityId(username)
             .getFirst()
             .getValue();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1052,8 +1052,8 @@ public class CompactRecordLogger {
         .append(formatId(value.getGroupId()))
         .append(", Name=")
         .append(formatId(value.getName()))
-        .append(", EntityKey=")
-        .append(shortenKey(value.getEntityKey()))
+        .append(", EntityId=")
+        .append(formatId(value.getEntityId()))
         .append(", EntityType=")
         .append(value.getEntityType())
         .append("]");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/GroupRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/GroupRecordStream.java
@@ -31,8 +31,8 @@ public class GroupRecordStream extends ExporterRecordStream<GroupRecordValue, Gr
     return valueFilter(v -> v.getName().equals(name));
   }
 
-  public GroupRecordStream withEntityKey(final long entityKey) {
-    return valueFilter(v -> v.getEntityKey() == entityKey);
+  public GroupRecordStream withEntityId(final String entityId) {
+    return valueFilter(v -> v.getEntityId().equals(entityId));
   }
 
   public GroupRecordStream withEntityType(final EntityType entityType) {


### PR DESCRIPTION
## Description

Store and retrieve related entities to a mapping using mappingId instead of mappingKey.
It refactors group management to use mappingId (String) instead of the previous mappingKey (Long). The changes include:

Updating method signatures and event creation in the engine to use string-based identifiers.
Modifying schema definitions, query filters, transformations, and integration tests to align with the new approach.

Adjusting database models and authentication services to reflect the updated identifier semantics.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

part of #29534