### PR TITLE
Feat/30661 start pi cancel by camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -29,6 +29,7 @@ import io.camunda.client.api.command.ClockResetCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
 import io.camunda.client.api.command.CreateDocumentCommandStep1;
 import io.camunda.client.api.command.CreateDocumentLinkCommandStep1;
@@ -1741,4 +1742,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the update authorization command
    */
   UpdateAuthorizationCommandStep1 newUpdateAuthorizationCommand(long authorizationKey);
+
+  /**
+   * Command to create a batch operation
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * camundaClient
+   *   .newCreateBatchOperationCommand()
+   *   .processInstanceCancel()
+   *   .filter(filter)
+   *   .send();
+   * </pre>
+   *
+   * @return a builder to configure and send the create batch operation command
+   */
+  CreateBatchOperationCommandStep1 newCreateBatchOperationCommand();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import java.util.function.Consumer;
+
+public interface CreateBatchOperationCommandStep1 {
+
+  /**
+   * Defines the type of the batch operation.
+   *
+   * @return the builder for this command
+   */
+  CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceCancel();
+
+  interface CreateBatchOperationCommandStep2<E extends SearchRequestFilter> {
+
+    CreateBatchOperationCommandStep3<E> filter(E filter);
+
+    CreateBatchOperationCommandStep3<E> filter(Consumer<E> filter);
+  }
+
+  interface CreateBatchOperationCommandStep3<E extends SearchRequestFilter>
+      extends FinalCommandStep<CreateBatchOperationResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateBatchOperationResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateBatchOperationResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface CreateBatchOperationResponse {
+
+  long getBatchOperationKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -37,6 +37,7 @@ import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateDocumentBatchCommandStep1;
 import io.camunda.client.api.command.CreateDocumentCommandStep1;
 import io.camunda.client.api.command.CreateDocumentLinkCommandStep1;
@@ -118,6 +119,7 @@ import io.camunda.client.impl.command.ClockResetCommandImpl;
 import io.camunda.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.client.impl.command.CorrelateMessageCommandImpl;
 import io.camunda.client.impl.command.CreateAuthorizationCommandImpl;
+import io.camunda.client.impl.command.CreateBatchOperationCommandImpl.CreateBatchOperationCommandStep1Impl;
 import io.camunda.client.impl.command.CreateDocumentBatchCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentCommandImpl;
 import io.camunda.client.impl.command.CreateDocumentLinkCommandImpl;
@@ -945,6 +947,11 @@ public final class CamundaClientImpl implements CamundaClient {
   public UpdateAuthorizationCommandStep1 newUpdateAuthorizationCommand(
       final long authorizationKey) {
     return new UpdateAuthorizationCommandImpl(httpClient, jsonMapper, authorizationKey);
+  }
+
+  @Override
+  public CreateBatchOperationCommandStep1 newCreateBatchOperationCommand() {
+    return new CreateBatchOperationCommandStep1Impl(httpClient, jsonMapper) {};
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import static io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider.provideSearchRequestProperty;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1.CreateBatchOperationCommandStep2;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1.CreateBatchOperationCommandStep3;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
+import io.camunda.client.api.search.request.SearchRequestBuilders;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.CreateBatchOperationResponseImpl;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
+    implements CreateBatchOperationCommandStep2<E>, CreateBatchOperationCommandStep3<E> {
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  private final BatchOperationTypeEnum type;
+  private final Supplier<E> filterFactory;
+  private E filter;
+
+  public CreateBatchOperationCommandImpl(
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper,
+      final BatchOperationTypeEnum type,
+      final Supplier<E> filterFactory) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+
+    this.type = type;
+    this.filterFactory = filterFactory;
+  }
+
+  @Override
+  public CreateBatchOperationCommandStep3<E> filter(final E filter) {
+    this.filter = Objects.requireNonNull(filter, "must specify a filter");
+    return this;
+  }
+
+  @Override
+  public CreateBatchOperationCommandStep3<E> filter(final Consumer<E> fn) {
+    Objects.requireNonNull(fn, "must specify a filter consumer");
+    filter = filterFactory.get();
+    fn.accept(filter);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<CreateBatchOperationResponse> requestTimeout(
+      final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<CreateBatchOperationResponse> send() {
+    final HttpCamundaFuture<CreateBatchOperationResponse> result = new HttpCamundaFuture<>();
+    final CreateBatchOperationResponseImpl response = new CreateBatchOperationResponseImpl();
+    httpClient.post(
+        getUrl(),
+        jsonMapper.toJson(provideSearchRequestProperty(filter)),
+        httpRequestConfig.build(),
+        BatchOperationCreatedResult.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+
+  private String getUrl() {
+    switch (type) {
+      case PROCESS_CANCELLATION:
+        return "/process-instances/batch-operations/cancellation";
+      default:
+        throw new IllegalArgumentException("Unsupported batch operation type: " + type);
+    }
+  }
+
+  public static class CreateBatchOperationCommandStep1Impl
+      implements CreateBatchOperationCommandStep1 {
+
+    private final HttpClient httpClient;
+    private final JsonMapper jsonMapper;
+
+    public CreateBatchOperationCommandStep1Impl(
+        final HttpClient httpClient, final JsonMapper jsonMapper) {
+      this.httpClient = httpClient;
+      this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceCancel() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.PROCESS_CANCELLATION,
+          SearchRequestBuilders::processInstanceFilter);
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateBatchOperationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateBatchOperationResponseImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+
+public class CreateBatchOperationResponseImpl implements CreateBatchOperationResponse {
+
+  private long batchOperationKey;
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKey;
+  }
+
+  public CreateBatchOperationResponseImpl setResponse(final BatchOperationCreatedResult response) {
+    batchOperationKey = Long.parseLong(response.getBatchOperationKey());
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceFilter;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class CreateBatchOperationTest extends ClientRestTest {
+
+  @Test
+  public void shouldSendProcessInstanceCancelCommandEmptyFilter() {
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceCancel()
+        .filter(filter -> {})
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/batch-operations/cancellation");
+
+    final ProcessInstanceFilter filter = gatewayService.getLastRequest(ProcessInstanceFilter.class);
+    assertThat(filter).isNotNull();
+  }
+
+  @Test
+  public void shouldSendProcessInstanceCancelCommandWithFilter() {
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceCancel()
+        .filter(filter -> filter.processDefinitionId("test-01"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/batch-operations/cancellation");
+
+    final ProcessInstanceFilter filter = gatewayService.getLastRequest(ProcessInstanceFilter.class);
+    assertThat(filter.getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7854,6 +7854,11 @@ components:
         resourceKey:
           description: The unique key of this resource.
           type: string
+    BatchOperationTypeEnum:
+      description: The type of the batch operation.
+      type: string
+      enum:
+      - PROCESS_CANCELLATION
     BatchOperationCreatedResult:
       type: object
       properties:
@@ -7861,9 +7866,7 @@ components:
           description: Key of the batch operation.
           type: string
         batchOperationType:
-          description: The type of the batch operation.
-          type: string
-          example: PROCESS_CANCELLATION
+          $ref: "#/components/schemas/BatchOperationTypeEnum"
     BatchOperationSearchQuerySortRequest:
       type: object
       properties:
@@ -7903,10 +7906,7 @@ components:
           description: The batch operation key.
           type: string
         operationType:
-          type: string
-          description: The operation type of the batch operation.
-          enum:
-            - PROCESS_CANCELLATION
+          $ref: "#/components/schemas/BatchOperationTypeEnum"
         status:
           type: string
           description: The status of the batch operation.
@@ -7944,9 +7944,7 @@ components:
             - COMPLETED_WITH_ERRORS
             - CANCELED
         batchOperationType:
-          description: The type of the batch operation.
-          type: string
-          example: PROCESS_CANCELLATION
+          $ref: "#/components/schemas/BatchOperationTypeEnum"
         startDate:
           type: string
           description: The start date of the batch operation.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirementsResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionResult;
@@ -483,7 +484,8 @@ public final class ResponseMapper {
     final var response =
         new BatchOperationCreatedResult()
             .batchOperationKey(KeyUtil.keyToString(brokerResponse.getBatchOperationKey()))
-            .batchOperationType(brokerResponse.getBatchOperationType().toString());
+            .batchOperationType(
+                BatchOperationTypeEnum.valueOf(brokerResponse.getBatchOperationType().name()));
     return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -73,7 +73,6 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.gateway.protocol.rest.*;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter.OperationTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter.StatusEnum;
 import io.camunda.zeebe.gateway.rest.util.GenericVariable;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
@@ -546,7 +545,7 @@ public final class SearchQueryRequestMapper {
           .ifPresent(builder::batchOperationKeys);
       ofNullable(filter.getStatus()).map(StatusEnum::toString).ifPresent(builder::status);
       ofNullable(filter.getOperationType())
-          .map(OperationTypeEnum::toString)
+          .map(BatchOperationTypeEnum::toString)
           .ifPresent(builder::operationTypes);
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemResponse;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionResult;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionTypeEnum;
@@ -344,7 +345,7 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
         .status(BatchOperationResponse.StatusEnum.fromValue(entity.status().name()))
-        .batchOperationType(entity.operationType())
+        .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType()))
         .startDate(formatDate(entity.startDate()))
         .endDate(formatDate(entity.endDate()))
         .operationsTotalCount(entity.operationsTotalCount())


### PR DESCRIPTION
## Description

This adds the first batchOperation creation command to the Camunda Client. The API currently uses two steps:

```
camundaClient
  .newCreateBatchOperationCommand()
  .processInstanceCancel()
  .filter(filter)
  .send();
```

1. The first step creates a generic CreateBatchOperationCommand
2. The second step then specializes the command to a specific type and can apply a filter
3. possible additional generic steps can be added after this until the command is sent to the REST gateway

Note, that currently only the REST gateway is supported. Currently we have no GRPS representation of any search filter available.

The REST API also introduces a new BatchOperationTypeEnum (instead if the previous String). This is used to temporarily store the type in the command builder.

## Related issues

closes #30661 
