### PR TITLE
ci: document GHA workflow owners when known

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -1,6 +1,8 @@
 ---
 name: Build Frontend
 
+# owner: @camunda/monorepo-devops-team
+
 description: Builds the frontend project in a certain Yarn workspace
 
 inputs:

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -3,6 +3,9 @@
 
 ---
 name: Build Docker Image
+
+# owner: @camunda/monorepo-devops-team
+
 description: Builds the Docker image
 
 inputs:

--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -1,6 +1,8 @@
 ---
 name: Collect test artifacts
 
+# owner: @camunda/monorepo-devops-team
+
 description: Collects test outputs and uploads them as artifact
 
 inputs:

--- a/.github/actions/is-fork/action.yml
+++ b/.github/actions/is-fork/action.yml
@@ -1,6 +1,8 @@
 ---
 name: Is Fork
 
+# owner: @camunda/monorepo-devops-team
+
 description: |
   Checks if current job runs on code from a forked repository (via PR).
   This information can be used to disable certain CI features that are not

--- a/.github/actions/observe-aborted-jobs/action.yml
+++ b/.github/actions/observe-aborted-jobs/action.yml
@@ -6,6 +6,9 @@
 #   - VAULT_SECRET_ID
 ---
 name: Observe Aborted Jobs
+
+# owner: @camunda/monorepo-devops-team
+
 description: Checks failed jobs of a GHA workflow for runner problems and submits https://confluence.camunda.com/display/HAN/CI+Analytics data on their behalf
 
 inputs:

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -6,6 +6,9 @@
 #   - VAULT_SECRET_ID
 ---
 name: Observe Build Status
+
+# owner: @camunda/monorepo-devops-team
+
 description: Records the build status remotely for analytic purposes
 
 inputs:

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,6 +1,8 @@
 ---
 name: Common paths filter for camunda/camunda
 
+# owner: @camunda/monorepo-devops-team
+
 description: |
   Common filters to detect and group changes against a base branch
   It leverages the `dorny/paths-filter` action to filter paths

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,5 +1,8 @@
 ---
 name: Setup build
+
+# owner: @camunda/monorepo-devops-team
+
 description: Sets up the required stack to build, install, and run monorepo projects
 
 inputs:

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -1,6 +1,7 @@
 ---
 name: Setup Maven Cache
 
+# owner: @camunda/monorepo-devops-team
 
 description: Configured GHA cache for Maven global cache dir (no save on PRs), see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
 

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,7 +1,12 @@
+---
 name: Assign new issues to the default projects
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   issues:
     types: [ opened, reopened, transferred, labeled ]
+
 jobs:
   add-to-projects:
     name: Add issue to team projects if no project assigned and by corresponding component label
@@ -93,4 +98,3 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/33
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/c8run
-  

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,9 +1,14 @@
+---
 name: Backport labeled merged pull requests
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   pull_request:
     types: [closed]
   issue_comment:
     types: [created]
+
 jobs:
   backport:
     name: Create backport PRs

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -1,4 +1,7 @@
+---
 name: "C8Run: build/test"
+
+# owner: @camunda/distribution
 
 on:
   push:

--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -1,4 +1,7 @@
+---
 name: "C8Run: Issue Closed"
+
+# owner: @camunda/distribution
 
 on:
   issues:

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -1,4 +1,8 @@
+---
 name: "C8Run: Release"
+
+# owner: @camunda/distribution
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -1,5 +1,7 @@
 name: Camunda Helm Chart Integration Test
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   schedule:
     - cron: "0 5 * * 1-5"  # Mondays to Fridays, to keep it actionable

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -1,6 +1,8 @@
 ---
 name: Deploy Camunda Docker Images to SaaS registry
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -1,6 +1,8 @@
 ---
 name: Camunda Platform Release Dry Run from main
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-platform-release-manual.yml
+++ b/.github/workflows/camunda-platform-release-manual.yml
@@ -1,6 +1,8 @@
 ---
 name: Camunda Platform Release
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -1,4 +1,8 @@
+---
 name: Camunda Platform Release Workflow
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/chatops-command-ci-problems.yml
+++ b/.github/workflows/chatops-command-ci-problems.yml
@@ -1,6 +1,8 @@
 ---
 name: chatops-command-ci-problems
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ci-problems-command]

--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -1,6 +1,8 @@
 ---
 name: chatops-command-ci-disable-cache
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ci-disable-cache-command, ci-enable-cache-command]

--- a/.github/workflows/chatops-command-dispatch.yml
+++ b/.github/workflows/chatops-command-dispatch.yml
@@ -1,6 +1,8 @@
 ---
 name: ChatOps Command Dispatch
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,4 +1,7 @@
+---
 name: Check Licenses
+
+# owner: @camunda/monorepo-devops-team
 
 on:
   push:

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -1,6 +1,8 @@
 ---
 name: Check for PR conflicts
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   schedule:
   - cron: 23 1 * * 1-5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 ---
 name: CI
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   push:
     branches:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,10 @@
+---
 name: Commitlint
-on: [pull_request]
+
+# owner: @camunda/monorepo-devops-team
+
+on:
+  pull_request: {}
 
 jobs:
   lint-commits:

--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -1,9 +1,14 @@
+---
 name: Core Application E2E Tests Nightly
