### PR TITLE
refactor: use mappingId instead of mappingKey for related entity in MappingState

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -318,6 +318,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -318,14 +318,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -138,10 +138,7 @@ public final class IdentitySetupInitializeProcessor
                         persistedUser -> {
                           user.setUserKey(persistedUser.getUserKey());
                           if (assignEntityToRole(
-                              role,
-                              persistedUser.getUsername(),
-                              EntityType.USER,
-                              persistedUser.getUserKey())) {
+                              role, persistedUser.getUsername(), EntityType.USER)) {
                             createdNewEntities.set(true);
                           }
                           if (assignEntityToTenant(
@@ -164,7 +161,6 @@ public final class IdentitySetupInitializeProcessor
                     .get(mapping.getClaimName(), mapping.getClaimValue())
                     .ifPresentOrElse(
                         persistedMapping -> {
-                          mapping.setMappingKey(Long.parseLong(persistedMapping.getMappingId()));
                           mapping.setMappingId(persistedMapping.getMappingId());
                           // todo refactor with https://github.com/camunda/camunda/issues/30094
                           if (assignEntityToRole(
@@ -208,11 +204,7 @@ public final class IdentitySetupInitializeProcessor
                     .getUser(user.getUsername())
                     .ifPresentOrElse(
                         persistedUser -> {
-                          assignEntityToRole(
-                              role,
-                              persistedUser.getUsername(),
-                              EntityType.USER,
-                              persistedUser.getUserKey());
+                          assignEntityToRole(role, persistedUser.getUsername(), EntityType.USER);
                           assignEntityToTenant(
                               tenant, persistedUser.getUsername(), EntityType.USER);
                         },
@@ -239,7 +231,7 @@ public final class IdentitySetupInitializeProcessor
 
   private void createUser(final UserRecord user, final RoleRecord role, final TenantRecord tenant) {
     stateWriter.appendFollowUpEvent(user.getUserKey(), UserIntent.CREATED, user);
-    assignEntityToRole(role, user.getUsername(), EntityType.USER, user.getUserKey());
+    assignEntityToRole(role, user.getUsername(), EntityType.USER);
     assignEntityToTenant(tenant, user.getUsername(), EntityType.USER);
   }
 
@@ -250,21 +242,12 @@ public final class IdentitySetupInitializeProcessor
   private void createMapping(
       final MappingRecord mapping, final RoleRecord role, final TenantRecord tenant) {
     stateWriter.appendFollowUpEvent(mapping.getMappingKey(), MappingIntent.CREATED, mapping);
-    assignEntityToRole(role, mapping.getMappingId(), EntityType.MAPPING, mapping.getMappingKey());
+    assignEntityToRole(role, mapping.getMappingId(), EntityType.MAPPING);
     assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING);
   }
 
-  // todo delete
   private boolean assignEntityToRole(
       final RoleRecord role, final String entityId, final EntityType entityType) {
-    return assignEntityToRole(role, entityId, entityType, Long.parseLong(entityId));
-  }
-
-  private boolean assignEntityToRole(
-      final RoleRecord role,
-      final String entityId,
-      final EntityType entityType,
-      final long entityKey) {
     final var roleId = role.getRoleId();
     final var roleKey = role.getRoleKey();
     final var isAlreadyAssigned =
@@ -281,8 +264,9 @@ public final class IdentitySetupInitializeProcessor
         new RoleRecord()
             .setRoleKey(roleKey)
             .setRoleId(roleId)
-            // TODO remove entityKey from record https://github.com/camunda/camunda/issues/30126
-            .setEntityKey(entityKey)
+            //            // TODO remove entityKey from record
+            // https://github.com/camunda/camunda/issues/30126
+            //            .setEntityKey(entityKey)
             .setEntityId(entityId)
             .setEntityType(entityType);
     stateWriter.appendFollowUpEvent(roleKey, RoleIntent.ENTITY_ADDED, record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -162,7 +162,6 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         persistedMapping -> {
                           mapping.setMappingId(persistedMapping.getMappingId());
-                          // todo refactor with https://github.com/camunda/camunda/issues/30094
                           if (assignEntityToRole(
                               role, persistedMapping.getMappingId(), EntityType.MAPPING)) {
                             createdNewEntities.set(true);
@@ -264,9 +263,6 @@ public final class IdentitySetupInitializeProcessor
         new RoleRecord()
             .setRoleKey(roleKey)
             .setRoleId(roleId)
-            //            // TODO remove entityKey from record
-            // https://github.com/camunda/camunda/issues/30126
-            //            .setEntityKey(entityKey)
             .setEntityId(entityId)
             .setEntityType(entityType);
     stateWriter.appendFollowUpEvent(roleKey, RoleIntent.ENTITY_ADDED, record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -164,8 +164,9 @@ public final class IdentitySetupInitializeProcessor
                     .get(mapping.getClaimName(), mapping.getClaimValue())
                     .ifPresentOrElse(
                         persistedMapping -> {
-                          mapping.setMappingKey(persistedMapping.getMappingKey());
+                          mapping.setMappingKey(Long.parseLong(persistedMapping.getMappingId()));
                           mapping.setMappingId(persistedMapping.getMappingId());
+                          // todo refactor with https://github.com/camunda/camunda/issues/30094
                           if (assignEntityToRole(
                               role,
                               persistedMapping.getMappingId(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -168,10 +168,7 @@ public final class IdentitySetupInitializeProcessor
                           mapping.setMappingId(persistedMapping.getMappingId());
                           // todo refactor with https://github.com/camunda/camunda/issues/30094
                           if (assignEntityToRole(
-                              role,
-                              persistedMapping.getMappingId(),
-                              EntityType.MAPPING,
-                              persistedMapping.getMappingKey())) {
+                              role, persistedMapping.getMappingId(), EntityType.MAPPING)) {
                             createdNewEntities.set(true);
                           }
                           if (assignEntityToTenant(
@@ -230,10 +227,7 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         persistedMapping -> {
                           assignEntityToRole(
-                              role,
-                              persistedMapping.getMappingId(),
-                              EntityType.MAPPING,
-                              persistedMapping.getMappingKey());
+                              role, persistedMapping.getMappingId(), EntityType.MAPPING);
                           assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING);
                         },
                         () -> createMapping(mapping, role, tenant)));
@@ -258,6 +252,12 @@ public final class IdentitySetupInitializeProcessor
     stateWriter.appendFollowUpEvent(mapping.getMappingKey(), MappingIntent.CREATED, mapping);
     assignEntityToRole(role, mapping.getMappingId(), EntityType.MAPPING, mapping.getMappingKey());
     assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING);
+  }
+
+  // todo delete
+  private boolean assignEntityToRole(
+      final RoleRecord role, final String entityId, final EntityType entityType) {
+    return assignEntityToRole(role, entityId, entityType, Long.parseLong(entityId));
   }
 
   private boolean assignEntityToRole(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -110,9 +110,8 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     final var record = command.getValue();
     mappingState
         .get(record.getMappingId())
-        // todo
         .ifPresentOrElse(
-            r -> deleteMapping(r, record.getMappingKey()),
+            persistedMapping -> deleteMapping(persistedMapping, command.getKey()),
             () -> {
               final var errorMessage =
                   MAPPING_NOT_FOUND_ERROR_MESSAGE.formatted(record.getMappingKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -110,6 +110,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     final var record = command.getValue();
     mappingState
         .get(record.getMappingId())
+        // todo
         .ifPresentOrElse(
             r -> deleteMapping(r, record.getMappingKey()),
             () -> {
@@ -121,7 +122,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private void deleteMapping(final PersistedMapping mapping) {
+  private void deleteMapping(final PersistedMapping mapping, final long key) {
     final var mappingId = mapping.getMappingId();
     deleteAuthorizations(mappingId);
     for (final var tenantId :
@@ -148,7 +149,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
               // TODO: Use the role id instead of the key.
               .setRoleId(roleKey)
               .setRoleKey(Long.parseLong(roleKey))
-              .setEntityKey(mappingKey)
+              .setEntityId(mappingId)
               .setEntityType(EntityType.MAPPING));
     }
     for (final var groupKey :

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -139,7 +139,8 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
     return switch (entityType) {
       case USER -> userState.getUser(entityKey).isPresent();
-      case MAPPING -> mappingState.get(entityKey).isPresent();
+      // todo use entityId; refactor with https://github.com/camunda/camunda/issues/30094
+      case MAPPING -> mappingState.get(String.valueOf(entityKey)).isPresent();
       default -> false;
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -53,23 +53,22 @@ public class DbMappingState implements MutableMappingState {
 
   @Override
   public void create(final MappingRecord mappingRecord) {
-    final var id = mappingRecord.getMappingId();
+    final var mappingId = mappingRecord.getMappingId();
     final var name = mappingRecord.getName();
     final var claimName = mappingRecord.getClaimName();
     final var value = mappingRecord.getClaimValue();
 
-    mappingId.wrapString(id);
+    this.mappingId.wrapString(mappingId);
     this.claimName.wrapString(claimName);
     claimValue.wrapString(value);
-    mappingId.wrapString(id);
     persistedMapping.setMappingKey(mappingRecord.getMappingKey());
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);
-    persistedMapping.setMappingId(id);
+    persistedMapping.setMappingId(mappingId);
 
     mappingColumnFamily.insert(claim, persistedMapping);
-    claimByIdColumnFamily.insert(mappingId, fkClaim);
+    claimByIdColumnFamily.insert(this.mappingId, fkClaim);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -61,7 +61,6 @@ public class DbMappingState implements MutableMappingState {
     this.mappingId.wrapString(mappingId);
     this.claimName.wrapString(claimName);
     claimValue.wrapString(value);
-    persistedMapping.setMappingKey(mappingRecord.getMappingKey());
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -62,6 +62,7 @@ public class DbMappingState implements MutableMappingState {
     this.claimName.wrapString(claimName);
     claimValue.wrapString(value);
     mappingId.wrapString(id);
+    persistedMapping.setMappingKey(mappingRecord.getMappingKey());
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);
@@ -119,6 +120,16 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public Optional<PersistedMapping> get(final String id) {
+    mappingId.wrapString(id);
+    final var fk = claimByIdColumnFamily.get(mappingId);
+    if (fk != null) {
+      return Optional.of(mappingColumnFamily.get(fk.inner()));
+    }
+    return Optional.empty();
+  }
+
+  @Override
   public Optional<PersistedMapping> get(final String claimName, final String claimValue) {
     this.claimName.wrapString(claimName);
     this.claimValue.wrapString(claimValue);
@@ -129,15 +140,5 @@ public class DbMappingState implements MutableMappingState {
     }
 
     return Optional.of(persistedMapping.copy());
-  }
-
-  @Override
-  public Optional<PersistedMapping> get(final String id) {
-    mappingId.wrapString(id);
-    final var fk = claimByIdColumnFamily.get(mappingId);
-    if (fk != null) {
-      return Optional.of(mappingColumnFamily.get(fk.inner()));
-    }
-    return Optional.empty();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
-import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -28,10 +27,7 @@ public class DbMappingState implements MutableMappingState {
   private final ColumnFamily<DbCompositeKey<DbString, DbString>, PersistedMapping>
       mappingColumnFamily;
 
-  private final DbLong mappingKey;
   private final DbForeignKey<DbCompositeKey<DbString, DbString>> fkClaim;
-  private final ColumnFamily<DbLong, DbForeignKey<DbCompositeKey<DbString, DbString>>>
-      claimByKeyColumnFamily;
 
   private final DbString mappingId;
   private final ColumnFamily<DbString, DbForeignKey<DbCompositeKey<DbString, DbString>>>
@@ -47,11 +43,7 @@ public class DbMappingState implements MutableMappingState {
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.MAPPINGS, transactionContext, claim, persistedMapping);
 
-    mappingKey = new DbLong();
     fkClaim = new DbForeignKey<>(claim, ZbColumnFamilies.MAPPINGS);
-    claimByKeyColumnFamily =
-        zeebeDb.createColumnFamily(
-            ZbColumnFamilies.CLAIM_BY_KEY, transactionContext, mappingKey, fkClaim);
 
     mappingId = new DbString();
     claimByIdColumnFamily =
@@ -61,17 +53,15 @@ public class DbMappingState implements MutableMappingState {
 
   @Override
   public void create(final MappingRecord mappingRecord) {
-    final var key = mappingRecord.getMappingKey();
     final var id = mappingRecord.getMappingId();
     final var name = mappingRecord.getName();
     final var claimName = mappingRecord.getClaimName();
     final var value = mappingRecord.getClaimValue();
 
-    mappingKey.wrapLong(key);
+    mappingId.wrapString(id);
     this.claimName.wrapString(claimName);
     claimValue.wrapString(value);
     mappingId.wrapString(id);
-    persistedMapping.setMappingKey(key);
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);
@@ -79,7 +69,6 @@ public class DbMappingState implements MutableMappingState {
 
     mappingColumnFamily.insert(claim, persistedMapping);
     claimByIdColumnFamily.insert(mappingId, fkClaim);
-    claimByKeyColumnFamily.insert(mappingKey, fkClaim);
   }
 
   @Override
@@ -88,8 +77,6 @@ public class DbMappingState implements MutableMappingState {
     get(mappingRecord.getMappingId())
         .ifPresentOrElse(
             persistedMapping -> {
-              mappingKey.wrapLong(persistedMapping.getMappingKey());
-
               // remove old record from mapping by claim
               claimName.wrapString(persistedMapping.getClaimName());
               claimValue.wrapString(persistedMapping.getClaimValue());
@@ -102,7 +89,6 @@ public class DbMappingState implements MutableMappingState {
               claimName.wrapString(persistedMapping.getClaimName());
               claimValue.wrapString(persistedMapping.getClaimValue());
               mappingColumnFamily.insert(claim, persistedMapping);
-              claimByKeyColumnFamily.update(mappingKey, fkClaim);
               claimByIdColumnFamily.update(mappingId, fkClaim);
             },
             () -> {
@@ -118,11 +104,10 @@ public class DbMappingState implements MutableMappingState {
     get(id)
         .ifPresentOrElse(
             persistedMapping -> {
-              mappingKey.wrapLong(persistedMapping.getMappingKey());
+              mappingId.wrapString(persistedMapping.getMappingId());
               claimName.wrapString(persistedMapping.getClaimName());
               claimValue.wrapString(persistedMapping.getClaimValue());
               mappingColumnFamily.deleteExisting(claim);
-              claimByKeyColumnFamily.deleteExisting(mappingKey);
               claimByIdColumnFamily.deleteExisting(mappingId);
             },
             () -> {
@@ -131,16 +116,6 @@ public class DbMappingState implements MutableMappingState {
                       "Expected to delete mapping with id '%s', but a mapping with this id does not exist.",
                       id));
             });
-  }
-
-  @Override
-  public Optional<PersistedMapping> get(final long key) {
-    mappingKey.wrapLong(key);
-    final var fk = claimByKeyColumnFamily.get(mappingKey);
-    if (fk != null) {
-      return Optional.of(mappingColumnFamily.get(fk.inner()));
-    }
-    return Optional.empty();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.msgpack.property.ArrayProperty;
-import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -9,22 +9,21 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedMapping extends UnpackedObject implements DbValue {
 
-  private final LongProperty mappingKeyProp = new LongProperty("mappingKey", -1L);
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
 
   public PersistedMapping() {
-    super(5);
-    declareProperty(mappingKeyProp)
-        .declareProperty(claimNameProp)
+    super(4);
+    declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
         .declareProperty(mappingIdProp);
@@ -34,15 +33,6 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
     final var copy = new PersistedMapping();
     copy.copyFrom(this);
     return copy;
-  }
-
-  public long getMappingKey() {
-    return mappingKeyProp.getValue();
-  }
-
-  public PersistedMapping setMappingKey(final long mappingKey) {
-    mappingKeyProp.setValue(mappingKey);
-    return this;
   }
 
   public String getClaimName() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MappingState.java
@@ -12,9 +12,7 @@ import java.util.Optional;
 
 public interface MappingState {
 
-  Optional<PersistedMapping> get(final long key);
+  Optional<PersistedMapping> get(final String mappingId);
 
   Optional<PersistedMapping> get(final String claimName, final String claimValue);
-
-  Optional<PersistedMapping> get(final String mappingId);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -488,7 +488,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(mappingKey)
-            .setMappingId(Strings.newRandomValidIdentityId())
+            .setMappingId(String.valueOf(mappingKey))
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -484,15 +484,13 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   private MappingRecordValue createMapping(final String claimName, final String claimValue) {
-    final var mappingKey = random.nextLong();
     final var mapping =
         new MappingRecord()
-            .setMappingKey(mappingKey)
-            .setMappingId(String.valueOf(mappingKey))
+            .setMappingId(UUID.randomUUID().toString())
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);
-    mappingCreatedApplier.applyState(mappingKey, mapping);
+    mappingCreatedApplier.applyState(random.nextLong(), mapping);
     return mapping;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -615,7 +615,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(mappingKey)
-            .setMappingId(Strings.newRandomValidIdentityId())
+            .setMappingId(String.valueOf(mappingKey))
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -611,15 +611,13 @@ final class AuthorizationCheckBehaviorTest {
   }
 
   private MappingRecordValue createMapping(final String claimName, final String claimValue) {
-    final var mappingKey = random.nextLong();
     final var mapping =
         new MappingRecord()
-            .setMappingKey(mappingKey)
-            .setMappingId(String.valueOf(mappingKey))
+            .setMappingId(UUID.randomUUID().toString())
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);
-    mappingCreatedApplier.applyState(mappingKey, mapping);
+    mappingCreatedApplier.applyState(random.nextLong(), mapping);
     return mapping;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -664,7 +664,9 @@ public class CommandDistributionIdempotencyTest {
                         .withMapping(
                             new MappingRecord()
                                 .setMappingKey(4)
-                                .setMappingId("id")
+                                // todo replace to string with
+                                // https://github.com/camunda/camunda/issues/30389
+                                .setMappingId("1234")
                                 .setClaimName("claimName")
                                 .setClaimValue("claimValue"))
                         .initialize()),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -663,10 +663,7 @@ public class CommandDistributionIdempotencyTest {
                                 .setName("tenant-name"))
                         .withMapping(
                             new MappingRecord()
-                                .setMappingKey(4)
-                                // todo replace to string with
-                                // https://github.com/camunda/camunda/issues/30389
-                                .setMappingId("1234")
+                                .setMappingId("mapping-id")
                                 .setClaimName("claimName")
                                 .setClaimValue("claimValue"))
                         .initialize()),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -86,7 +86,6 @@ public class MappingStateTest {
 
     // then
     assertThat(retrievedMapping).isPresent();
-    assertThat(retrievedMapping.get().getMappingKey()).isEqualTo(key);
     assertThat(retrievedMapping.get().getName()).isEqualTo(name);
     assertThat(retrievedMapping.get().getMappingId()).isEqualTo(mappingId);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -48,8 +48,7 @@ public class MappingStateTest {
     mappingState.create(mapping);
 
     // then
-    final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getMappingKey()).isEqualTo(key);
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getMappingId()).isEqualTo(mappingId);
     assertThat(persistedMapping.getName()).isEqualTo(name);
     assertThat(persistedMapping.getClaimName()).isEqualTo(claimName);
@@ -59,7 +58,7 @@ public class MappingStateTest {
   @Test
   void shouldReturnEmptyIfMappingDoesNotExist() {
     // when
-    final var mapping = mappingState.get(1L);
+    final var mapping = mappingState.get("someMappingId");
 
     // then
     assertThat(mapping).isEmpty();
@@ -123,7 +122,7 @@ public class MappingStateTest {
 
     // then
     assertThat(retrievedMapping).isPresent();
-    assertThat(retrievedMapping.get().getMappingKey()).isEqualTo(key);
+    assertThat(retrievedMapping.get().getMappingId()).isEqualTo(mappingId);
     assertThat(retrievedMapping.get().getName()).isEqualTo(name);
     assertThat(retrievedMapping.get().getClaimName()).isEqualTo(claimName);
     assertThat(retrievedMapping.get().getClaimValue()).isEqualTo(claimValue);
@@ -148,7 +147,6 @@ public class MappingStateTest {
     mappingState.delete(mappingId);
 
     // then
-    assertThat(mappingState.get(key)).isEmpty();
     assertThat(mappingState.get(mappingId)).isEmpty();
     assertThat(mappingState.get(claimName, claimValue)).isEmpty();
   }


### PR DESCRIPTION
## Description

 - Store and retrieve related entities to a mapping with mapping id instead of mapping key in the MappingState
 - delete `mappingKey` from `PersistedRecord`  to ensure it is no longer used anywhere
 - correct related code and tests

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29534
