### PR TITLE
ci: adding affected version to issue templates and labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: <!-- Affected version -->
       multiple: true
-      description: Which version is affected?
+      description: Which version is affected? (You can select more than one)
       options:
         - <!-- -8.3 -->
         - <!-- -8.4 -->

--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -20,6 +20,21 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: affected-version
+    attributes:
+      label: <!-- Affected version -->
+      description: Which version is affected?
+      options:
+        - <!-- -8.3 -->
+        - <!-- -8.4 -->
+        - <!-- -8.5 -->
+        - <!-- -8.6 -->
+        - <!-- -8.7 -->
+        - <!-- -8.8 -->
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
     id: severity
     attributes:
       label: <!-- Severity -->

--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report a problem and help us fix it.
 labels: ["kind/bug"]
+type: bug
 body:
   - type: dropdown
     id: Component
@@ -16,13 +17,14 @@ body:
         - <!-- Zeebe- -->
         - <!-- C8Run- -->
         - <!-- Feel- -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: dropdown
     id: affected-version
     attributes:
       label: <!-- Affected version -->
+      multiple: true
       description: Which version is affected?
       options:
         - <!-- -8.3 -->
@@ -31,7 +33,7 @@ body:
         - <!-- -8.6 -->
         - <!-- -8.7 -->
         - <!-- -8.8 -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: dropdown
@@ -44,7 +46,7 @@ body:
         - <!-- Medium- -->
         - <!-- High- -->
         - <!-- Critical- -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: dropdown
@@ -57,7 +59,7 @@ body:
         - <!-- Low_ -->
         - <!-- Medium_ -->
         - <!-- High_ -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2. feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2. feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature Request
 description: Suggest an idea or a general improvement.
 labels: ["kind/feature"]
+type: feature
 body:
   - type: dropdown
     id: Component
@@ -16,7 +17,7 @@ body:
         - <!-- Zeebe- -->
         - <!-- C8Run- -->
         - <!-- Feel- -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/3. task.yml
+++ b/.github/ISSUE_TEMPLATE/3. task.yml
@@ -1,6 +1,7 @@
 name: Task
 description: Describe a generic activity we should carry out.
 labels: ["kind/task"]
+type: task
 body:
   - type: dropdown
     id: Component
@@ -16,7 +17,7 @@ body:
         - <!-- Zeebe- -->
         - <!-- C8Run- -->
         - <!-- Feel- -->
-      default: 0
+      default: null
     validations:
       required: true
   - type: textarea

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -32,3 +32,15 @@ likelihood/low:
   '(Low_)'
 likelihood/unknown:
   '(Unknown_)'
+affects/8.3:
+  - '(-8.3)'
+affects/8.4:
+  - '(-8.4)'
+affects/8.5:
+  - '(-8.5)'
+affects/8.6:
+  - '(-8.6)'
+affects/8.7:
+  - '(-8.7)'
+affects/8.8:
+  - '(-8.8)'


### PR DESCRIPTION
## Description

adding affected version drop down selection to issue templates and modifying labeler to add labels automatically.

Includes some minor fixes for all of the templates as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
