### PR TITLE
add verbose flag to tasklist backup list API to improve performance if verbose=false

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
@@ -603,7 +603,7 @@ public class BackupServiceElasticSearchTest {
     when(esClient.snapshot()).thenThrow(elsEx);
 
     final Exception exception =
-        assertThrows(TasklistRuntimeException.class, () -> backupService.getBackups());
+        assertThrows(TasklistRuntimeException.class, () -> backupService.getBackups(true));
 
     final String expectedMessage =
         String.format("No repository with name [%s] could be found.", repoName);
@@ -623,7 +623,7 @@ public class BackupServiceElasticSearchTest {
                 SNAPSHOT_MISSING_EXCEPTION_TYPE, RestStatus.NOT_FOUND));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    assertThat(backupService.getBackups()).isEmpty();
+    assertThat(backupService.getBackups(true)).isEmpty();
   }
 
   @Test
@@ -635,7 +635,7 @@ public class BackupServiceElasticSearchTest {
 
     final Exception exception =
         assertThrows(
-            TasklistElasticsearchConnectionException.class, () -> backupService.getBackups());
+            TasklistElasticsearchConnectionException.class, () -> backupService.getBackups(true));
     final String expectedMessage =
         String.format(
             "Encountered an error connecting to Elasticsearch while searching for snapshots. Repository name: [%s].",
@@ -697,7 +697,7 @@ public class BackupServiceElasticSearchTest {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupService.getBackups();
+    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true);
     assertThat(backups).hasSize(3);
     final GetBackupStateResponseDto backup3 = backups.get(0);
     assertThat(backup3.getState()).isEqualTo(IN_PROGRESS);
@@ -746,7 +746,7 @@ public class BackupServiceElasticSearchTest {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupService.getBackups();
+    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true);
     assertThat(backups).hasSize(1);
     final GetBackupStateResponseDto backup1 = backups.get(0);
     assertThat(backup1.getState()).isEqualTo(COMPLETED);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/BackupManager.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/BackupManager.java
@@ -39,9 +39,13 @@ public abstract class BackupManager {
 
   public abstract GetBackupStateResponseDto getBackupState(Long backupId);
 
-  public abstract List<GetBackupStateResponseDto> getBackups();
+  public List<GetBackupStateResponseDto> getBackups() {
+    return getBackups(true);
+  }
 
-  protected String getFullQualifiedName(BackupPriority index) {
+  public abstract List<GetBackupStateResponseDto> getBackups(boolean verbose);
+
+  protected String getFullQualifiedName(final BackupPriority index) {
     if (index instanceof IndexDescriptor) {
       return ((IndexDescriptor) index).getFullQualifiedName();
     } else if (index instanceof TemplateDescriptor) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.opensearch.client.json.JsonData;
 
 public class Metadata {
 
@@ -30,6 +31,15 @@ public class Metadata {
   private String version;
   private Integer partNo;
   private Integer partCount;
+
+  public Metadata() {}
+
+  public Metadata(final Metadata metadata) {
+    backupId = metadata.backupId;
+    version = metadata.version;
+    partNo = metadata.partNo;
+    partCount = metadata.partCount;
+  }
 
   public Long getBackupId() {
     return backupId;
@@ -114,11 +124,31 @@ public class Metadata {
     }
   }
 
+  public static Metadata fromObjectMapper(
+      final ObjectMapper objectMapper, final Map<String, Object> jsonMap) {
+    if (jsonMap == null) {
+      return null;
+    }
+    return objectMapper.convertValue(jsonMap, Metadata.class);
+  }
+
+  public static Metadata fromOSJsonData(final Map<String, JsonData> jsonDataMap) {
+    if (jsonDataMap == null) {
+      return null;
+    }
+    try {
+      return new Metadata()
+          .setBackupId(jsonDataMap.get("backupId").to(Long.class))
+          .setPartCount(jsonDataMap.get("partCount").to(Integer.class))
+          .setPartNo(jsonDataMap.get("partNo").to(Integer.class))
+          .setVersion(jsonDataMap.get("version").to(String.class));
+    } catch (final Exception e) {
+      return null;
+    }
+  }
+
   public static Metadata extractFromMetadataOrName(
-      final ObjectMapper objectMapper,
-      final Map<String, Object> metadata,
-      final String snapshotName) {
-    final Metadata fromMetadata = objectMapper.convertValue(metadata, Metadata.class);
+      final Metadata fromMetadata, final String snapshotName) {
     if (fromMetadata != null && fromMetadata.isInitialized()) {
       return fromMetadata;
     } else {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.tasklist.webapp.es.backup;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,6 +21,11 @@ public class Metadata {
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =
       Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");
+  private static final Pattern METADATA_PATTERN =
+      Pattern.compile(
+          SNAPSHOT_NAME_PREFIX
+              + "(?<backupId>\\d+)_(?<version>[^_]+)_part_(?<index>\\d+)_of_(?<count>\\d+)");
+
   private Long backupId;
   private String version;
   private Integer partNo;
@@ -28,7 +35,7 @@ public class Metadata {
     return backupId;
   }
 
-  public Metadata setBackupId(Long backupId) {
+  public Metadata setBackupId(final Long backupId) {
     this.backupId = backupId;
     return this;
   }
@@ -37,7 +44,7 @@ public class Metadata {
     return version;
   }
 
-  public Metadata setVersion(String version) {
+  public Metadata setVersion(final String version) {
     this.version = version;
     return this;
   }
@@ -46,7 +53,7 @@ public class Metadata {
     return partNo;
   }
 
-  public Metadata setPartNo(Integer partNo) {
+  public Metadata setPartNo(final Integer partNo) {
     this.partNo = partNo;
     return this;
   }
@@ -55,7 +62,7 @@ public class Metadata {
     return partCount;
   }
 
-  public Metadata setPartCount(Integer partCount) {
+  public Metadata setPartCount(final Integer partCount) {
     this.partCount = partCount;
     return this;
   }
@@ -68,12 +75,16 @@ public class Metadata {
         .replace("{count}", partCount + "");
   }
 
-  public static String buildSnapshotNamePrefix(Long backupId) {
+  public boolean isInitialized() {
+    return partCount != null && partNo != null && version != null;
+  }
+
+  public static String buildSnapshotNamePrefix(final Long backupId) {
     return SNAPSHOT_NAME_PREFIX_PATTERN.replace("{backupId}", String.valueOf(backupId));
   }
 
   // backward compatibility with v. 8.1
-  public static Long extractBackupIdFromSnapshotName(String snapshotName) {
+  public static Long extractBackupIdFromSnapshotName(final String snapshotName) {
     final Matcher matcher = BACKUPID_PATTERN.matcher(snapshotName);
     if (matcher.matches()) {
       return Long.valueOf(matcher.group(1));
@@ -83,8 +94,45 @@ public class Metadata {
     }
   }
 
+  public static Metadata extractMetadataFromSnapshotName(final String snapshotName) {
+    Objects.requireNonNull(snapshotName, "Snapshot name cannot be null");
+    final Matcher matcher = METADATA_PATTERN.matcher(snapshotName);
+    if (matcher.matches()) {
+      final Long backupId = Long.parseLong(matcher.group("backupId"));
+      final String version = matcher.group("version");
+      final Integer index = Integer.parseInt(matcher.group("index"));
+      final Integer count = Integer.parseInt(matcher.group("count"));
+
+      return new Metadata()
+          .setBackupId(backupId)
+          .setPartCount(count)
+          .setPartNo(index)
+          .setVersion(version);
+    } else {
+      throw new IllegalArgumentException(
+          "Unable to extract metadata. Snapshot name: " + snapshotName);
+    }
+  }
+
+  public static Metadata extractFromMetadataOrName(
+      final ObjectMapper objectMapper,
+      final Map<String, Object> metadata,
+      final String snapshotName) {
+    final Metadata fromMetadata = objectMapper.convertValue(metadata, Metadata.class);
+    if (fromMetadata != null && fromMetadata.isInitialized()) {
+      return fromMetadata;
+    } else {
+      return Metadata.extractMetadataFromSnapshotName(snapshotName);
+    }
+  }
+
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    return Objects.hash(version, partNo, partCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -95,10 +143,5 @@ public class Metadata {
     return Objects.equals(version, metadata.version)
         && Objects.equals(partNo, metadata.partNo)
         && Objects.equals(partCount, metadata.partCount);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(version, partNo, partCount);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Component
@@ -63,9 +64,11 @@ public class BackupService extends ManagementAPIErrorController {
   }
 
   @GetMapping
-  public List<GetBackupStateResponseDto> getBackups() {
+  public List<GetBackupStateResponseDto> getBackups(
+      @RequestParam(value = "verbose", defaultValue = "true", required = false)
+          final boolean verbose) {
     validateRepositoryNameIsConfigured();
-    return backupManager.getBackups();
+    return backupManager.getBackups(verbose);
   }
 
   @DeleteMapping("/{backupId}")

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/MetadataTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/MetadataTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.es.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class MetadataTest {
+  @Test
+  public void shouldExtractMetadataFromSnapshotname() {
+    final Metadata metadata =
+        new Metadata().setBackupId(23L).setVersion("8.7.1").setPartCount(6).setPartNo(2);
+    final var name = metadata.buildSnapshotName();
+    final var fromName = Metadata.extractMetadataFromSnapshotName(name);
+    assertThat(metadata).isEqualTo(fromName);
+    assertThat(Metadata.extractFromMetadataOrName(new ObjectMapper(), Map.of(), name))
+        .isEqualTo(fromName);
+  }
+
+  @Test
+  public void shouldPreferExtractingFromMetadataField() {
+    final Metadata metadata =
+        new Metadata().setBackupId(23L).setVersion("8.7.1").setPartCount(6).setPartNo(2);
+    final var extracted =
+        Metadata.extractFromMetadataOrName(
+            new ObjectMapper(),
+            Map.of(
+                "backupId",
+                metadata.getBackupId(),
+                "partNo",
+                metadata.getPartNo(),
+                "partCount",
+                metadata.getPartCount(),
+                "version",
+                metadata.getVersion()),
+            "");
+    assertThat(extracted).isEqualTo(metadata);
+  }
+}

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.es.backup.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.webapp.es.backup.Metadata;
+import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@ExtendWith(MockitoExtension.class)
+class BackupManagerElasticsearchTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private RestHighLevelClient searchClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private TasklistProperties tasklistProperties;
+
+  @InjectMocks private BackupManagerElasticSearch backupManager;
+
+  @Mock
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
+
+  @ParameterizedTest
+  @EnumSource(value = SnapshotState.class)
+  void shouldReturnPartialDataWhenVerboseIsFalse(final SnapshotState state) throws IOException {
+    // given
+    final var metadata =
+        new Metadata().setBackupId(2L).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+    when(objectMapper.convertValue(any(), eq(Metadata.class)))
+        .thenAnswer(invocation -> MAPPER.convertValue(invocation.getArgument(0), Metadata.class));
+    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn("test-repo");
+    final var snapshots = new ArrayList<SnapshotInfo>(metadata.getPartCount());
+    for (int i = 1; i <= metadata.getPartCount(); i++) {
+      final var copy = new Metadata(metadata);
+      copy.setPartNo(i);
+      final var snapshotInfo = mock(SnapshotInfo.class, Answers.RETURNS_DEEP_STUBS);
+      snapshots.add(snapshotInfo);
+      when(snapshotInfo.snapshotId().getName()).thenReturn(copy.buildSnapshotName());
+      when(snapshotInfo.state()).thenReturn(state);
+    }
+
+    final var snapshotResponse = mock(GetSnapshotsResponse.class, Answers.RETURNS_DEEP_STUBS);
+    when(snapshotResponse.getSnapshots()).thenReturn(snapshots);
+    when(searchClient.snapshot().get(any(), any())).thenReturn(snapshotResponse);
+
+    // when
+    final var backupResponse = backupManager.getBackups(false);
+
+    // then
+    assertThat(backupResponse)
+        .singleElement()
+        .satisfies(
+            snap -> {
+              final var expectedState =
+                  switch (state) {
+                    case SUCCESS -> BackupStateDto.COMPLETED;
+                    case IN_PROGRESS -> BackupStateDto.IN_PROGRESS;
+                    case PARTIAL, FAILED -> BackupStateDto.FAILED;
+                    case INCOMPATIBLE -> BackupStateDto.INCOMPATIBLE;
+                    default -> null;
+                  };
+              assertThat(snap.getState()).isEqualTo(expectedState);
+              assertThat(snap.getBackupId()).isEqualTo(metadata.getBackupId());
+              assertThat(snap.getDetails())
+                  .hasSize(metadata.getPartCount())
+                  .zipSatisfy(
+                      snapshots,
+                      (detail, snapshotInfo) -> {
+                        assertThat(detail.getState()).isEqualTo(state.toString());
+                        assertThat(detail.getSnapshotName())
+                            .isEqualTo(snapshotInfo.snapshotId().getName());
+                      });
+            });
+  }
+}


### PR DESCRIPTION
## Description

> [!WARNING]
> This PR is very similar to this PR for operate #30730

Adding `verbose=false` to the request sent to ES/OS speeds up the query by a lot, but we don't get startTime and metadata fields populated.
The information inside `metadata` can be extracted from the snapshot name if metadata field is missing.
> [!WARNING]
> The consequence is that the snapshot name must follow the pattern currently in use. Previously only the backupId was matched from the snapshot name. Technically this must hold when `verbose=false` is set, in the other case the metadata field is used.


The difference in the response between verbose `false` or `true` wil be that the following fields will be null:
-  failures
- failureReasons
- startTime

and the snapshots inside the `details` field will not be ordered by `start_time`.

## Related issues

closes #30736 
