### PR TITLE
[Backport stable/8.6] deps: remove explicit dependency on reactor

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -139,7 +139,6 @@
     <version.postgresql>42.7.5</version.postgresql>
     <version.h2>2.3.232</version.h2>
     <version.aws-signing>2.3.1</version.aws-signing>
-    <version.reactor-netty>1.1.23</version.reactor-netty>
     <version.tc-keycloak>3.3.1</version.tc-keycloak>
     <version.jakarta-activation>2.1.3</version.jakarta-activation>
     <version.jakarta.json-api>2.1.3</version.jakarta.json-api>
@@ -1274,12 +1273,6 @@
       </dependency>
 
       <dependency>
-        <groupId>io.projectreactor.netty</groupId>
-        <artifactId>reactor-netty-http</artifactId>
-        <version>${version.reactor-netty}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${version.elasticsearch}</version>
@@ -1790,13 +1783,6 @@
         <groupId>com.google.j2objc</groupId>
         <artifactId>j2objc-annotations</artifactId>
         <version>3.0.0</version>
-      </dependency>
-
-      <!-- between io.projectreactor.netty:reactor-netty-http:1.1.8 and org.springframework:spring-webflux:6.0.11 -->
-      <dependency>
-        <groupId>io.projectreactor</groupId>
-        <artifactId>reactor-core</artifactId>
-        <version>3.6.11</version>
       </dependency>
 
       <!-- between com.github.dasniko:testcontainers-keycloak and its own dependencies -->


### PR DESCRIPTION
# Description
Backport of #26143 to `stable/8.6`.

relates to 