### PR TITLE
feat: Continue flow after completing canceling task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -196,6 +196,9 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                   context, String.format("Unexpected element state: '%s'", elementState));
         }
         break;
+      case CONTINUE_TERMINATING_ELEMENT:
+        processor.finalizeTermination(element, context);
+        break;
       default:
         throw new BpmnProcessingException(
             context,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -71,6 +71,8 @@ public final class ProcessInstanceStateTransitionGuard {
               ProcessInstanceIntent.ELEMENT_ACTIVATING,
               ProcessInstanceIntent.ELEMENT_ACTIVATED,
               ProcessInstanceIntent.ELEMENT_COMPLETING);
+      case CONTINUE_TERMINATING_ELEMENT ->
+          hasElementInstanceWithState(context, ProcessInstanceIntent.ELEMENT_TERMINATING);
       case COMPLETE_EXECUTION_LISTENER ->
           hasElementInstanceWithState(
               context,
@@ -79,7 +81,8 @@ public final class ProcessInstanceStateTransitionGuard {
       default ->
           Either.left(
               String.format(
-                  "Expected the check of the preconditions of a command with intent [activate,complete,terminate] but the intent was '%s'",
+                  "Expected the check of the preconditions of a command with intent "
+                      + "[activate,complete,terminate,continue_terminating,complete_el] but the intent was '%s'",
                   context.getIntent()));
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -31,6 +31,11 @@ import java.util.Optional;
  */
 public final class ProcessInstanceStateTransitionGuard {
 
+  private static final String UNSUPPORTED_INTENT_MESSAGE =
+      "Expected the check of the preconditions of a command with intent "
+          + "[ACTIVATE_ELEMENT,COMPLETE_ELEMENT,TERMINATE_ELEMENT,"
+          + "CONTINUE_TERMINATING_ELEMENT,COMPLETE_EXECUTION_LISTENER] but the intent was '%s'";
+
   private final BpmnStateBehavior stateBehavior;
   private final BpmnInclusiveGatewayBehavior inclusiveGatewayBehavior;
 
@@ -78,12 +83,7 @@ public final class ProcessInstanceStateTransitionGuard {
               context,
               ProcessInstanceIntent.ELEMENT_ACTIVATING,
               ProcessInstanceIntent.ELEMENT_COMPLETING);
-      default ->
-          Either.left(
-              String.format(
-                  "Expected the check of the preconditions of a command with intent "
-                      + "[activate,complete,terminate,continue_terminating,complete_el] but the intent was '%s'",
-                  context.getIntent()));
+      default -> Either.left(UNSUPPORTED_INTENT_MESSAGE.formatted(context.getIntent()));
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -61,7 +61,7 @@ public final class UserTaskCommandProcessors {
                 new UserTaskCompleteProcessor(
                     processingState, eventHandle, writers, authCheckBehavior),
                 UserTaskIntent.CANCEL,
-                new UserTaskCancelProcessor()));
+                new UserTaskCancelProcessor(processingState, writers)));
     validateProcessorsSetup(commandToProcessor);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -365,14 +365,12 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     final var userTaskIntent =
         switch (lifecycleState) {
+          case CREATING -> UserTaskIntent.CREATE;
           case ASSIGNING -> UserTaskIntent.ASSIGN;
           case CLAIMING -> UserTaskIntent.CLAIM;
           case UPDATING -> UserTaskIntent.UPDATE;
           case COMPLETING -> UserTaskIntent.COMPLETE;
-          case CREATING, CANCELING ->
-              throw new UnsupportedOperationException(
-                  "Conversion from '%s' user task lifecycle state to a user task command is not yet supported"
-                      .formatted(lifecycleState));
+          case CANCELING -> UserTaskIntent.CANCEL;
           default ->
               throw new IllegalArgumentException(
                   "Unexpected user task lifecycle state: '%s'".formatted(lifecycleState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
@@ -7,16 +7,44 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public class UserTaskCancelProcessor implements UserTaskCommandProcessor {
+
+  private final ElementInstanceState elementInstanceState;
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+
+  public UserTaskCancelProcessor(final ProcessingState state, final Writers writers) {
+    elementInstanceState = state.getElementInstanceState();
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+  }
 
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
-    throw new UnsupportedOperationException(
-        "UserTaskCancelProcessor.onFinalizeCommand is not yet implemented. "
-            + "It should be covered by: https://github.com/camunda/camunda/issues/28570");
+    final long userTaskKey = command.getKey();
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELED, userTaskRecord);
+
+    final var userTaskElementInstanceKey = userTaskRecord.getElementInstanceKey();
+    final var userTaskElementInstance =
+        elementInstanceState.getInstance(userTaskElementInstanceKey);
+    if (userTaskElementInstance != null) {
+      commandWriter.appendFollowUpCommand(
+          userTaskElementInstanceKey,
+          ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT,
+          userTaskElementInstance.getValue());
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
@@ -40,7 +40,7 @@ public class UserTaskCancelProcessor implements UserTaskCommandProcessor {
     final var userTaskElementInstanceKey = userTaskRecord.getElementInstanceKey();
     final var userTaskElementInstance =
         elementInstanceState.getInstance(userTaskElementInstanceKey);
-    if (userTaskElementInstance != null) {
+    if (userTaskElementInstance != null && userTaskElementInstance.isTerminating()) {
       commandWriter.appendFollowUpCommand(
           userTaskElementInstanceKey,
           ProcessInstanceIntent.CONTINUE_TERMINATING_ELEMENT,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -377,14 +377,13 @@ public class TaskListenerBlockedTransitionTest {
         listenerType + "_3");
 
     final Predicate<Record<?>> isUserTaskOrVariableDocumentWithElementInstanceKey =
-        r -> {
-          if (r.getValue() instanceof final UserTaskRecord utr) {
-            return utr.getElementInstanceKey() == userTaskElementInstanceKey;
-          } else if (r.getValue() instanceof final VariableDocumentRecord vdr) {
-            return vdr.getScopeKey() == userTaskElementInstanceKey;
-          }
-          return false;
-        };
+        r ->
+            switch (r.getValue()) {
+              case final UserTaskRecord u ->
+                  u.getElementInstanceKey() == userTaskElementInstanceKey;
+              case final VariableDocumentRecord v -> v.getScopeKey() == userTaskElementInstanceKey;
+              default -> false;
+            };
 
     assertThat(
             RecordingExporter.records()
@@ -563,14 +562,13 @@ public class TaskListenerBlockedTransitionTest {
         userTask -> assertThat(userTask.getAction()).isEmpty());
 
     final Predicate<Record<?>> isUserTaskOrProcessInstanceRecordWithUserTaskInstanceKey =
-        r -> {
-          if (r.getValue() instanceof UserTaskRecord utr) {
-            return utr.getElementInstanceKey() == userTaskElementInstanceKey;
-          } else if (r.getValue() instanceof ProcessInstanceRecord) {
-            return r.getKey() == userTaskElementInstanceKey;
-          }
-          return false;
-        };
+        r ->
+            switch (r.getValue()) {
+              case final UserTaskRecord u ->
+                  u.getElementInstanceKey() == userTaskElementInstanceKey;
+              case final ProcessInstanceRecord ignored -> r.getKey() == userTaskElementInstanceKey;
+              default -> false;
+            };
 
     assertThat(
             RecordingExporter.records()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
@@ -11,7 +11,6 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.engine.util.client.UserTaskClient;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.Protocol;
@@ -45,23 +44,30 @@ public class TaskListenerTaskHeadersTest {
   public void shouldIncludeUserTaskHeadersInJobCustomHeadersForAssigningTaskListener() {
     shouldIncludeUserTaskHeadersInJobCustomHeaders(
         ZeebeTaskListenerEventType.assigning,
-        userTask -> userTask.withAssignee("initial_assignee").claim());
+        pik -> ENGINE.userTask().ofInstance(pik).withAssignee("initial_assignee").claim());
   }
 
   @Test
   public void shouldIncludeUserTaskHeadersInJobCustomHeadersForCompletingTaskListener() {
     shouldIncludeUserTaskHeadersInJobCustomHeaders(
-        ZeebeTaskListenerEventType.completing, UserTaskClient::complete);
+        ZeebeTaskListenerEventType.completing, pik -> ENGINE.userTask().ofInstance(pik).complete());
   }
 
   @Test
   public void shouldIncludeUserTaskHeadersInJobCustomHeadersForUpdatingTaskListener() {
     shouldIncludeUserTaskHeadersInJobCustomHeaders(
-        ZeebeTaskListenerEventType.updating, UserTaskClient::update);
+        ZeebeTaskListenerEventType.updating, pik -> ENGINE.userTask().ofInstance(pik).update());
+  }
+
+  @Test
+  public void shouldIncludeUserTaskHeadersInJobCustomHeadersForCancelingTaskListener() {
+    shouldIncludeUserTaskHeadersInJobCustomHeaders(
+        ZeebeTaskListenerEventType.canceling,
+        pik -> ENGINE.processInstance().withInstanceKey(pik).expectTerminating().cancel());
   }
 
   private void shouldIncludeUserTaskHeadersInJobCustomHeaders(
-      final ZeebeTaskListenerEventType eventType, final Consumer<UserTaskClient> userTaskAction) {
+      final ZeebeTaskListenerEventType eventType, final Consumer<Long> transitionTrigger) {
     final BpmnModelInstance processWithZeebeUserTask =
         helper.createProcessWithZeebeUserTask(
             taskBuilder ->
@@ -72,8 +78,8 @@ public class TaskListenerTaskHeadersTest {
     // given
     final long processInstanceKey = helper.createProcessInstance(processWithZeebeUserTask);
 
-    // when
-    userTaskAction.accept(ENGINE.userTask().ofInstance(processInstanceKey));
+    // when: trigger the user task transition
+    transitionTrigger.accept(processInstanceKey);
 
     // then
     final var activatedListenerJob = helper.activateJob(processInstanceKey, listenerType);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -47,12 +47,26 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    */
   COMPLETE_EXECUTION_LISTENER((short) 12),
   /** Represents the intent signaling the migration of an ancestor element instance. */
-  ANCESTOR_MIGRATED((short) 13);
+  ANCESTOR_MIGRATED((short) 13),
+
+  /**
+   * Represents the intent that triggers the continuation of a previously started termination of a
+   * BPMN element.
+   *
+   * <p>This command is typically used after a pause in the termination flow - for example, when a
+   * `canceling` task listener was triggered - to resume and finalize the termination of the user
+   * task element.
+   */
+  CONTINUE_TERMINATING_ELEMENT((short) 14);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
-          ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT, COMPLETE_EXECUTION_LISTENER);
+          ACTIVATE_ELEMENT,
+          COMPLETE_ELEMENT,
+          TERMINATE_ELEMENT,
+          COMPLETE_EXECUTION_LISTENER,
+          CONTINUE_TERMINATING_ELEMENT);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -100,6 +114,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return COMPLETE_EXECUTION_LISTENER;
       case 13:
         return ANCESTOR_MIGRATED;
+      case 14:
+        return CONTINUE_TERMINATING_ELEMENT;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -218,6 +218,17 @@ public final class ZeebeAssertHelper {
     consumer.accept(userTask);
   }
 
+  public static void assertUserTaskCanceled(
+      final long userTaskKey, final Consumer<UserTaskRecordValue> consumer) {
+    final UserTaskRecordValue userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CANCELED)
+            .withRecordKey(userTaskKey)
+            .getFirst()
+            .getValue();
+
+    consumer.accept(userTask);
+  }
+
   public static void assertClockPinned(final Consumer<ClockRecordValue> consumer) {
     assertClockRecordValue(ClockIntent.PINNED, consumer);
   }


### PR DESCRIPTION
## Description

This PR introduces the ability to resume and finalize the termination of a user task after all `"canceling"` user task listeners have been completed.

### Included changes:
- Added a new `ProcessInstanceIntent`: `CONTINUE_TERMINATING_ELEMENT` to resume termination flow after `"canceling"` listeners.
- Implemented `UserTaskCancelProcessor` to handle finalization of the `CANCEL` command by:
  - Emitting the `UserTaskIntent.CANCELED` event.
  - Emitting the `CONTINUE_TERMINATING_ELEMENT` command.
- Updated `BpmnStreamProcessor` to handle the new `CONTINUE_TERMINATING_ELEMENT` intent.
- Adjusted `ProcessInstanceStateTransitionGuard` to allow this new command.
- Enhanced `CANCELING` and `CANCELED` appliers to cleanup task listener indices.
- Added a test to verify support for `"canceling"` listeners:
  - Listeners blocking behavior;
  - Listeners retry in case of failure;
  - Corrections support (covers #28577 issue);
  - User task headers propagation to `"canceling"` task listener job headers;

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28570
closes #28577
