### PR TITLE
fix: remove processInstanceDetailsDiagramStore deps from queries

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -26,7 +26,6 @@ import {
   createVariable,
   mockProcessWithInputOutputMappingsXML,
 } from 'modules/testUtils';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
@@ -44,7 +43,6 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
 import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -1603,8 +1601,9 @@ describe('VariablePanel', () => {
       ],
     };
     mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
 
     mockFetchFlowNodeMetadata().withSuccess({
       ...singleInstanceMetadata,
@@ -1632,7 +1631,11 @@ describe('VariablePanel', () => {
       modificationsStore.cancelAllTokens('Activity_0qtp1k6');
     });
 
-    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('edit-variable-value'),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it('should display readonly state for existing node if cancel modification is applied on the flow node and one new token is added', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
@@ -39,6 +39,8 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 jest.mock('react-transition-group', () => {
   const FakeTransition = jest.fn(({children}) => children);
@@ -65,13 +67,15 @@ type Props = {
 
 const Wrapper: React.FC<Props> = ({children}) => {
   return (
-    <QueryClientProvider client={getMockQueryClient()}>
-      <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-        <Routes>
-          <Route path={Paths.processInstance()} element={children} />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 
@@ -87,6 +91,9 @@ describe('TopPanel', () => {
   });
 
   beforeEach(() => {
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
 
     mockFetchProcessInstance().withSuccess(

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useExecutedFlowNode.test.tsx
@@ -10,36 +10,33 @@ import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {useExecutedFlowNodes} from './useExecutedFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
-import {useEffect} from 'react';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('useExecutedFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
-    useEffect(() => {
-      return () => {
-        processInstanceDetailsDiagramStore.reset();
-      };
-    }, []);
-
     return (
-      <QueryClientProvider client={getMockQueryClient()}>
-        {children}
-      </QueryClientProvider>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 
   beforeEach(async () => {
-    jest
-      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
-      .mockReturnValue({processInstanceId: 'processInstanceId123'});
-
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
   });
 
   afterEach(() => {
@@ -78,8 +75,6 @@ describe('useExecutedFlowNodes', () => {
     const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
-
-    expect(result.current.isLoading).toBe(true);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -142,10 +137,12 @@ describe('useExecutedFlowNodes', () => {
   });
 
   it('should handle loading state', async () => {
+    mockFetchFlownodeInstancesStatistics().withDelay({items: []});
+
     const {result} = renderHook(() => useExecutedFlowNodes(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
@@ -6,36 +6,36 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  skipToken,
-  useQuery,
-  UseQueryOptions,
-  UseQueryResult,
-} from '@tanstack/react-query';
+import {skipToken, useQuery, UseQueryResult} from '@tanstack/react-query';
 import {RequestError} from 'modules/request';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
 import {fetchFlownodeInstancesStatistics} from 'modules/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {isEmpty} from 'lodash';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from '../processDefinitions/useProcessInstanceXml';
 
 function getQueryKey(processInstanceKey?: string) {
   return ['flownodeInstancesStatistics', processInstanceKey];
 }
 
-function getFlownodeInstancesStatisticsOptions<
+const useFlownodeInstancesStatistics = <
   T = GetProcessInstanceStatisticsResponseBody,
 >(
-  processInstanceId?: string,
   select?: (data: GetProcessInstanceStatisticsResponseBody) => T,
   enabled: boolean = true,
-): UseQueryOptions<GetProcessInstanceStatisticsResponseBody, RequestError, T> {
-  return {
+): UseQueryResult<T, RequestError> => {
+  const {processInstanceId} = useProcessInstancePageParams();
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const businessObjects =
+    useProcessInstanceXml({
+      processDefinitionKey: processDefinitionKey,
+    }).data?.businessObjects ?? {};
+
+  return useQuery({
     queryKey: getQueryKey(processInstanceId),
     queryFn:
-      enabled &&
-      !!processInstanceId &&
-      !isEmpty(processInstanceDetailsDiagramStore.businessObjects)
+      enabled && !!processInstanceId && !isEmpty(businessObjects)
         ? async () => {
             const {response, error} =
               await fetchFlownodeInstancesStatistics(processInstanceId);
@@ -48,20 +48,7 @@ function getFlownodeInstancesStatisticsOptions<
           }
         : skipToken,
     select,
-  };
-}
-
-const useFlownodeInstancesStatistics = <
-  T = GetProcessInstanceStatisticsResponseBody,
->(
-  select?: (data: GetProcessInstanceStatisticsResponseBody) => T,
-  enabled: boolean = true,
-): UseQueryResult<T, RequestError> => {
-  const {processInstanceId} = useProcessInstancePageParams();
-
-  return useQuery(
-    getFlownodeInstancesStatisticsOptions(processInstanceId, select, enabled),
-  );
+  });
 };
 
 export {useFlownodeInstancesStatistics};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
@@ -10,36 +10,35 @@ import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {useFlownodeStatistics} from './useFlownodeStatistics';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
-import {useEffect} from 'react';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 describe('useFlownodeStatistics', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
-    useEffect(() => {
-      return () => {
-        processInstanceDetailsDiagramStore.reset();
-      };
-    }, []);
-
     return (
-      <QueryClientProvider client={getMockQueryClient()}>
-        {children}
-      </QueryClientProvider>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 
   beforeEach(async () => {
-    jest
-      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
-      .mockReturnValue({processInstanceId: 'processInstanceId123'});
-
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
   });
 
   afterEach(() => {
@@ -72,7 +71,8 @@ describe('useFlownodeStatistics', () => {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
+    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
+    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -125,10 +125,12 @@ describe('useFlownodeStatistics', () => {
   });
 
   it('should handle loading state', async () => {
+    mockFetchFlownodeInstancesStatistics().withDelay({items: []});
+
     const {result} = renderHook(() => useFlownodeStatistics(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useSelectableFlowNodes.test.tsx
@@ -10,36 +10,33 @@ import {renderHook, waitFor} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {useSelectableFlowNodes} from './useSelectableFlowNodes';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
-import {useEffect} from 'react';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 
 describe('useSelectableFlowNodes', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
-    useEffect(() => {
-      return () => {
-        processInstanceDetailsDiagramStore.reset();
-      };
-    }, []);
-
     return (
-      <QueryClientProvider client={getMockQueryClient()}>
-        {children}
-      </QueryClientProvider>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 
   beforeEach(async () => {
-    jest
-      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
-      .mockReturnValue({processInstanceId: 'processInstanceId123'});
-
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
   });
 
   afterEach(() => {
@@ -78,8 +75,6 @@ describe('useSelectableFlowNodes', () => {
     const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
-
-    expect(result.current.isLoading).toBe(true);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -131,10 +126,12 @@ describe('useSelectableFlowNodes', () => {
   });
 
   it('should handle loading state', async () => {
+    mockFetchFlownodeInstancesStatistics().withDelay({items: []});
+
     const {result} = renderHook(() => useSelectableFlowNodes(), {
       wrapper: Wrapper,
     });
 
-    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
   });
 });

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
@@ -15,36 +15,35 @@ import {
   useTotalRunningInstancesVisibleForFlowNodes,
 } from './useTotalRunningInstancesForFlowNode';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import * as pageParamsModule from 'App/ProcessInstance/useProcessInstancePageParams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
-import {useEffect} from 'react';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {Paths} from 'modules/Routes';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 describe('useTotalRunningInstancesForFlowNode hooks', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
-    useEffect(() => {
-      return () => {
-        processInstanceDetailsDiagramStore.reset();
-      };
-    }, []);
-
     return (
-      <QueryClientProvider client={getMockQueryClient()}>
-        {children}
-      </QueryClientProvider>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 
   beforeEach(async () => {
-    jest
-      .spyOn(pageParamsModule, 'useProcessInstancePageParams')
-      .mockReturnValue({processInstanceId: 'processInstanceId123'});
-
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
   });
 
   afterEach(() => {
@@ -71,7 +70,8 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
       {wrapper: Wrapper},
     );
 
-    expect(result.current.isLoading).toBe(true);
+    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
+    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -109,8 +109,6 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
       {wrapper: Wrapper},
     );
 
-    expect(result.current.isLoading).toBe(true);
-
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toStrictEqual({
@@ -138,8 +136,6 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
       () => useTotalRunningInstancesVisibleForFlowNode('StartEvent_1'),
       {wrapper: Wrapper},
     );
-
-    expect(result.current.isLoading).toBe(true);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -176,8 +172,6 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
         ]),
       {wrapper: Wrapper},
     );
-
-    expect(result.current.isLoading).toBe(true);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -229,11 +223,13 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
   });
 
   it('should handle loading state', async () => {
+    mockFetchFlownodeInstancesStatistics().withDelay({items: []});
+
     const {result} = renderHook(
       () => useTotalRunningInstancesForFlowNode('StartEvent_1'),
       {wrapper: Wrapper},
     );
 
-    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
   });
 });


### PR DESCRIPTION
## Description

As we migrated statistics stores to use tanstack query (Milestone 1), we've introduced dependencies on `processInstanceDetailsDiagramStore` which is itself being removed (Milestone 0).
As a result, Milestone 0 work has become more complex. This PR is removing dependencies from queries and updating tests.

## Related issues

related to #30591