### PR TITLE
Remove default value from `groupId` property

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -22,7 +22,7 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
   private final StringProperty nameProp = new StringProperty("name");
 
   public PersistedGroup() {
-    super(3);
+    super(4);
     declareProperty(groupKeyProp)
         .declareProperty(groupIdProp)
         .declareProperty(descriptionProp)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -18,16 +18,21 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   private final LongProperty groupKeyProp = new LongProperty("groupKey");
   private final StringProperty groupIdProp = new StringProperty("groupId");
+  private final StringProperty descriptionProp = new StringProperty("description");
   private final StringProperty nameProp = new StringProperty("name");
 
   public PersistedGroup() {
     super(3);
-    declareProperty(groupKeyProp).declareProperty(groupIdProp).declareProperty(nameProp);
+    declareProperty(groupKeyProp)
+        .declareProperty(groupIdProp)
+        .declareProperty(descriptionProp)
+        .declareProperty(nameProp);
   }
 
   public void wrap(final GroupRecord group) {
     groupKeyProp.setValue(group.getGroupKey());
     groupIdProp.setValue(group.getGroupId());
+    descriptionProp.setValue(group.getDescription());
     nameProp.setValue(group.getNameBuffer());
   }
 
@@ -46,6 +51,15 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   public PersistedGroup setGroupId(final String groupId) {
     groupIdProp.setValue(groupId);
+    return this;
+  }
+
+  public String getDescription() {
+    return BufferUtil.bufferAsString(descriptionProp.getValue());
+  }
+
+  public PersistedGroup setDescription(final String description) {
+    descriptionProp.setValue(description);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -37,7 +37,9 @@ public class GroupStateTest {
     // given
     final var groupId = "1";
     final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
+    final var description = "description";
+    final var groupRecord =
+        new GroupRecord().setGroupId(groupId).setName(groupName).setDescription(description);
 
     // when
     groupState.create(groupRecord);
@@ -47,6 +49,7 @@ public class GroupStateTest {
     assertThat(group.isPresent()).isTrue();
     final var persistedGroup = group.get();
     assertThat(persistedGroup.getName()).isEqualTo(groupName);
+    assertThat(persistedGroup.getDescription()).isEqualTo(description);
   }
 
   @Test
@@ -81,6 +84,29 @@ public class GroupStateTest {
     final var persistedGroup = group.get();
     assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
     assertThat(persistedGroup.getGroupId()).isEqualTo(groupId);
+  }
+
+  @Test
+  void shouldUpdateGroupDescription() {
+    // given
+    final var groupId = "1";
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
+    groupState.create(groupRecord);
+
+    final var updatedDescription = "updatedDescription";
+    groupRecord.setDescription(updatedDescription);
+
+    // when
+    groupState.update(groupRecord);
+
+    // then
+    final var group = groupState.get(groupId);
+    assertThat(group.isPresent()).isTrue();
+    final var persistedGroup = group.get();
+    assertThat(persistedGroup.getDescription()).isEqualTo(updatedDescription);
+    assertThat(persistedGroup.getGroupId()).isEqualTo(groupId);
+    assertThat(persistedGroup.getName()).isEqualTo(groupName);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -58,7 +58,7 @@ public class GroupControllerTest extends RestControllerTest {
     when(groupServices.createGroup(createGroupRequest))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new GroupRecord().setEntityId("entityId").setName(groupName)));
+                new GroupRecord().setGroupId(groupId).setEntityId("entityId").setName(groupName)));
 
     // when
     webClient

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -20,8 +20,7 @@ import org.agrona.DirectBuffer;
 public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue {
 
   private final LongProperty groupKeyProp = new LongProperty("groupKey", -1L);
-  // TODO remove default empty string https://github.com/camunda/camunda/issues/30139
-  private final StringProperty groupId = new StringProperty("groupId", "");
+  private final StringProperty groupId = new StringProperty("groupId");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
   private final StringProperty entityIdProp = new StringProperty("entityId", "");

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2990,11 +2990,11 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty GroupRecord",
-        (Supplier<GroupRecord>) GroupRecord::new,
+        (Supplier<GroupRecord>) () -> new GroupRecord().setGroupId("groupId"),
         """
       {
         "groupKey": -1,
-        "groupId": "",
+        "groupId": "groupId",
         "name": "",
         "description": "",
         "entityId": "",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The `groupId` should be always set. If not an error should be raised.
This PR also adds the `description` property in the persisted group object stored in the state

## Related issues

closes #30139 
