### PR TITLE
feat: migrate TimeStampPill component to v2 XML API

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/TimeStampPill/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/TimeStampPill/index.test.tsx
@@ -9,36 +9,38 @@
 import {render, screen, waitFor} from 'modules/testing-library';
 import {TimeStampPill} from './index';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {useEffect} from 'react';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 jest.mock('modules/utils/bpmn');
 
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
   mockFetchFlowNodeInstances().withSuccess({});
-  mockFetchProcessXML().withSuccess('');
+  mockFetchProcessDefinitionXml().withSuccess('');
 
   useEffect(() => {
     flowNodeInstanceStore.fetchInstanceExecutionHistory('1');
-    processInstanceDetailsDiagramStore.fetchProcessXml('1');
     return () => {
       flowNodeTimeStampStore.reset();
-      processInstanceDetailsDiagramStore.reset();
       flowNodeInstanceStore.reset();
     };
   }, []);
 
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
 describe('TimeStampPill', () => {
-  beforeEach(() => {
-    mockFetchProcessXML().withSuccess('');
-  });
-
   it('should render "Show" / "Hide" label', async () => {
     const {user} = render(<TimeStampPill />, {wrapper: Wrapper});
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/TimeStampPill/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/TimeStampPill/index.tsx
@@ -9,20 +9,22 @@
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
 import {observer} from 'mobx-react';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {tracking} from 'modules/tracking';
 import {Toggle} from './styled';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 
 const TimeStampPill: React.FC = observer(() => {
   const {status: flowNodeInstanceStatus} = flowNodeInstanceStore.state;
-  const {status: diagramStatus} = processInstanceDetailsDiagramStore.state;
   const {
     state: {isTimeStampVisible},
     toggleTimeStampVisibility,
   } = flowNodeTimeStampStore;
 
-  const isDisabled =
-    flowNodeInstanceStatus !== 'fetched' && diagramStatus !== 'fetched';
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {isSuccess} = useProcessInstanceXml({processDefinitionKey});
+
+  const isDisabled = flowNodeInstanceStatus !== 'fetched' && !isSuccess;
   return (
     <Toggle
       aria-label={`${isTimeStampVisible ? 'Hide' : 'Show'} End Date`}


### PR DESCRIPTION
## Description

- migrate TimeStampPill component to v2 XML API

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
