### PR TITLE
feat: migrate FlowNodeInstancesTree to v2 XML API

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -8,7 +8,6 @@
 
 import React, {useRef} from 'react';
 import {observer} from 'mobx-react';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {
@@ -25,6 +24,8 @@ import {FlowNodeIcon} from 'modules/components/FlowNodeIcon';
 import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
 import {Bar} from './Bar';
 import {isAdHocSubProcess} from 'modules/bpmn-js/utils/isAdHocSubProcess';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 
 const TREE_NODE_HEIGHT = 32;
 
@@ -113,11 +114,19 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
     const hasVisibleChildPlaceholders = visibleChildPlaceholders.length > 0;
     const hasVisibleChildNodes = visibleChildNodes.length > 0;
 
+    const processDefinitionKey = useProcessDefinitionKeyContext();
+    const {data: processInstanceXmlData} = useProcessInstanceXml({
+      processDefinitionKey,
+    });
+
+    const bpmnProcessId =
+      processInstanceDetailsStore.state.processInstance?.bpmnProcessId;
+
     const businessObject = isProcessInstance
-      ? processInstanceDetailsDiagramStore.processBusinessObject
-      : processInstanceDetailsDiagramStore.businessObjects[
-          flowNodeInstance.flowNodeId
-        ];
+      ? bpmnProcessId
+        ? processInstanceXmlData?.diagramModel.elementsById[bpmnProcessId]
+        : undefined
+      : processInstanceXmlData?.businessObjects[flowNodeInstance.flowNodeId];
 
     const isMultiInstanceBody = flowNodeInstance.type === 'MULTI_INSTANCE_BODY';
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/adHocSubProcess.test.tsx
@@ -21,11 +21,13 @@ import {FlowNodeInstancesTree} from '..';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('FlowNodeInstancesTree - Ad Hoc Sub Process', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(adHocSubProcessesInstance);
     mockFetchProcessXML().withSuccess(open('AdHocProcess.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(open('AdHocProcess.bpmn'));
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(
       adHocSubProcessesInstance.bpmnProcessId,
@@ -72,7 +74,7 @@ describe('FlowNodeInstancesTree - Ad Hoc Sub Process', () => {
     mockFetchFlowNodeInstances().withSuccess(adHocNodeFlowNodeInstances.level2);
 
     await user.type(
-      screen.getByLabelText('Ad Hoc Sub Process', {
+      await screen.findByLabelText('Ad Hoc Sub Process', {
         selector: "[aria-expanded='false']",
       }),
       '{arrowright}',

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/eventSubprocess.test.tsx
@@ -25,11 +25,13 @@ import {createRef} from 'react';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('FlowNodeInstancesTree - Event Subprocess', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(eventSubprocessProcessInstance);
     mockFetchProcessXML().withSuccess(eventSubProcess);
+    mockFetchProcessDefinitionXml().withSuccess(eventSubProcess);
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(processId);
 
@@ -69,7 +71,7 @@ describe('FlowNodeInstancesTree - Event Subprocess', () => {
     );
 
     await user.type(
-      screen.getByLabelText('Event Subprocess', {
+      await screen.findByLabelText('Event Subprocess', {
         selector: "[aria-expanded='false']",
       }),
       '{arrowright}',

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/mocks.tsx
@@ -23,6 +23,9 @@ import {
 import {useEffect} from 'react';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {TreeView} from '@carbon/react';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const multiInstanceProcessInstance: ProcessInstanceEntity = Object.freeze(
   createInstance({
@@ -767,9 +770,13 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
   }, []);
 
   return (
-    <TreeView label={'instance history'} hideLabel>
-      {children}
-    </TreeView>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <TreeView label={'instance history'} hideLabel>
+          {children}
+        </TreeView>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
@@ -32,11 +32,13 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetch
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(multiInstanceProcessInstance);
     mockFetchProcessXML().withSuccess(multiInstanceProcess);
+    mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
   });
 
   it('should show and remove two add modification flow nodes', async () => {
@@ -171,7 +173,9 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
       modificationsStore.cancelAllTokens('peterJoin');
     });
 
-    expect(screen.getByText('Multi-Instance Process')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Multi-Instance Process'),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('Peter Join')).toHaveLength(2);
 
     // modification icons
@@ -224,6 +228,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
     );
 
     mockFetchProcessXML().withSuccess(mockNestedSubprocess);
+    mockFetchProcessDefinitionXml().withSuccess(mockNestedSubprocess);
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(processId);
 
@@ -255,7 +260,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
     );
 
     expect(
-      screen.getAllByLabelText('parent_sub_process', {
+      await screen.findAllByLabelText('parent_sub_process', {
         selector: "[aria-expanded='false']",
       }),
     ).toHaveLength(2);
@@ -428,6 +433,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
     );
 
     mockFetchProcessXML().withSuccess(mockNestedSubprocess);
+    mockFetchProcessDefinitionXml().withSuccess(mockNestedSubprocess);
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(processId);
 
@@ -458,7 +464,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
     );
 
     expect(
-      screen.getAllByLabelText('parent_sub_process', {
+      await screen.findAllByLabelText('parent_sub_process', {
         selector: "[aria-expanded='false']",
       }),
     ).toHaveLength(2);

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/multiInstanceSubprocess.test.tsx
@@ -24,11 +24,13 @@ import {
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('FlowNodeInstancesTree - Multi Instance Subprocess', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(multiInstanceProcessInstance);
     mockFetchProcessXML().withSuccess(multiInstanceProcess);
+    mockFetchProcessDefinitionXml().withSuccess(multiInstanceProcess);
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(processId);
   });
@@ -54,7 +56,9 @@ describe('FlowNodeInstancesTree - Multi Instance Subprocess', () => {
       },
     );
 
-    expect(screen.getByText('Multi-Instance Process')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Multi-Instance Process'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Peter Fork')).toBeInTheDocument();
     expect(
       screen.getByText('Filter-Map Sub Process (Multi Instance)'),
@@ -92,7 +96,7 @@ describe('FlowNodeInstancesTree - Multi Instance Subprocess', () => {
     mockFetchFlowNodeInstances().withSuccess(flowNodeInstances.level2);
 
     await user.type(
-      screen.getByLabelText('Filter-Map Sub Process (Multi Instance)', {
+      await screen.findByLabelText('Filter-Map Sub Process (Multi Instance)', {
         selector: "[aria-expanded='false']",
       }),
       '{arrowright}',

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/nestedSubprocess.test.tsx
@@ -24,11 +24,15 @@ import {generateUniqueID} from 'modules/utils/generateUniqueID';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {
     mockFetchProcessInstance().withSuccess(nestedSubProcessesInstance);
     mockFetchProcessXML().withSuccess(open('NestedSubProcesses.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('NestedSubProcesses.bpmn'),
+    );
 
     await processInstanceDetailsDiagramStore.fetchProcessXml(
       nestedSubProcessesInstance.bpmnProcessId,
@@ -56,7 +60,7 @@ describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
       },
     );
 
-    expect(screen.getByText('Nested Sub Processes')).toBeInTheDocument();
+    expect(await screen.findByText('Nested Sub Processes')).toBeInTheDocument();
     expect(screen.getByText('Start Event 1')).toBeInTheDocument();
     expect(screen.queryByText('Sub Process 1')).not.toBeInTheDocument();
     expect(screen.queryByText('Sub Process 2')).not.toBeInTheDocument();
@@ -119,7 +123,7 @@ describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
       },
     );
 
-    expect(screen.getByText('Nested Sub Processes')).toBeInTheDocument();
+    expect(await screen.findByText('Nested Sub Processes')).toBeInTheDocument();
     expect(screen.getByText('Start Event 1')).toBeInTheDocument();
     expect(screen.queryByText('Sub Process 1')).not.toBeInTheDocument();
     expect(screen.queryByText('Sub Process 2')).not.toBeInTheDocument();

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
@@ -56,7 +56,6 @@ class ProcessInstanceDetailsDiagram extends NetworkReconnectionHandler {
       compensationAssociations: computed,
       flowNodes: computed,
       businessObjects: computed,
-      processBusinessObject: computed,
       cancellableFlowNodes: computed,
       appendableFlowNodes: computed,
       modifiableFlowNodes: computed,
@@ -95,17 +94,6 @@ class ProcessInstanceDetailsDiagram extends NetworkReconnectionHandler {
       },
       {},
     );
-  }
-
-  get processBusinessObject(): BusinessObject | undefined {
-    const bpmnProcessId =
-      processInstanceDetailsStore.state.processInstance?.bpmnProcessId;
-
-    if (bpmnProcessId === undefined) {
-      return undefined;
-    }
-
-    return this.state.diagramModel?.elementsById[bpmnProcessId];
   }
 
   fetchProcessXml = this.retryOnConnectionLost(


### PR DESCRIPTION
## Description

- migrate FlowNodeInstancesTree to v2 XML API

There is still a transitive dependency to processInstanceDetailsDiagramStore (in instanceHistoryModificationStore), that's why the store dependency and the old API mocks can't be removed from the tests yet.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
