### PR TITLE
feat: migrate ModificationDropdown (getParentElement) to V2 API

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -29,6 +29,7 @@ import {
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
+import {getParentElement} from 'modules/bpmn-js/utils/getParentElement';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -101,11 +102,14 @@ const ModificationDropdown: React.FC<Props> = observer(
                         size="sm"
                         renderIcon={Add}
                         onClick={() => {
+                          const parentElement = getParentElement(
+                            processDefinitionData?.businessObjects?.[
+                              flowNodeId
+                            ],
+                          );
                           if (
                             processInstanceDetailsDiagramStore.hasMultipleScopes(
-                              processInstanceDetailsDiagramStore.getParentFlowNode(
-                                flowNodeId,
-                              ),
+                              parentElement,
                             )
                           ) {
                             modificationsStore.startAddingToken(flowNodeId);

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -358,16 +358,10 @@ describe('Modification Dropdown', () => {
   it('should not support move operation for sub processes', async () => {
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
-      mockProcessWithEventBasedGateway,
+      open('diagramForModifications.bpmn'),
     );
 
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
@@ -379,9 +373,9 @@ describe('Modification Dropdown', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Add/)).toBeInTheDocument();
+    expect(await screen.findByText(/Add/)).toBeInTheDocument();
+    expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
     expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Cancel/)).toBeInTheDocument();
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
@@ -39,6 +39,7 @@ import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusiness
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
+import {getParentElement} from 'modules/bpmn-js/utils/getParentElement';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -121,9 +122,14 @@ const ModificationDropdown: React.FC<Props> = observer(
                           size="sm"
                           renderIcon={Add}
                           onClick={() => {
+                            const parentElement = getParentElement(
+                              processDefinitionData?.businessObjects?.[
+                                flowNodeId
+                              ],
+                            );
                             if (
                               hasMultipleScopes(
-                                businessObjects[flowNodeId]?.$parent,
+                                parentElement,
                                 totalRunningInstancesByFlowNode,
                               )
                             ) {

--- a/operate/client/src/modules/bpmn-js/utils/getParentElement.test.ts
+++ b/operate/client/src/modules/bpmn-js/utils/getParentElement.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {getParentElement} from './getParentElement';
+
+const parentElement: BusinessObject = {
+  id: 'subProcess',
+  name: 'Sub Process',
+  $type: 'bpmn:SubProcess',
+};
+
+const element: BusinessObject = {
+  id: 'task',
+  name: 'Task',
+  $type: 'bpmn:ServiceTask',
+  $parent: parentElement,
+};
+
+describe('getParentElement', () => {
+  it('should return the parent element when a valid child element is provided', () => {
+    const result = getParentElement(element);
+
+    expect(result).toEqual(parentElement);
+  });
+
+  it('should return undefined when the child element has no parent', () => {
+    const result = getParentElement(parentElement);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when the input is undefined', () => {
+    expect(getParentElement(undefined)).toBeUndefined();
+  });
+});

--- a/operate/client/src/modules/bpmn-js/utils/getParentElement.ts
+++ b/operate/client/src/modules/bpmn-js/utils/getParentElement.ts
@@ -8,8 +8,7 @@
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 
-const getParentElement = (businessObject?: BusinessObject) => {
-  return businessObject?.$parent;
-};
+const getParentElement = (businessObject?: BusinessObject) =>
+  businessObject?.$parent;
 
 export {getParentElement};

--- a/operate/client/src/modules/bpmn-js/utils/getParentElement.ts
+++ b/operate/client/src/modules/bpmn-js/utils/getParentElement.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+
+const getParentElement = (businessObject?: BusinessObject) => {
+  return businessObject?.$parent;
+};
+
+export {getParentElement};

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
@@ -271,11 +271,6 @@ class ProcessInstanceDetailsDiagram extends NetworkReconnectionHandler {
     return isMultiInstance(businessObject);
   };
 
-  getParentFlowNode = (flowNodeId: string) => {
-    const businessObject = this.businessObjects[flowNodeId];
-    return businessObject?.$parent;
-  };
-
   handleFetchFailure = (error?: unknown) => {
     this.state.status = 'error';
   };

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
@@ -491,29 +491,4 @@ describe('stores/processInstanceDiagram', () => {
       }),
     ).toBe(true);
   });
-
-  it('should get parent flow node', async () => {
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
-
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
-    expect(
-      processInstanceDetailsDiagramStore.getParentFlowNode(
-        'subprocess-service-task',
-      ),
-    ).toEqual({
-      $type: 'bpmn:SubProcess',
-      flowElements: [
-        {$type: 'bpmn:StartEvent', id: 'subprocess-start-1'},
-        {$type: 'bpmn:SequenceFlow', id: 'Flow_1vur7mf'},
-        {$type: 'bpmn:EndEvent', id: 'subprocess-end-task'},
-        {$type: 'bpmn:SequenceFlow', id: 'Flow_0r3hsrs'},
-        {$type: 'bpmn:ServiceTask', id: 'subprocess-service-task'},
-      ],
-      id: 'multi-instance-subprocess',
-      loopCharacteristics: {$type: 'bpmn:MultiInstanceLoopCharacteristics'},
-    });
-  });
 });


### PR DESCRIPTION
## Description

Partially migrate ModificationDropdown to v2 REST API

- Use getParentElement util
- Remove dependency to processInstanceDetailsDiagramStore.getParentFlowNode
- Remove processInstanceDetailsDiagramStore.getParentFlowNode

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
