### PR TITLE
fix: switch to n2-standard-4-stable

### DIFF
--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -2,8 +2,9 @@
 camunda-platform:
   core:
     # Require n2-standard-2 to ensure the broker is the only application running on its node
+    # However, that node does not have the required cpu/memory capacity
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2-stable
+      cloud.google.com/gke-nodepool: n2-standard-4-stable
 
     # Ignore the stable VM node taints
     tolerations:
@@ -14,8 +15,9 @@ camunda-platform:
 
   zeebe:
     # Require n2-standard-2 to ensure the broker is the only application running on its node
+    # However, that node does not have the required cpu/memory capacity
     nodeSelector:
-      cloud.google.com/gke-nodepool: n2-standard-2-stable
+      cloud.google.com/gke-nodepool: n2-standard-4-stable
 
     # Ignore the stable VM node taints
     tolerations:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The n2-standard-2-stable node does not have the required cpu/memory capacity:

```
resources:
  limits:
    cpu: "2"
    memory: 12Gi
  requests:
    cpu: "2"
    memory: 6Gi
```

By switching to the n2-standard-4-stable (with 4 CPU and 16GB RAM) it should be possible to run the release benchmark again.

This means that the application may no longer be the only one running on its node, which may reduce stability.

## Related issues

relates to https://bru-2.tasklist.camunda.io/689a796f-7efa-487f-9e44-76ca3a98c77b/tasklist/4503599751515985
