### PR TITLE
fix: add correct labels in the core application test e2e request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/core_application_test_request.md
+++ b/.github/ISSUE_TEMPLATE/core_application_test_request.md
@@ -41,13 +41,11 @@ Scenario: As a user, I can ...
 ### Supported Versions
 
 <!-- List the versions impacted by the feature, including when it was introduced and supported versions. -->
-
 - Version X.X
 
 ### Implementation Timeline
 
 <!-- Specify when the feature will be available or when it’s expected to be implemented. -->
-
 - Available in: Version Y.Y
 
 ### Priority
@@ -63,5 +61,5 @@ Scenario: As a user, I can ...
 ### Definition of Ready - Checklist
 
 <!-- The assignee will check the DRI. -->
-
 - [ ] The test case has a meaningful title, description, and testable acceptance criteria
+

--- a/.github/ISSUE_TEMPLATE/core_application_test_request.md
+++ b/.github/ISSUE_TEMPLATE/core_application_test_request.md
@@ -1,11 +1,9 @@
 ---
-
 name: Core Application – Automated E2E Test Request
 about: Create a test case for the automated Core Application E2E test suite based on a user flow.
 title: "E2E - [Module or Area Name] - [Short scenario description]"
-labels: ["kind/bug", "qa/core-application-e2e-test-suite"]
-assignees: ''
-
+labels: ["kind/test-case", "qa/core-application-e2e-test-suite"]
+assignees: ""
 ---
 
 ### Description
@@ -41,11 +39,13 @@ Scenario: As a user, I can ...
 ### Supported Versions
 
 <!-- List the versions impacted by the feature, including when it was introduced and supported versions. -->
+
 - Version X.X
 
 ### Implementation Timeline
 
 <!-- Specify when the feature will be available or when it’s expected to be implemented. -->
+
 - Available in: Version Y.Y
 
 ### Priority
@@ -61,5 +61,5 @@ Scenario: As a user, I can ...
 ### Definition of Ready - Checklist
 
 <!-- The assignee will check the DRI. -->
-- [ ] The test case has a meaningful title, description, and testable acceptance criteria
 
+- [ ] The test case has a meaningful title, description, and testable acceptance criteria

--- a/.github/ISSUE_TEMPLATE/core_application_test_request.md
+++ b/.github/ISSUE_TEMPLATE/core_application_test_request.md
@@ -1,9 +1,11 @@
 ---
+
 name: Core Application – Automated E2E Test Request
 about: Create a test case for the automated Core Application E2E test suite based on a user flow.
 title: "E2E - [Module or Area Name] - [Short scenario description]"
 labels: ["kind/test-case", "qa/core-application-e2e-test-suite"]
-assignees: ""
+assignees: ''
+
 ---
 
 ### Description


### PR DESCRIPTION
## Description
Within the previous PR, `kind/bug` label was added by mistake, this PR adds the correct label `kind/test-case`
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
