### PR TITLE
Feat/30715 query batch operations camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -64,6 +64,8 @@ import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.BatchOperationGetRequest;
+import io.camunda.client.api.fetch.BatchOperationItemsGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.DecisionInstanceGetRequest;
@@ -1759,4 +1761,34 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the create batch operation command
    */
   CreateBatchOperationCommandStep1 newCreateBatchOperationCommand();
+
+  /**
+   * Request to get a single batch operation by batch operation key.
+   *
+   * <pre>
+   * camundaClient
+   *  .newBatchOperationGetRequest(batchOperationKey)
+   *  .send();
+   * </pre>
+   *
+   * @param batchOperationKey the key which identifies the corresponding batch operation
+   * @return a builder for the request
+   */
+  BatchOperationGetRequest newBatchOperationGetRequest(Long batchOperationKey);
+
+  /**
+   * Request to get all items for a batch operation by batch operation key. This request is will
+   * return <b>ALL</b> items of the batch operation. Depending on the number of elements, this may
+   * be a large set of items.
+   *
+   * <pre>
+   * camundaClient
+   *  .newBatchOperationItemsGetRequest(batchOperationKey)
+   *  .send();
+   * </pre>
+   *
+   * @param batchOperationKey the key which identifies the corresponding batch operation
+   * @return a builder for the request
+   */
+  BatchOperationItemsGetRequest newBatchOperationItemsGetRequest(Long batchOperationKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/BatchOperationGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/BatchOperationGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.BatchOperation;
+
+public interface BatchOperationGetRequest extends FinalCommandStep<BatchOperation> {}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/BatchOperationItemsGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/BatchOperationItemsGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.BatchOperationItems;
+
+public interface BatchOperationItemsGetRequest extends FinalCommandStep<BatchOperationItems> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationItemState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum BatchOperationItemState {
+  ACTIVE,
+  COMPLETED,
+  FAILED,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum BatchOperationState {
+  CREATED,
+  ACTIVE,
+  PAUSED,
+  COMPLETED,
+  COMPLETED_WITH_ERRORS,
+  CANCELED,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum BatchOperationType {
+  PROCESS_CANCELLATION,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+
+public interface BatchOperation {
+
+  Long getBatchOperationKey();
+
+  BatchOperationState getStatus();
+
+  BatchOperationType getType();
+
+  String getStartDate();
+
+  String getEndDate();
+
+  Integer getOperationsTotalCount();
+
+  Integer getOperationsFailedCount();
+
+  Integer getOperationsCompletedCount();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import java.util.List;
+
+public interface BatchOperationItems {
+
+  List<BatchOperationItem> items();
+
+  interface BatchOperationItem {
+    Long getBatchOperationKey();
+
+    Long getKey();
+
+    BatchOperationItemState getStatus();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -75,6 +75,8 @@ import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.BatchOperationGetRequest;
+import io.camunda.client.api.fetch.BatchOperationItemsGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.DecisionInstanceGetRequest;
@@ -155,6 +157,8 @@ import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
+import io.camunda.client.impl.fetch.BatchOperationGetRequestImpl;
+import io.camunda.client.impl.fetch.BatchOperationItemsGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.DecisionInstanceGetRequestImpl;
@@ -952,6 +956,17 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateBatchOperationCommandStep1 newCreateBatchOperationCommand() {
     return new CreateBatchOperationCommandStep1Impl(httpClient, jsonMapper) {};
+  }
+
+  @Override
+  public BatchOperationGetRequest newBatchOperationGetRequest(final Long batchOperationKey) {
+    return new BatchOperationGetRequestImpl(httpClient, batchOperationKey);
+  }
+
+  @Override
+  public BatchOperationItemsGetRequest newBatchOperationItemsGetRequest(
+      final Long batchOperationKey) {
+    return new BatchOperationItemsGetRequestImpl(httpClient, batchOperationKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationGetRequestImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.BatchOperationGetRequest;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.BatchOperationResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class BatchOperationGetRequestImpl implements BatchOperationGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long batchOperationKey;
+
+  public BatchOperationGetRequestImpl(final HttpClient httpClient, final long batchOperationKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.batchOperationKey = batchOperationKey;
+  }
+
+  @Override
+  public FinalCommandStep<BatchOperation> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<BatchOperation> send() {
+    final HttpCamundaFuture<BatchOperation> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/batch-operations/%d", batchOperationKey),
+        httpRequestConfig.build(),
+        BatchOperationResponse.class,
+        SearchResponseMapper::toBatchOperationGetResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationItemsGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationItemsGetRequestImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.BatchOperationItemsGetRequest;
+import io.camunda.client.api.search.response.BatchOperationItems;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.BatchOperationItemSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class BatchOperationItemsGetRequestImpl implements BatchOperationItemsGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long batchOperationKey;
+
+  public BatchOperationItemsGetRequestImpl(
+      final HttpClient httpClient, final long batchOperationKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.batchOperationKey = batchOperationKey;
+  }
+
+  @Override
+  public FinalCommandStep<BatchOperationItems> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<BatchOperationItems> send() {
+    final HttpCamundaFuture<BatchOperationItems> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/batch-operations/%d/items", batchOperationKey),
+        httpRequestConfig.build(),
+        BatchOperationItemSearchQueryResult.class,
+        SearchResponseMapper::toBatchOperationItemsGetResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
+import io.camunda.client.protocol.rest.BatchOperationResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchOperationImpl implements BatchOperation {
+
+  private final Long batchOperationKey;
+  private final BatchOperationType type;
+  private final BatchOperationState status;
+  private final String startDate;
+  private final String endDate;
+  private final Integer operationsTotalCount;
+  private final Integer operationsFailedCount;
+  private final Integer operationsCompletedCount;
+  private final List<Long> keys = new ArrayList<>();
+
+  public BatchOperationImpl(final BatchOperationCreatedResult item) {
+    batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+    type =
+        item.getBatchOperationType() != null
+            ? BatchOperationType.valueOf(item.getBatchOperationType().name())
+            : null;
+    status = null;
+    startDate = null;
+    endDate = null;
+    operationsTotalCount = null;
+    operationsFailedCount = null;
+    operationsCompletedCount = null;
+  }
+
+  public BatchOperationImpl(final BatchOperationResponse item) {
+    batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+    type =
+        item.getBatchOperationType() != null
+            ? BatchOperationType.valueOf(item.getBatchOperationType().name())
+            : null;
+    status = item.getStatus() != null ? BatchOperationState.valueOf(item.getStatus().name()) : null;
+    startDate = item.getStartDate();
+    endDate = item.getEndDate();
+    operationsTotalCount = item.getOperationsTotalCount();
+    operationsFailedCount = item.getOperationsFailedCount();
+    operationsCompletedCount = item.getOperationsCompletedCount();
+  }
+
+  @Override
+  public Long getBatchOperationKey() {
+    return batchOperationKey;
+  }
+
+  @Override
+  public BatchOperationState getStatus() {
+    return status;
+  }
+
+  @Override
+  public BatchOperationType getType() {
+    return type;
+  }
+
+  @Override
+  public String getStartDate() {
+    return startDate;
+  }
+
+  @Override
+  public String getEndDate() {
+    return endDate;
+  }
+
+  @Override
+  public Integer getOperationsTotalCount() {
+    return operationsTotalCount;
+  }
+
+  @Override
+  public Integer getOperationsFailedCount() {
+    return operationsFailedCount;
+  }
+
+  @Override
+  public Integer getOperationsCompletedCount() {
+    return operationsCompletedCount;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.response.BatchOperationItems;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.BatchOperationItemResponse;
+import io.camunda.client.protocol.rest.BatchOperationItemSearchQueryResult;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchOperationItemsImpl implements BatchOperationItems {
+
+  private final List<BatchOperationItem> items;
+
+  public BatchOperationItemsImpl(final BatchOperationItemSearchQueryResult queryResult) {
+    items =
+        queryResult.getItems().stream()
+            .map(BatchOperationItemImpl::new)
+            .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+  }
+
+  @Override
+  public List<BatchOperationItem> items() {
+    return items;
+  }
+
+  public static class BatchOperationItemImpl implements BatchOperationItem {
+
+    private final Long batchOperationKey;
+
+    private final Long itemKey;
+
+    private final BatchOperationItemState status;
+
+    public BatchOperationItemImpl(final BatchOperationItemResponse item) {
+      batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+      itemKey = ParseUtil.parseLongOrNull(item.getItemKey());
+      status = EnumUtil.convert(item.getStatus(), BatchOperationItemState.class);
+    }
+
+    @Override
+    public Long getBatchOperationKey() {
+      return batchOperationKey;
+    }
+
+    @Override
+    public Long getKey() {
+      return itemKey;
+    }
+
+    @Override
+    public BatchOperationItemState getStatus() {
+      return status;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -16,6 +16,8 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.api.search.response.BatchOperationItems;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
@@ -137,6 +139,15 @@ public final class SearchResponseMapper {
         toSearchResponseInstances(
             response.getItems(), item -> new DecisionInstanceImpl(item, jsonMapper));
     return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static BatchOperation toBatchOperationGetResponse(final BatchOperationResponse response) {
+    return new BatchOperationImpl(response);
+  }
+
+  public static BatchOperationItems toBatchOperationItemsGetResponse(
+      final BatchOperationItemSearchQueryResult response) {
+    return new BatchOperationItemsImpl(response);
   }
 
   private static <T, R> List<R> toSearchResponseInstances(

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.*;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+
+public class QueryBatchOperationTest extends ClientRestTest {
+
+  @Test
+  public void shouldGetBatchOperationByKey() {
+    // when
+    client.newBatchOperationGetRequest(123L).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/123");
+    assertThat(request.getBodyAsString()).isEmpty();
+  }
+
+  @Test
+  public void shouldGetBatchOperationItemsByKey() {
+    // when
+    client.newBatchOperationItemsGetRequest(123L).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/123/items");
+    assertThat(request.getBodyAsString()).isEmpty();
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
@@ -18,6 +18,9 @@ package io.camunda.client.impl.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.search.enums.*;
+import io.camunda.client.protocol.rest.BatchOperationItemResponse;
+import io.camunda.client.protocol.rest.BatchOperationResponse;
+import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
 import org.junit.jupiter.api.Test;
 
 public class EnumUtilTest {
@@ -440,6 +443,86 @@ public class EnumUtilTest {
       if (protocolValue
           == io.camunda.client.protocol.rest.UserTaskFilter.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(UserTaskState.UNKNOWN_ENUM_VALUE);
+      } else {
+        assertThat(value.name()).isEqualTo(protocolValue.name());
+      }
+    }
+  }
+
+  @Test
+  public void shouldConvertBatchOperationState() {
+
+    for (final BatchOperationState value : BatchOperationState.values()) {
+      final BatchOperationResponse.StatusEnum protocolValue =
+          EnumUtil.convert(value, BatchOperationResponse.StatusEnum.class);
+      assertThat(protocolValue).isNotNull();
+      if (value == BatchOperationState.UNKNOWN_ENUM_VALUE) {
+        assertThat(protocolValue)
+            .isEqualTo(BatchOperationResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API);
+      } else {
+        assertThat(protocolValue.name()).isEqualTo(value.name());
+      }
+    }
+
+    for (final BatchOperationResponse.StatusEnum protocolValue :
+        BatchOperationResponse.StatusEnum.values()) {
+      final BatchOperationState value = EnumUtil.convert(protocolValue, BatchOperationState.class);
+      assertThat(value).isNotNull();
+      if (protocolValue == BatchOperationResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API) {
+        assertThat(value).isEqualTo(BatchOperationState.UNKNOWN_ENUM_VALUE);
+      } else {
+        assertThat(value.name()).isEqualTo(protocolValue.name());
+      }
+    }
+  }
+
+  @Test
+  public void shouldConvertBatchOperationItemState() {
+
+    for (final BatchOperationItemState value : BatchOperationItemState.values()) {
+      final BatchOperationItemResponse.StatusEnum protocolValue =
+          EnumUtil.convert(value, BatchOperationItemResponse.StatusEnum.class);
+      assertThat(protocolValue).isNotNull();
+      if (value == BatchOperationItemState.UNKNOWN_ENUM_VALUE) {
+        assertThat(protocolValue)
+            .isEqualTo(BatchOperationItemResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API);
+      } else {
+        assertThat(protocolValue.name()).isEqualTo(value.name());
+      }
+    }
+
+    for (final BatchOperationItemResponse.StatusEnum protocolValue :
+        BatchOperationItemResponse.StatusEnum.values()) {
+      final BatchOperationItemState value =
+          EnumUtil.convert(protocolValue, BatchOperationItemState.class);
+      assertThat(value).isNotNull();
+      if (protocolValue == BatchOperationItemResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API) {
+        assertThat(value).isEqualTo(BatchOperationItemState.UNKNOWN_ENUM_VALUE);
+      } else {
+        assertThat(value.name()).isEqualTo(protocolValue.name());
+      }
+    }
+  }
+
+  @Test
+  public void shouldConvertBatchOperationType() {
+
+    for (final BatchOperationType value : BatchOperationType.values()) {
+      final BatchOperationTypeEnum protocolValue =
+          EnumUtil.convert(value, BatchOperationTypeEnum.class);
+      assertThat(protocolValue).isNotNull();
+      if (value == BatchOperationType.UNKNOWN_ENUM_VALUE) {
+        assertThat(protocolValue).isEqualTo(BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API);
+      } else {
+        assertThat(protocolValue.name()).isEqualTo(value.name());
+      }
+    }
+
+    for (final BatchOperationTypeEnum protocolValue : BatchOperationTypeEnum.values()) {
+      final BatchOperationType value = EnumUtil.convert(protocolValue, BatchOperationType.class);
+      assertThat(value).isNotNull();
+      if (protocolValue == BatchOperationTypeEnum.UNKNOWN_DEFAULT_OPEN_API) {
+        assertThat(value).isEqualTo(BatchOperationType.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());
       }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchCancelProcessInstanceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForFlowNodeInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilFlowNodeInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchCancelProcessInstanceTest {
+
+  static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  public static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+    final List<String> processes =
+        List.of(
+            "service_tasks_v1.bpmn",
+            "service_tasks_v2.bpmn",
+            "incident_process_v1.bpmn",
+            "manual_process.bpmn",
+            "parent_process_v1.bpmn",
+            "child_process_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, DEPLOYED_PROCESSES.size());
+
+    // Does two will not be active when we cancel, since they just have manual steps
+    startProcessInstance(camundaClient, "manual_process");
+    startProcessInstance(camundaClient, "parent_process_v1");
+
+    ACTIVE_PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"bar\"}"));
+    ACTIVE_PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}"));
+    ACTIVE_PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "incident_process_v1"));
+
+    waitForProcessInstancesToStart(camundaClient, 6);
+    waitForFlowNodeInstances(camundaClient, 20);
+    waitUntilFlowNodeInstanceHasIncidents(camundaClient, 1);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 1);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+    ACTIVE_PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldCancelProcessInstancesWithBatch() throws InterruptedException {
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(new ProcessInstanceFilterImpl())
+            .send()
+            .join();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // then
+    assertThat(result).isNotNull();
+    //    assertThat(result.getBatchOperationKey()).isNotNull();
+
+    // and
+    Awaitility.await("should complete batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient
+                      .newBatchOperationGetRequest(result.getBatchOperationKey())
+                      .send()
+                      .join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getEndDate()).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+            });
+
+    final var activeKeys =
+        ACTIVE_PROCESS_INSTANCES.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
+    for (final Long key : activeKeys) {
+      waitForProcessInstanceToBeTerminated(camundaClient, key);
+    }
+
+    // and
+    final var itemsObj =
+        camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getKey).toList();
+
+    assertThat(itemsObj.items()).hasSize(3);
+    assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
+        .containsExactly(BatchOperationItemState.COMPLETED);
+    assertThat(itemKeys).containsExactlyInAnyOrder(activeKeys.toArray(Long[]::new));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -16,8 +16,10 @@ import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.IncidentState;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -107,6 +109,19 @@ public final class TestHelper {
             () -> {
               final var result = camundaClient.newProcessInstanceSearchRequest().send().join();
               assertThat(result.page().totalItems()).isEqualTo(expectedProcessInstances);
+            });
+  }
+
+  public static void waitForProcessInstanceToBeTerminated(
+      final CamundaClient camundaClient, final Long processInstanceKey) {
+    Awaitility.await("should wait until process is terminated")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+              assertThat(result.getState()).isEqualTo(ProcessInstanceState.TERMINATED);
             });
   }
 


### PR DESCRIPTION
## Description

This PR introduces batch operation GET requests to the camunda client:
- GET request to read a single batch operation
- GET request to read the items of a single batch operation

Also a first round-trip E2E for batch operations test using the camunda-client is added.

## Related issues

closes #30715 
