### PR TITLE
test: assert that camunda client is disabled

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientProdAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientProdAutoConfiguration.java
@@ -73,7 +73,7 @@ public class CamundaClientProdAutoConfiguration {
         interceptors,
         chainHandlers,
         camundaClientExecutorService,
-        camundaClientCredentialsProvider) {};
+        camundaClientCredentialsProvider);
   }
 
   @Bean(destroyMethod = "close")

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
@@ -5,7 +5,7 @@
 # Licensed under the Camunda License 1.0. You may not use this file
 # except in compliance with the Camunda License 1.0.
 #
-camunda.client.enabled=camunda.client.zeebe.enabled
+camunda.client.enabled=camunda.client.zeebe.enabled, zeebe.client.enabled
 camunda.client.rest-address=camunda.client.zeebe.rest-address, zeebe.client.broker.rest-address, zeebe.rest.address
 camunda.client.grpc-address=camunda.client.zeebe.grpc-address, zeebe.client.broker.grpc-address, zeebe.grpc.address, zeebe.client.broker.gateway-address
 camunda.client.tenant-id=zeebe.client.default-tenant-id

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
@@ -19,19 +19,52 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.configuration.CamundaClientProdAutoConfiguration;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(
-    classes = CamundaClientProdAutoConfiguration.class,
-    properties = {"camunda.client.enabled=false"})
 public class CamundaClientEnabledTest {
-  @Autowired(required = false)
-  CamundaClient camundaClient;
 
-  @Test
-  void shouldNotEnableCamundaClient() {
-    assertThat(camundaClient).isNull();
+  @Nested
+  @SpringBootTest(
+      classes = CamundaClientProdAutoConfiguration.class,
+      properties = {"camunda.client.enabled=false"})
+  class CurrentConfiguration {
+    @Autowired(required = false)
+    CamundaClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = CamundaClientProdAutoConfiguration.class,
+      properties = {"camunda.client.zeebe.enabled=false"})
+  class ZeebeClientConfiguration {
+    @Autowired(required = false)
+    CamundaClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = CamundaClientProdAutoConfiguration.class,
+      properties = {"zeebe.client.enabled=false"})
+  class LegacyConfiguration {
+    @Autowired(required = false)
+    CamundaClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNull();
+    }
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.spring.client.configuration.CamundaClientProdAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = CamundaClientProdAutoConfiguration.class,
+    properties = {"camunda.client.enabled=false"})
+public class CamundaClientEnabledTest {
+  @Autowired(required = false)
+  CamundaClient camundaClient;
+
+  @Test
+  void shouldNotEnableCamundaClient() {
+    assertThat(camundaClient).isNull();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a test to assert that the `camunda.client.enabled` flag actually works.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
