### PR TITLE
feat: migrate ExecutionToggleCount and FlowNodeInstancesLog to v2 REST API

### DIFF
--- a/operate/client/e2e-playwright/mocks/processInstance/index.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/index.ts
@@ -105,6 +105,21 @@ function mockResponses({
       });
     }
 
+    if (
+      route
+        .request()
+        .url()
+        .match(/\/v2\/process-definitions\/\d+\/xml/)
+    ) {
+      return route.fulfill({
+        status: xml === undefined ? 400 : 200,
+        body: xml,
+        headers: {
+          'content-type': 'application/xml',
+        },
+      });
+    }
+
     if (route.request().url().includes('xml')) {
       return route.fulfill({
         status: xml === undefined ? 400 : 200,

--- a/operate/client/e2e-playwright/visual/modifications.spec.ts
+++ b/operate/client/e2e-playwright/visual/modifications.spec.ts
@@ -50,7 +50,7 @@ test.describe('modifications', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -85,7 +85,7 @@ test.describe('modifications', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -130,7 +130,7 @@ test.describe('modifications', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: instanceWithIncident.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -197,7 +197,7 @@ test.describe('modifications', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: instanceWithIncident.detail.id,
         options: {
           waitUntil: 'networkidle',
         },

--- a/operate/client/e2e-playwright/visual/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstance.spec.ts
@@ -48,7 +48,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -77,7 +77,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -106,7 +106,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -136,7 +136,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: runningInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -207,7 +207,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: completedInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },
@@ -241,7 +241,7 @@ test.describe('process instance page', () => {
       );
 
       await processInstancePage.navigateToProcessInstance({
-        id: '1',
+        id: compensationProcessInstance.detail.id,
         options: {
           waitUntil: 'networkidle',
         },

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/ExecutionCountToggle/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/ExecutionCountToggle/index.test.tsx
@@ -6,30 +6,28 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect} from 'react';
 import {render, screen, waitFor} from 'modules/testing-library';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {ExecutionCountToggle} from './index';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 jest.mock('modules/utils/bpmn');
 
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
-  mockFetchProcessXML().withSuccess('');
-
-  useEffect(() => {
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
-    return () => {
-      processInstanceDetailsDiagramStore.reset();
-    };
-  }, []);
-
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
-describe('TimeStampPill', () => {
+describe('ExecutionCountToggle', () => {
   beforeEach(() => {
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
   });
 
   it('should render "Show" / "Hide" label', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/ExecutionCountToggle/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/ExecutionCountToggle/index.tsx
@@ -8,12 +8,12 @@
 
 import {observer} from 'mobx-react';
 import {Toggle} from '@carbon/react';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {executionCountToggleStore} from 'modules/stores/executionCountToggle';
 import {useEffect} from 'react';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 
 const ExecutionCountToggle: React.FC = observer(() => {
-  const {status: diagramStatus} = processInstanceDetailsDiagramStore.state;
   const {
     state: {isExecutionCountVisible},
     toggleExecutionCountVisibility,
@@ -21,7 +21,9 @@ const ExecutionCountToggle: React.FC = observer(() => {
 
   useEffect(() => executionCountToggleStore.reset, []);
 
-  const isDisabled = diagramStatus !== 'fetched';
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {isSuccess} = useProcessInstanceXml({processDefinitionKey});
+
   return (
     <Toggle
       aria-label={`${isExecutionCountVisible ? 'Hide' : 'Show'} Execution Count`}
@@ -29,7 +31,7 @@ const ExecutionCountToggle: React.FC = observer(() => {
       labelA="Show Execution Count"
       labelB="Hide Execution Count"
       onClick={toggleExecutionCountVisibility}
-      disabled={isDisabled}
+      disabled={!isSuccess}
       size="sm"
       toggled={isExecutionCountVisible}
     />

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.test.tsx
@@ -27,6 +27,10 @@ import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
 import {useEffect} from 'react';
 import {MOCK_TIMESTAMP} from 'modules/utils/date/__mocks__/formatDate';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 jest.mock('modules/utils/bpmn');
 
@@ -41,7 +45,13 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
     };
   }, []);
 
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
 describe('FlowNodeInstanceLog', () => {
@@ -61,6 +71,7 @@ describe('FlowNodeInstanceLog', () => {
         ],
       }),
     );
+    mockFetchProcessDefinitionXml().withSuccess('');
 
     processInstanceDetailsStore.init({id: '1'});
   });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.test.tsx
@@ -16,14 +16,12 @@ import {
 import {FlowNodeInstanceLog} from './index';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {
   createInstance,
   createMultiInstanceFlowNodeInstances,
   createOperation,
 } from 'modules/testUtils';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
 import {useEffect} from 'react';
 import {MOCK_TIMESTAMP} from 'modules/utils/date/__mocks__/formatDate';
@@ -41,7 +39,6 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
     return () => {
       processInstanceDetailsStore.reset();
       flowNodeInstanceStore.reset();
-      processInstanceDetailsDiagramStore.reset();
     };
   }, []);
 
@@ -71,16 +68,14 @@ describe('FlowNodeInstanceLog', () => {
         ],
       }),
     );
-    mockFetchProcessDefinitionXml().withSuccess('');
 
     processInstanceDetailsStore.init({id: '1'});
   });
 
   it('should render skeleton when instance tree is not loaded', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 
@@ -93,9 +88,8 @@ describe('FlowNodeInstanceLog', () => {
 
   it('should render skeleton when instance diagram is not loaded', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 
@@ -110,9 +104,8 @@ describe('FlowNodeInstanceLog', () => {
 
   it('should display error when instance tree data could not be fetched', async () => {
     mockFetchFlowNodeInstances().withServerError();
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 
@@ -123,27 +116,21 @@ describe('FlowNodeInstanceLog', () => {
 
   it('should display error when instance diagram could not be fetched', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
-    mockFetchProcessXML().withServerError();
+    mockFetchProcessDefinitionXml().withServerError();
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 
     expect(
       await screen.findByText('Instance History could not be fetched'),
     ).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(processInstanceDetailsDiagramStore.state.status).toBe('error'),
-    );
   });
 
   it('should continue polling after poll failure', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
     jest.useFakeTimers();
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 
@@ -191,9 +178,8 @@ describe('FlowNodeInstanceLog', () => {
 
   it('should render flow node instances tree', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
-    mockFetchProcessXML().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
     flowNodeInstanceStore.init();
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
 
     render(<FlowNodeInstanceLog />, {wrapper: Wrapper});
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/index.tsx
@@ -17,12 +17,13 @@ import {
   PanelHeader,
   ErrorMessage,
 } from './styled';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {TimeStampPill} from './TimeStampPill';
 import {modificationsStore} from 'modules/stores/modifications';
 import {Stack, TreeView} from '@carbon/react';
 import {Skeleton} from './Skeleton';
 import {ExecutionCountToggle} from './ExecutionCountToggle';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 
 const FlowNodeInstanceLog: React.FC = observer(() => {
   const {
@@ -30,10 +31,11 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
     isInstanceExecutionHistoryAvailable,
     state: {status: flowNodeInstanceStatus},
   } = flowNodeInstanceStore;
-  const {
-    areDiagramDefinitionsAvailable,
-    state: {status: diagramStatus},
-  } = processInstanceDetailsDiagramStore;
+
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {isSuccess, isError, isPending} = useProcessInstanceXml({
+    processDefinitionKey,
+  });
 
   const LOADING_STATES = ['initial', 'first-fetch'];
 
@@ -50,7 +52,7 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
           </Stack>
         )}
       </PanelHeader>
-      {areDiagramDefinitionsAvailable && isInstanceExecutionHistoryAvailable ? (
+      {isSuccess && isInstanceExecutionHistoryAvailable ? (
         <InstanceHistory ref={instanceHistoryRef}>
           <NodeContainer>
             <TreeView
@@ -68,12 +70,12 @@ const FlowNodeInstanceLog: React.FC = observer(() => {
         </InstanceHistory>
       ) : (
         <>
-          {(flowNodeInstanceStatus === 'error' ||
-            diagramStatus === 'error') && (
+          {(flowNodeInstanceStatus === 'error' || isError) && (
             <ErrorMessage message="Instance History could not be fetched" />
           )}
-          {(LOADING_STATES.includes(flowNodeInstanceStatus) ||
-            LOADING_STATES.includes(diagramStatus)) && <Skeleton />}
+          {(LOADING_STATES.includes(flowNodeInstanceStatus) || isPending) && (
+            <Skeleton />
+          )}
         </>
       )}
     </Container>


### PR DESCRIPTION
## Description

This PR is part of https://github.com/camunda/camunda/issues/30591 with the goal to replace processInstanceDetailsDiagramStore by Tanstack query.

- migrate ExecutionCountToggle
- migrate FlowNodeInstanceLog
- adjust tests
- fix visual regression test, update snapshot (retry button in incident table is now correctly shown)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591
