### PR TITLE
test: make sure camunda app is stopped on test failure

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -283,16 +283,18 @@ public class PrefixMigrationIT {
     prefixMigration(OLD_OPERATE_PREFIX, OLD_TASKLIST_PREFIX, "prefixmigrationit");
 
     // then
-    STANDALONE_CAMUNDA.start();
-    STANDALONE_CAMUNDA.awaitCompleteTopology();
-    try (final var currentCamundaClient = STANDALONE_CAMUNDA.newClientBuilder().build()) {
-      final var processDefinitions =
-          currentCamundaClient.newProcessDefinitionSearchRequest().send().join();
-      assertThat(processDefinitions.items().size()).isEqualTo(1);
-      assertThat(processDefinitions.items().getFirst().getProcessDefinitionKey())
-          .isEqualTo(event.getProcesses().getFirst().getProcessDefinitionKey());
+    try {
+      STANDALONE_CAMUNDA.start();
+      STANDALONE_CAMUNDA.awaitCompleteTopology();
+      try (final var currentCamundaClient = STANDALONE_CAMUNDA.newClientBuilder().build()) {
+        final var processDefinitions =
+            currentCamundaClient.newProcessDefinitionSearchRequest().send().join();
+        assertThat(processDefinitions.items().size()).isEqualTo(1);
+        assertThat(processDefinitions.items().getFirst().getProcessDefinitionKey())
+            .isEqualTo(event.getProcesses().getFirst().getProcessDefinitionKey());
+      }
+    } finally {
+      STANDALONE_CAMUNDA.stop();
     }
-
-    STANDALONE_CAMUNDA.stop();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in [Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1744125772038569)
`PrefixMigrationIT.shouldMigrateCorrectIndicesDuringPrefixMigration` is not idempotent for retries on test failures.
The problem may come from the app not being stopped when there are assert failures.
I added a finally block to make sure to stop the app on assertion failures

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/30782
