### PR TITLE
fix: zeebe client enabled works as expected now

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 @ConditionalOnProperty(
-    prefix = "zeebe.client",
+    prefix = "camunda.client.zeebe",
     name = "enabled",
     havingValue = "true",
     matchIfMissing = true)

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Bean;
  * All configurations that will only be used in production code - meaning NO TEST cases
  */
 @ConditionalOnProperty(
-    prefix = "zeebe.client",
+    prefix = "camunda.client.zeebe",
     name = "enabled",
     havingValue = "true",
     matchIfMissing = true)

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 /*
@@ -53,6 +54,7 @@ import org.springframework.context.annotation.Bean;
   CredentialsProviderConfiguration.class,
 })
 @AutoConfigureBefore(ZeebeClientAllAutoConfiguration.class)
+@EnableConfigurationProperties({CamundaClientProperties.class})
 public class ZeebeClientProdAutoConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientProdAutoConfiguration.class);

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
@@ -5,6 +5,7 @@
 # Licensed under the Camunda License 1.0. You may not use this file
 # except in compliance with the Camunda License 1.0.
 #
+camunda.client.zeebe.enabled=zeebe.client.enabled
 camunda.client.zeebe.rest-address=zeebe.client.broker.rest-address, zeebe.rest.address
 camunda.client.zeebe.grpc-address=zeebe.client.broker.grpc-address, zeebe.grpc.address, zeebe.client.broker.gateway-address
 camunda.client.tenant-id=zeebe.client.default-tenant-id

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
@@ -53,4 +53,16 @@ public class ZeebeClientEnabledTest {
       assertThat(camundaClient).isNull();
     }
   }
+
+  @Nested
+  @SpringBootTest(classes = ZeebeClientProdAutoConfiguration.class)
+  class NegativeTest {
+    @Autowired(required = false)
+    ZeebeClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNotNull();
+    }
+  }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+public class ZeebeClientEnabledTest {
+
+  @Nested
+  @SpringBootTest(
+      classes = ZeebeClientProdAutoConfiguration.class,
+      properties = {"camunda.client.zeebe.enabled=false"})
+  class CurrentConfiguration {
+    @Autowired(required = false)
+    ZeebeClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNull();
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = ZeebeClientProdAutoConfiguration.class,
+      properties = {"zeebe.client.enabled=false"})
+  class LegacyConfiguration {
+    @Autowired(required = false)
+    ZeebeClient camundaClient;
+
+    @Test
+    void shouldNotEnableCamundaClient() {
+      assertThat(camundaClient).isNull();
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR makes the `camunda.client.zeebe.enabled` flag work as expected.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
