### PR TITLE
[Backport stable/8.6] add verbose flag to operate backup list API to improve performance if `verbose=false`

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -10,9 +10,10 @@ env-up:
 env-os-up:
 	docker compose -f docker-compose.yml up -d opensearch zeebe-opensearch \
 	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
-	&& CAMUNDA_OPERATE_TASKLIST_URL=http://localhost:8081 \
-	&& CAMUNDA_OPERATE_DATABASE=opensearch \
-	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,auth
+	&& 	CAMUNDA_OPERATE_TASKLIST_URL="http://localhost:8081" \
+      CAMUNDA_OPERATE_DATABASE=opensearch \
+      CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME=test \
+         mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,auth
 
 # Look up for users (bender/bender etc) in: https://github.com/rroemhild/docker-test-openldap
 .PHONY: env-ldap-up

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.webapp;
 
-import static io.camunda.operate.util.CollectionUtil.asMap;
 import static io.camunda.operate.webapp.elasticsearch.backup.ElasticsearchBackupRepository.SNAPSHOT_MISSING_EXCEPTION_TYPE;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.COMPLETED;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.FAILED;
@@ -269,7 +268,7 @@ public class BackupControllerIT {
   @Test
   public void shouldFailCreateBackupOnBackupIdNotFound() throws IOException {
     final Long backupId = 2L;
-    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, Answers.RETURNS_DEEP_STUBS);
     when(snapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshotName", "uuid"));
     final List<SnapshotInfo> snapshotInfos = asList(new SnapshotInfo[] {snapshotInfo});
     when(snapshotClient.get(any(), any()))
@@ -377,13 +376,13 @@ public class BackupControllerIT {
     final Long backupId = 2L;
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3});
     when(snapshotClient.get(any(), any()))
@@ -403,10 +402,10 @@ public class BackupControllerIT {
     final Long backupId = 2L;
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotShardFailure failure1 =
         new SnapshotShardFailure(
             "someNodeId1",
@@ -420,7 +419,7 @@ public class BackupControllerIT {
     final List<SnapshotShardFailure> shardFailures = asList(failure1, failure2);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.FAILED, shardFailures);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.FAILED, shardFailures);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3});
     when(snapshotClient.get(any(), any()))
@@ -431,7 +430,8 @@ public class BackupControllerIT {
     assertThat(backupState.getState()).isEqualTo(FAILED);
     assertThat(backupState.getBackupId()).isEqualTo(backupId);
     assertThat(backupState.getFailureReason())
-        .isEqualTo("There were failures with the following snapshots: snapshotName3");
+        .isEqualTo(
+            "There were failures with the following snapshots: camunda_operate_2_8.7.0_part_3_of_3");
 
     assertBackupDetails(snapshotInfos, backupState);
 
@@ -450,13 +450,13 @@ public class BackupControllerIT {
     final Long backupId = 2L;
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.PARTIAL);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.PARTIAL, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3});
     when(snapshotClient.get(any(), any()))
@@ -467,7 +467,7 @@ public class BackupControllerIT {
     assertThat(backupState.getState()).isEqualTo(FAILED);
     assertThat(backupState.getBackupId()).isEqualTo(backupId);
     assertThat(backupState.getFailureReason())
-        .isEqualTo("Some of the snapshots are partial: snapshotName3");
+        .isEqualTo("Some of the snapshots are partial: camunda_operate_2_8.7.0_part_3_of_3");
 
     assertBackupDetails(snapshotInfos, backupState);
   }
@@ -477,16 +477,16 @@ public class BackupControllerIT {
     final Long backupId = 2L;
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo4 =
         createSnapshotInfoMock(
-            "snapshotName4", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 4, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3, snapshotInfo4});
     when(snapshotClient.get(any(), any()))
@@ -506,13 +506,13 @@ public class BackupControllerIT {
     final Long backupId = 2L;
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.INCOMPATIBLE);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.INCOMPATIBLE, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3});
     when(snapshotClient.get(any(), any()))
@@ -533,10 +533,10 @@ public class BackupControllerIT {
     // we have only 2 out of 3 snapshots
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2});
     when(snapshotClient.get(any(), any()))
