### PR TITLE
fix: remove processInstanceDetailsDiagramStore deps from hooks

### DIFF
--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -40,6 +40,7 @@ import {Forbidden} from 'modules/components/Forbidden';
 import {notificationsStore} from 'modules/stores/notifications';
 import {Frame} from 'modules/components/Frame';
 import {processInstanceListenersStore} from 'modules/stores/processInstanceListeners';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 const startPolling = (processInstanceId: ProcessInstanceEntity['id']) => {
   variablesStore.startPolling(processInstanceId, {runImmediately: true});
@@ -164,6 +165,10 @@ const ProcessInstance: React.FC = observer(() => {
   }, []);
 
   const {
+    state: {processInstance},
+  } = processInstanceDetailsStore;
+
+  const {
     isModificationModeEnabled,
     state: {modifications, status: modificationStatus},
   } = modificationsStore;
@@ -184,7 +189,7 @@ const ProcessInstance: React.FC = observer(() => {
   }
 
   return (
-    <>
+    <ProcessDefinitionKeyContext.Provider value={processInstance?.processId}>
       <VisuallyHiddenH1>
         {`Operate Process Instance${
           isModificationModeEnabled ? ' - Modification Mode' : ''
@@ -312,7 +317,7 @@ const ProcessInstance: React.FC = observer(() => {
           </p>
         </Modal>
       )}
-    </>
+    </ProcessDefinitionKeyContext.Provider>
   );
 });
 

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -24,10 +24,6 @@ const useFlowNodes = () => {
     useProcessInstanceXml({
       processDefinitionKey: processDefinitionKey,
     }).data?.businessObjects ?? {};
-  const {data} = useProcessInstanceXml({
-    processDefinitionKey: processDefinitionKey,
-  });
-  console.log('data', data);
 
   return Object.values(businessObjects).map((flowNode) => {
     const flowNodeState = statistics?.items.find(

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -6,32 +6,46 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
+import {useTotalRunningInstancesByFlowNode} from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {modificationsStore} from 'modules/stores/modifications';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
 
 const useFlowNodes = () => {
   const {data: statistics} = useFlownodeInstancesStatistics();
-  return Object.values(processInstanceDetailsDiagramStore.businessObjects).map(
-    (flowNode) => {
-      const flowNodeState = statistics?.items.find(
-        ({flowNodeId}) => flowNodeId === flowNode.id,
-      );
+  const {data: totalRunningInstancesByFlowNode} =
+    useTotalRunningInstancesByFlowNode();
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const businessObjects =
+    useProcessInstanceXml({
+      processDefinitionKey: processDefinitionKey,
+    }).data?.businessObjects ?? {};
+  const {data} = useProcessInstanceXml({
+    processDefinitionKey: processDefinitionKey,
+  });
+  console.log('data', data);
 
-      return {
-        id: flowNode.id,
-        isCancellable:
-          flowNodeState !== undefined &&
-          (flowNodeState.active > 0 || flowNodeState.incidents > 0),
-        isMoveModificationTarget: isMoveModificationTarget(flowNode),
-        hasMultipleScopes: processInstanceDetailsDiagramStore.hasMultipleScopes(
-          flowNode.$parent,
-        ),
-      };
-    },
-  );
+  return Object.values(businessObjects).map((flowNode) => {
+    const flowNodeState = statistics?.items.find(
+      ({flowNodeId}) => flowNodeId === flowNode.id,
+    );
+
+    return {
+      id: flowNode.id,
+      isCancellable:
+        flowNodeState !== undefined &&
+        (flowNodeState.active > 0 || flowNodeState.incidents > 0),
+      isMoveModificationTarget: isMoveModificationTarget(flowNode),
+      hasMultipleScopes: hasMultipleScopes(
+        flowNode.$parent,
+        totalRunningInstancesByFlowNode,
+      ),
+    };
+  });
 };
 
 const useAppendableFlowNodes = () => {

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.ts
@@ -33,6 +33,22 @@ const totalRunningInstancesForFlowNodesParser =
     }, {});
   };
 
+const totalRunningInstancesByFlowNodeParser = (
+  response: GetProcessInstanceStatisticsResponseBody,
+): Record<string, number> => {
+  const statistics = getStatisticsByFlowNode(response.items);
+
+  return Object.keys(statistics).reduce<Record<string, number>>(
+    (acc, flowNodeId) => {
+      const active = statistics[flowNodeId]?.active ?? 0;
+      const incidents = statistics[flowNodeId]?.incidents ?? 0;
+      acc[flowNodeId] = active + incidents;
+      return acc;
+    },
+    {},
+  );
+};
+
 const totalRunningInstancesVisibleForFlowNodeParser =
   (flowNodeId?: string) =>
   (response: GetProcessInstanceStatisticsResponseBody) => {
@@ -69,7 +85,11 @@ const useTotalRunningInstancesForFlowNodes = (flowNodeIds: string[]) => {
   );
 };
 
-const useTotalRunningInstancesVisibleForFlowNode = (flowNodeId: string) => {
+const useTotalRunningInstancesByFlowNode = () => {
+  return useFlownodeInstancesStatistics(totalRunningInstancesByFlowNodeParser);
+};
+
+const useTotalRunningInstancesVisibleForFlowNode = (flowNodeId?: string) => {
   return useFlownodeInstancesStatistics(
     totalRunningInstancesVisibleForFlowNodeParser(flowNodeId),
   );
@@ -84,6 +104,7 @@ const useTotalRunningInstancesVisibleForFlowNodes = (flowNodeIds: string[]) => {
 export {
   useTotalRunningInstancesForFlowNode,
   useTotalRunningInstancesForFlowNodes,
+  useTotalRunningInstancesByFlowNode,
   useTotalRunningInstancesVisibleForFlowNode,
   useTotalRunningInstancesVisibleForFlowNodes,
 };

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {hasMultipleScopes} from './processInstanceDetailsDiagram';
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+describe('hasMultipleScopes', () => {
+  it('should return false if parentFlowNode is undefined', () => {
+    const result = hasMultipleScopes(undefined, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false if totalRunningInstancesByFlowNode is undefined', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+    };
+    const result = hasMultipleScopes(parentFlowNode, undefined);
+    expect(result).toBe(false);
+  });
+
+  it('should return false if totalRunningInstancesByFlowNode does not contain the parentFlowNode id', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+    };
+    const result = hasMultipleScopes(parentFlowNode, {});
+    expect(result).toBe(false);
+  });
+
+  it('should return false if the scope count is 0 or undefined', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+    };
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+    };
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true if the scope count is greater than 1', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+    };
+    const totalRunningInstancesByFlowNode = {
+      node1: 2,
+    };
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return false if the parentFlowNode has no parent and scope count is not greater than 1', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+      $parent: undefined,
+    };
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+    };
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true if a parent in the hierarchy has a scope count greater than 1', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:Process',
+      $parent: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:SubProcess',
+        $parent: {
+          id: 'node3',
+          name: 'Node 3',
+          $type: 'bpmn:SubProcess',
+          $parent: undefined,
+        },
+      },
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+      node2: 0,
+      node3: 2, // Parent node3 has a scope count greater than 1
+    };
+
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return false if no parent in the hierarchy has a scope count greater than 1', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:Process',
+      $parent: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:SubProcess',
+        $parent: {
+          id: 'node3',
+          name: 'Node 3',
+          $type: 'bpmn:SubProcess',
+          $parent: undefined,
+        },
+      },
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+      node2: 0,
+      node3: 0, // No parent has a scope count greater than 1
+    };
+
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should stop checking parents if a non-SubProcess parent is encountered', () => {
+    const parentFlowNode: BusinessObject = {
+      id: 'node1',
+      name: 'Node 1',
+      $type: 'bpmn:SequenceFlow',
+      $parent: {
+        id: 'node2',
+        name: 'Node 2',
+        $type: 'bpmn:SequenceFlow',
+        $parent: {
+          id: 'node3',
+          name: 'Node 3',
+          $type: 'bpmn:SubProcess',
+          $parent: undefined,
+        },
+      },
+    };
+
+    const totalRunningInstancesByFlowNode = {
+      node1: 0,
+      node2: 2, // This node is not a SubProcess, so it should not be checked
+      node3: 0,
+    };
+
+    const result = hasMultipleScopes(
+      parentFlowNode,
+      totalRunningInstancesByFlowNode,
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+const hasMultipleScopes = (
+  parentFlowNode?: BusinessObject,
+  totalRunningInstancesByFlowNode?: Record<string, number>,
+): boolean => {
+  if (parentFlowNode === undefined) {
+    return false;
+  }
+
+  const totalRunningInstancesCount =
+    totalRunningInstancesByFlowNode?.[parentFlowNode.id];
+
+  const scopeCount = totalRunningInstancesCount ?? 0;
+
+  if (scopeCount > 1) {
+    return true;
+  }
+
+  if (parentFlowNode.$parent?.$type !== 'bpmn:SubProcess') {
+    return false;
+  }
+
+  return hasMultipleScopes(
+    parentFlowNode.$parent,
+    totalRunningInstancesByFlowNode,
+  );
+};
+
+export {hasMultipleScopes};


### PR DESCRIPTION
## Description

As we migrated statistics stores to use tanstack query (Milestone 1), we've introduced dependencies on `processInstanceDetailsDiagramStore` which is itself being removed (Milestone 0).
As a result, Milestone 0 work has become more complex. This PR is removing dependencies from hooks.

## Related issues

related to #30591