### PR TITLE
feat: allow configuring an id for the initial mappings 

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -76,12 +76,13 @@ spring.servlet.multipart.max-request-size=10MB
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate
 spring.liquibase.enabled=false
-# forward spring datasource properties
+# forward spring datasource propertiesf
 spring.datasource.url=${camunda.database.url:}
 spring.datasource.username=${camunda.database.username:}
 spring.datasource.password=${camunda.database.password:}
 mybatis.mapper-locations:classpath:mapper/**/*-mapper.xml
 # Security configuration
+camunda.security.initialization.mappings[0].mappingId=${INITIAL_MAPPING_ID:admin-mapping}
 camunda.security.initialization.mappings[0].claimName=${INITIAL_CLAIM_NAME:oid}
 camunda.security.initialization.mappings[0].claimValue=${INITIAL_CLAIM_VALUE}
 

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -76,7 +76,7 @@ spring.servlet.multipart.max-request-size=10MB
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate
 spring.liquibase.enabled=false
-# forward spring datasource propertiesf
+# forward spring datasource properties
 spring.datasource.url=${camunda.database.url:}
 spring.datasource.username=${camunda.database.username:}
 spring.datasource.password=${camunda.database.password:}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
@@ -11,14 +11,27 @@ import static io.camunda.security.util.ArgumentUtil.ensureNotNullOrEmpty;
 
 public class ConfiguredMapping {
 
+  private String mappingId;
   private String claimName;
   private String claimValue;
 
-  public ConfiguredMapping(final String claimName, final String claimValue) {
+  public ConfiguredMapping(
+      final String mappingId, final String claimName, final String claimValue) {
+    ensureNotNullOrEmpty("mappingId", mappingId);
     ensureNotNullOrEmpty("claimName", claimName);
     ensureNotNullOrEmpty("claimValue", claimValue);
+    this.mappingId = mappingId;
     this.claimName = claimName;
     this.claimValue = claimValue;
+  }
+
+  public String getMappingId() {
+    return mappingId;
+  }
+
+  public void setMappingId(final String mappingId) {
+    ensureNotNullOrEmpty("mappingId", mappingId);
+    this.mappingId = mappingId;
   }
 
   public String getClaimName() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -162,9 +162,9 @@ public final class IdentitySetupInitializeProcessor
                   mappingState.get(mapping.getClaimName(), mapping.getClaimValue());
 
               if (existingById.isPresent() || existingByClaim.isPresent()) {
-                final var persistedMapping = existingById.orElseGet(existingByClaim::get);
+                final var persistedMapping = existingByClaim.orElseGet(existingById::get);
                 mapping.setMappingId(persistedMapping.getMappingId());
-                if (assignEntityToRole(role, persistedMapping.getMappingId(), EntityType.MAPPING)) {
+                if (assignEntityToRole(role, mapping.getMappingId(), EntityType.MAPPING)) {
                   createdNewEntities.set(true);
                 }
                 if (assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -214,7 +214,7 @@ public final class IdentitySetupInitializeProcessor
         .forEach(
             mapping ->
                 mappingState
-                    .get(mapping.getClaimName(), mapping.getClaimValue())
+                    .get(mapping.getMappingId())
                     .ifPresentOrElse(
                         persistedMapping -> {
                           assignEntityToRole(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -100,7 +100,8 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
                   new MappingRecord()
                       .setMappingId(mapping.getMappingId())
                       .setClaimName(mapping.getClaimName())
-                      .setClaimValue(mapping.getClaimValue());
+                      .setClaimValue(mapping.getClaimValue())
+                      .setName(mapping.getMappingId());
               setupRecord.addMapping(mappingrecord);
             });
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -98,7 +98,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             mapping -> {
               final var mappingrecord =
                   new MappingRecord()
-                      .setMappingId(mapping.getClaimName() + "-" + mapping.getClaimValue())
+                      .setMappingId(mapping.getMappingId())
                       .setClaimName(mapping.getClaimName())
                       .setClaimValue(mapping.getClaimValue());
               setupRecord.addMapping(mappingrecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -64,6 +64,7 @@ public class DbMappingState implements MutableMappingState {
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);
+    persistedMapping.setMappingKey(mappingRecord.getMappingKey());
     persistedMapping.setMappingId(mappingId);
 
     mappingColumnFamily.insert(claim, persistedMapping);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -9,19 +9,22 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedMapping extends UnpackedObject implements DbValue {
 
+  private final LongProperty mappingKeyProp = new LongProperty("mappingKey", -1L);
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
 
   public PersistedMapping() {
-    super(4);
-    declareProperty(claimNameProp)
+    super(5);
+    declareProperty(mappingKeyProp)
+        .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
         .declareProperty(mappingIdProp);
@@ -31,6 +34,15 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
     final var copy = new PersistedMapping();
     copy.copyFrom(this);
     return copy;
+  }
+
+  public long getMappingKey() {
+    return mappingKeyProp.getValue();
+  }
+
+  public PersistedMapping setMappingKey(final long mappingKey) {
+    mappingKeyProp.setValue(mappingKey);
+    return this;
   }
 
   public String getClaimName() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -50,6 +50,7 @@ public class MappingStateTest {
     // then
     final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getMappingId()).isEqualTo(mappingId);
+    assertThat(persistedMapping.getMappingKey()).isEqualTo(key);
     assertThat(persistedMapping.getName()).isEqualTo(name);
     assertThat(persistedMapping.getClaimName()).isEqualTo(claimName);
     assertThat(persistedMapping.getClaimValue()).isEqualTo(claimValue);
@@ -88,6 +89,7 @@ public class MappingStateTest {
     assertThat(retrievedMapping).isPresent();
     assertThat(retrievedMapping.get().getName()).isEqualTo(name);
     assertThat(retrievedMapping.get().getMappingId()).isEqualTo(mappingId);
+    assertThat(retrievedMapping.get().getMappingKey()).isEqualTo(key);
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -84,7 +84,9 @@ public class OidcAuthOverGrpcIT {
 
                 c.getInitialization()
                     .setMappings(
-                        List.of(new ConfiguredMapping(USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
+                        List.of(
+                            new ConfiguredMapping(
+                                DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
               });
 
   @BeforeAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -84,7 +84,9 @@ public class OidcAuthOverRestIT {
 
                 c.getInitialization()
                     .setMappings(
-                        List.of(new ConfiguredMapping(USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
+                        List.of(
+                            new ConfiguredMapping(
+                                DEFAULT_USER_ID, USER_ID_CLAIM_NAME, DEFAULT_USER_ID)));
               });
 
   @BeforeAll


### PR DESCRIPTION
## Description

prevent mapping creation if mappingId or claim pair already exists

Ensures that IdentitySetup skips creation of new mappings when either
the mapping ID or the claim name/value pair already exists in state.
This avoids overwriting preconfigured mappings and keeps mappingId stable.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27820