@@ -557,13 +557,13 @@ public class BackupControllerIT {
     // we have only 2 out of 3 snapshots
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+            backupId, 2, 3, UUID.randomUUID().toString(), SnapshotState.SUCCESS, null);
     final SnapshotInfo snapshotInfo3 =
         createSnapshotInfoMock(
-            "snapshotName3", UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS);
+            backupId, 3, 3, UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2, snapshotInfo3});
     when(snapshotClient.get(any(), any()))
@@ -584,10 +584,10 @@ public class BackupControllerIT {
     // we have only 2 out of 3 snapshots
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
-            "snapshotName1", UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS, null);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
-            "snapshotName2", UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS);
+            backupId, 1, 3, UUID.randomUUID().toString(), SnapshotState.IN_PROGRESS, null);
     final List<SnapshotInfo> snapshotInfos =
         asList(new SnapshotInfo[] {snapshotInfo1, snapshotInfo2});
     when(snapshotClient.get(any(), any()))
@@ -837,7 +837,7 @@ public class BackupControllerIT {
     final Metadata metadata =
         new Metadata().setBackupId(backupId).setVersion("8.8.8").setPartNo(1).setPartCount(1);
 
-    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, Answers.RETURNS_DEEP_STUBS);
     when(snapshotInfo.snapshotId())
         .thenReturn(new SnapshotId(metadata.buildSnapshotName(), "snapshot-uuid"));
     when(snapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
@@ -880,42 +880,36 @@ public class BackupControllerIT {
   }
 
   private SnapshotInfo createSnapshotInfoMock(
-      final String name, final String uuid, final SnapshotState state) {
-    return createSnapshotInfoMock(null, name, uuid, state, null);
+      final long backupId,
+      final int part,
+      final int count,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
+    final var metadata =
+        new Metadata()
+            .setPartNo(part)
+            .setPartCount(count)
+            .setVersion("8.7.0")
+            .setBackupId(backupId);
+    return createSnapshotInfoMock(metadata, uuid, state, failures);
   }
 
   private SnapshotInfo createSnapshotInfoMock(
       final Metadata metadata, final String uuid, final SnapshotState state) {
-    return createSnapshotInfoMock(metadata, null, uuid, state, null);
-  }
-
-  @NotNull
-  private SnapshotInfo createSnapshotInfoMock(
-      final String name,
-      final String uuid,
-      final SnapshotState state,
-      final List<SnapshotShardFailure> failures) {
-    return createSnapshotInfoMock(null, name, uuid, state, failures);
+    return createSnapshotInfoMock(metadata, uuid, state, null);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
       final Metadata metadata,
-      final String name,
       final String uuid,
       final SnapshotState state,
       final List<SnapshotShardFailure> failures) {
-    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
-    if (metadata != null) {
-      when(snapshotInfo.snapshotId())
-          .thenReturn(new SnapshotId(metadata.buildSnapshotName(), uuid));
-      when(snapshotInfo.userMetadata())
-          .thenReturn(objectMapper.convertValue(metadata, new TypeReference<>() {}));
-    } else {
-      when(snapshotInfo.snapshotId()).thenReturn(new SnapshotId(name, uuid));
-      when(snapshotInfo.userMetadata())
-          .thenReturn(asMap("version", "someVersion", "partNo", 1, "partCount", 3));
-    }
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, Answers.RETURNS_DEEP_STUBS);
+    when(snapshotInfo.snapshotId()).thenReturn(new SnapshotId(metadata.buildSnapshotName(), uuid));
+    when(snapshotInfo.userMetadata())
+        .thenReturn(objectMapper.convertValue(metadata, new TypeReference<>() {}));
     when(snapshotInfo.state()).thenReturn(state);
     when(snapshotInfo.shardFailures()).thenReturn(failures);
     when(snapshotInfo.startTime()).thenReturn(OffsetDateTime.now().toInstant().toEpochMilli());

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -176,6 +176,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
@@ -47,10 +47,10 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
                 e -> format("Failed to get repository %s", repository)));
   }
 