-permissions:
-  contents: read
+
+# owner: @camunda/qa-engineering
+
 on:
   schedule:
     - cron: "0 0 * * *" # Run all tests at midnight UTC
+
+permissions:
+  contents: read
 
 jobs:
   nightly-tests:

--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -1,6 +1,8 @@
+---
 name: Core Application E2E Tests On Demand
-permissions:
-  contents: read
+
+# owner: @camunda/qa-engineering
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,6 +15,9 @@ on:
           - main
           - stable/8.6
           - stable/8.7
+
+permissions:
+  contents: read
 
 jobs:
   core-e2e-component-tests:

--- a/.github/workflows/dispatch-release-8-3.yaml
+++ b/.github/workflows/dispatch-release-8-3.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.3
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [trigger_release_8_3]

--- a/.github/workflows/dispatch-release-8-4.yaml
+++ b/.github/workflows/dispatch-release-8-4.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.4
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ trigger_release_8_4 ]

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.5
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ trigger_release_8_5 ]

--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.6
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ trigger_release_8_6 ]

--- a/.github/workflows/dispatch-release-8-7.yaml
+++ b/.github/workflows/dispatch-release-8-7.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.7
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ trigger_release_8_7 ]

--- a/.github/workflows/dispatch-release-8-8.yaml
+++ b/.github/workflows/dispatch-release-8-8.yaml
@@ -3,6 +3,8 @@
 #
 name: Repo dispatch Release 8.8
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   repository_dispatch:
     types: [ trigger_release_8_8 ]

--- a/.github/workflows/issue-add-support-label.yml
+++ b/.github/workflows/issue-add-support-label.yml
@@ -1,10 +1,11 @@
+---
 name: Add support label to issue
+
+# owner: @camunda/monorepo-devops-team
 
 on:
   issues:
-    types:
-      - opened
-      - edited
+    types: [ opened, edited ]
 
 permissions:
   issues: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,10 @@
+---
 name: "Pull Request Labeler"
+
+# owner: @camunda/monorepo-devops-team
+
 on:
-- pull_request_target
+  pull_request_target: {}
 
 jobs:
   labeler:

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -1,6 +1,8 @@
 ---
 name: Preview Environment Build and Deploy
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   pull_request:
     types: [labeled, synchronize]

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -1,6 +1,8 @@
 ---
 name: Preview Env Clean
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   schedule:
   - cron: 0 6,22 * * *

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -1,5 +1,8 @@
 ---
 name: Preview Env Teardown
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   pull_request:
     types: [unlabeled, closed]

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -7,7 +7,11 @@
 # An example is a pull request that builds upon the work of another pull request.
 
 name: Reject Merge Commits
-on: [pull_request]
+
+# owner: @camunda/monorepo-devops-team
+
+on:
+  pull_request: {}
 
 permissions: {}
 

--- a/.github/workflows/renovatelint.yml
+++ b/.github/workflows/renovatelint.yml
@@ -1,5 +1,8 @@
 ---
 name: Renovate lint
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -3,6 +3,8 @@
 # errors, flaky tests, etc.
 name: Retry Workflow Run
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -1,6 +1,8 @@
 ---
 name: Statistics Daily
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   schedule:
     - cron: '0 6 * * 2-5'  # Tuesdays to Fridays, to keep it actionable

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -2,6 +2,8 @@
 # NOTE: This workflow is not just for Zeebe, but also for 8.6+ monorepo release!
 name: Zeebe Release Dry Run from stable branches
 
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch: {}
   schedule:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,26 @@
 # Observability
 /docs/observability.md       @npepinpe @ChrisKujawa
 /docs/assets/observability*  @npepinpe @ChrisKujawa
+
+# C8Run by Distro team
+.github/workflows/c8run* @camunda/distribution
+
+# General Automation, Unified CI and release helpers by Monorepo DevOps team
+/.github/workflows/add-to-projects.yml                   @camunda/monorepo-devops-team
+/.github/workflows/backport.yml                          @camunda/monorepo-devops-team
+/.github/workflows/camunda-helm-integration.yml          @camunda/monorepo-devops-team
+/.github/workflows/camunda-platform-release*             @camunda/monorepo-devops-team
+/.github/workflows/chatops*                              @camunda/monorepo-devops-team
+/.github/workflows/check-licenses.yml                    @camunda/monorepo-devops-team
+/.github/workflows/check-pr-conflicts.yml                @camunda/monorepo-devops-team
+/.github/workflows/ci*                                   @camunda/monorepo-devops-team
+/.github/workflows/commitlint.yml                        @camunda/monorepo-devops-team
+/.github/workflows/dispatch-release*                     @camunda/monorepo-devops-team
+/.github/workflows/issue-add-support-label.yml           @camunda/monorepo-devops-team
+/.github/workflows/labeler.yml                           @camunda/monorepo-devops-team
+/.github/workflows/preview-env*                          @camunda/monorepo-devops-team
+/.github/workflows/reject-updates-using-merge-commit.yml @camunda/monorepo-devops-team
+/.github/workflows/renovatelint.yml                      @camunda/monorepo-devops-team
+/.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
+/.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
+/.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

Based on my research I left in-file comments and added CODEOWNERS entries for which workflows are in-scope of the Monorepo DevOps team.

The CODEOWNERS entries will lead to [PR review requests automatically](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) which might be noisy -> we can reconsider that part.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #30689 
