### PR TITLE
fix: default port of distro is 8088

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/self-managed.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/self-managed.yaml
@@ -6,7 +6,7 @@ camunda:
       token-url: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
     zeebe:
       enabled: true
-      rest-address: http://localhost:8086
+      rest-address: http://localhost:8088
       grpc-address: http://localhost:26500
       audience: zeebe-api
       prefer-rest-over-grpc: false

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
@@ -63,7 +63,7 @@ public class ZeebeClientConfigurationImplSelfManagedTest {
   @Test
   void shouldHaveRestAddress() {
     assertThat(zeebeClientConfiguration.getRestAddress().toString())
-        .isEqualTo("http://localhost:8086");
+        .isEqualTo("http://localhost:8088");
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
@@ -34,7 +34,7 @@ public class ZeebeClientPropertiesSelfManagedTest {
     assertThat(properties.getZeebe().getGrpcAddress().toString())
         .isEqualTo("http://localhost:26500");
     assertThat(properties.getZeebe().getRestAddress().toString())
-        .isEqualTo("http://localhost:8086");
+        .isEqualTo("http://localhost:8088");
     assertThat(properties.getZeebe().getPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getZeebe().getEnabled()).isEqualTo(true);
     assertThat(properties.getZeebe().getAudience()).isEqualTo("zeebe-api");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adjusts the default port to the one of the distribution:

docker compose: https://github.com/camunda/camunda-distributions/blob/main/docker-compose/versions/camunda-8.7/docker-compose.yaml#L20
helm: https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.7/templates/NOTES.txt#L98

This PR is a logical backport of https://github.com/camunda/camunda/pull/30791 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
