### PR TITLE
Fix/30781 align batch operation status enums

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -56,7 +56,7 @@ public class BatchOperationImpl implements BatchOperation {
         item.getBatchOperationType() != null
             ? BatchOperationType.valueOf(item.getBatchOperationType().name())
             : null;
-    status = item.getStatus() != null ? BatchOperationState.valueOf(item.getStatus().name()) : null;
+    status = item.getState() != null ? BatchOperationState.valueOf(item.getState().name()) : null;
     startDate = item.getStartDate();
     endDate = item.getEndDate();
     operationsTotalCount = item.getOperationsTotalCount();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
@@ -51,7 +51,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     public BatchOperationItemImpl(final BatchOperationItemResponse item) {
       batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
       itemKey = ParseUtil.parseLongOrNull(item.getItemKey());
-      status = EnumUtil.convert(item.getStatus(), BatchOperationItemState.class);
+      status = EnumUtil.convert(item.getState(), BatchOperationItemState.class);
     }
 
     @Override

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnumUtilTest.java
@@ -453,22 +453,22 @@ public class EnumUtilTest {
   public void shouldConvertBatchOperationState() {
 
     for (final BatchOperationState value : BatchOperationState.values()) {
-      final BatchOperationResponse.StatusEnum protocolValue =
-          EnumUtil.convert(value, BatchOperationResponse.StatusEnum.class);
+      final BatchOperationResponse.StateEnum protocolValue =
+          EnumUtil.convert(value, BatchOperationResponse.StateEnum.class);
       assertThat(protocolValue).isNotNull();
       if (value == BatchOperationState.UNKNOWN_ENUM_VALUE) {
         assertThat(protocolValue)
-            .isEqualTo(BatchOperationResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API);
+            .isEqualTo(BatchOperationResponse.StateEnum.UNKNOWN_DEFAULT_OPEN_API);
       } else {
         assertThat(protocolValue.name()).isEqualTo(value.name());
       }
     }
 
-    for (final BatchOperationResponse.StatusEnum protocolValue :
-        BatchOperationResponse.StatusEnum.values()) {
+    for (final BatchOperationResponse.StateEnum protocolValue :
+        BatchOperationResponse.StateEnum.values()) {
       final BatchOperationState value = EnumUtil.convert(protocolValue, BatchOperationState.class);
       assertThat(value).isNotNull();
-      if (protocolValue == BatchOperationResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == BatchOperationResponse.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(BatchOperationState.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());
@@ -480,23 +480,23 @@ public class EnumUtilTest {
   public void shouldConvertBatchOperationItemState() {
 
     for (final BatchOperationItemState value : BatchOperationItemState.values()) {
-      final BatchOperationItemResponse.StatusEnum protocolValue =
-          EnumUtil.convert(value, BatchOperationItemResponse.StatusEnum.class);
+      final BatchOperationItemResponse.StateEnum protocolValue =
+          EnumUtil.convert(value, BatchOperationItemResponse.StateEnum.class);
       assertThat(protocolValue).isNotNull();
       if (value == BatchOperationItemState.UNKNOWN_ENUM_VALUE) {
         assertThat(protocolValue)
-            .isEqualTo(BatchOperationItemResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API);
+            .isEqualTo(BatchOperationItemResponse.StateEnum.UNKNOWN_DEFAULT_OPEN_API);
       } else {
         assertThat(protocolValue.name()).isEqualTo(value.name());
       }
     }
 
-    for (final BatchOperationItemResponse.StatusEnum protocolValue :
-        BatchOperationItemResponse.StatusEnum.values()) {
+    for (final BatchOperationItemResponse.StateEnum protocolValue :
+        BatchOperationItemResponse.StateEnum.values()) {
       final BatchOperationItemState value =
           EnumUtil.convert(protocolValue, BatchOperationItemState.class);
       assertThat(value).isNotNull();
-      if (protocolValue == BatchOperationItemResponse.StatusEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == BatchOperationItemResponse.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(BatchOperationItemState.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -474,7 +474,7 @@
       <column name="BATCH_OPERATION_KEY" type="BIGINT">
         <constraints primaryKey="true" nullable="false"/>
       </column>
-      <column name="STATUS" type="VARCHAR(255)"/>
+      <column name="STATE" type="VARCHAR(255)"/>
       <column name="OPERATION_TYPE" type="VARCHAR(255)"/>
       <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
@@ -493,7 +493,7 @@
         />
       </column>
       <column name="ITEM_KEY" type="BIGINT"/>
-      <column name="STATUS" type="VARCHAR(20)" defaultValue="ACTIVE"/>
+      <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
     </createTable>
 
     <createIndex tableName="${prefix}BATCH_OPERATION_ITEM"

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
@@ -15,7 +15,7 @@ public class BatchOperationEntityMapper {
   public static BatchOperationEntity toEntity(final BatchOperationDbModel dbModel) {
     return new BatchOperationEntity(
         dbModel.batchOperationKey(),
-        dbModel.status(),
+        dbModel.state(),
         dbModel.operationType(),
         dbModel.startDate(),
         dbModel.endDate(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -11,7 +11,7 @@ import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -39,17 +39,17 @@ public interface BatchOperationMapper {
   List<BatchOperationItemEntity> getItems(Long batchOperationKey);
 
   record BatchOperationUpdateDto(
-      long batchOperationKey, BatchOperationStatus status, OffsetDateTime endDate) {}
+      long batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}
 
   record BatchOperationUpdateTotalCountDto(long batchOperationKey, int operationsTotalCount) {}
 
   record BatchOperationItemsDto(Long batchOperationKey, Set<Long> items) {}
 
   record BatchOperationItemDto(
-      Long batchOperationKey, Long itemKey, BatchOperationEntity.BatchOperationItemStatus status) {}
+      Long batchOperationKey, Long itemKey, BatchOperationEntity.BatchOperationItemState state) {}
 
   record BatchOperationItemStatusUpdateDto(
       Long batchOperationKey,
-      BatchOperationEntity.BatchOperationItemStatus oldState,
-      BatchOperationEntity.BatchOperationItemStatus newState) {}
+      BatchOperationEntity.BatchOperationItemState oldState,
+      BatchOperationEntity.BatchOperationItemState newState) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.db.rdbms.write.domain;
 
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 
 public record BatchOperationDbModel(
     Long batchOperationKey,
-    BatchOperationStatus status,
+    BatchOperationState state,
     String operationType,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
@@ -25,7 +25,7 @@ public record BatchOperationDbModel(
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
 
     private Long batchOperationKey;
-    private BatchOperationStatus status;
+    private BatchOperationState state;
     private String operationType;
     private OffsetDateTime startDate;
     private OffsetDateTime endDate = null;
@@ -40,8 +40,8 @@ public record BatchOperationDbModel(
       return this;
     }
 
-    public Builder status(final BatchOperationStatus status) {
-      this.status = status;
+    public Builder state(final BatchOperationState state) {
+      this.state = state;
       return this;
     }
 
@@ -79,7 +79,7 @@ public record BatchOperationDbModel(
     public BatchOperationDbModel build() {
       return new BatchOperationDbModel(
           batchOperationKey,
-          status,
+          state,
           operationType,
           startDate,
           endDate,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -18,8 +18,8 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -70,7 +70,7 @@ public class BatchOperationWriter {
   }
 
   public void updateItem(
-      final long batchOperationKey, final long itemKey, final BatchOperationItemStatus state) {
+      final long batchOperationKey, final long itemKey, final BatchOperationItemState state) {
 
     // TODO merging this into one statement would be more efficient
     executionQueue.executeInQueue(
@@ -81,7 +81,7 @@ public class BatchOperationWriter {
             "io.camunda.db.rdbms.sql.BatchOperationMapper.updateItem",
             new BatchOperationItemDto(batchOperationKey, itemKey, state)));
 
-    if (state == BatchOperationItemStatus.FAILED) {
+    if (state == BatchOperationItemState.FAILED) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.BATCH_OPERATION,
@@ -89,7 +89,7 @@ public class BatchOperationWriter {
               batchOperationKey,
               "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementFailedOperationsCount",
               batchOperationKey));
-    } else if (state == BatchOperationItemStatus.COMPLETED) {
+    } else if (state == BatchOperationItemState.COMPLETED) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.BATCH_OPERATION,
@@ -103,28 +103,28 @@ public class BatchOperationWriter {
   public void finish(final long batchOperationKey, final OffsetDateTime endDate) {
     updateCompleted(
         batchOperationKey,
-        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.COMPLETED, endDate));
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.COMPLETED, endDate));
   }
 
   public void cancel(final long batchOperationKey, final OffsetDateTime endDate) {
     updateCompleted(
         batchOperationKey,
-        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.CANCELED, endDate));
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.CANCELED, endDate));
 
-    updateItemsWithStatus(
-        batchOperationKey, BatchOperationItemStatus.ACTIVE, BatchOperationItemStatus.CANCELED);
+    updateItemsWithState(
+        batchOperationKey, BatchOperationItemState.ACTIVE, BatchOperationItemState.CANCELED);
   }
 
   public void paused(final long batchOperationKey) {
     updateCompleted(
         batchOperationKey,
-        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.PAUSED, null));
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.PAUSED, null));
   }
 
   public void resumed(final long batchOperationKey) {
     updateCompleted(
         batchOperationKey,
-        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.ACTIVE, null));
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.ACTIVE, null));
   }
 
   private void updateCompleted(final long batchOperationKey, final BatchOperationUpdateDto dto) {
@@ -137,10 +137,10 @@ public class BatchOperationWriter {
             dto));
   }
 
-  private void updateItemsWithStatus(
+  private void updateItemsWithState(
       final long batchOperationKey,
-      final BatchOperationItemStatus oldState,
-      final BatchOperationItemStatus newState) {
+      final BatchOperationItemState oldState,
+      final BatchOperationItemState newState) {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.BATCH_OPERATION,

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -9,8 +9,8 @@
     type="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     <constructor>
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
-      <arg column="STATUS"
-        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationStatus"/>
+      <arg column="STATE"
+        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationState"/>
       <arg column="OPERATION_TYPE" javaType="java.lang.String"/>
       <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
       <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
@@ -25,14 +25,14 @@
     <constructor>
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
-      <arg column="STATUS"
-        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemStatus"/>
+      <arg column="STATE"
+        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemState"/>
     </constructor>
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     INSERT INTO ${prefix}BATCH_OPERATION (BATCH_OPERATION_KEY,
-                                 STATUS,
+                                 STATE,
                                  OPERATION_TYPE,
                                  START_DATE,
                                  END_DATE,
@@ -40,7 +40,7 @@
                                  OPERATIONS_FAILED_COUNT,
                                  OPERATIONS_COMPLETED_COUNT)
     VALUES (#{batchOperationKey},
-            #{status},
+            #{state},
             #{operationType},
             #{startDate},
             #{endDate},
@@ -61,7 +61,7 @@
   <update id="updateCompleted"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateDto">
     UPDATE ${prefix}BATCH_OPERATION
-    SET STATUS = #{status},
+    SET STATE = #{state},
         END_DATE = #{endDate}
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
   </update>
@@ -69,7 +69,7 @@
   <update id="updateItem"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto">
     UPDATE ${prefix}BATCH_OPERATION_ITEM
-    SET STATUS = #{status}
+    SET STATE = #{state}
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
       AND ITEM_KEY = #{itemKey}
   </update>
@@ -77,9 +77,9 @@
   <update id="updateItemsWithState"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemDto">
     UPDATE ${prefix}BATCH_OPERATION_ITEM
-    SET STATUS = #{newState}
+    SET STATE = #{newState}
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
-      AND STATUS = #{oldState}
+      AND STATE = #{oldState}
   </update>
 
   <update id="incrementOperationsTotalCount"
@@ -104,7 +104,7 @@
   <select id="getItems"
     parameterType="java.lang.Long"
     resultMap="BatchOperationItemResultMap">
-    SELECT BATCH_OPERATION_KEY, ITEM_KEY, STATUS
+    SELECT BATCH_OPERATION_KEY, ITEM_KEY, STATE
     FROM ${prefix}BATCH_OPERATION_ITEM
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
   </select>
@@ -123,7 +123,7 @@
   SELECT * FROM (
     SELECT
     bo.BATCH_OPERATION_KEY,
-    bo.STATUS,
+    bo.STATE,
     bo.OPERATION_TYPE,
     bo.START_DATE,
     bo.END_DATE,
@@ -153,9 +153,9 @@
         #{value}
       </foreach>
     </if>
-    <if test="filter.status != null and !filter.status.isEmpty()">
-      AND STATUS IN
-      <foreach collection="filter.status" item="value" open="(" separator=", " close=")">#{value}
+    <if test="filter.state != null and !filter.state.isEmpty()">
+      AND STATE IN
+      <foreach collection="filter.state" item="value" open="(" separator=", " close=")">#{value}
       </foreach>
     </if>
   </sql>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -13,7 +13,7 @@ import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +31,7 @@ public final class BatchOperationFixtures {
     final var builder =
         new Builder()
             .batchOperationKey(key)
-            .status(randomEnum(BatchOperationStatus.class))
+            .state(randomEnum(BatchOperationState.class))
             .operationType("some-operation" + RANDOM.nextInt(1000))
             .startDate(OffsetDateTime.now())
             .endDate(OffsetDateTime.now().plusSeconds(1))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -17,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
@@ -79,14 +79,14 @@ class RdbmsExporterBatchOperationsIT {
     var batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
 
     // and when we complete it
     exporter.export(batchOperationExecutionCompletedRecord);
 
     // then it should be completed
     batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.COMPLETED);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.COMPLETED);
   }
 
   @Test
@@ -106,14 +106,14 @@ class RdbmsExporterBatchOperationsIT {
     var batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
 
     // and when we cancel it
     exporter.export(batchOperationCanceledRecord);
 
     // then it should be canceled
     batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.CANCELED);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.CANCELED);
 
     // and the items should be canceled
     final var batchOperationItems =
@@ -121,7 +121,7 @@ class RdbmsExporterBatchOperationsIT {
     assertThat(batchOperationItems).hasSize(3);
     assertThat(
             batchOperationItems.stream()
-                .allMatch(item -> item.status() == BatchOperationItemStatus.CANCELED))
+                .allMatch(item -> item.state() == BatchOperationItemState.CANCELED))
         .isTrue();
   }
 
@@ -147,7 +147,7 @@ class RdbmsExporterBatchOperationsIT {
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
     assertThat(batchOperation.operationsFailedCount()).isEqualTo(0);
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
   }
 
   @Test
@@ -172,6 +172,6 @@ class RdbmsExporterBatchOperationsIT {
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
     assertThat(batchOperation.operationsFailedCount()).isEqualTo(1);
-    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -13,7 +13,7 @@ import java.time.OffsetDateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BatchOperationEntity(
     Long batchOperationKey,
-    BatchOperationStatus status,
+    BatchOperationState state,
     String operationType,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
@@ -22,9 +22,9 @@ public record BatchOperationEntity(
     Integer operationsCompletedCount) {
 
   public record BatchOperationItemEntity(
-      Long batchOperationKey, Long itemKey, BatchOperationItemStatus status) {}
+      Long batchOperationKey, Long itemKey, BatchOperationItemState state) {}
 
-  public enum BatchOperationStatus {
+  public enum BatchOperationState {
     CREATED,
     ACTIVE,
     PAUSED,
@@ -33,7 +33,7 @@ public record BatchOperationEntity(
     CANCELED
   }
 
-  public enum BatchOperationItemStatus {
+  public enum BatchOperationItemState {
     ACTIVE,
     COMPLETED,
     CANCELED,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -16,14 +16,14 @@ import java.util.List;
 import java.util.Objects;
 
 public record BatchOperationFilter(
-    List<Long> batchOperationKeys, List<String> operationTypes, List<String> status)
+    List<Long> batchOperationKeys, List<String> operationTypes, List<String> state)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
 
     private List<Long> batchOperationKeys;
     private List<String> operationTypes;
-    private List<String> status;
+    private List<String> state;
 
     public Builder batchOperationKeys(final Long value, final Long... values) {
       return batchOperationKeys(collectValues(value, values));
@@ -43,12 +43,12 @@ public record BatchOperationFilter(
       return this;
     }
 
-    public Builder status(final String value, final String... values) {
-      return status(collectValues(value, values));
+    public Builder state(final String value, final String... values) {
+      return state(collectValues(value, values));
     }
 
-    public Builder status(final List<String> values) {
-      status = addValuesToList(status, values);
+    public Builder state(final List<String> values) {
+      state = addValuesToList(state, values);
       return this;
     }
 
@@ -57,7 +57,7 @@ public record BatchOperationFilter(
       return new BatchOperationFilter(
           Objects.requireNonNullElse(batchOperationKeys, Collections.emptyList()),
           Objects.requireNonNullElse(operationTypes, Collections.emptyList()),
-          Objects.requireNonNullElse(status, Collections.emptyList()));
+          Objects.requireNonNullElse(state, Collections.emptyList()));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
@@ -31,8 +31,8 @@ public record BatchOperationSort(List<FieldSorting> orderings) implements SortOp
       return this;
     }
 
-    public Builder status() {
-      currentOrdering = new FieldSorting("status", null);
+    public Builder state() {
+      currentOrdering = new FieldSorting("state", null);
       return this;
     }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationCreatedExportHandler.java
@@ -10,7 +10,7 @@ package io.camunda.exporter.rdbms.handlers;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -45,7 +45,7 @@ public class BatchOperationCreatedExportHandler
     final var value = record.getValue();
     return new BatchOperationDbModel.Builder()
         .batchOperationKey(record.getKey())
-        .status(BatchOperationStatus.ACTIVE)
+        .state(BatchOperationState.ACTIVE)
         .operationType(value.getBatchOperationType().name())
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationRe
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -44,12 +44,12 @@ public class ProcessInstanceBatchOperationExportHandler
       batchOperationWriter.updateItem(
           record.getOperationReference(),
           value.getProcessInstanceKey(),
-          BatchOperationItemStatus.COMPLETED);
+          BatchOperationItemState.COMPLETED);
     } else if (isFailed(record)) {
       batchOperationWriter.updateItem(
           record.getOperationReference(),
           value.getProcessInstanceKey(),
-          BatchOperationItemStatus.FAILED);
+          BatchOperationItemState.FAILED);
     }
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7876,7 +7876,7 @@ components:
           enum:
             - batchOperationKey
             - operationType
-            - status
+            - state
             - startDate
             - endDate
         order:
@@ -7907,9 +7907,9 @@ components:
           type: string
         operationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"
-        status:
+        state:
           type: string
-          description: The status of the batch operation.
+          description: The state of the batch operation.
           enum:
             - CREATED
             - ACTIVE
@@ -7933,8 +7933,8 @@ components:
         batchOperationKey:
           description: Key of the batch operation.
           type: string
-        status:
-          description: The status of the batch operation.
+        state:
+          description: The state of the batch operation.
           type: string
           enum:
             - CREATED
@@ -7984,8 +7984,8 @@ components:
         itemKey:
           description: Key of the item, e.g. a process instance key.
           type: string
-        status:
-          description: Status of the item.
+        state:
+          description: State of the item.
           type: string
           enum:
             - ACTIVE

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -73,7 +73,7 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.gateway.protocol.rest.*;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter.StatusEnum;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter.StateEnum;
 import io.camunda.zeebe.gateway.rest.util.GenericVariable;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.gateway.rest.util.ProcessInstanceStateConverter;
@@ -543,7 +543,7 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getBatchOperationKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::batchOperationKeys);
-      ofNullable(filter.getStatus()).map(StatusEnum::toString).ifPresent(builder::state);
+      ofNullable(filter.getState()).map(StateEnum::toString).ifPresent(builder::state);
       ofNullable(filter.getOperationType())
           .map(BatchOperationTypeEnum::toString)
           .ifPresent(builder::operationTypes);
@@ -561,7 +561,7 @@ public final class SearchQueryRequestMapper {
     } else {
       switch (field) {
         case BATCH_OPERATION_KEY -> builder.batchOperationKey();
-        case STATUS -> builder.status();
+        case STATE -> builder.state();
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();
         case END_DATE -> builder.endDate();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -543,7 +543,7 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getBatchOperationKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::batchOperationKeys);
-      ofNullable(filter.getStatus()).map(StatusEnum::toString).ifPresent(builder::status);
+      ofNullable(filter.getStatus()).map(StatusEnum::toString).ifPresent(builder::state);
       ofNullable(filter.getOperationType())
           .map(BatchOperationTypeEnum::toString)
           .ifPresent(builder::operationTypes);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -344,7 +344,7 @@ public final class SearchQueryResponseMapper {
   public static BatchOperationResponse toBatchOperation(final BatchOperationEntity entity) {
     return new BatchOperationResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
-        .status(BatchOperationResponse.StatusEnum.fromValue(entity.state().name()))
+        .state(BatchOperationResponse.StateEnum.fromValue(entity.state().name()))
         .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType()))
         .startDate(formatDate(entity.startDate()))
         .endDate(formatDate(entity.endDate()))
@@ -365,7 +365,7 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationItemResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
         .itemKey(entity.itemKey().toString())
-        .status(BatchOperationItemResponse.StatusEnum.fromValue(entity.state().name()));
+        .state(BatchOperationItemResponse.StateEnum.fromValue(entity.state().name()));
   }
 
   private static List<RoleResult> toRoles(final List<RoleEntity> roles) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -344,7 +344,7 @@ public final class SearchQueryResponseMapper {
   public static BatchOperationResponse toBatchOperation(final BatchOperationEntity entity) {
     return new BatchOperationResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
-        .status(BatchOperationResponse.StatusEnum.fromValue(entity.status().name()))
+        .status(BatchOperationResponse.StatusEnum.fromValue(entity.state().name()))
         .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType()))
         .startDate(formatDate(entity.startDate()))
         .endDate(formatDate(entity.endDate()))
@@ -365,7 +365,7 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationItemResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
         .itemKey(entity.itemKey().toString())
-        .status(BatchOperationItemResponse.StatusEnum.fromValue(entity.status().name()));
+        .status(BatchOperationItemResponse.StatusEnum.fromValue(entity.state().name()));
   }
 
   private static List<RoleResult> toRoles(final List<RoleEntity> roles) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -60,7 +60,7 @@ class BatchOperationControllerTest extends RestControllerTest {
             """
           {
               "batchOperationKey":"1",
-              "status":"COMPLETED",
+              "state":"COMPLETED",
               "batchOperationType":"PROCESS_CANCELLATION",
               "startDate":"2025-03-18T10:57:44.000+01:00",
               "endDate":"2025-03-18T10:57:45.000+01:00",
@@ -95,7 +95,7 @@ class BatchOperationControllerTest extends RestControllerTest {
           {"items":[
           {
             "batchOperationKey":"1",
-            "status":"COMPLETED",
+            "state":"COMPLETED",
             "batchOperationType":"PROCESS_CANCELLATION",
             "startDate":"2025-03-18T10:57:44.000+01:00",
             "endDate":"2025-03-18T10:57:45.000+01:00",
@@ -173,7 +173,7 @@ class BatchOperationControllerTest extends RestControllerTest {
                 {
                    "batchOperationKey":"1",
                    "itemKey":"1",
-                   "status":"COMPLETED"}
+                   "state":"COMPLETED"}
                 ]}
           """);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -11,8 +11,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.BatchOperationEntity;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
-import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
@@ -79,7 +79,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
     final var searchQuery =
         new BatchOperationSearchQuery()
-            .filter(new BatchOperationFilter().status(BatchOperationFilter.StatusEnum.ACTIVE));
+            .filter(new BatchOperationFilter().state(BatchOperationFilter.StateEnum.ACTIVE));
 
     webClient
         .post()
@@ -155,7 +155,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
     final var batchOperationItem =
         new BatchOperationEntity.BatchOperationItemEntity(
-            batchOperationKey, 1L, BatchOperationItemStatus.COMPLETED);
+            batchOperationKey, 1L, BatchOperationItemState.COMPLETED);
     when(batchOperationServices.getItemsByKey(batchOperationKey))
         .thenReturn(List.of(batchOperationItem));
 
@@ -181,7 +181,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   private static BatchOperationEntity getBatchOperationEntity(final long batchOperationKey) {
     return new BatchOperationEntity(
         batchOperationKey,
-        BatchOperationStatus.COMPLETED,
+        BatchOperationState.COMPLETED,
         "PROCESS_CANCELLATION",
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),


### PR DESCRIPTION
## Description

This PR fixes naming inconsistencies of the batch operation status/state fields in search-api, RDBMS impl, Rest API and camunda-client

## Related issues

closes #30781
