### PR TITLE
ci: have buffer to avoid short Tasklist FE timeouts

### DIFF
--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -10,7 +10,7 @@ jobs:
   fe-type-check:
     name: Type check
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -40,7 +40,7 @@ jobs:
   fe-eslint:
     name: ESLint
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:
@@ -70,7 +70,7 @@ jobs:
   fe-stylelint:
     name: Stylelint
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions: {} # GITHUB_TOKEN unused in this job
     defaults:
       run:


### PR DESCRIPTION
## Description

The jobs previously set to time out after only 3 minutes are now allowed to run for 5 minutes, to avoid cases like https://github.com/camunda/camunda/actions/runs/14327041442/job/40154434702 where the job is just taking slightly too long (due to more tests/network delay/CI health observability).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
