### PR TITLE
refactor: create group with groupId as constructor parameter

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -744,7 +744,7 @@ public class CommandDistributionIdempotencyTest {
   }
 
   private static Record<GroupRecordValue> createGroup(final String groupId) {
-    return ENGINE.group().newGroup(UUID.randomUUID().toString()).withGroupId(groupId).create();
+    return ENGINE.group().newGroup(groupId).withName(UUID.randomUUID().toString()).create();
   }
 
   private static Record<RoleRecordValue> createRole() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -54,7 +54,7 @@ public class AddEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
 
     assertThat(
@@ -119,7 +119,7 @@ public class AddEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // then
@@ -152,7 +152,7 @@ public class AddEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
@@ -42,7 +42,7 @@ public class CreateGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = Strings.newRandomValidIdentityId();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     assertThat(
             RecordingExporter.records()
@@ -88,7 +88,7 @@ public class CreateGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = Strings.newRandomValidIdentityId();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // then
     assertThat(
@@ -111,7 +111,7 @@ public class CreateGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = Strings.newRandomValidIdentityId();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
@@ -40,7 +40,7 @@ public class DeleteGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().deleteGroup(groupId).delete();
 
     assertThat(
@@ -94,7 +94,7 @@ public class DeleteGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().deleteGroup(groupId).delete();
 
     // then
@@ -114,7 +114,7 @@ public class DeleteGroupMultiPartitionTest {
       interceptGroupCreateForPartition(partitionId);
     }
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().deleteGroup(groupId).delete();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -32,7 +32,7 @@ public class GroupTest {
   public void shouldCreateGroup() {
     final var name = UUID.randomUUID().toString();
     final var groupId = Strings.newRandomValidIdentityId();
-    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
+    final var groupRecord = engine.group().newGroup(groupId).withName(name).create();
 
     final var createdGroup = groupRecord.getValue();
     assertThat(createdGroup).hasName(name);
@@ -44,11 +44,11 @@ public class GroupTest {
     // given
     final var name = UUID.randomUUID().toString();
     final var groupId = Strings.newRandomValidIdentityId();
-    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
+    final var groupRecord = engine.group().newGroup(groupId).withName(name).create();
 
     // when
     final var duplicatedGroupRecord =
-        engine.group().newGroup(name).withGroupId(groupId).expectRejection().create();
+        engine.group().newGroup(groupId).withName(name).expectRejection().create();
 
     final var createdGroup = groupRecord.getValue();
     Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
@@ -66,7 +66,7 @@ public class GroupTest {
     // given
     final var name = UUID.randomUUID().toString();
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // when
     final var updatedName = name + "-updated";
@@ -109,7 +109,7 @@ public class GroupTest {
             .getValue()
             .getUsername();
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create().getValue().getGroupKey();
+    engine.group().newGroup(groupId).withName(name).create().getValue().getGroupKey();
 
     // when
     final var updatedGroup =
@@ -145,7 +145,7 @@ public class GroupTest {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
+    final var groupRecord = engine.group().newGroup(groupId).withName(name).create();
     final var notPresentEntityId = Strings.newRandomValidIdentityId();
 
     // when
@@ -174,7 +174,7 @@ public class GroupTest {
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     final var username =
         engine
             .user()
@@ -221,7 +221,7 @@ public class GroupTest {
             .getValue()
             .getUsername();
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // when
@@ -262,7 +262,7 @@ public class GroupTest {
     final var groupId = Strings.newRandomValidIdentityId();
     final var notPresentEntityId = Strings.newRandomValidIdentityId();
     final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).withGroupId(groupId).create();
+    final var groupRecord = engine.group().newGroup(groupId).withName(name).create();
 
     // when
     final var createdGroup = groupRecord.getValue();
@@ -289,7 +289,7 @@ public class GroupTest {
     // given
     final var groupId = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // when
     final var deletedGroup = engine.group().deleteGroup(groupId).delete().getValue();
@@ -314,7 +314,7 @@ public class GroupTest {
             .getValue()
             .getUsername();
     final var name = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -52,7 +52,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .group()
@@ -123,7 +123,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .group()
@@ -162,7 +162,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     final var name = UUID.randomUUID().toString();
     // TODO: revisit with https://github.com/camunda/camunda/issues/30091
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().addEntity(groupId).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .group()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -40,7 +40,7 @@ public class UpdateGroupMultiPartitionTest {
     // given
     final var name = UUID.randomUUID().toString();
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // when
     engine.group().updateGroup(groupId).withName("updated-" + name).update();
@@ -96,7 +96,7 @@ public class UpdateGroupMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine.group().updateGroup(groupId).withName(name + "-updated").update();
 
     // then
@@ -115,7 +115,7 @@ public class UpdateGroupMultiPartitionTest {
       interceptGroupCommandForPartition(partitionId, GroupIntent.CREATE);
     }
     final var groupId = UUID.randomUUID().toString();
-    engine.group().newGroup(UUID.randomUUID().toString()).withGroupId(groupId).create().getKey();
+    engine.group().newGroup(groupId).withName(UUID.randomUUID().toString()).create().getKey();
 
     // when
     final var name = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -241,7 +241,7 @@ public class MappingTest {
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create();
     final var groupId = "123";
     final var groupKey = Long.parseLong(groupId);
-    engine.group().newGroup("group").withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName("group").create();
     final var role = engine.role().newRole("role").create();
     engine
         .group()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -203,13 +203,7 @@ public class AddEntityTenantTest {
   }
 
   private long createGroup(final String groupId) {
-    return engine
-        .group()
-        .newGroup("groupName")
-        .withGroupId(groupId)
-        .create()
-        .getValue()
-        .getGroupKey();
+    return engine.group().newGroup(groupId).withName("groupName").create().getValue().getGroupKey();
   }
 
   private String createMapping() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
@@ -159,7 +159,7 @@ public class RemoveEntityTenantTest {
         .getTenantKey();
     final var name = "foo";
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     engine
         .tenant()
         .addEntity(tenantId)
@@ -203,7 +203,7 @@ public class RemoveEntityTenantTest {
     final var name = UUID.randomUUID().toString();
     final var groupId = "123";
     final var tenantRecord = engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
 
     // when
     final var createdTenant = tenantRecord.getValue();
@@ -236,7 +236,7 @@ public class RemoveEntityTenantTest {
     // when
     final var name = "foo";
     final var groupId = "123";
-    engine.group().newGroup(name).withGroupId(groupId).create();
+    engine.group().newGroup(groupId).withName(name).create();
     final var notAssignedUpdateRecord =
         engine
             .tenant()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -62,7 +62,7 @@ public class DeleteUserTest {
             .withEmail("foo@bar.com")
             .withPassword("password")
             .create();
-    final var group = ENGINE.group().newGroup("group").withGroupId(groupId).create();
+    final var group = ENGINE.group().newGroup(groupId).withName("group").create();
     final var role = ENGINE.role().newRole("role").create();
     final var tenant = ENGINE.tenant().newTenant().withTenantId(tenantId).create();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -63,14 +63,14 @@ public class GroupClient {
     private final GroupRecord groupRecord;
     private Function<Long, Record<GroupRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public GroupCreateClient(final CommandWriter writer, final String name) {
+    public GroupCreateClient(final CommandWriter writer, final String groupId) {
       this.writer = writer;
       groupRecord = new GroupRecord();
-      groupRecord.setName(name);
+      groupRecord.setGroupId(groupId);
     }
 
-    public GroupCreateClient withGroupId(final String groupId) {
-      groupRecord.setGroupId(groupId);
+    public GroupCreateClient withName(final String name) {
+      groupRecord.setName(name);
       return this;
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR modifies the `GroupClient` in order to create a group by providing the `groupId` as a parameter instead of the `name`

## Related issues

closes #30376 
