### PR TITLE
feat: migrate ModificationDropdown (getFlowNodeName) to v2 REST API

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -26,6 +26,9 @@ import {
   Button,
   InlineLoading,
 } from './styled';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {getFlowNodeName} from 'modules/utils/flowNodes';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -38,6 +41,11 @@ const ModificationDropdown: React.FC<Props> = observer(
     const flowNodeInstanceId =
       flowNodeSelectionStore.state.selection?.flowNodeInstanceId ??
       flowNodeMetaDataStore.state.metaData?.flowNodeInstanceId;
+
+    const processDefinitionKey = useProcessDefinitionKeyContext();
+    const {data: processDefinitionData} = useProcessInstanceXml({
+      processDefinitionKey,
+    });
 
     if (
       flowNodeId === undefined ||
@@ -113,9 +121,12 @@ const ModificationDropdown: React.FC<Props> = observer(
                                 scopeId: generateUniqueID(),
                                 flowNode: {
                                   id: flowNodeId,
-                                  name: processInstanceDetailsDiagramStore.getFlowNodeName(
-                                    flowNodeId,
-                                  ),
+                                  name:
+                                    getFlowNodeName({
+                                      diagramModel:
+                                        processDefinitionData?.diagramModel,
+                                      flowNodeId,
+                                    }) ?? '',
                                 },
                                 affectedTokenCount: 1,
                                 visibleAffectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
@@ -23,6 +23,7 @@ import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetc
 import {incidentFlowNodeMetaData} from 'modules/mocks/metadata';
 import {open} from 'modules/mocks/diagrams';
 import {act} from 'react';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('Modification Dropdown', () => {
   beforeEach(() => {
@@ -86,6 +87,9 @@ describe('Modification Dropdown', () => {
     ]);
 
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
     modificationsStore.enableModificationMode();
   });
 
@@ -275,7 +279,9 @@ describe('Modification Dropdown', () => {
     ]);
 
     mockFetchProcessXML().withSuccess(mockProcessWithEventBasedGateway);
-
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithEventBasedGateway,
+    );
     renderPopover();
 
     await waitFor(() =>

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mocks.tsx
@@ -19,6 +19,9 @@ import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInsta
 import {modificationsStore} from 'modules/stores/modifications';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {Paths} from 'modules/Routes';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => {
@@ -28,9 +31,13 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   }, []);
 
   return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      {children}
-    </MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          {children}
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
@@ -16,10 +16,15 @@ import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/proces
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {act} from 'react';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('Modification Dropdown - Multi Scopes', () => {
   beforeEach(() => {
     mockFetchProcessXML().withSuccess(open('multipleInstanceSubProcess.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('multipleInstanceSubProcess.bpmn'),
+    );
+
     modificationsStore.enableModificationMode();
   });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/selectedRunningInstanceCount.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/selectedRunningInstanceCount.test.tsx
@@ -14,6 +14,7 @@ import {renderPopover} from './mocks';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {open} from 'modules/mocks/diagrams';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('selectedRunningInstanceCount', () => {
   beforeEach(() => {
@@ -70,6 +71,9 @@ describe('selectedRunningInstanceCount', () => {
     ]);
 
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
   });
 
   it('should not render when there are no running instances selected', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -214,7 +214,7 @@ describe('Modification Dropdown', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+    expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
     expect(screen.getByText(/Move/)).toBeInTheDocument();
     expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
   });
@@ -357,6 +357,9 @@ describe('Modification Dropdown', () => {
 
   it('should not support move operation for sub processes', async () => {
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithEventBasedGateway,
+    );
 
     renderPopover();
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
@@ -36,6 +36,9 @@ import {
 import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
 import {generateParentScopeIds} from 'modules/utils/modifications';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {getFlowNodeName} from 'modules/utils/flowNodes';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -60,6 +63,11 @@ const ModificationDropdown: React.FC<Props> = observer(
       selectedRunningInstanceCount,
     );
     const canBeModified = useCanBeModified();
+
+    const processDefinitionKey = useProcessDefinitionKeyContext();
+    const {data: processDefinitionData} = useProcessInstanceXml({
+      processDefinitionKey,
+    });
 
     if (
       flowNodeId === undefined ||
@@ -133,8 +141,11 @@ const ModificationDropdown: React.FC<Props> = observer(
                                   flowNode: {
                                     id: flowNodeId,
                                     name:
-                                      businessObjects[flowNodeId]?.name ||
-                                      flowNodeId,
+                                      getFlowNodeName({
+                                        diagramModel:
+                                          processDefinitionData?.diagramModel,
+                                        flowNodeId,
+                                      }) ?? '',
                                   },
                                   affectedTokenCount: 1,
                                   visibleAffectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/mocks.tsx
@@ -116,26 +116,31 @@ function getWrapper(options?: {
     }, []);
 
     return (
-      <ProcessDefinitionKeyContext.Provider value="123">
-        <QueryClientProvider client={getMockQueryClient()}>
-          <HistoryRouter
-            history={createMemoryHistory({
-              initialEntries: [initialPath],
-            })}
-            basename={contextPath ?? ''}
-          >
-            <Routes>
-              <Route path={Paths.processInstance()} element={children} />
-              <Route path={Paths.processes()} element={<>instances page</>} />
-              <Route path={Paths.dashboard()} element={<>dashboard page</>} />
-            </Routes>
-            {selectableFlowNode && (
-              <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
-            )}
-            <LocationLog />
-          </HistoryRouter>
-        </QueryClientProvider>
-      </ProcessDefinitionKeyContext.Provider>
+      <HistoryRouter
+        history={createMemoryHistory({
+          initialEntries: [initialPath],
+        })}
+        basename={contextPath ?? ''}
+      >
+        <Routes>
+          <Route
+            path={Paths.processInstance()}
+            element={
+              <ProcessDefinitionKeyContext.Provider value="123">
+                <QueryClientProvider client={getMockQueryClient()}>
+                  {children}
+                </QueryClientProvider>
+              </ProcessDefinitionKeyContext.Provider>
+            }
+          />
+          <Route path={Paths.processes()} element={<>instances page</>} />
+          <Route path={Paths.dashboard()} element={<>dashboard page</>} />
+        </Routes>
+        {selectableFlowNode && (
+          <FlowNodeSelector selectableFlowNode={selectableFlowNode} />
+        )}
+        <LocationLog />
+      </HistoryRouter>
     );
   };
 

--- a/operate/client/src/App/ProcessInstance/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/mocks.tsx
@@ -46,6 +46,8 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('4294980768');
 
@@ -54,7 +56,7 @@ const mockRequests = (contextPath: string = '') => {
     testData.fetch.onPageLoad.processInstanceWithIncident,
   );
   mockFetchProcessXML(contextPath).withSuccess('');
-  mockFetchProcessDefinitionXml().withSuccess('');
+  mockFetchProcessDefinitionXml({contextPath}).withSuccess('');
   mockFetchSequenceFlows(contextPath).withSuccess(mockSequenceFlows);
   mockFetchFlowNodeInstances(contextPath).withSuccess(
     processInstancesMock.level1,
@@ -74,6 +76,7 @@ const mockRequests = (contextPath: string = '') => {
     count: 2,
   });
   mockFetchProcess(contextPath).withSuccess(mockProcess);
+  mockFetchProcessInstanceListeners(contextPath).withSuccess(noListeners);
 };
 
 type FlowNodeSelectorProps = {


### PR DESCRIPTION
## Description

Partially migrate ModificationDropdown to v2 REST API

- Add useProcessInstanceXml to ModificationDropdown
- Use getFlowNodeName util
- Remove dependency to `processInstanceDetailsDiagramStore.getFlowNodeName`
- Adjust tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
