### PR TITLE
In tasklist add optional pattern query param in list backup API

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
@@ -603,7 +603,7 @@ public class BackupServiceElasticSearchTest {
     when(esClient.snapshot()).thenThrow(elsEx);
 
     final Exception exception =
-        assertThrows(TasklistRuntimeException.class, () -> backupService.getBackups(true));
+        assertThrows(TasklistRuntimeException.class, () -> backupService.getBackups(true, null));
 
     final String expectedMessage =
         String.format("No repository with name [%s] could be found.", repoName);
@@ -623,7 +623,7 @@ public class BackupServiceElasticSearchTest {
                 SNAPSHOT_MISSING_EXCEPTION_TYPE, RestStatus.NOT_FOUND));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    assertThat(backupService.getBackups(true)).isEmpty();
+    assertThat(backupService.getBackups(true, null)).isEmpty();
   }
 
   @Test
@@ -635,7 +635,8 @@ public class BackupServiceElasticSearchTest {
 
     final Exception exception =
         assertThrows(
-            TasklistElasticsearchConnectionException.class, () -> backupService.getBackups(true));
+            TasklistElasticsearchConnectionException.class,
+            () -> backupService.getBackups(true, null));
     final String expectedMessage =
         String.format(
             "Encountered an error connecting to Elasticsearch while searching for snapshots. Repository name: [%s].",
@@ -697,7 +698,7 @@ public class BackupServiceElasticSearchTest {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true);
+    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true, null);
     assertThat(backups).hasSize(3);
     final GetBackupStateResponseDto backup3 = backups.get(0);
     assertThat(backup3.getState()).isEqualTo(IN_PROGRESS);
@@ -746,7 +747,7 @@ public class BackupServiceElasticSearchTest {
         .thenReturn(new GetSnapshotsResponse(snapshotInfos, null, null, 6, 1));
     when(esClient.snapshot()).thenReturn(snapshotClient);
 
-    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true);
+    final List<GetBackupStateResponseDto> backups = backupService.getBackups(true, null);
     assertThat(backups).hasSize(1);
     final GetBackupStateResponseDto backup1 = backups.get(0);
     assertThat(backup1.getState()).isEqualTo(COMPLETED);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/BackupManager.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/BackupManager.java
@@ -16,14 +16,18 @@ import io.camunda.tasklist.schema.backup.Prio3Backup;
 import io.camunda.tasklist.schema.backup.Prio4Backup;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.schema.templates.TemplateDescriptor;
