### PR TITLE
[Backport stable/8.6] ci: make GHA best practices linter extensible to more files

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -4,14 +4,12 @@ package main
 # aligned with the inclusion criteria and best practices:
 # See https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci
 
-unified_ci_workflow_names = ["CI", "Tasklist Frontend Jobs", "Zeebe CI"]
-
 # The `input` variable is a data structure that contains a YAML file's contents
 # as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_timeoutminutes(input.jobs)) > 0
 
@@ -20,8 +18,8 @@ deny[msg] {
 }
 
 warn[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
 
@@ -30,8 +28,8 @@ warn[msg] {
 }
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_cihealth(input.jobs)) > 0
 
@@ -40,8 +38,8 @@ deny[msg] {
 }
 
 deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == unified_ci_workflow_names[_]
+    # only enforced on workflows that opted-in
+    input.env.GHA_BEST_PRACTICES_LINTER == "enabled"
 
     count(get_jobs_without_permissions(input.jobs)) > 0
 

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   helm-deploy:
     name: Helm chart Integration Tests
@@ -33,11 +36,14 @@ jobs:
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+
   notify:
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [helm-deploy]
-    if: ${{ always() }}
+    if: always()
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
@@ -67,3 +73,13 @@ jobs:
                 }
               ]
             }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ defaults:
 
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+  GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
   detect-changes:

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -3,6 +3,9 @@ name: Tasklist Frontend Jobs
 on:
   workflow_call: {}
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   fe-type-check:
     name: Type check

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -12,6 +12,7 @@ defaults:
 
 env:
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+  GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
   smoke-tests:


### PR DESCRIPTION
# Description
Backport of #30553 to `stable/8.6`.

relates to 