-  public OpenSearchGetSnapshotResponse get(final GetSnapshotRequest.Builder requestBuilder) {
-    final var request = requestBuilder.build();
+  public OpenSearchGetSnapshotResponse get(final GetSnapshotRequest request) {
     final var repository = request.repository();
     final var snapshots = request.snapshot();
+    final var verbose = request.verbose();
     if (snapshots.size() > 1) {
       logger.warn(
           "More than one snapshot names given: {} . Use only first one: {}",
@@ -64,7 +64,10 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
                 safe(
                     () ->
                         extendedOpenSearchClient.arbitraryRequest(
-                            "GET", String.format("/_snapshot/%s/%s", repository, snapshot), "{}"),
+                            "GET",
+                            String.format(
+                                "/_snapshot/%s/%s?verbose=%s", repository, snapshot, verbose),
+                            "{}"),
                     e ->
                         format(
                             "Failed to get snapshot %s in repository %s", snapshot, repository)));

--- a/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
@@ -105,7 +105,8 @@ class OpenSearchSnapshotOperationsTest {
     when(openSearchClient.arbitraryRequest("GET", "/_snapshot/test-repository/test-snapshot", "{}"))
         .thenReturn(openSearchResponse);
     final var response =
-        snapshotOperations.get(getSnapshotRequestBuilder("test-repository", "test-snapshot"));
+        snapshotOperations.get(
+            getSnapshotRequestBuilder("test-repository", "test-snapshot").build());
     assertThat(response.snapshots()).hasSize(1);
     final var snapshotInfo = response.snapshots().getFirst();
     assertSnapshotInfo(snapshotInfo);
@@ -120,7 +121,7 @@ class OpenSearchSnapshotOperationsTest {
             OperateRuntimeException.class,
             () ->
                 snapshotOperations.get(
-                    getSnapshotRequestBuilder("test-repository", "test-snapshot")));
+                    getSnapshotRequestBuilder("test-repository", "test-snapshot").build()));
     assertThat(exception)
         .hasMessage("Failed to get snapshot test-snapshot in repository test-repository");
     assertThat(exception.getCause()).isInstanceOf(IOException.class);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -19,7 +19,11 @@ public interface BackupRepository {
 
   GetBackupStateResponseDto getBackupState(String repositoryName, Long backupId);
 
-  List<GetBackupStateResponseDto> getBackups(String repositoryName);
+  List<GetBackupStateResponseDto> getBackups(String repositoryName, boolean verbose);
+
+  default List<GetBackupStateResponseDto> getBackups(final String repositoryName) {
+    return getBackups(repositoryName, true);
+  }
 
   void executeSnapshotting(
       BackupService.SnapshotRequest snapshotRequest, Runnable onSuccess, Runnable onFailure);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
@@ -53,13 +53,13 @@ public class BackupService {
   private String[][] indexPatternsOrdered;
 
   public BackupService(
-      @Qualifier("backupThreadPoolExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor,
-      List<Prio1Backup> prio1BackupIndices,
-      List<Prio2Backup> prio2BackupTemplates,
-      List<Prio3Backup> prio3BackupTemplates,
-      List<Prio4Backup> prio4BackupIndices,
-      OperateProperties operateProperties,
-      BackupRepository repository) {
+      @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor,
+      final List<Prio1Backup> prio1BackupIndices,
+      final List<Prio2Backup> prio2BackupTemplates,
+      final List<Prio3Backup> prio3BackupTemplates,
+      final List<Prio4Backup> prio4BackupIndices,
+      final OperateProperties operateProperties,
+      final BackupRepository repository) {
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.prio1BackupIndices = prio1BackupIndices;
     this.prio2BackupTemplates = prio2BackupTemplates;
@@ -69,7 +69,7 @@ public class BackupService {
     this.operateProperties = operateProperties;
   }
 
-  public void deleteBackup(Long backupId) {
+  public void deleteBackup(final Long backupId) {
     repository.validateRepositoryExists(getRepositoryName());
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
@@ -86,7 +86,7 @@ public class BackupService {
     }
   }
 
-  public TakeBackupResponseDto takeBackup(TakeBackupRequestDto request) {
+  public TakeBackupResponseDto takeBackup(final TakeBackupRequestDto request) {
     repository.validateRepositoryExists(getRepositoryName());
     repository.validateNoDuplicateBackupId(getRepositoryName(), request.getBackupId());
     if (!requestsQueue.isEmpty()) {
@@ -100,7 +100,7 @@ public class BackupService {
     }
   }
 
-  private TakeBackupResponseDto scheduleSnapshots(TakeBackupRequestDto request) {
+  private TakeBackupResponseDto scheduleSnapshots(final TakeBackupRequestDto request) {
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
     final List<String> snapshotNames = new ArrayList<>();
@@ -186,12 +186,12 @@ public class BackupService {
     return operateProperties.getVersion().toLowerCase();
   }
 
-  public GetBackupStateResponseDto getBackupState(Long backupId) {
+  public GetBackupStateResponseDto getBackupState(final Long backupId) {
     return repository.getBackupState(getRepositoryName(), backupId);
   }
 
-  public List<GetBackupStateResponseDto> getBackups() {
-    return repository.getBackups(getRepositoryName());
+  public List<GetBackupStateResponseDto> getBackups(final boolean verbose) {
+    return repository.getBackups(getRepositoryName(), verbose);
   }
 
   public record SnapshotRequest(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -34,7 +34,7 @@ public class Metadata {
   public Metadata() {}
 
   public boolean isInitialized() {
-    return backupId != null && partCount != null && partNo != null && version != null;
+    return partCount != null && partNo != null && version != null;
   }
 
   public static String buildSnapshotNamePrefix(final Long backupId) {
@@ -143,7 +143,6 @@ public class Metadata {
     }
     final Metadata that = (Metadata) o;
     return Objects.equals(version, that.version)
-        && Objects.equals(backupId, that.backupId)
         && Objects.equals(partNo, that.partNo)
         && Objects.equals(partCount, that.partCount);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.operate.webapp.backup;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,11 +21,21 @@ public class Metadata {
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =
       Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");
+  private static final Pattern METADATA_PATTERN =
+      Pattern.compile(
+          SNAPSHOT_NAME_PREFIX
+              + "(?<backupId>\\d+)_(?<version>[^_]+)_part_(?<index>\\d+)_of_(?<count>\\d+)");
 
   private Long backupId;
   private String version;
   private Integer partNo;
   private Integer partCount;
+
+  public Metadata() {}
+
+  public boolean isInitialized() {
+    return backupId != null && partCount != null && partNo != null && version != null;
+  }
 
   public static String buildSnapshotNamePrefix(final Long backupId) {
     return SNAPSHOT_NAME_PREFIX_PATTERN.replace("{backupId}", String.valueOf(backupId));
@@ -37,6 +49,37 @@ public class Metadata {
     } else {
       throw new OperateRuntimeException(
           "Unable to extract backupId. Snapshot name: " + snapshotName);
+    }
+  }
+
+  public static Metadata extractMetadataFromSnapshotName(final String snapshotName) {
+    final Matcher matcher = METADATA_PATTERN.matcher(snapshotName);
+    if (matcher.matches()) {
+      final Long backupId = Long.parseLong(matcher.group("backupId"));
+      final String version = matcher.group("version");
+      final Integer index = Integer.parseInt(matcher.group("index"));
+      final Integer count = Integer.parseInt(matcher.group("count"));
+
+      return new Metadata()
+          .setBackupId(backupId)
+          .setPartCount(count)
+          .setPartNo(index)
+          .setVersion(version);
+    } else {
+      throw new IllegalArgumentException(
+          "Unable to extract metadata. Snapshot name: " + snapshotName);
+    }
+  }
+
+  public static Metadata extractFromMetadataOrName(
+      final ObjectMapper objectMapper,
+      final Map<String, Object> metadata,
+      final String snapshotName) {
+    final Metadata fromMetadata = objectMapper.convertValue(metadata, Metadata.class);
+    if (fromMetadata != null && fromMetadata.isInitialized()) {
+      return fromMetadata;
+    } else {
+      return Metadata.extractMetadataFromSnapshotName(snapshotName);
     }
   }
 
@@ -99,6 +142,7 @@ public class Metadata {
     }
     final Metadata that = (Metadata) o;
     return Objects.equals(version, that.version)
+        && Objects.equals(backupId, that.backupId)
         && Objects.equals(partNo, that.partNo)
         && Objects.equals(partCount, that.partCount);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -53,6 +53,7 @@ public class Metadata {
   }
 
   public static Metadata extractMetadataFromSnapshotName(final String snapshotName) {
+    Objects.requireNonNull(snapshotName, "Snapshot name cannot be null");
     final Matcher matcher = METADATA_PATTERN.matcher(snapshotName);
     if (matcher.matches()) {
       final Long backupId = Long.parseLong(matcher.group("backupId"));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -193,9 +193,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                       si -> {
                         final Metadata metadata =
                             Metadata.extractFromMetadataOrName(
-                                objectMapper,
-                                si.userMetadata(),
-                                si.snapshot().getSnapshotId().getName());
+                                objectMapper, si.userMetadata(), si.snapshotId().getName());
                         Long backupId = metadata.getBackupId();
                         // backward compatibility with v. 8.1
                         if (backupId == null) {
@@ -389,7 +387,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         Metadata.extractFromMetadataOrName(
             objectMapper,
             snapshots.getFirst().userMetadata(),
-            snapshots.getFirst().snapshot().getSnapshotId().getName());
+            snapshots.getFirst().snapshotId().getName());
     final Integer expectedSnapshotsCount = metadata.getPartCount();
     if (snapshots.size() == expectedSnapshotsCount
         && snapshots.stream().map(SnapshotInfo::state).allMatch(s -> SUCCESS.equals(s))) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/management/BackupController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/management/BackupController.java
@@ -16,9 +16,6 @@ import io.camunda.operate.webapp.management.dto.TakeBackupResponseDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
 import java.util.List;
-import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.context.annotation.Profile;
@@ -32,8 +29,6 @@ import org.springframework.web.bind.annotation.*;
 @Profile("standalone")
 public class BackupController extends ErrorController {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BackupController.class);
-  private final Pattern pattern = Pattern.compile("((?![A-Z \"*\\\\<|,>\\/?_]).){0,3996}$");
   @Autowired private BackupService backupService;
   @Autowired private OperateProperties operateProperties;
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/MetadataTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/backup/MetadataTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class MetadataTest {
+  @Test
+  public void shouldExtractMetadataFromSnapshotname() {
+    final Metadata metadata =
+        new Metadata().setBackupId(23L).setVersion("8.7.1").setPartCount(6).setPartNo(2);
+    final var name = metadata.buildSnapshotName();
+    final var fromName = Metadata.extractMetadataFromSnapshotName(name);
+    assertThat(metadata).isEqualTo(fromName);
+    assertThat(Metadata.extractFromMetadataOrName(new ObjectMapper(), Map.of(), name))
+        .isEqualTo(fromName);
+  }
+
+  @Test
+  public void shouldPreferExtractingFromMetadataField() {
+    final Metadata metadata =
+        new Metadata().setBackupId(23L).setVersion("8.7.1").setPartCount(6).setPartNo(2);
+    final var extracted =
+        Metadata.extractFromMetadataOrName(
+            new ObjectMapper(),
+            Map.of(
+                "backupId",
+                metadata.getBackupId(),
+                "partNo",
+                metadata.getPartNo(),
+                "partCount",
+                metadata.getPartCount(),
+                "version",
+                metadata.getVersion()),
+            "");
+    assertThat(extracted).isEqualTo(metadata);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
@@ -42,7 +41,6 @@ import org.elasticsearch.snapshots.SnapshotState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
-import org.mockito.ArgumentMatcher;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -151,15 +149,7 @@ public class ElasticsearchBackupRepositoryTest {
     when(snapshotClient.get(any(), any())).thenReturn(response);
 
     final var responses = backupRepository.getBackups(repositoryName, false);
-    final var notVerbose =
-        new ArgumentMatcher<GetSnapshotsRequest>() {
-
-          @Override
-          public boolean matches(final GetSnapshotsRequest argument) {
-            return !argument.verbose();
-          }
-        };
-    verify(snapshotClient).get(argThat(notVerbose), any());
+    verify(snapshotClient).get(argThat(req -> !req.verbose()), any());
     assertThat(responses)
         .singleElement()
         .satisfies(

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch._types.ErrorCause;
@@ -129,17 +128,10 @@ class OpensearchBackupRepositoryTest {
                 .setState(SnapshotState.STARTED));
     final var response = new OpenSearchGetSnapshotResponse(snapshotInfos);
     mockObjectMapperForMetadata(metadata);
-    final var requestIsNotVerbose =
-        new ArgumentMatcher<GetSnapshotRequest>() {
-          @Override
-          public boolean matches(final GetSnapshotRequest request) {
-            return request.verbose().equals(false);
-          }
-        };
     when(openSearchSnapshotOperations.get(any())).thenReturn(response);
     mockSynchronSnapshotOperations();
     final var snapshotDtoList = repository.getBackups("repo", false);
-    verify(openSearchSnapshotOperations).get(argThat(requestIsNotVerbose));
+    verify(openSearchSnapshotOperations).get(argThat(req -> !req.verbose()));
 
     assertThat(snapshotDtoList)
         .singleElement()

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -233,7 +233,7 @@ class OpensearchBackupRepositoryTest {
             new OpenSearchGetSnapshotResponse(
                 List.of(
                     new OpenSearchSnapshotInfo()
-                        .setSnapshot("snapshot")
+                        .setSnapshot("camunda_operate_1_8.7.0_part_1_of_6")
                         .setState(SnapshotState.SUCCESS)
                         .setStartTimeInMillis(23L))));
 
@@ -247,7 +247,7 @@ class OpensearchBackupRepositoryTest {
     final var snapshotDetail = snapshotDetails.get(0);
     assertThat(snapshotDetail.getState()).isEqualTo(SnapshotState.SUCCESS.toString());
     assertThat(snapshotDetail.getStartTime().toInstant().toEpochMilli()).isEqualTo(23L);
-    assertThat(snapshotDetail.getSnapshotName()).isEqualTo("snapshot");
+    assertThat(snapshotDetail.getSnapshotName()).isEqualTo("camunda_operate_1_8.7.0_part_1_of_6");
     assertThat(snapshotDetail.getFailures()).isNull();
   }
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -218,14 +218,14 @@ class OpensearchBackupRepositoryTest {
   @Test
   void getBackupState() {
     mockSynchronSnapshotOperations();
-    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+    mockObjectMapperForMetadata(new Metadata().setPartNo(1).setVersion("8.7.0").setPartCount(3));
 
     when(openSearchSnapshotOperations.get(any()))
         .thenReturn(
             new OpenSearchGetSnapshotResponse(
                 List.of(
                     new OpenSearchSnapshotInfo()
-                        .setSnapshot("camunda_operate_1_8.7.0_part_1_of_6")
+                        .setSnapshot("snapshot")
                         .setState(SnapshotState.SUCCESS)
                         .setStartTimeInMillis(23L))));
 
@@ -239,7 +239,7 @@ class OpensearchBackupRepositoryTest {
     final var snapshotDetail = snapshotDetails.get(0);
     assertThat(snapshotDetail.getState()).isEqualTo(SnapshotState.SUCCESS.toString());
     assertThat(snapshotDetail.getStartTime().toInstant().toEpochMilli()).isEqualTo(23L);
-    assertThat(snapshotDetail.getSnapshotName()).isEqualTo("camunda_operate_1_8.7.0_part_1_of_6");
+    assertThat(snapshotDetail.getSnapshotName()).isEqualTo("snapshot");
     assertThat(snapshotDetail.getFailures()).isNull();
   }
 


### PR DESCRIPTION
# Description
Backport of #30730 to `stable/8.6`.

relates to #30695