+import io.camunda.tasklist.util.Either;
 import io.camunda.tasklist.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupResponseDto;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class BackupManager {
+  // Match all numbers, optionally ending with a *
+  static Pattern backupIdPattern = Pattern.compile("^(\\d*)\\*?$");
 
   @Autowired private List<Prio1Backup> prio1BackupIndices;
   @Autowired private List<Prio2Backup> prio2BackupTemplates;
@@ -40,10 +44,21 @@ public abstract class BackupManager {
   public abstract GetBackupStateResponseDto getBackupState(Long backupId);
 
   public List<GetBackupStateResponseDto> getBackups() {
-    return getBackups(true);
+    return getBackups(true, null);
   }
 
-  public abstract List<GetBackupStateResponseDto> getBackups(boolean verbose);
+  public abstract List<GetBackupStateResponseDto> getBackups(
+      final boolean verbose, final String pattern);
+
+  public static Either<Throwable, String> validPattern(final String pattern) {
+    if (pattern == null || pattern.isEmpty()) {
+      return Either.right("*");
+    } else if (pattern.length() <= 20 && backupIdPattern.matcher(pattern).matches()) {
+      return Either.right(pattern);
+    } else {
+      return Either.left(new IllegalArgumentException("Invalid pattern: " + pattern));
+    }
+  }
 
   protected String getFullQualifiedName(final BackupPriority index) {
     if (index instanceof IndexDescriptor) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -133,11 +133,17 @@ public class BackupManagerElasticSearch extends BackupManager {
   }
 
   @Override
-  public List<GetBackupStateResponseDto> getBackups(final boolean verbose) {
+  public List<GetBackupStateResponseDto> getBackups(final boolean verbose, final String pattern) {
+    final var validatedPattern = validPattern(pattern);
+
+    validatedPattern.ifLeft(
+        ex -> {
+          throw new InvalidRequestException(ex.getMessage(), ex);
+        });
     GetSnapshotsRequest snapshotsStatusRequest =
         new GetSnapshotsRequest()
             .repository(getRepositoryName())
-            .snapshots(new String[] {Metadata.SNAPSHOT_NAME_PREFIX + "*"})
+            .snapshots(new String[] {Metadata.SNAPSHOT_NAME_PREFIX + validatedPattern.get()})
             .verbose(verbose);
     if (verbose) {
       snapshotsStatusRequest =

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -134,12 +134,18 @@ public class BackupManagerOpenSearch extends BackupManager {
   }
 
   @Override
-  public List<GetBackupStateResponseDto> getBackups(final boolean verbose) {
+  public List<GetBackupStateResponseDto> getBackups(final boolean verbose, final String pattern) {
+    final var validatedPattern = validPattern(pattern);
+
+    validatedPattern.ifLeft(
+        ex -> {
+          throw new InvalidRequestException(ex.getMessage(), ex);
+        });
     final GetSnapshotRequest snapshotStatusRequest =
         GetSnapshotRequest.of(
             gsr ->
                 gsr.repository(getRepositoryName())
-                    .snapshot(Metadata.SNAPSHOT_NAME_PREFIX + "*")
+                    .snapshot(Metadata.SNAPSHOT_NAME_PREFIX + validatedPattern.get())
                     .verbose(verbose));
     final GetCustomSnapshotResponse response;
     try {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
@@ -66,9 +66,10 @@ public class BackupService extends ManagementAPIErrorController {
   @GetMapping
   public List<GetBackupStateResponseDto> getBackups(
       @RequestParam(value = "verbose", defaultValue = "true", required = false)
-          final boolean verbose) {
+          final boolean verbose,
+      @RequestParam(value = "pattern", defaultValue = "*", required = false) final String pattern) {
     validateRepositoryNameIsConfigured();
-    return backupManager.getBackups(verbose);
+    return backupManager.getBackups(verbose, pattern);
   }
 
   @DeleteMapping("/{backupId}")

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/BackupManagerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/BackupManagerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.es.backup;
+
+import static io.camunda.tasklist.webapp.es.backup.BackupManager.validPattern;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.tasklist.util.Either;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class BackupManagerTest {
+
+  @Nested
+  class BackupIdPattern {
+    @ParameterizedTest
+    @ValueSource(strings = {""})
+    public void shouldMatchDefaultPattern(final String pattern) {
+      assertThat(validPattern(pattern)).isEqualTo(Either.right("*"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"23", "*", "12390*", "1230891283*", "20250401*", "20250401"})
+    public void shouldBeAValidPattern(final String pattern) {
+      assertThat(validPattern(pattern)).isEqualTo(Either.right(pattern));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"23a", "backup24*", "**", "12389128391829381923891238", "  ", "\n", "\t"})
+    public void shouldNotBeAvalidPattern(final String pattern) {
+      assertThat(validPattern(pattern))
+          .satisfies(p -> assertThat(p.isLeft()).withFailMessage("result is " + p).isTrue());
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add an optional parameter that can be used to match on the `backupId` pattern

When there are a lot of backups in ES/OS the query to get them can be slow. The user can add a pattern to the REST call to filter the backupIds to a subset (if they were taken with some pattern).
Example:
If backupIds follow the pattern YYYYMMddHHmm
Then the user can make the HTTP call /actuator/backups?verbose=false&pattern=20250401* to get all backups done on 2025/04/01

Validation verifies that the pattern is composed up of digits and optionally terminates with a `"*"`. Moreover we match on the pattern length to avoid running a regex on a potentially large input: the backupId is just a `long`, that cannot be more than 19 digits long.
When a pattern is empty or null, the default "*" is used instead.

## Related issues

closes #30836 
