### PR TITLE
feat: add support for RESOLVE_INCIDENT to engine core #29880

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemKeyProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemKeyProvider.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import com.google.common.collect.Lists;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.FilterBase;
+import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPageBuilders;
+import io.camunda.search.query.SearchQueryBuilders;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides methods to fetch entity keys for batch operations. It uses the search client
+ * proxy to access the secondary database.
+ */
+public class BatchOperationItemKeyProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationItemKeyProvider.class);
+
+  /**
+   * The size of a page when fetching entity keys. This is the maximum number of keys that can be
+   * fetched in a single query and is limited by ElasticSearch.
+   */
+  private static final int PAGE_SIZE = 10000;
+
+  /**
+   * The maximum number of keys that can be passed in a single IN clause in a query. This is limited
+   * to 1000 because the Oracle DB supports a maximum of 1000 elements in an IN clause.
+   */
+  private static final int IN_CLAUSE_SIZE = 1000;
+
+  private final SearchClientsProxy searchClientsProxy;
+
+  public BatchOperationItemKeyProvider(final SearchClientsProxy searchClientsProxy) {
+    this.searchClientsProxy = searchClientsProxy;
+  }
+
+  /**
+   * Fetches the process instance keys based on the provided filter. The keys are fetched
+   * sequentially in pages. Depending on the overall size of the result this can cause multiple
+   * queries to the secondary database.
+   *
+   * @param filter the filter to use
+   * @param shouldAbort if the process should be aborted
+   * @return a set of all found process instance keys
+   */
+  public Set<Long> fetchProcessInstanceKeys(
+      final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
+    return fetchEntityKeys(new ProcessInstanceKeyPageFetcher(), filter, shouldAbort);
+  }
+
+  /**
+   * Fetches the incident keys based on the provided incident filter. The keys are fetched
+   * sequentially in pages. Depending on the overall size of the result this can cause multiple
+   * queries to the secondary database.
+   *
+   * @param filter the filter to use
+   * @param shouldAbort if the process should be aborted
+   * @return a set of all found process instance keys
+   */
+  public Set<Long> fetchIncidentKeys(
+      final IncidentFilter filter, final Supplier<Boolean> shouldAbort) {
+    return fetchEntityKeys(new IncidentKeyPageFetcher(), filter, shouldAbort);
+  }
+
+  /**
+   * Fetches the incident keys based on the provided process instance filter. This will return
+   * <b>ALL</b> incidents of the matching processInstances. The keys are fetched sequentially in
+   * pages. Depending on the overall size of the result this can cause multiple queries to the
+   * secondary database.
+   *
+   * @param filter the filter to use
+   * @param shouldAbort if the process should be aborted
+   * @return a set of all found process instance keys
+   */
+  public Set<Long> fetchIncidentKeys(
+      final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
+    // first fetch all matching processInstances
+    final var processInstanceKeys = fetchProcessInstanceKeys(filter, shouldAbort);
+
+    // then fetch all incidents of the matching processInstances
+    return getIncidentKeysOfProcessInstanceKeys(new ArrayList<>(processInstanceKeys), shouldAbort);
+  }
+
+  private <F extends FilterBase> Set<Long> fetchEntityKeys(
+      final ItemKeyPageFetcher<F> itemKeyPageFetcher,
+      final F filter,
+      final Supplier<Boolean> shouldAbort) {
+    final var itemKeys = new LinkedHashSet<Long>();
+
+    Object[] searchValues = null;
+    while (true) {
+      // Check if the batch operation is still present, could be canceled in the meantime
+      if (shouldAbort.get()) {
+        LOG.warn("Batch operation is no longer active, stopping query.");
+        return Set.of();
+      }
+
+      final var result = itemKeyPageFetcher.fetchKeys(filter, searchValues);
+      itemKeys.addAll(result.keys);
+      searchValues = result.lastSortValues();
+
+      if (itemKeys.size() >= result.total() || result.keys.isEmpty()) {
+        break;
+      }
+    }
+
+    return itemKeys;
+  }
+
+  private Set<Long> getIncidentKeysOfProcessInstanceKeys(
+      final List<Long> processInstanceKeys, final Supplier<Boolean> shouldAbort) {
+    final Set<Long> incidentKeys = new HashSet<>();
+
+    final List<List<Long>> processInstanceKeysBatches =
+        Lists.partition(processInstanceKeys, IN_CLAUSE_SIZE);
+
+    for (final List<Long> processInstanceKeysBatch : processInstanceKeysBatches) {
+      if (shouldAbort.get()) {
+        return Set.of();
+      }
+      final var filter =
+          new IncidentFilter.Builder().processInstanceKeys(processInstanceKeysBatch).build();
+      incidentKeys.addAll(fetchIncidentKeys(filter, shouldAbort));
+    }
+
+    return incidentKeys;
+  }
+
+  /**
+   * Internal abstraction to hold the result of a page of entity keys.
+   *
+   * @param keys the fetched keys
+   * @param lastSortValues the last sortValues for pagination
+   * @param total the total amount of found keys
+   */
+  private record ItemKeyPage(List<Long> keys, Object[] lastSortValues, long total) {}
+
+  /**
+   * Internal abstraction interface to get a single page of entity keys of a specific type. This is
+   * needed because the actual query to the secondary database is different for specific entity
+   * types.
+   *
+   * @param <F> the filter type
+   */
+  private interface ItemKeyPageFetcher<F extends FilterBase> {
+
+    /**
+     * Fetches a page of entity keys based on the provided filter and search values.
+     *
+     * @param filter the filter to apply
+     * @param sortValues the current sortValues
+     * @return the fetched keys and pagination information
+     */
+    ItemKeyPage fetchKeys(F filter, Object[] sortValues);
+  }
+
+  private final class ProcessInstanceKeyPageFetcher
+      implements ItemKeyPageFetcher<ProcessInstanceFilter> {
+    @Override
+    public ItemKeyPage fetchKeys(final ProcessInstanceFilter filter, final Object[] sortValues) {
+      final var page =
+          SearchQueryPageBuilders.page().size(PAGE_SIZE).searchAfter(sortValues).build();
+      final var query =
+          SearchQueryBuilders.processInstanceSearchQuery()
+              .filter(filter)
+              .page(page)
+              .resultConfig(c -> c.onlyKey(true))
+              .build();
+      final var result = searchClientsProxy.searchProcessInstances(query);
+      return new ItemKeyPage(
+          result.items().stream()
+              .map(ProcessInstanceEntity::processInstanceKey)
+              .collect(Collectors.toList()),
+          result.lastSortValues(),
+          result.total());
+    }
+  }
+
+  private final class IncidentKeyPageFetcher implements ItemKeyPageFetcher<IncidentFilter> {
+    @Override
+    public ItemKeyPage fetchKeys(final IncidentFilter filter, final Object[] sortValues) {
+      final var page =
+          SearchQueryPageBuilders.page().size(PAGE_SIZE).searchAfter(sortValues).build();
+      final var query = SearchQueryBuilders.incidentSearchQuery().filter(filter).page(page).build();
+      final var result = searchClientsProxy.searchIncidents(query);
+      return new ItemKeyPage(
+          result.items().stream().map(IncidentEntity::incidentKey).collect(Collectors.toList()),
+          result.lastSortValues(),
+          result.total());
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/BatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/BatchOperationExecutor.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.handlers;
+
+public interface BatchOperationExecutor {
+
+  void handle(long entityKey, long batchOperationKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.handlers;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CancelProcessInstanceBatchOperationExecutor implements BatchOperationExecutor {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CancelProcessInstanceBatchOperationExecutor.class);
+
+  final TypedCommandWriter commandWriter;
+
+  public CancelProcessInstanceBatchOperationExecutor(final TypedCommandWriter commandWriter) {
+    this.commandWriter = commandWriter;
+  }
+
+  @Override
+  public void handle(final long processInstanceKey, final long batchOperationKey) {
+    LOGGER.info("Cancelling process instance with key '{}'", processInstanceKey);
+
+    final var command = new ProcessInstanceRecord();
+    command.setProcessInstanceKey(processInstanceKey);
+    commandWriter.appendFollowUpCommand(
+        processInstanceKey, ProcessInstanceIntent.CANCEL, command, batchOperationKey);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.handlers;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.immutable.IncidentState;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResolveIncidentBatchOperationExecutor implements BatchOperationExecutor {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ResolveIncidentBatchOperationExecutor.class);
+
+  final TypedCommandWriter commandWriter;
+  final IncidentState incidentState;
+
+  public ResolveIncidentBatchOperationExecutor(
+      final TypedCommandWriter commandWriter, final IncidentState incidentState) {
+    this.commandWriter = commandWriter;
+    this.incidentState = incidentState;
+  }
+
+  @Override
+  public void handle(final long incidentKey, final long batchOperationKey) {
+    final var incident = incidentState.getIncidentRecord(incidentKey);
+    if (incidentState.isJobIncident(incident)) {
+      LOGGER.info("Increasing retries for job with key '{}'", incident.getJobKey());
+      final var jobRecord = new JobRecord().setRetries(1);
+      commandWriter.appendFollowUpCommand(
+          incident.getJobKey(), JobIntent.UPDATE_RETRIES, jobRecord);
+    }
+
+    LOGGER.info("Resolving incident with key '{}'", incidentKey);
+    final var command = new IncidentRecord();
+    commandWriter.appendFollowUpCommand(
+        incidentKey, IncidentIntent.RESOLVE, command, batchOperationKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -9,14 +9,11 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static io.camunda.zeebe.engine.processing.batchoperation.BatchOperationExecutionScheduler.CHUNK_SIZE_IN_RECORD;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.PROCESS_CANCELLATION;
+import static io.camunda.zeebe.protocol.record.value.BatchOperationType.RESOLVE_INCIDENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.search.query.ProcessInstanceQuery;
-import io.camunda.search.query.SearchQueryResult;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState.BatchOperationVisitor;
@@ -32,7 +29,8 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class BatchOperationExecutionSchedulerTest {
 
   @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
-  @Mock private SearchClientsProxy searchClientsProxy;
+  @Mock private BatchOperationItemKeyProvider entityKeyProvider;
   @Mock private TaskResultBuilder taskResultBuilder;
   @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
   @Mock private ProcessingScheduleService scheduleService;
@@ -55,7 +53,6 @@ public class BatchOperationExecutionSchedulerTest {
   @Mock private PersistedBatchOperation batchOperation;
 
   @Captor private ArgumentCaptor<Task> taskCaptor;
-  @Captor private ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
   @Captor private ArgumentCaptor<BatchOperationChunkRecord> chunkRecordCaptor;
 
   private BatchOperationExecutionScheduler scheduler;
@@ -80,7 +77,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, searchClientsProxy, Duration.ofSeconds(1));
+            scheduledTaskStateFactory, entityKeyProvider, Duration.ofSeconds(1));
   }
 
   @Test
@@ -109,17 +106,11 @@ public class BatchOperationExecutionSchedulerTest {
 
   @Test
   public void shouldAppendChunkForBatchOperations() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
+
     // given
-    final var result =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(
-                List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L)))
-            .total(3)
-            .build();
-    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture())).thenReturn(result);
+    when(entityKeyProvider.fetchProcessInstanceKeys(queryCaptor.capture(), any()))
+        .thenReturn(Set.of(1L, 2L, 3L));
 
     // when our scheduler fires
     execute();
@@ -137,28 +128,13 @@ public class BatchOperationExecutionSchedulerTest {
   }
 
   @Test
-  public void shouldQueryMultipleTimesIfTotalIsHigher() {
+  public void shouldAppendChunkOfIncidents() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
+    when(batchOperation.getBatchOperationType()).thenReturn(RESOLVE_INCIDENT);
+
     // given
-    final var result =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(
-                List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L)))
-            .total(6)
-            .build();
-    final var result2 =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(
-                List.of(
-                    mockProcessInstanceEntity(4L),
-                    mockProcessInstanceEntity(5L),
-                    mockProcessInstanceEntity(6L)))
-            .total(6)
-            .build();
-    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
-        .thenReturn(result, result2);
+    when(entityKeyProvider.fetchIncidentKeys(queryCaptor.capture(), any()))
+        .thenReturn(Set.of(1L, 2L, 3L));
 
     // when our scheduler fires
     execute();
@@ -172,40 +148,17 @@ public class BatchOperationExecutionSchedulerTest {
         .appendCommandRecord(
             anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
     final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
-    assertThat(batchOperationChunkRecord.getItemKeys().size()).isEqualTo(6);
-  }
-
-  @Test
-  public void shouldNotQueryOfBatchIsNotLongerActive() {
-    // given
-    when(batchOperationState.exists(anyLong())).thenReturn(false);
-
-    // when our scheduler fires
-    execute();
-
-    // then
-    verify(batchOperationState).foreachPendingBatchOperation(any());
-    verify(taskResultBuilder)
-        .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
-    verify(taskResultBuilder, never())
-        .appendCommandRecord(anyLong(), eq(BatchOperationChunkIntent.CREATE), any());
+    assertThat(batchOperationChunkRecord.getItemKeys().size()).isEqualTo(3);
   }
 
   @Test
   public void shouldCreateMultipleChunks() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
+
     // given
-    final var queryItems =
-        LongStream.range(0, CHUNK_SIZE_IN_RECORD * 2)
-            .boxed()
-            .map(this::mockProcessInstanceEntity)
-            .toList();
-    final var result =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(queryItems)
-            .total(queryItems.size())
-            .build();
-    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture())).thenReturn(result);
+    final var queryItemKeys = LongStream.range(0, CHUNK_SIZE_IN_RECORD * 2).boxed().toList();
+    when(entityKeyProvider.fetchProcessInstanceKeys(queryCaptor.capture(), any()))
+        .thenReturn(new HashSet<>(queryItemKeys));
 
     // when our scheduler fires
     execute();
@@ -218,8 +171,6 @@ public class BatchOperationExecutionSchedulerTest {
     verify(taskResultBuilder, times(2))
         .appendCommandRecord(
             anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
-    final var queryItemKeys =
-        queryItems.stream().map(ProcessInstanceEntity::processInstanceKey).toList();
     var batchOperationChunkRecord = chunkRecordCaptor.getAllValues().get(0);
     assertThat(batchOperationChunkRecord.getItemKeys().size()).isEqualTo(CHUNK_SIZE_IN_RECORD);
     assertThat(batchOperationChunkRecord.getItemKeys())
@@ -236,13 +187,11 @@ public class BatchOperationExecutionSchedulerTest {
 
   @Test
   public void shouldRescheduleAtTheEndOfExecution() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
+
     // given
-    final var result =
-        new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(List.of(mockProcessInstanceEntity(1L)))
-            .total(1)
-            .build();
-    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture())).thenReturn(result);
+    when(entityKeyProvider.fetchProcessInstanceKeys(queryCaptor.capture(), any()))
+        .thenReturn(Set.of(1L));
 
     // when our scheduler fires
     execute();
@@ -262,11 +211,5 @@ public class BatchOperationExecutionSchedulerTest {
     when(scheduledTaskStateFactory.get().getBatchOperationState()).thenReturn(batchOperationState);
     when(streamProcessorContext.getScheduleService()).thenReturn(scheduleService);
     when(scheduleService.runDelayedAsync(any(), taskCaptor.capture(), any())).thenReturn(null);
-  }
-
-  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemKeyProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemKeyProviderTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BatchOperationItemKeyProviderTest {
+
+  private final SearchClientsProxy searchClientsProxy = mock(SearchClientsProxy.class);
+
+  private final BatchOperationItemKeyProvider provider =
+      new BatchOperationItemKeyProvider(searchClientsProxy);
+
+  @Test
+  public void shouldFetchProcessInstanceKeys() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(1L),
+                    mockProcessInstanceEntity(2L),
+                    mockProcessInstanceEntity(3L)))
+            .total(3)
+            .build();
+    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture())).thenReturn(result);
+
+    // when
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var resultKeys = provider.fetchProcessInstanceKeys(filter, () -> false);
+
+    // then
+    assertThat(resultKeys).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  public void shouldFetchProcessInstanceKeysInMultiplePages() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(1L),
+                    mockProcessInstanceEntity(2L),
+                    mockProcessInstanceEntity(3L)))
+            .total(6)
+            .build();
+    final var result2 =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(4L),
+                    mockProcessInstanceEntity(5L),
+                    mockProcessInstanceEntity(6L)))
+            .total(6)
+            .build();
+    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
+        .thenReturn(result)
+        .thenReturn(result2);
+
+    // when
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var resultKeys = provider.fetchProcessInstanceKeys(filter, () -> false);
+
+    // then
+    assertThat(resultKeys).containsExactly(1L, 2L, 3L, 4L, 5L, 6L);
+  }
+
+  @Test
+  public void shouldFetchProcessInstanceKeysWithEmptyPage() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(1L),
+                    mockProcessInstanceEntity(2L),
+                    mockProcessInstanceEntity(3L)))
+            .total(6)
+            .build();
+    final var result2 =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>().items(List.of()).total(6).build();
+    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
+        .thenReturn(result)
+        .thenReturn(result2);
+
+    // when
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var resultKeys = provider.fetchProcessInstanceKeys(filter, () -> false);
+
+    // then
+    assertThat(resultKeys).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  public void shouldReturnEmptyListWhenAborted() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
+    final AtomicBoolean shouldAbort = new AtomicBoolean(false);
+
+    // given
+    final var result =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(1L),
+                    mockProcessInstanceEntity(2L),
+                    mockProcessInstanceEntity(3L)))
+            .total(6)
+            .build();
+    final var result2 =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(4L),
+                    mockProcessInstanceEntity(5L),
+                    mockProcessInstanceEntity(6L)))
+            .total(6)
+            .build();
+    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
+        .then(
+            (i) -> {
+              shouldAbort.set(true);
+              return result;
+            })
+        .thenReturn(result2);
+
+    // when
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var resultKeys = provider.fetchProcessInstanceKeys(filter, shouldAbort::get);
+
+    // then
+    assertThat(resultKeys).isEmpty();
+  }
+
+  @Test
+  public void shouldFetchIncidentKeys() {
+    // given
+    final var processInstanceResult =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>()
+            .items(
+                List.of(
+                    mockProcessInstanceEntity(1L),
+                    mockProcessInstanceEntity(2L),
+                    mockProcessInstanceEntity(3L)))
+            .total(3)
+            .build();
+    when(searchClientsProxy.searchProcessInstances(any())).thenReturn(processInstanceResult);
+
+    // given
+    final var incidentResult =
+        new SearchQueryResult.Builder<IncidentEntity>()
+            .items(
+                List.of(mockIncidentEntity(11L), mockIncidentEntity(12L), mockIncidentEntity(13L)))
+            .total(3)
+            .build();
+    when(searchClientsProxy.searchIncidents(any())).thenReturn(incidentResult);
+
+    // when
+    final var filter = new ProcessInstanceFilter.Builder().build();
+    final var resultKeys = provider.fetchIncidentKeys(filter, () -> false);
+
+    // then
+    assertThat(resultKeys).containsExactly(11L, 12L, 13L);
+  }
+
+  private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
+    final var entity = mock(ProcessInstanceEntity.class);
+    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
+    return entity;
+  }
+
+  private IncidentEntity mockIncidentEntity(final long incidentKey) {
+    final var entity = mock(IncidentEntity.class);
+    when(entity.incidentKey()).thenReturn(incidentKey);
+    return entity;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.collection.Maps;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperationTest {
+
+  private static final String JOB_TYPE = "test";
+
+  @Test
+  public void shouldResolveJobIncident() {
+    // given
+    // create a process with a failed job
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask(
+                    "failingTask", t -> t.zeebeJobType(JOB_TYPE).zeebeInputExpression("foo", "foo"))
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariables(Maps.of(entry("foo", "bar")))
+            .create();
+
+    // wait for the job to exist
+    RecordingExporter.jobRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(JobIntent.CREATED)
+        .getFirst();
+
+    engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(1).activate();
+
+    // fail the job
+    final Record<JobRecordValue> failedEvent =
+        engine.job().withType(JOB_TYPE).ofInstance(processInstanceKey).withRetries(0).fail();
+
+    final var incidentKey =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withJobKey(failedEvent.getKey())
+            .getFirst()
+            .getKey();
+
+    final var batchOperationKey =
+        createNewResolveIncidentsBatchOperation(Map.of(processInstanceKey, Set.of(incidentKey)));
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a job retry command and a resolve incident command
+    assertThat(RecordingExporter.jobRecords().withRecordKey(failedEvent.getKey()))
+        .extracting(Record::getIntent)
+        .containsSequence(JobIntent.UPDATE_RETRIES);
+    assertThat(RecordingExporter.incidentRecords().withRecordKey(incidentKey))
+        .extracting(Record::getIntent)
+        .containsSequence(IncidentIntent.RESOLVE);
+  }
+
+  @Test
+  public void shouldResolveNonJobIncident() {
+    // given
+    // create a process with a failed job
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .intermediateCatchEvent(
+                    "catch",
+                    e -> e.message(m -> m.name("cancel").zeebeCorrelationKeyExpression("orderId")))
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId("process").withVariable("orderId", true).create();
+
+    final var incidentKey =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    final var batchOperationKey =
+        createNewResolveIncidentsBatchOperation(Map.of(processInstanceKey, Set.of(incidentKey)));
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a resolve incident command
+    assertThat(RecordingExporter.jobRecords().withProcessInstanceKey(processInstanceKey)).isEmpty();
+    assertThat(RecordingExporter.incidentRecords().withRecordKey(incidentKey))
+        .extracting(Record::getIntent)
+        .containsSequence(IncidentIntent.RESOLVE);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a second batch operation to the engine core: RESOLVE_INCIDENT. For this additional refactorings have been made:
- The BatchOperationExecutionScheduler now uses the new component BatchOperationEntityKeyProvider to fetch all needed keys. That new component is responsible to handle the pagination and other special handling for fulfilling the fetch task.
- The BatchOperationExecuteProcessor now delegates the actual batch operation task to a separate BatchOperationExecutionHandler. That one exists for each batch operation type and handles the type specific task

The current implementation for fetching the incidentKeys is rather temporary. It uses a two-step solution:
1. fetch all processInstances matching the given ProcessInstanceFilter
2. fetch all incidents of the found processInstanceKeys

This solutions takes more time as it needs more queries to the secondary storage. There is still an open discussion to resolve the link between processInstance and incident within the engine. Depending on that discussion, the solution might change again in #30919 

## Related issues

closes #29880 
