### PR TITLE
feat: apply mappings to search layer

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaJwtAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaJwtAuthenticationConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.entity.CamundaJwtUser;
+import io.camunda.security.entity.AuthenticationMethod;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+public class CamundaJwtAuthenticationConverter
+    implements Converter<Jwt, AbstractAuthenticationToken> {
+
+  JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+  final CamundaOAuthPrincipalService camundaOAuthPrincipalService;
+
+  public CamundaJwtAuthenticationConverter(
+      final CamundaOAuthPrincipalService camundaOAuthPrincipalService) {
+    this.camundaOAuthPrincipalService = camundaOAuthPrincipalService;
+  }
+
+  @Override
+  public AbstractAuthenticationToken convert(final Jwt source) {
+    final AbstractAuthenticationToken token = jwtAuthenticationConverter.convert(source);
+    return new CamundaJwtAuthenticationToken(
+        source,
+        new CamundaJwtUser(
+            source, camundaOAuthPrincipalService.loadOAuthContext(source.getClaims())),
+        token.getCredentials(),
+        token.getAuthorities());
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/CamundaJwtAuthenticationToken.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaJwtAuthenticationToken.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.entity.CamundaJwtUser;
+import java.util.Collection;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+
+public class CamundaJwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationToken<Jwt> {
+
+  public CamundaJwtAuthenticationToken(
+      final Jwt token,
+      final CamundaJwtUser principal,
+      final Object credentials,
+      final Collection<? extends GrantedAuthority> authorities) {
+    super(token, principal, credentials, authorities);
+    setAuthenticated(true);
+  }
+
+  @Override
+  public Map<String, Object> getTokenAttributes() {
+    return getToken().getClaims();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.entity.AuthenticationContext;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.MappingEntity;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.service.AuthorizationServices;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import io.camunda.service.TenantServices.TenantDTO;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+public class CamundaOAuthPrincipalService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CamundaOAuthPrincipalService.class);
+
+  private final MappingServices mappingServices;
+  private final TenantServices tenantServices;
+  private final RoleServices roleServices;
+  private final GroupServices groupServices;
+  private final AuthorizationServices authorizationServices;
+  private final String usernameClaim;
+
+  public CamundaOAuthPrincipalService(
+      final MappingServices mappingServices,
+      final TenantServices tenantServices,
+      final RoleServices roleServices,
+      final GroupServices groupServices,
+      final AuthorizationServices authorizationServices,
+      final SecurityConfiguration securityConfiguration) {
+    this.mappingServices = mappingServices;
+    this.tenantServices = tenantServices;
+    this.roleServices = roleServices;
+    this.groupServices = groupServices;
+    this.authorizationServices = authorizationServices;
+    usernameClaim = securityConfiguration.getAuthentication().getOidc().getUsernameClaim();
+  }
+
+  public OAuthContext loadOAuthContext(final Map<String, Object> claims)
+      throws OAuth2AuthenticationException {
+    final List<MappingEntity> mappings = mappingServices.getMatchingMappings(claims);
+    final Set<Long> mappingKeys =
+        mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
+    final Set<String> mappingIds =
+        mappings.stream().map(MappingEntity::mappingId).collect(Collectors.toSet());
+    if (mappingKeys.isEmpty() && mappingIds.isEmpty()) {
+      LOG.debug("No mappings found for these claims: {}", claims);
+    }
+
+    final var assignedRoles = roleServices.getRolesByMemberKeys(mappingKeys);
+
+    return new OAuthContext(
+        mappingKeys,
+        mappingIds,
+        new AuthenticationContext(
+            getUsernameFromClaims(claims),
+            assignedRoles,
+            authorizationServices.getAuthorizedApplications(
+                Stream.concat(
+                        assignedRoles.stream().map(r -> r.roleKey().toString()),
+                        mappingKeys.stream().map(Object::toString))
+                    .collect(Collectors.toSet())),
+            tenantServices.getTenantsByMemberIds(mappingIds).stream()
+                .map(TenantDTO::fromEntity)
+                .toList(),
+            groupServices.getGroupsByMemberKeys(mappingKeys).stream()
+                .map(GroupEntity::name)
+                .toList()));
+  }
+
+  private String getUsernameFromClaims(final Map<String, Object> claims) {
+    return Optional.ofNullable(claims.get(usernameClaim))
+        .map(Object::toString)
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Configured username claim %s not found in claims. Please check your OIDC configuration."
+                        .formatted(usernameClaim)));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -7,26 +7,9 @@
  */
 package io.camunda.authentication;
 
-import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
-import io.camunda.search.entities.GroupEntity;
-import io.camunda.search.entities.MappingEntity;
-import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
-import io.camunda.service.AuthorizationServices;
-import io.camunda.service.GroupServices;
-import io.camunda.service.MappingServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
-import io.camunda.service.TenantServices.TenantDTO;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -36,73 +19,17 @@ import org.springframework.stereotype.Service;
 @Service
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
 public class CamundaOidcUserService extends OidcUserService {
-  private static final Logger LOG = LoggerFactory.getLogger(CamundaOidcUserService.class);
-  private final MappingServices mappingServices;
-  private final TenantServices tenantServices;
-  private final RoleServices roleServices;
-  private final GroupServices groupServices;
-  private final AuthorizationServices authorizationServices;
-  private final String usernameClaim;
 
-  public CamundaOidcUserService(
-      final MappingServices mappingServices,
-      final TenantServices tenantServices,
-      final RoleServices roleServices,
-      final GroupServices groupServices,
-      final AuthorizationServices authorizationServices,
-      final SecurityConfiguration securityConfiguration) {
-    this.mappingServices = mappingServices;
-    this.tenantServices = tenantServices;
-    this.roleServices = roleServices;
-    this.groupServices = groupServices;
-    this.authorizationServices = authorizationServices;
-    usernameClaim = securityConfiguration.getAuthentication().getOidc().getUsernameClaim();
+  private final CamundaOAuthPrincipalService camundaOAuthPrincipalService;
+
+  public CamundaOidcUserService(final CamundaOAuthPrincipalService camundaOAuthPrincipalService) {
+    this.camundaOAuthPrincipalService = camundaOAuthPrincipalService;
   }
 
   @Override
   public OidcUser loadUser(final OidcUserRequest userRequest) throws OAuth2AuthenticationException {
     final OidcUser oidcUser = super.loadUser(userRequest);
-
     final Map<String, Object> claims = userRequest.getIdToken().getClaims();
-    final List<MappingEntity> mappings = mappingServices.getMatchingMappings(claims);
-    final Set<Long> mappingKeys =
-        mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
-    final Set<String> mappingIds =
-        mappings.stream().map(MappingEntity::mappingId).collect(Collectors.toSet());
-    if (mappingKeys.isEmpty()) {
-      LOG.debug("No mappings found for these claims: {}", claims);
-    }
-
-    final var assignedRoles = roleServices.getRolesByMemberKeys(mappingKeys);
-
-    return new CamundaOidcUser(
-        oidcUser,
-        mappingKeys,
-        mappingIds,
-        new AuthenticationContext(
-            getUsernameFromClaims(claims),
-            assignedRoles,
-            authorizationServices.getAuthorizedApplications(
-                Stream.concat(
-                        assignedRoles.stream().map(r -> r.roleKey().toString()),
-                        mappingKeys.stream()
-                            .map(String::valueOf)) // TODO remove mapping when refactoring to IDs
-                    .collect(Collectors.toSet())),
-            tenantServices.getTenantsByMemberIds(mappingIds).stream()
-                .map(TenantDTO::fromEntity)
-                .toList(),
-            groupServices.getGroupsByMemberKeys(mappingKeys).stream()
-                .map(GroupEntity::name)
-                .toList()));
-  }
-
-  private String getUsernameFromClaims(final Map<String, Object> claims) {
-    return Optional.ofNullable(claims.get(usernameClaim))
-        .map(Object::toString)
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "Configured username claim %s not found in claims. Please check your OIDC configuration."
-                        .formatted(usernameClaim)));
+    return new CamundaOidcUser(oidcUser, camundaOAuthPrincipalService.loadOAuthContext(claims));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config;
 
+import io.camunda.authentication.CamundaJwtAuthenticationConverter;
 import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.ConditionalOnUnprotectedApi;
@@ -305,7 +306,8 @@ public class WebSecurityConfig {
     public SecurityFilterChain oidcApiSecurity(
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
-        final JwtDecoder jwtDecoder)
+        final JwtDecoder jwtDecoder,
+        final CamundaJwtAuthenticationConverter converter)
         throws Exception {
       return httpSecurity
           .securityMatcher(API_PATHS.toArray(new String[0]))
@@ -324,7 +326,10 @@ public class WebSecurityConfig {
           .formLogin(AbstractHttpConfigurer::disable)
           .anonymous(AbstractHttpConfigurer::disable)
           .oauth2ResourceServer(
-              oauth2 -> oauth2.jwt(jwtConfigurer -> jwtConfigurer.decoder(jwtDecoder)))
+              oauth2 ->
+                  oauth2.jwt(
+                      jwtConfigurer ->
+                          jwtConfigurer.decoder(jwtDecoder).jwtAuthenticationConverter(converter)))
           .oauth2Login(AbstractHttpConfigurer::disable)
           .oidcLogout(AbstractHttpConfigurer::disable)
           .logout(AbstractHttpConfigurer::disable)
@@ -338,7 +343,8 @@ public class WebSecurityConfig {
         final AuthFailureHandler authFailureHandler,
         final ClientRegistrationRepository clientRegistrationRepository,
         final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter,
-        final JwtDecoder jwtDecoder)
+        final JwtDecoder jwtDecoder,
+        final CamundaJwtAuthenticationConverter converter)
         throws Exception {
       return httpSecurity
           .securityMatcher(WEBAPP_PATHS.toArray(new String[0]))
@@ -357,7 +363,10 @@ public class WebSecurityConfig {
           .formLogin(AbstractHttpConfigurer::disable)
           .anonymous(AbstractHttpConfigurer::disable)
           .oauth2ResourceServer(
-              oauth2 -> oauth2.jwt(jwtConfigurer -> jwtConfigurer.decoder(jwtDecoder)))
+              oauth2 ->
+                  oauth2.jwt(
+                      jwtConfigurer ->
+                          jwtConfigurer.decoder(jwtDecoder).jwtAuthenticationConverter(converter)))
           .oauth2Login(
               oauthLoginConfigurer -> {
                 oauthLoginConfigurer

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaJwtUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaJwtUser.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.entity;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class CamundaJwtUser implements CamundaOAuthPrincipal, Serializable {
+  private final Jwt jwt;
+  private final OAuthContext oauthContext;
+
+  public CamundaJwtUser(
+      final Jwt jwt, final Set<String> mappingIds, final AuthenticationContext authentication) {
+    this.jwt = jwt;
+    oauthContext = new OAuthContext(new HashSet<>(), mappingIds, authentication);
+  }
+
+  public CamundaJwtUser(final Jwt jwt, final OAuthContext oauthContext) {
+    this.jwt = jwt;
+    this.oauthContext = oauthContext;
+  }
+
+  @Override
+  public String getEmail() {
+    return jwt.getClaimAsString("email");
+  }
+
+  @Override
+  public String getDisplayName() {
+    return jwt.getClaimAsString("displayName");
+  }
+
+  @Override
+  public AuthenticationContext getAuthenticationContext() {
+    return oauthContext.authenticationContext();
+  }
+
+  @Override
+  public OAuthContext getOAuthContext() {
+    return oauthContext;
+  }
+
+  @Override
+  public Map<String, Object> getClaims() {
+    return jwt.getClaims();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOAuthPrincipal.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOAuthPrincipal.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.entity;
+
+import java.util.Map;
+
+public interface CamundaOAuthPrincipal extends CamundaPrincipal {
+  OAuthContext getOAuthContext();
+
+  Map<String, Object> getClaims();
+}

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -16,12 +16,9 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
-public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable {
+public class CamundaOidcUser implements OidcUser, CamundaOAuthPrincipal, Serializable {
   private final OidcUser user;
-  private final AuthenticationContext authentication;
-  // todo remove after fully migrating to mapping IDs #27207
-  private final Set<Long> mappingKeys;
-  private final Set<String> mappingIds;
+  private final OAuthContext oAuthContext;
 
   public CamundaOidcUser(
       final OidcUser oidcUser,
@@ -29,9 +26,12 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
       final Set<String> mappingIds,
       final AuthenticationContext authentication) {
     user = oidcUser;
-    this.mappingKeys = mappingKeys;
-    this.mappingIds = mappingIds;
-    this.authentication = authentication;
+    oAuthContext = new OAuthContext(mappingKeys, mappingIds, authentication);
+  }
+
+  public CamundaOidcUser(final OidcUser user, final OAuthContext oAuthContext) {
+    this.user = user;
+    this.oAuthContext = oAuthContext;
   }
 
   @Override
@@ -46,7 +46,7 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
 
   @Override
   public AuthenticationContext getAuthenticationContext() {
-    return authentication;
+    return oAuthContext.authenticationContext();
   }
 
   @Override
@@ -80,10 +80,15 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
   }
 
   public Set<Long> getMappingKeys() {
-    return mappingKeys;
+    return oAuthContext.mappingKeys();
   }
 
   public Set<String> getMappingIds() {
-    return mappingIds;
+    return oAuthContext.mappingIds();
+  }
+
+  @Override
+  public OAuthContext getOAuthContext() {
+    return oAuthContext;
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/OAuthContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/OAuthContext.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.entity;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public record OAuthContext(
+    Set<Long> mappingKeys, Set<String> mappingIds, AuthenticationContext authenticationContext)
+    implements Serializable {}

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -9,7 +9,7 @@ package io.camunda.authentication.service;
 
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.entity.AuthenticationContext;
-import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.entity.CamundaOAuthPrincipal;
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -30,10 +30,10 @@ public class OidcCamundaUserService implements CamundaUserService {
   // TODO: This needs to be set for SaaS purposes
   private static final Map<AppName, String> C8_LINKS = Map.of();
 
-  private Optional<CamundaOidcUser> getCamundaUser() {
+  private Optional<CamundaOAuthPrincipal> getCamundaUser() {
     return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
         .map(Authentication::getPrincipal)
-        .map(principal -> principal instanceof final CamundaOidcUser user ? user : null);
+        .map(principal -> principal instanceof final CamundaOAuthPrincipal user ? user : null);
   }
 
   @Override

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.entity.AuthenticationContext;
+import io.camunda.authentication.entity.OAuthContext;
+import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.AuthorizationServices;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CamundaOAuthPrincipalServiceTest {
+  private static final String REGISTRATION_ID = "test";
+  private static final String TOKEN_VALUE = "{}";
+  private static final Instant TOKEN_ISSUED_AT = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+  private static final Instant TOKEN_EXPIRES_AT = TOKEN_ISSUED_AT.plus(1, ChronoUnit.DAYS);
+
+  private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
+
+  @Mock private MappingServices mappingServices;
+  @Mock private TenantServices tenantServices;
+  @Mock private RoleServices roleServices;
+  @Mock private GroupServices groupServices;
+  @Mock private AuthorizationServices authorizationServices;
+  @Mock private SecurityConfiguration securityConfiguration;
+  @Mock private AuthenticationConfiguration authenticationConfiguration;
+  @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
+
+    camundaOAuthPrincipalService =
+        new CamundaOAuthPrincipalService(
+            mappingServices,
+            tenantServices,
+            roleServices,
+            groupServices,
+            authorizationServices,
+            securityConfiguration);
+  }
+
+  @Test
+  public void loadUser() {
+    // given
+    final Map<String, Object> claims =
+        Map.of(
+            "sub", "test|foo@camunda.test",
+            "email", "foo@camunda.test",
+            "role", "R1",
+            "group", "G1");
+    when(mappingServices.getMatchingMappings(claims))
+        .thenReturn(
+            List.of(
+                new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
+                new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
+
+    final var roleR1 = new RoleEntity(8L, "Role R1");
+    when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
+    when(authorizationServices.getAuthorizedApplications(Set.of("5", "7", "8")))
+        .thenReturn(List.of("*"));
+
+    // when
+    final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
+
+    // then
+    assertThat(oAuthContext).isNotNull();
+    assertThat(oAuthContext.mappingKeys()).isEqualTo(Set.of(5L, 7L));
+    assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
+    final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
+    assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
+    assertThat(authenticationContext.groups()).isEmpty();
+    assertThat(authenticationContext.tenants()).isEmpty();
+    assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -12,18 +12,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
-import io.camunda.search.entities.MappingEntity;
+import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.RoleEntity;
-import io.camunda.security.configuration.AuthenticationConfiguration;
-import io.camunda.security.configuration.OidcAuthenticationConfiguration;
-import io.camunda.security.configuration.SecurityConfiguration;
-import io.camunda.service.AuthorizationServices;
-import io.camunda.service.GroupServices;
-import io.camunda.service.MappingServices;
-import io.camunda.service.RoleServices;
-import io.camunda.service.TenantServices;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,31 +40,12 @@ public class CamundaOidcUserServiceTest {
 
   private CamundaOidcUserService camundaOidcUserService;
 
-  @Mock private MappingServices mappingServices;
-  @Mock private TenantServices tenantServices;
-  @Mock private RoleServices roleServices;
-  @Mock private GroupServices groupServices;
-  @Mock private AuthorizationServices authorizationServices;
-  @Mock private SecurityConfiguration securityConfiguration;
-  @Mock private AuthenticationConfiguration authenticationConfiguration;
-  @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+  @Mock private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
 
   @BeforeEach
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-
-    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
-    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
-    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
-
-    camundaOidcUserService =
-        new CamundaOidcUserService(
-            mappingServices,
-            tenantServices,
-            roleServices,
-            groupServices,
-            authorizationServices,
-            securityConfiguration);
+    camundaOidcUserService = new CamundaOidcUserService(camundaOAuthPrincipalService);
   }
 
   @Test
@@ -83,16 +57,16 @@ public class CamundaOidcUserServiceTest {
             "email", "foo@camunda.test",
             "role", "R1",
             "group", "G1");
-    when(mappingServices.getMatchingMappings(claims))
-        .thenReturn(
-            List.of(
-                new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
-                new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
     final var roleR1 = new RoleEntity(8L, "Role R1");
-    when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
-    when(authorizationServices.getAuthorizedApplications(Set.of("5", "7", "8")))
-        .thenReturn(List.of("*"));
+
+    when(camundaOAuthPrincipalService.loadOAuthContext(claims))
+        .thenReturn(
+            new OAuthContext(
+                Set.of(5L, 7L),
+                Set.of("test-id", "test-id-2"),
+                new AuthenticationContext(
+                    null, List.of(roleR1), List.of("*"), new ArrayList<>(), new ArrayList<>())));
 
     // when
     final OidcUser oidcUser = camundaOidcUserService.loadUser(createOidcUserRequest(claims));
@@ -105,7 +79,6 @@ public class CamundaOidcUserServiceTest {
     assertThat(camundaUser.getMappingKeys()).isEqualTo(Set.of(5L, 7L));
     assertThat(camundaUser.getMappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
-    assertThat(authenticationContext.username()).isEqualTo("test|foo@camunda.test");
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.groups()).isEmpty();
     assertThat(authenticationContext.tenants()).isEmpty();

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
@@ -25,6 +25,7 @@ public final class Authentication {
   private final List<Long> authenticatedGroupKeys;
   private final List<Long> authenticatedRoleKeys;
   private final List<String> authenticatedTenantIds;
+  private final List<String> authenticatedMappingIds;
   private final Map<String, Object> claims;
 
   @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -33,11 +34,13 @@ public final class Authentication {
       final @JsonProperty("authenticated_group_keys") List<Long> authenticatedGroupKeys,
       final @JsonProperty("authenticated_role_keys") List<Long> authenticatedRoleKeys,
       final @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
+      final @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
       final @JsonProperty("claims") Map<String, Object> claims) {
     this.authenticatedUsername = authenticatedUsername;
     this.authenticatedGroupKeys = authenticatedGroupKeys;
     this.authenticatedRoleKeys = authenticatedRoleKeys;
     this.authenticatedTenantIds = authenticatedTenantIds;
+    this.authenticatedMappingIds = authenticatedMappingIds;
     this.claims = claims;
   }
 
@@ -65,6 +68,10 @@ public final class Authentication {
     return authenticatedTenantIds;
   }
 
+  public List<String> authenticatedMappingIds() {
+    return authenticatedMappingIds;
+  }
+
   public Map<String, Object> claims() {
     return claims;
   }
@@ -76,6 +83,7 @@ public final class Authentication {
         authenticatedGroupKeys,
         authenticatedRoleKeys,
         authenticatedTenantIds,
+        authenticatedMappingIds,
         claims);
   }
 
@@ -92,6 +100,7 @@ public final class Authentication {
         && Objects.equals(authenticatedGroupKeys, that.authenticatedGroupKeys)
         && Objects.equals(authenticatedRoleKeys, that.authenticatedRoleKeys)
         && Objects.equals(authenticatedTenantIds, that.authenticatedTenantIds)
+        && Objects.equals(authenticatedMappingIds, that.authenticatedMappingIds)
         && Objects.equals(claims, that.claims);
   }
 
@@ -110,6 +119,9 @@ public final class Authentication {
         + "authenticatedTenantIds="
         + authenticatedTenantIds
         + ", "
+        + "authenticatedMappingIds="
+        + authenticatedMappingIds
+        + ", "
         + "claims="
         + claims
         + ']';
@@ -121,6 +133,7 @@ public final class Authentication {
     private final List<Long> groupKeys = new ArrayList<>();
     private final List<Long> roleKeys = new ArrayList<>();
     private final List<String> tenants = new ArrayList<>();
+    private final List<String> mappings = new ArrayList<>();
     private Map<String, Object> claims;
 
     public Builder user(final String value) {
@@ -161,6 +174,17 @@ public final class Authentication {
       return this;
     }
 
+    public Builder mapping(final String mapping) {
+      return mapping(Collections.singletonList(mapping));
+    }
+
+    public Builder mapping(final List<String> values) {
+      if (values != null) {
+        mappings.addAll(values);
+      }
+      return this;
+    }
+
     public Builder claims(final Map<String, Object> value) {
       claims = value;
       return this;
@@ -172,6 +196,7 @@ public final class Authentication {
           unmodifiableList(groupKeys),
           unmodifiableList(roleKeys),
           unmodifiableList(tenants),
+          unmodifiableList(mappings),
           claims);
     }
   }

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -127,6 +127,7 @@ public class AuthorizationChecker {
   private List<String> collectOwnerIds(final Authentication authentication) {
     final List<String> ownerIds = new ArrayList<>();
     ownerIds.add(authentication.authenticatedUsername());
+    ownerIds.addAll(authentication.authenticatedMappingIds());
     ownerIds.addAll(
         // TODO remove this mapping when refactoring Groups to IDs
         authentication.authenticatedGroupKeys().stream()

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -397,10 +397,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-resource-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-jose</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -13,26 +13,30 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import io.camunda.authentication.CamundaJwtAuthenticationToken;
 import io.camunda.authentication.entity.AuthenticationContext;
+import io.camunda.authentication.entity.CamundaJwtUser;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
+import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.zeebe.auth.Authorization;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -109,8 +113,20 @@ class RequestMapperTest {
             Instant.ofEpochSecond(100),
             Map.of("alg", "RSA256"),
             Map.of("sub", sub, "aud", aud, "groups", List.of("g1", "g2")));
-    final JwtAuthenticationToken jwtAuthenticationToken = new JwtAuthenticationToken(jwt);
-    SecurityContextHolder.getContext().setAuthentication(jwtAuthenticationToken);
+
+    final AbstractAuthenticationToken token =
+        new CamundaJwtAuthenticationToken(
+            jwt,
+            new CamundaJwtUser(
+                jwt,
+                new OAuthContext(
+                    new HashSet<>(),
+                    new HashSet<>(),
+                    new AuthenticationContext(
+                        sub, List.of(), List.of(), List.of(), List.of("g1", "g2")))),
+            null,
+            null);
+    SecurityContextHolder.getContext().setAuthentication(token);
   }
 
   private void setOidcAuthenticationInContext(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -54,6 +55,10 @@ public class OidcAuthOverGrpcIT {
   private static final String USER_ID_CLAIM_NAME = "sub";
 
   @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @Container
   private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
 
   @AutoClose private static CamundaClient defaultMappingClient;
@@ -64,6 +69,7 @@ public class OidcAuthOverGrpcIT {
       new TestStandaloneBroker()
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -54,6 +56,10 @@ public class OidcAuthOverRestIT {
   private static final String USER_ID_CLAIM_NAME = "sub";
 
   @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @Container
   private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
 
   @AutoClose private static CamundaClient defaultMappingClient;
@@ -64,6 +70,7 @@ public class OidcAuthOverRestIT {
       new TestStandaloneBroker()
           .withAuthenticatedAccess()
           .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
           .withSecurityConfig(
               c -> {
                 c.getAuthorizations().setEnabled(true);


### PR DESCRIPTION
## Description

In current state mapping's are not handled as Authorizations owner directly or indirectly. With this task, we should be able to apply authorizations in search queries when OIDC is enabled.

## Related issues

closes #30242 
