### PR TITLE
feat: migrate Operation component to v2

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/v2/Operation.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/v2/Operation.tsx
@@ -15,6 +15,7 @@ import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {Button} from '@carbon/react';
 import {TrashCan} from '@carbon/react/icons';
 import {Operations} from '../../Operations';
+import {useNewScopeIdForFlowNode} from 'modules/hooks/modifications';
 
 type Props = {
   variableName: string;
@@ -25,12 +26,11 @@ const Operation: React.FC<Props> = ({variableName, onRemove}) => {
   const {
     input: {value: currentId},
   } = useField(createNewVariableFieldName(variableName, 'id'));
+  const newScopeIdForFlowNode = useNewScopeIdForFlowNode(
+    flowNodeSelectionStore.state.selection?.flowNodeId,
+  );
 
-  const scopeId =
-    variablesStore.scopeId ??
-    modificationsStore.getNewScopeIdForFlowNode(
-      flowNodeSelectionStore.state.selection?.flowNodeId,
-    );
+  const scopeId = variablesStore.scopeId ?? newScopeIdForFlowNode;
 
   return (
     <Operations>

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/VariablesTable.tsx
@@ -27,9 +27,11 @@ import {ExistingVariableValue} from './ExistingVariableValue';
 import {Name} from './NewVariableModification/Name';
 import {Value} from './NewVariableModification/Value';
 import {Operation} from './NewVariableModification/Operation';
+import {Operation as OperationV2} from './NewVariableModification/v2/Operation';
 import {ViewFullVariableButton} from './ViewFullVariableButton';
 import {MAX_VARIABLES_STORED} from 'modules/constants/variables';
 import {notificationsStore} from 'modules/stores/notifications';
+import {IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 type Props = {
   scopeId: string | null;
@@ -156,14 +158,22 @@ const VariablesTable: React.FC<Props> = observer(
                               width: '55%',
                             },
                             {
-                              cellContent: (
-                                <Operation
-                                  variableName={variableName}
-                                  onRemove={() => {
-                                    fields.remove(index);
-                                  }}
-                                />
-                              ),
+                              cellContent:
+                                IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED ? (
+                                  <OperationV2
+                                    variableName={variableName}
+                                    onRemove={() => {
+                                      fields.remove(index);
+                                    }}
+                                  />
+                                ) : (
+                                  <Operation
+                                    variableName={variableName}
+                                    onRemove={() => {
+                                      fields.remove(index);
+                                    }}
+                                  />
+                                ),
                               width: '10%',
                             },
                           ],

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -192,6 +192,42 @@ const useModificationsByFlowNode = () => {
   }, {});
 };
 
+const useNewScopeIdForFlowNode = (flowNodeId?: string) => {
+  const modificationsByFlowNode = useModificationsByFlowNode();
+
+  if (
+    flowNodeId === undefined ||
+    (modificationsByFlowNode[flowNodeId]?.newTokens ?? 0) !== 1
+  ) {
+    return null;
+  }
+
+  const addTokenModification = modificationsStore.flowNodeModifications.find(
+    (modification) =>
+      modification.operation === TOKEN_OPERATIONS.ADD_TOKEN &&
+      modification.flowNode.id === flowNodeId,
+  );
+
+  if (addTokenModification !== undefined && 'scopeId' in addTokenModification) {
+    return addTokenModification.scopeId;
+  }
+
+  const moveTokenModification = modificationsStore.flowNodeModifications.find(
+    (modification) =>
+      modification.operation === TOKEN_OPERATIONS.MOVE_TOKEN &&
+      modification.targetFlowNode.id === flowNodeId,
+  );
+
+  if (
+    moveTokenModification !== undefined &&
+    'scopeIds' in moveTokenModification
+  ) {
+    return moveTokenModification.scopeIds[0] ?? null;
+  }
+
+  return null;
+};
+
 const useCanBeCanceled = (selectedRunningInstanceCount: number) => {
   const cancellableFlowNodes = useCancellableFlowNodes();
   const canBeModified = useCanBeModified();
@@ -287,5 +323,6 @@ export {
   useAvailableModifications,
   useCanBeModified,
   useModificationsByFlowNode,
+  useNewScopeIdForFlowNode,
   useWillAllFlowNodesBeCanceled,
 };


### PR DESCRIPTION
## Description

This PR migrates `Operation ` component away from `processInstanceDetailsStatisticsStore`. There is no direct dependency on that store but the `modificationsStore` depends on which depends on `processInstanceDetailsStatisticsStore`.

## Related issues

closes #30272 
