### PR TITLE
feat: add pattern queryparam to BackupController list API to filter snapshots in ES/OS

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -655,7 +655,7 @@ public class BackupControllerIT {
         assertThrows(
             OperateRuntimeException.class,
             () -> {
-              backupController.getBackups(true);
+              backupController.getBackups(true, null);
             });
 
     final String expectedMessage =
@@ -675,7 +675,7 @@ public class BackupControllerIT {
                 SNAPSHOT_MISSING_EXCEPTION_TYPE, RestStatus.NOT_FOUND));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    assertThat(backupController.getBackups(true)).isEmpty();
+    assertThat(backupController.getBackups(true, null)).isEmpty();
   }
 
   @Test
@@ -686,7 +686,7 @@ public class BackupControllerIT {
         assertThrows(
             OperateElasticsearchConnectionException.class,
             () -> {
-              backupController.getBackups(true);
+              backupController.getBackups(true, null);
             });
     final String expectedMessage =
         String.format(
@@ -748,7 +748,7 @@ public class BackupControllerIT {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupController.getBackups(true);
+    final List<GetBackupStateResponseDto> backups = backupController.getBackups(true, null);
     assertThat(backups).hasSize(3);
 
     final GetBackupStateResponseDto backup3 =
@@ -811,7 +811,7 @@ public class BackupControllerIT {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupController.getBackups(true);
+    final List<GetBackupStateResponseDto> backups = backupController.getBackups(true, null);
     assertThat(backups).hasSize(1);
     final GetBackupStateResponseDto backup1 = backups.get(0);
     assertThat(backup1.getState()).isEqualTo(COMPLETED);
@@ -846,7 +846,7 @@ public class BackupControllerIT {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 1, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final var backups = backupController.getBackups(false);
+    final var backups = backupController.getBackups(false, null);
     assertThat(backups)
         .allSatisfy(
             backupState -> {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -16,6 +16,9 @@ public interface BackupRepository {
   // Match all numbers, optionally ending with a *
   Pattern BACKUPID_PATTERN = Pattern.compile("^(\\d*)\\*?$");
 
+  // Maximum length of a length when converted to a string
+  static final int LONG_MAX_LENGTH_AS_STRING = 19;
+
   void deleteSnapshot(String repositoryName, String snapshotName);
 
   void validateRepositoryExists(String repositoryName);
@@ -37,7 +40,8 @@ public interface BackupRepository {
   static Either<Throwable, String> validPattern(final String pattern) {
     if (pattern == null || pattern.isEmpty()) {
       return Either.right("*");
-    } else if (pattern.length() <= 20 && BACKUPID_PATTERN.matcher(pattern).matches()) {
+    } else if (pattern.length() <= (LONG_MAX_LENGTH_AS_STRING + 1)
+        && BACKUPID_PATTERN.matcher(pattern).matches()) {
       return Either.right(pattern);
     } else {
       return Either.left(new IllegalArgumentException("Invalid pattern: " + pattern));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -17,7 +17,7 @@ public interface BackupRepository {
   Pattern BACKUPID_PATTERN = Pattern.compile("^(\\d*)\\*?$");
 
   // Maximum length of a length when converted to a string
-  static final int LONG_MAX_LENGTH_AS_STRING = 19;
+  int LONG_MAX_LENGTH_AS_STRING = 19;
 
   void deleteSnapshot(String repositoryName, String snapshotName);
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
@@ -190,8 +190,8 @@ public class BackupService {
     return repository.getBackupState(getRepositoryName(), backupId);
   }
 
-  public List<GetBackupStateResponseDto> getBackups(final boolean verbose) {
-    return repository.getBackups(getRepositoryName(), verbose);
+  public List<GetBackupStateResponseDto> getBackups(final boolean verbose, final String pattern) {
+    return repository.getBackups(getRepositoryName(), verbose, pattern);
   }
 
   public record SnapshotRequest(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -163,11 +163,17 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
   @Override
   public List<GetBackupStateResponseDto> getBackups(
-      final String repositoryName, final boolean verbose) {
+      final String repositoryName, final boolean verbose, final String pattern) {
+    final var validatedPattern = BackupRepository.validPattern(pattern);
+
+    validatedPattern.ifLeft(
+        ex -> {
+          throw new InvalidRequestException(ex.getMessage(), ex);
+        });
     GetSnapshotsRequest snapshotsStatusRequest =
         new GetSnapshotsRequest()
             .repository(repositoryName)
-            .snapshots(new String[] {Metadata.SNAPSHOT_NAME_PREFIX + "*"})
+            .snapshots(new String[] {Metadata.SNAPSHOT_NAME_PREFIX + validatedPattern.get()})
             .verbose(verbose);
     if (verbose) {
       // it looks like sorting as well as size/offset are not working, need to sort

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/management/BackupController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/management/BackupController.java
@@ -57,9 +57,10 @@ public class BackupController extends ErrorController {
   @GetMapping
   public List<GetBackupStateResponseDto> getBackups(
       @RequestParam(value = "verbose", defaultValue = "true", required = false)
-          final boolean verbose) {
+          final boolean verbose,
+      @RequestParam(value = "pattern", defaultValue = "*", required = false) final String pattern) {
     validateRepositoryNameIsConfigured();
-    return backupService.getBackups(verbose);
+    return backupService.getBackups(verbose, pattern);
   }
 
   @DeleteMapping("/{backupId}")

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -145,9 +145,16 @@ public class OpensearchBackupRepository implements BackupRepository {
 
   @Override
   public List<GetBackupStateResponseDto> getBackups(
-      final String repositoryName, final boolean verbose) {
+      final String repositoryName, final boolean verbose, final String pattern) {
+    final var validatedPattern = BackupRepository.validPattern(pattern);
+
+    validatedPattern.ifLeft(
+        ex -> {
+          throw new InvalidRequestException(ex.getMessage(), ex);
+        });
     final var request =
-        getSnapshotRequestBuilder(repositoryName, Metadata.SNAPSHOT_NAME_PREFIX + "*")
+        getSnapshotRequestBuilder(
+                repositoryName, Metadata.SNAPSHOT_NAME_PREFIX + validatedPattern.get())
             .verbose(verbose)
             .build();
     final OpenSearchGetSnapshotResponse response;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
@@ -32,7 +32,17 @@ public class BackupRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"23a", "backup24*", "**", "12389128391829381923891238", "  ", "\n", "\t", "abcd123*", "123*?query=all"})
+        strings = {
+          "23a",
+          "backup24*",
+          "**",
+          "12389128391829381923891238",
+          "  ",
+          "\n",
+          "\t",
+          "abcd123*",
+          "123*?query=all"
+        })
     public void shouldNotBeAvalidPattern(final String pattern) {
       assertThat(BackupRepository.validPattern(pattern))
           .satisfies(p -> assertThat(p.isLeft()).withFailMessage("result is " + p).isTrue());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.util.Either;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class BackupRepositoryTest {
+
+  @Nested
+  class BackupIdPattern {
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    public void shouldMatchDefaultPattern(final String pattern) {
+      assertThat(BackupRepository.validPattern(pattern)).isEqualTo(Either.right("*"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"23", "*", "12390*", "1230891283*", "20250401*", "20250401"})
+    public void shouldBeAValidPattern(final String pattern) {
+      assertThat(BackupRepository.validPattern(pattern)).isEqualTo(Either.right(pattern));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"23a", "backup24*", "**", "12389128391829381923891238", "  ", "\n", "\t"})
+    public void shouldNotBeAvalidPattern(final String pattern) {
+      assertThat(BackupRepository.validPattern(pattern))
+          .satisfies(p -> assertThat(p.isLeft()).withFailMessage("result is " + p).isTrue());
+    }
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/BackupRepositoryTest.java
@@ -32,7 +32,7 @@ public class BackupRepositoryTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"23a", "backup24*", "**", "12389128391829381923891238", "  ", "\n", "\t"})
+        strings = {"23a", "backup24*", "**", "12389128391829381923891238", "  ", "\n", "\t", "abcd123*", "123*?query=all"})
     public void shouldNotBeAvalidPattern(final String pattern) {
       assertThat(BackupRepository.validPattern(pattern))
           .satisfies(p -> assertThat(p.isLeft()).withFailMessage("result is " + p).isTrue());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -140,7 +140,7 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   public void shouldForwardVerboseFlagToES() throws IOException {
-    // mock calls to `findSnapshot` and `operateProperties`
+    // given
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
     when(snapshotInfo.state()).thenReturn(SnapshotState.IN_PROGRESS);
     when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
@@ -149,7 +149,10 @@ public class ElasticsearchBackupRepositoryTest {
     when(esClient.snapshot()).thenReturn(snapshotClient);
     when(snapshotClient.get(any(), any())).thenReturn(response);
 
+    // when
     final var responses = backupRepository.getBackups(repositoryName, false, null);
+
+    // then
     verify(snapshotClient).get(argThat(req -> !req.verbose()), any());
     assertThat(responses)
         .singleElement()
@@ -162,7 +165,6 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   public void shouldForwardThePatternToES() throws IOException {
-    // mock calls to `findSnapshot` and `operateProperties`
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
     when(snapshotInfo.state()).thenReturn(SnapshotState.IN_PROGRESS);
     when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
@@ -171,7 +173,10 @@ public class ElasticsearchBackupRepositoryTest {
     when(esClient.snapshot()).thenReturn(snapshotClient);
     when(snapshotClient.get(any(), any())).thenReturn(response);
 
+    // when
     backupRepository.getBackups(repositoryName, true, "2023*");
+
+    // then
     verify(snapshotClient)
         .get(
             argThat(req -> Arrays.asList(req.snapshots()).contains("camunda_operate_2023*")),

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -144,6 +144,7 @@ class OpensearchBackupRepositoryTest {
 
   @Test
   void shouldForwardSnapshotPatternFlagToOpensearch() {
+    // given
     final var metadata =
         new Metadata().setBackupId(5L).setVersion("1").setPartNo(1).setPartCount(3);
     final var snapshotInfos =
@@ -155,7 +156,11 @@ class OpensearchBackupRepositoryTest {
     mockObjectMapperForMetadata(metadata);
     when(openSearchSnapshotOperations.get(any())).thenReturn(response);
     mockSynchronSnapshotOperations();
+
+    // when
     repository.getBackups("repo", false, "2023*");
+
+    // then
     verify(openSearchSnapshotOperations)
         .get(argThat(req -> req.snapshot().contains("camunda_operate_2023*")));
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -130,7 +130,7 @@ class OpensearchBackupRepositoryTest {
     mockObjectMapperForMetadata(metadata);
     when(openSearchSnapshotOperations.get(any())).thenReturn(response);
     mockSynchronSnapshotOperations();
-    final var snapshotDtoList = repository.getBackups("repo", false);
+    final var snapshotDtoList = repository.getBackups("repo", false, null);
     verify(openSearchSnapshotOperations).get(argThat(req -> !req.verbose()));
 
     assertThat(snapshotDtoList)
@@ -140,6 +140,24 @@ class OpensearchBackupRepositoryTest {
               assertThat(backup.getBackupId()).isEqualTo(5L);
               assertThat(backup.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
             });
+  }
+
+  @Test
+  void shouldForwardSnapshotPatternFlagToOpensearch() {
+    final var metadata =
+        new Metadata().setBackupId(5L).setVersion("1").setPartNo(1).setPartCount(3);
+    final var snapshotInfos =
+        List.of(
+            new OpenSearchSnapshotInfo()
+                .setSnapshot("test-snapshot")
+                .setState(SnapshotState.STARTED));
+    final var response = new OpenSearchGetSnapshotResponse(snapshotInfos);
+    mockObjectMapperForMetadata(metadata);
+    when(openSearchSnapshotOperations.get(any())).thenReturn(response);
+    mockSynchronSnapshotOperations();
+    repository.getBackups("repo", false, "2023*");
+    verify(openSearchSnapshotOperations)
+        .get(argThat(req -> req.snapshot().contains("camunda_operate_2023*")));
   }
 
   @Test


### PR DESCRIPTION
## Description

Add an optional parameter that can be used to match on the `backupId` pattern

When there are a lot of backups in ES/OS the query to get them can be slow. The user can add a pattern to the REST call to filter the backupIds to a subset (if they were taken with some pattern).
Example:
If backupIds follow the pattern YYYYMMddHHmm
Then the user can make the HTTP call /actuator/backups?verbose=false&pattern=20250401* to get all backups done on 2025/04/01

Validation verifies that the pattern is composed up of digits and optionally terminates with a `"*"`. Moreover we match on the pattern length to avoid running a regex on a potentially large input: the backupId is just a `long`, that cannot be more than 19 digits long.
When a pattern is empty or null, the default "*" is used instead.

## Related issues

closes #30829 
