### PR TITLE
feat: allow non-self task assignment

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/FeatureFlagProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/FeatureFlagProperties.java
@@ -10,13 +10,23 @@ package io.camunda.tasklist.property;
 public class FeatureFlagProperties {
 
   private Boolean processPublicEndpoints = true;
+  private Boolean allowNonSelfAssignment = false;
 
   public Boolean getProcessPublicEndpoints() {
     return processPublicEndpoints;
   }
 
-  public FeatureFlagProperties setProcessPublicEndpoints(Boolean processPublicEndpoints) {
+  public FeatureFlagProperties setProcessPublicEndpoints(final Boolean processPublicEndpoints) {
     this.processPublicEndpoints = processPublicEndpoints;
+    return this;
+  }
+
+  public Boolean getAllowNonSelfAssignment() {
+    return allowNonSelfAssignment;
+  }
+
+  public FeatureFlagProperties setAllowNonSelfAssignment(final Boolean allowNonSelfAssignment) {
+    this.allowNonSelfAssignment = allowNonSelfAssignment;
     return this;
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
@@ -13,6 +13,7 @@ import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED;
 import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED_TO_CURRENT_USER;
 import static io.camunda.tasklist.util.ErrorHandlingUtils.createErrorMessage;
 
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.dto.UserDTO;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Component;
 public class TaskValidator {
 
   @Autowired private UserReader userReader;
+  @Autowired private TasklistProperties tasklistProperties;
 
   public void validateCanPersistDraftTaskVariables(final TaskEntity task) {
     validateTaskStateAndAssignment(task);
@@ -75,7 +77,9 @@ public class TaskValidator {
       final TaskEntity taskBefore, final boolean allowOverrideAssignment) {
     validateTaskIsActive(taskBefore);
 
-    if (TasklistAuthenticationUtil.isApiUser() && allowOverrideAssignment) {
+    if ((TasklistAuthenticationUtil.isApiUser()
+            || tasklistProperties.getFeatureFlag().getAllowNonSelfAssignment())
+        && allowOverrideAssignment) {
       // JWT Token/API users can reassign task
       return;
     }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/TaskValidatorTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.tasklist.property.FeatureFlagProperties;
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.dto.UserDTO;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
@@ -36,6 +38,7 @@ public class TaskValidatorTest {
   public static final String TEST_USER = "TestUser";
 
   @Mock private UserReader userReader;
+  @Mock private TasklistProperties tasklistProperties;
 
   @InjectMocks private TaskValidator instance;
 
@@ -288,6 +291,7 @@ public class TaskValidatorTest {
   @Test
   public void nonApiUserShouldNotBeAbleToReassignToAnotherUser() {
     // given
+    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);
@@ -307,6 +311,7 @@ public class TaskValidatorTest {
   @Test
   public void nonApiUserShouldNotBeAbleToReassignToAnotherUserWhenOverrideAllowed() {
     // given
+    when(tasklistProperties.getFeatureFlag()).thenReturn(new FeatureFlagProperties());
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(false);
     final TaskEntity task =
         new TaskEntity().setAssignee("AnotherTestUser").setState(TaskState.CREATED);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -304,11 +304,12 @@ class TaskServiceTest {
     final var userA = "userA";
     final var userB = "userB";
     return Stream.of(
-        Arguments.of(null, true, userA, new UserDTO().setUserId(userA), false, userA, false),
-        Arguments.of(false, false, userA, new UserDTO().setUserId(userB), true, userA, false),
-        Arguments.of(true, true, null, new UserDTO().setUserId(userB), false, userB, false),
-        Arguments.of(true, true, "", new UserDTO().setUserId(userB), false, userB, false),
-        Arguments.of(false, false, userA, new UserDTO().setUserId(userB), false, userA, true));
+        Arguments.of(null, true, userA, new UserDTO().setUserId(userA), false, userA, false, null),
+        Arguments.of(false, false, userA, new UserDTO().setUserId(userB), true, userA, false, null),
+        Arguments.of(true, true, null, new UserDTO().setUserId(userB), false, userB, false, null),
+        Arguments.of(true, true, "", new UserDTO().setUserId(userB), false, userB, false, null),
+        Arguments.of(false, false, userA, new UserDTO().setUserId(userB), false, userA, true, null),
+        Arguments.of(true, true, userA, new UserDTO().setUserId(userB), false, userA, true, userB));
   }
 
   @ParameterizedTest
@@ -320,7 +321,8 @@ class TaskServiceTest {
       final UserDTO user,
       final boolean isApiUser,
       final String expectedAssignee,
-      final boolean allowNonSelfAssignment) {
+      final boolean allowNonSelfAssignment,
+      final String currentAssignee) {
 
     // Given
     when(tasklistProperties.getFeatureFlag())
@@ -328,6 +330,7 @@ class TaskServiceTest {
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(isApiUser);
     final var taskId = "123";
     final var taskBefore = mock(TaskEntity.class);
+    when(taskBefore.getAssignee()).thenReturn(currentAssignee);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
     when(userReader.getCurrentUser()).thenReturn(user);
     final var assignedTask = new TaskEntity().setAssignee(expectedAssignee);
@@ -560,14 +563,15 @@ class TaskServiceTest {
       final UserDTO user,
       final boolean isApiUser,
       final String expectedAssignee,
-      final boolean allowNonSelfAssignment) {
+      final boolean allowNonSelfAssignment,
+      final String currentAssignee) {
     // Given
     when(tasklistProperties.getFeatureFlag())
         .thenReturn(new FeatureFlagProperties().setAllowNonSelfAssignment(allowNonSelfAssignment));
     authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(isApiUser);
     final var taskId = "123";
     final var taskBefore = mock(TaskEntity.class);
-
+    when(taskBefore.getAssignee()).thenReturn(currentAssignee);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
     when(userReader.getCurrentUser()).thenReturn(user);
     final var assignedTask = new TaskEntity().setAssignee(expectedAssignee);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -28,6 +29,7 @@ import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.TaskMetricsStore;
 import io.camunda.tasklist.store.TaskStore;
 import io.camunda.tasklist.store.VariableStore.GetVariablesRequest;
@@ -81,6 +83,9 @@ class TaskServiceTest {
   @Mock private AssigneeMigrator assigneeMigrator;
   @Mock private TaskValidator taskValidator;
   @Mock private TasklistServicesAdapter tasklistServicesAdapter;
+
+  @Mock(answer = CALLS_REAL_METHODS)
+  private TasklistProperties tasklistProperties;
 
   @InjectMocks private TaskService instance;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the possibility to allow non-self assignment on user tasks for all users.

This is controlled by a feature flag and has to be enabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30487 
