### PR TITLE
feat: migrate VariablesContent component to v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
@@ -16,8 +16,10 @@ import {processInstanceListenersStore} from 'modules/stores/processInstanceListe
 import {useProcessInstancePageParams} from '../../useProcessInstancePageParams';
 import {InputOutputMappings} from './InputOutputMappings';
 import {VariablesContent} from './VariablesContent';
+import {VariablesContent as VariablesContentV2} from './v2/VariablesContent';
 import {Listeners} from './Listeners';
 import {WarningFilled} from './styled';
+import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 const VariablePanel = observer(function VariablePanel() {
   const {processInstanceId = ''} = useProcessInstancePageParams();
@@ -84,7 +86,11 @@ const VariablePanel = observer(function VariablePanel() {
         {
           id: 'variables',
           label: 'Variables',
-          content: <VariablesContent />,
+          content: IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED ? (
+            <VariablesContentV2 />
+          ) : (
+            <VariablesContent />
+          ),
           removePadding: true,
           onClick: () => {
             setListenerTabVisibility(false);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesContent.tsx
@@ -17,15 +17,13 @@ import {ErrorMessage} from 'modules/components/ErrorMessage';
 import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {Loading} from '@carbon/react';
 import {VariablesForm} from './VariablesForm';
-import {VariablesForm as VariablesFormV2} from '../v2/VariablesForm';
 import {notificationsStore} from 'modules/stores/notifications';
-import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
+import {useDisplayStatus} from 'modules/hooks/variables';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 
 const VariablesContent: React.FC = observer(() => {
   const {processInstanceId = ''} = useProcessInstancePageParams();
-
-  const {displayStatus} = variablesStore;
+  const displayStatus = useDisplayStatus();
 
   if (displayStatus === 'error') {
     return (
@@ -61,13 +59,7 @@ const VariablesContent: React.FC = observer(() => {
           },
         }}
         key={variablesStore.scopeId}
-        render={(props) =>
-          IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED ? (
-            <VariablesFormV2 {...props} />
-          ) : (
-            <VariablesForm {...props} />
-          )
-        }
+        render={(props) => <VariablesForm {...props} />}
         onSubmit={async (values, form) => {
           const {initialValues} = form.getState();
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -55,11 +55,6 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
-jest.mock('modules/feature-flags', () => ({
-  ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
-}));
-
 const getWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -180,62 +180,57 @@ describe('Modification Dropdown - Multi Scopes', () => {
     },
   );
 
-  (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it.skip : it)(
-    'should render no modifications available',
-    async () => {
-      mockFetchFlownodeInstancesStatistics().withSuccess({
-        items: [
-          {
-            flowNodeId: 'OuterSubProcess',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            flowNodeId: 'InnerSubProcess',
-            active: 10,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            flowNodeId: 'TaskB',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-        ],
-      });
-
-      renderPopover();
-
-      await waitFor(() =>
-        expect(
-          processInstanceDetailsDiagramStore.state.diagramModel,
-        ).not.toBeNull(),
-      );
-
-      modificationsStore.cancelAllTokens('TaskB');
-
-      act(() => {
-        flowNodeSelectionStore.selectFlowNode({
+  it.skip('should render no modifications available', async () => {
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          flowNodeId: 'OuterSubProcess',
+          active: 1,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+        {
+          flowNodeId: 'InnerSubProcess',
+          active: 10,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+        {
           flowNodeId: 'TaskB',
-        });
-      });
+          active: 1,
+          incidents: 0,
+          completed: 0,
+          canceled: 0,
+        },
+      ],
+    });
 
+    renderPopover();
+
+    await waitFor(() =>
       expect(
-        await screen.findByText(/Flow Node Modifications/),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/No modifications available/),
-      ).toBeInTheDocument();
-      expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
-    },
-  );
+        processInstanceDetailsDiagramStore.state.diagramModel,
+      ).not.toBeNull(),
+    );
+
+    modificationsStore.cancelAllTokens('TaskB');
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'TaskB',
+      });
+    });
+
+    expect(
+      await screen.findByText(/Flow Node Modifications/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/No modifications available/)).toBeInTheDocument();
+    expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
+  });
 
   (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it : it.skip)(
     'should render add modification for flow nodes that has multiple running scopes',

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -14,12 +14,17 @@ import {open} from 'modules/mocks/diagrams';
 import {renderPopover} from './mocks';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
+import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {act} from 'react';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('Modification Dropdown - Multi Scopes', () => {
   beforeEach(() => {
+    jest
+      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
+      .mockReturnValue({processInstanceId: 'processInstanceId123'});
+
     mockFetchProcessXML().withSuccess(open('multipleInstanceSubProcess.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('multipleInstanceSubProcess.bpmn'),

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -180,57 +180,62 @@ describe('Modification Dropdown - Multi Scopes', () => {
     },
   );
 
-  it.skip('should render no modifications available', async () => {
-    mockFetchFlownodeInstancesStatistics().withSuccess({
-      items: [
-        {
-          flowNodeId: 'OuterSubProcess',
-          active: 1,
-          incidents: 0,
-          completed: 0,
-          canceled: 0,
-        },
-        {
-          flowNodeId: 'InnerSubProcess',
-          active: 10,
-          incidents: 0,
-          completed: 0,
-          canceled: 0,
-        },
-        {
-          flowNodeId: 'TaskB',
-          active: 1,
-          incidents: 0,
-          completed: 0,
-          canceled: 0,
-        },
-      ],
-    });
-
-    renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
-
-    modificationsStore.cancelAllTokens('TaskB');
-
-    act(() => {
-      flowNodeSelectionStore.selectFlowNode({
-        flowNodeId: 'TaskB',
+  (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it.skip : it)(
+    'should render no modifications available',
+    async () => {
+      mockFetchFlownodeInstancesStatistics().withSuccess({
+        items: [
+          {
+            flowNodeId: 'OuterSubProcess',
+            active: 1,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+          {
+            flowNodeId: 'InnerSubProcess',
+            active: 10,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+          {
+            flowNodeId: 'TaskB',
+            active: 1,
+            incidents: 0,
+            completed: 0,
+            canceled: 0,
+          },
+        ],
       });
-    });
 
-    expect(
-      await screen.findByText(/Flow Node Modifications/),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/No modifications available/)).toBeInTheDocument();
-    expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
-  });
+      renderPopover();
+
+      await waitFor(() =>
+        expect(
+          processInstanceDetailsDiagramStore.state.diagramModel,
+        ).not.toBeNull(),
+      );
+
+      modificationsStore.cancelAllTokens('TaskB');
+
+      act(() => {
+        flowNodeSelectionStore.selectFlowNode({
+          flowNodeId: 'TaskB',
+        });
+      });
+
+      expect(
+        await screen.findByText(/Flow Node Modifications/),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/No modifications available/),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
+    },
+  );
 
   (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it : it.skip)(
     'should render add modification for flow nodes that has multiple running scopes',

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -14,17 +14,12 @@ import {open} from 'modules/mocks/diagrams';
 import {renderPopover} from './mocks';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
-import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {act} from 'react';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('Modification Dropdown - Multi Scopes', () => {
   beforeEach(() => {
-    jest
-      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
-      .mockReturnValue({processInstanceId: 'processInstanceId123'});
-
     mockFetchProcessXML().withSuccess(open('multipleInstanceSubProcess.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('multipleInstanceSubProcess.bpmn'),

--- a/operate/client/src/modules/hooks/flowNodeMetadata.ts
+++ b/operate/client/src/modules/hooks/flowNodeMetadata.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {useHasRunningOrFinishedTokens} from './flowNodeSelection';
+
+const useHasMultipleInstances = () => {
+  const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+  const {metaData} = flowNodeMetaDataStore.state;
+
+  if (
+    flowNodeSelectionStore.state.selection?.flowNodeInstanceId !== undefined
+  ) {
+    return false;
+  }
+
+  if (!hasRunningOrFinishedTokens) {
+    return flowNodeSelectionStore.newTokenCountForSelectedNode > 1;
+  }
+
+  return (
+    (metaData?.instanceCount ?? 0) > 1 ||
+    flowNodeSelectionStore.newTokenCountForSelectedNode > 0
+  );
+};
+
+export {useHasMultipleInstances};

--- a/operate/client/src/modules/hooks/variables.ts
+++ b/operate/client/src/modules/hooks/variables.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {logger} from 'modules/logger';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {modificationsStore} from 'modules/stores/modifications';
+import {variablesStore} from 'modules/stores/variables';
+import {
+  useHasRunningOrFinishedTokens,
+  useNewTokenCountForSelectedNode,
+} from './flowNodeSelection';
+import {useHasMultipleInstances} from './flowNodeMetadata';
+
+const useHasNoContent = () => {
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+  const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+
+  return (
+    !flowNodeSelectionStore.isRootNodeSelected &&
+    !hasRunningOrFinishedTokens &&
+    newTokenCountForSelectedNode === 0
+  );
+};
+
+const useDisplayStatus = () => {
+  const hasNoContent = useHasNoContent();
+  const hasMultipleInstances = useHasMultipleInstances();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+  const {status, items} = variablesStore.state;
+
+  if (status === 'error') {
+    return 'error';
+  }
+
+  if (hasNoContent) {
+    return 'no-content';
+  }
+
+  if (hasMultipleInstances) {
+    return 'multi-instances';
+  }
+
+  if (
+    flowNodeSelectionStore.state.selection?.isPlaceholder ||
+    newTokenCountForSelectedNode === 1
+  ) {
+    return 'no-variables';
+  }
+
+  if (['initial', 'first-fetch'].includes(status)) {
+    return variablesStore.areVariablesLoadedOnce ? 'spinner' : 'skeleton';
+  }
+
+  if (
+    modificationsStore.isModificationModeEnabled &&
+    variablesStore.scopeId === null
+  ) {
+    return 'no-variables';
+  }
+  if (status === 'fetching' || variablesStore.scopeId === null) {
+    return 'spinner';
+  }
+  if (variablesStore.hasNoVariables) {
+    return 'no-variables';
+  }
+  if (
+    ['fetched', 'fetching-next', 'fetching-prev'].includes(status) &&
+    items.length > 0
+  ) {
+    return 'variables';
+  }
+
+  logger.error('Failed to show Variables');
+  return 'error';
+};
+
+export {useDisplayStatus};


### PR DESCRIPTION
## Description

This PR migrates VariablesContent component away from `processInstanceDetailsStatisticsStore`. There is no direct dependency on that store but the `variablesStore` depends on `flowNodeSelectionStore` and `flowNodeMetadataStore` which both depend on `processInstanceDetailsStatisticsStore`. This component is tightly coupled with `Variables` component so I think it makes more sense to fix/update the tests during `Variables` migration to v2.

## Related issues

closes #30269
