### PR TITLE
feat: migrate Variables component to v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
@@ -16,7 +16,7 @@ import {generateUniqueID} from 'modules/utils/generateUniqueID';
 import {FormRenderProps} from 'react-final-form';
 
 import {AddVariableButton, Form, VariablesContainer} from '../styled';
-import Variables from '../../Variables';
+import Variables from '../../Variables/v2';
 import {useWillAllFlowNodesBeCanceled} from 'modules/hooks/modifications';
 import {useHasPendingCancelOrMoveModification} from 'modules/hooks/flowNodeSelection';
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -15,8 +15,8 @@ import {
 } from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import Variables from '../index';
-import {Wrapper, mockVariables} from './mocks';
+import Variables from './index';
+import {getWrapper, mockVariables} from './mocks';
 import {createInstance} from 'modules/testUtils';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 import {act} from 'react';
@@ -35,7 +35,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(
@@ -86,7 +86,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -124,7 +124,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
 
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
@@ -222,7 +222,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -311,7 +311,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -373,7 +373,7 @@ describe('Add variable', () => {
 
     variablesStore.fetchVariables('1');
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -398,7 +398,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(
@@ -448,7 +448,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -493,7 +493,7 @@ describe('Add variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
@@ -15,8 +15,8 @@ import {
 } from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import Variables from '../index';
-import {Wrapper, mockVariables} from './mocks';
+import Variables from './index';
+import {getWrapper, mockVariables} from './mocks';
 import {createInstance, createVariable} from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
@@ -44,7 +44,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     const [activeOperationVariable] = variablesStore.state.items.filter(
@@ -80,7 +80,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     const [inactiveOperationVariable] = variablesStore.state.items.filter(
@@ -117,7 +117,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
@@ -163,7 +163,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
@@ -194,7 +194,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
@@ -249,7 +249,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
@@ -302,7 +302,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
@@ -341,7 +341,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(screen.getByText('"full-value"')).toBeInTheDocument();
@@ -376,7 +376,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables isVariableModificationAllowed />, {
-      wrapper: Wrapper,
+      wrapper: getWrapper(),
     });
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
@@ -417,7 +417,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables isVariableModificationAllowed />, {
-      wrapper: Wrapper,
+      wrapper: getWrapper(),
     });
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
@@ -448,7 +448,7 @@ describe('Edit variable', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    const {user} = render(<Variables />, {wrapper: Wrapper});
+    const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /edit variable/i}));

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
@@ -14,12 +14,12 @@ import {
 } from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import Variables from '../index';
+import Variables from './index';
 import {mockVariables} from '../index.setup';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {createInstance, createVariable} from 'modules/testUtils';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
-import {Wrapper} from './mocks';
+import {getWrapper} from './mocks';
 
 const instanceMock = createInstance({id: '1'});
 
@@ -40,7 +40,7 @@ describe('Variables', () => {
         payload: {pageSize: 10, scopeId: '1'},
       });
 
-      render(<Variables />, {wrapper: Wrapper});
+      render(<Variables />, {wrapper: getWrapper()});
       await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
       expect(screen.getByText('Name')).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('Variables', () => {
         payload: {pageSize: 10, scopeId: '1'},
       });
 
-      render(<Variables />, {wrapper: Wrapper});
+      render(<Variables />, {wrapper: getWrapper()});
       await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
       const {items} = variablesStore.state;
       const [activeOperationVariable] = items.filter(
@@ -108,7 +108,7 @@ describe('Variables', () => {
         payload: {pageSize: 10, scopeId: '1'},
       });
 
-      render(<Variables />, {wrapper: Wrapper});
+      render(<Variables />, {wrapper: getWrapper()});
 
       await waitForElementToBeRemoved(() =>
         screen.getByTestId('variables-skeleton'),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.tsx
@@ -23,6 +23,7 @@ import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {VariablesTable} from '../VariablesTable';
 import {Footer} from '../Footer';
 import {Skeleton} from '../Skeleton';
+import {useDisplayStatus} from 'modules/hooks/variables';
 
 type Props = {
   isVariableModificationAllowed?: boolean;
@@ -30,9 +31,9 @@ type Props = {
 
 const Variables: React.FC<Props> = observer(
   ({isVariableModificationAllowed = false}) => {
+    const displayStatus = useDisplayStatus();
     const {
       state: {pendingItem, loadingItemId, status},
-      displayStatus,
     } = variablesStore;
 
     const scopeId =

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/mocks.tsx
@@ -14,43 +14,51 @@ import {useEffect} from 'react';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {variablesStore} from 'modules/stores/variables';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {modificationsStore} from 'modules/stores/modifications';
 import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
-type Props = {
-  children?: React.ReactNode;
-};
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      flowNodeSelectionStore.init();
 
-const Wrapper: React.FC<Props> = ({children}) => {
-  useEffect(() => {
-    flowNodeSelectionStore.init();
+      return () => {
+        processInstanceDetailsStore.reset();
+        variablesStore.reset();
+        flowNodeSelectionStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
 
-    return () => {
-      processInstanceDetailsStore.reset();
-      variablesStore.reset();
-      flowNodeSelectionStore.reset();
-      processInstanceDetailsStatisticsStore.reset();
-      modificationsStore.reset();
-    };
-  });
-
-  return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route
-          path={Paths.processInstance()}
-          element={
-            <Form onSubmit={() => {}} mutators={{...arrayMutators}}>
-              {({handleSubmit}) => {
-                return <form onSubmit={handleSubmit}>{children} </form>;
-              }}
-            </Form>
-          }
-        />
-      </Routes>
-    </MemoryRouter>
-  );
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route
+                path={Paths.processInstance()}
+                element={
+                  <Form onSubmit={() => {}} mutators={{...arrayMutators}}>
+                    {({handleSubmit}) => {
+                      return <form onSubmit={handleSubmit}>{children} </form>;
+                    }}
+                  </Form>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
 };
 
 const mockVariables: VariableEntity[] = [
@@ -93,4 +101,4 @@ const mockMetaData: MetaDataDto = {
   incidentCount: 0,
 };
 
-export {Wrapper, mockVariables, mockMetaData};
+export {getWrapper, mockVariables, mockMetaData};

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
@@ -13,8 +13,8 @@ import {
 } from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import Variables from '../index';
-import {Wrapper} from './mocks';
+import Variables from './index';
+import {getWrapper} from './mocks';
 import {createInstance, createVariable} from 'modules/testUtils';
 import {authenticationStore} from 'modules/stores/authentication';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
@@ -62,7 +62,7 @@ describe('Restricted user with resource based permissions', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(
@@ -84,7 +84,7 @@ describe('Restricted user with resource based permissions', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(
@@ -106,7 +106,7 @@ describe('Restricted user with resource based permissions', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
 
     await waitForElementToBeRemoved(() =>
       screen.getByTestId('variables-skeleton'),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/skeleton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/skeleton.test.tsx
@@ -12,8 +12,8 @@ import {
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
-import Variables from '../index';
-import {Wrapper, mockVariables, mockMetaData} from './mocks';
+import Variables from './index';
+import {getWrapper, mockVariables, mockMetaData} from './mocks';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 
@@ -29,7 +29,7 @@ describe('Skeleton', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
 
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
     expect(await screen.findByText(EMPTY_PLACEHOLDER)).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe('Skeleton', () => {
       payload: {pageSize: 10, scopeId: '1'},
     });
 
-    render(<Variables />, {wrapper: Wrapper});
+    render(<Variables />, {wrapper: getWrapper()});
 
     expect(screen.getByTestId('variables-skeleton')).toBeInTheDocument();
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
@@ -10,18 +10,11 @@ import {act, render, screen} from 'modules/testing-library';
 import {ModificationIcons} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
-<<<<<<< HEAD
 import {useEffect} from 'react';
 import {open} from 'modules/mocks/diagrams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-=======
-import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
-import {useEffect} from 'react';
-import {open} from 'modules/mocks/diagrams';
->>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 
 type Props = {
   children?: React.ReactNode;
@@ -32,20 +25,15 @@ const Wrapper = ({children}: Props) => {
     return modificationsStore.reset;
   }, []);
 
-<<<<<<< HEAD
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       {children}
     </QueryClientProvider>
   );
-=======
-  return <>{children}</>;
->>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 };
 
 describe('<ModificationIcons />', () => {
   beforeEach(() => {
-<<<<<<< HEAD
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
@@ -71,31 +59,6 @@ describe('<ModificationIcons />', () => {
         },
       ],
     });
-=======
-    mockFetchProcessInstanceDetailStatistics().withSuccess([
-      {
-        activityId: 'parent_sub_process',
-        active: 3,
-        incidents: 0,
-        completed: 0,
-        canceled: 0,
-      },
-      {
-        activityId: 'inner_sub_process',
-        active: 3,
-        incidents: 0,
-        completed: 0,
-        canceled: 0,
-      },
-      {
-        activityId: 'user_task',
-        active: 3,
-        incidents: 0,
-        completed: 0,
-        canceled: 0,
-      },
-    ]);
->>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
   });
@@ -128,10 +91,6 @@ describe('<ModificationIcons />', () => {
   });
 
   it('should show modification planned to be canceled icon if all the running tokens on the flow node is canceled', async () => {
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
     render(
       <ModificationIcons
         flowNodeInstance={{
@@ -159,10 +118,6 @@ describe('<ModificationIcons />', () => {
   });
 
   it('should show modification planned to be canceled icon if one of the running tokens on the flow node is canceled', async () => {
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
     render(
       <ModificationIcons
         flowNodeInstance={{
@@ -186,10 +141,6 @@ describe('<ModificationIcons />', () => {
   });
 
   it('should not show modification planned to be canceled icon if one of the other running tokens on the flow node is canceled', async () => {
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
     render(
       <ModificationIcons
         flowNodeInstance={{
@@ -215,10 +166,6 @@ describe('<ModificationIcons />', () => {
   });
 
   it('should show modification planned to be canceled icon if one of the parent running tokens on the flow node is canceled', async () => {
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
     render(
       <ModificationIcons
         flowNodeInstance={{
@@ -244,10 +191,6 @@ describe('<ModificationIcons />', () => {
   });
 
   it('should show modification planned to be canceled icon if one of the other parent running tokens on the flow node is canceled', async () => {
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
     render(
       <ModificationIcons
         flowNodeInstance={{

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
@@ -11,11 +11,17 @@ import {ModificationIcons} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+<<<<<<< HEAD
 import {useEffect} from 'react';
 import {open} from 'modules/mocks/diagrams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+=======
+import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
+import {useEffect} from 'react';
+import {open} from 'modules/mocks/diagrams';
+>>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 
 type Props = {
   children?: React.ReactNode;
@@ -26,15 +32,20 @@ const Wrapper = ({children}: Props) => {
     return modificationsStore.reset;
   }, []);
 
+<<<<<<< HEAD
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       {children}
     </QueryClientProvider>
   );
+=======
+  return <>{children}</>;
+>>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 };
 
 describe('<ModificationIcons />', () => {
   beforeEach(() => {
+<<<<<<< HEAD
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
@@ -60,6 +71,31 @@ describe('<ModificationIcons />', () => {
         },
       ],
     });
+=======
+    mockFetchProcessInstanceDetailStatistics().withSuccess([
+      {
+        activityId: 'parent_sub_process',
+        active: 3,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+      {
+        activityId: 'inner_sub_process',
+        active: 3,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+      {
+        activityId: 'user_task',
+        active: 3,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+    ]);
+>>>>>>> 7ce1478b393 (feat: prepare ModificationIcons component migration)
 
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
   });


### PR DESCRIPTION
## Description

This PR migrates `Variables` component away from `processInstanceDetailsStatisticsStore`. There is no direct dependency on that store but the `variablesStore` depends on `flowNodeSelectionStore` and `flowNodeMetadataStore` which both depend on `processInstanceDetailsStatisticsStore`.

I'm not yet migrating [this test](https://github.com/camunda/camunda/blob/5869120843a84b09b16941465611032b8685d22d/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx) because it's a bigger change so I will do it in a separate PR.

## Related issues

closes #30270
