### PR TITLE
fix: remove processInstanceDetailsDiagramStore deps from utils

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
@@ -22,7 +22,6 @@ import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {createInstance, createVariable} from 'modules/testUtils';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
@@ -83,7 +82,6 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
       variablesStore.reset();
       flowNodeSelectionStore.reset();
       flowNodeMetaDataStore.reset();
-      processInstanceDetailsDiagramStore.reset();
       modificationsStore.reset();
       processInstanceDetailsStatisticsStore.reset();
     };

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
@@ -50,6 +50,7 @@ import {
   useTotalRunningInstancesVisibleForFlowNode,
 } from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
 import {finishMovingToken} from 'modules/utils/modifications';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 
 const OVERLAY_TYPE_STATE = 'flowNodeState';
 const OVERLAY_TYPE_MODIFICATIONS_BADGE = 'modificationsBadge';
@@ -79,6 +80,7 @@ const TopPanel: React.FC = observer(() => {
   const {data: totalRunningInstances} = useTotalRunningInstancesForFlowNode(
     currentSelection?.flowNodeId,
   );
+  const {data: businessObjects} = useBusinessObjects();
 
   const affectedTokenCount =
     (sourceFlowNodeIdForMoveOperation &&
@@ -220,16 +222,21 @@ const TopPanel: React.FC = observer(() => {
           isOpen={incidentsStore.state.isIncidentBarOpen}
         />
       )}
-      {modificationsStore.state.status === 'moving-token' && (
-        <ModificationInfoBanner
-          text="Select the target flow node in the diagram"
-          button={{
-            onClick: () =>
-              finishMovingToken(affectedTokenCount, visibleAffectedTokenCount),
-            label: 'Discard',
-          }}
-        />
-      )}
+      {modificationsStore.state.status === 'moving-token' &&
+        businessObjects && (
+          <ModificationInfoBanner
+            text="Select the target flow node in the diagram"
+            button={{
+              onClick: () =>
+                finishMovingToken(
+                  affectedTokenCount,
+                  visibleAffectedTokenCount,
+                  businessObjects,
+                ),
+              label: 'Discard',
+            }}
+          />
+        )}
       {modificationsStore.isModificationModeEnabled &&
         getSelectedRunningInstanceCount(totalRunningInstances || 0) > 1 && (
           <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
@@ -245,7 +252,7 @@ const TopPanel: React.FC = observer(() => {
       )}
       <DiagramPanel>
         <DiagramShell status={getStatus()}>
-          {xml !== null && (
+          {xml !== null && businessObjects && (
             <Diagram
               xml={xml}
               selectableFlowNodes={
@@ -264,6 +271,7 @@ const TopPanel: React.FC = observer(() => {
                   finishMovingToken(
                     affectedTokenCount,
                     visibleAffectedTokenCount,
+                    businessObjects,
                     flowNodeId,
                   );
                 } else {

--- a/operate/client/src/App/ProcessInstance/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/mocks.tsx
@@ -45,6 +45,7 @@ import {mockProcess} from '../ProcessInstanceHeader/index.setup';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('4294980768');
 
@@ -53,6 +54,7 @@ const mockRequests = (contextPath: string = '') => {
     testData.fetch.onPageLoad.processInstanceWithIncident,
   );
   mockFetchProcessXML(contextPath).withSuccess('');
+  mockFetchProcessDefinitionXml().withSuccess('');
   mockFetchSequenceFlows(contextPath).withSuccess(mockSequenceFlows);
   mockFetchFlowNodeInstances(contextPath).withSuccess(
     processInstancesMock.level1,

--- a/operate/client/src/modules/hooks/modifications.test.tsx
+++ b/operate/client/src/modules/hooks/modifications.test.tsx
@@ -22,8 +22,6 @@ import {Paths} from 'modules/Routes';
 import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 describe('modifications hooks', () => {
   const getWrapper = (
@@ -34,7 +32,6 @@ describe('modifications hooks', () => {
     const Wrapper = ({children}: {children: React.ReactNode}) => {
       useEffect(() => {
         return () => {
-          processInstanceDetailsDiagramStore.reset();
           modificationsStore.reset();
         };
       }, []);
@@ -231,8 +228,9 @@ describe('modifications hooks', () => {
         wrapper: getWrapper(),
       });
 
-      mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-      await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+      mockFetchProcessDefinitionXml().withSuccess(
+        mockProcessWithInputOutputMappingsXML,
+      );
 
       expect(result.current).toEqual({
         node1: {
@@ -262,8 +260,9 @@ describe('modifications hooks', () => {
       const {result} = renderHook(() => useModificationsByFlowNode(), {
         wrapper: getWrapper(),
       });
-      mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-      await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+      mockFetchProcessDefinitionXml().withSuccess(
+        mockProcessWithInputOutputMappingsXML,
+      );
 
       expect(result.current).toEqual({
         node1: {

--- a/operate/client/src/modules/hooks/modifications.ts
+++ b/operate/client/src/modules/hooks/modifications.ts
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {getFlowElementIds} from 'modules/bpmn-js/utils/getFlowElementIds';
 import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
 import {TOKEN_OPERATIONS} from 'modules/constants';
@@ -15,7 +14,7 @@ import {
   useTotalRunningInstancesForFlowNodes,
   useTotalRunningInstancesVisibleForFlowNodes,
 } from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
-import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {
   EMPTY_MODIFICATION,
   modificationsStore,
@@ -49,11 +48,7 @@ const useModificationsByFlowNode = () => {
   const flowNodeIds = modificationsStore.flowNodeModifications.map(
     (modification) => modification.flowNode.id,
   );
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const businessObjects =
-    useProcessInstanceXml({
-      processDefinitionKey: processDefinitionKey,
-    }).data?.businessObjects ?? {};
+  const {data: businessObjects} = useBusinessObjects();
 
   const {data: flowNodeDataArray} =
     useTotalRunningInstancesForFlowNodes(flowNodeIds);
@@ -68,7 +63,7 @@ const useModificationsByFlowNode = () => {
   }, [flowNodeIds, flowNodeDataArray]);
 
   const elementIds = flowNodeIds.flatMap((flowNodeId) =>
-    getFlowElementIds(businessObjects[flowNodeId]),
+    getFlowElementIds(businessObjects?.[flowNodeId]),
   );
 
   const {data: elementCancelledTokens} =
@@ -138,7 +133,9 @@ const useModificationsByFlowNode = () => {
         ...EMPTY_MODIFICATION,
       };
 
-      targetFlowNode.newTokens += isMultiInstance(businessObjects[flowNode.id])
+      targetFlowNode.newTokens += isMultiInstance(
+        businessObjects?.[flowNode.id],
+      )
         ? 1
         : affectedTokenCount;
 

--- a/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/hooks/processInstanceDetailsDiagram.ts
@@ -6,12 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {useTotalRunningInstancesByFlowNode} from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
-import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {modificationsStore} from 'modules/stores/modifications';
 import {hasMultipleScopes} from 'modules/utils/processInstanceDetailsDiagram';
 
@@ -19,13 +18,9 @@ const useFlowNodes = () => {
   const {data: statistics} = useFlownodeInstancesStatistics();
   const {data: totalRunningInstancesByFlowNode} =
     useTotalRunningInstancesByFlowNode();
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const businessObjects =
-    useProcessInstanceXml({
-      processDefinitionKey: processDefinitionKey,
-    }).data?.businessObjects ?? {};
+  const {data: businessObjects} = useBusinessObjects();
 
-  return Object.values(businessObjects).map((flowNode) => {
+  return Object.values(businessObjects ?? {}).map((flowNode) => {
     const flowNodeState = statistics?.items.find(
       ({flowNodeId}) => flowNodeId === flowNode.id,
     );

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics.ts
@@ -12,8 +12,7 @@ import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-s
 import {fetchFlownodeInstancesStatistics} from 'modules/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {isEmpty} from 'lodash';
-import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
-import {useProcessInstanceXml} from '../processDefinitions/useProcessInstanceXml';
+import {useBusinessObjects} from '../processDefinitions/useBusinessObjects';
 
 function getQueryKey(processInstanceKey?: string) {
   return ['flownodeInstancesStatistics', processInstanceKey];
@@ -26,11 +25,7 @@ const useFlownodeInstancesStatistics = <
   enabled: boolean = true,
 ): UseQueryResult<T, RequestError> => {
   const {processInstanceId} = useProcessInstancePageParams();
-  const processDefinitionKey = useProcessDefinitionKeyContext();
-  const businessObjects =
-    useProcessInstanceXml({
-      processDefinitionKey: processDefinitionKey,
-    }).data?.businessObjects ?? {};
+  const {data: businessObjects} = useBusinessObjects();
 
   return useQuery({
     queryKey: getQueryKey(processInstanceId),

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.test.tsx
@@ -17,8 +17,6 @@ import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinit
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 describe('useFlownodeStatistics', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -71,8 +69,9 @@ describe('useFlownodeStatistics', () => {
       wrapper: Wrapper,
     });
 
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.ts
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useFlownodeStatistics.ts
@@ -9,51 +9,59 @@
 import {useFlownodeInstancesStatistics} from './useFlownodeInstancesStatistics';
 import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
 import {getStatisticsByFlowNode} from 'modules/utils/statistics/flownodeInstances';
+import {useBusinessObjects} from '../processDefinitions/useBusinessObjects';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 
-const statisticsByFlowNodeParser = (
-  response: GetProcessInstanceStatisticsResponseBody,
-) => {
-  return Object.keys(getStatisticsByFlowNode(response.items)).flatMap((id) => {
-    const types = [
-      'active',
-      'incidents',
-      'canceled',
-      'completed',
-      'completedEndEvents',
-    ] as const;
+const statisticsByFlowNodeParser =
+  (businessObjects?: BusinessObjects) =>
+  (response: GetProcessInstanceStatisticsResponseBody) => {
+    const statistics = getStatisticsByFlowNode(response.items, businessObjects);
 
-    const statistic = getStatisticsByFlowNode(response.items)[id];
+    return Object.keys(statistics).flatMap((id) => {
+      const types = [
+        'active',
+        'incidents',
+        'canceled',
+        'completed',
+        'completedEndEvents',
+      ] as const;
 
-    return types.reduce<
-      {
-        id: string;
-        count: number;
-        flowNodeState: FlowNodeState | 'completedEndEvents';
-      }[]
-    >((states, flowNodeState) => {
-      const count =
-        flowNodeState === 'active'
-          ? (statistic?.['filteredActive'] ?? 0)
-          : (statistic?.[flowNodeState] ?? 0);
+      const statistic = statistics[id];
 
-      if (count === 0) {
-        return states;
-      }
-
-      return [
-        ...states,
+      return types.reduce<
         {
-          id,
-          count,
-          flowNodeState,
-        },
-      ];
-    }, []);
-  });
-};
+          id: string;
+          count: number;
+          flowNodeState: FlowNodeState | 'completedEndEvents';
+        }[]
+      >((states, flowNodeState) => {
+        const count =
+          flowNodeState === 'active'
+            ? (statistic?.['filteredActive'] ?? 0)
+            : (statistic?.[flowNodeState] ?? 0);
+
+        if (count === 0) {
+          return states;
+        }
+
+        return [
+          ...states,
+          {
+            id,
+            count,
+            flowNodeState,
+          },
+        ];
+      }, []);
+    });
+  };
 
 const useFlownodeStatistics = () => {
-  return useFlownodeInstancesStatistics(statisticsByFlowNodeParser);
+  const {data: businessObjects} = useBusinessObjects();
+
+  return useFlownodeInstancesStatistics(
+    statisticsByFlowNodeParser(businessObjects),
+  );
 };
 
 export {useFlownodeStatistics};

--- a/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
+++ b/operate/client/src/modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode.test.tsx
@@ -22,8 +22,6 @@ import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinit
 import {Paths} from 'modules/Routes';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 describe('useTotalRunningInstancesForFlowNode hooks', () => {
   const Wrapper = ({children}: {children: React.ReactNode}) => {
@@ -70,8 +68,9 @@ describe('useTotalRunningInstancesForFlowNode hooks', () => {
       {wrapper: Wrapper},
     );
 
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 

--- a/operate/client/src/modules/queries/processDefinitions/useBusinessObjects.test.tsx
+++ b/operate/client/src/modules/queries/processDefinitions/useBusinessObjects.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {useBusinessObjects} from './useBusinessObjects';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+
+describe('useBusinessObjects', () => {
+  const businessObjects = {
+    Activity_0qtp1k6: {
+      $type: 'bpmn:CallActivity',
+      extensionElements: {
+        $type: 'bpmn:ExtensionElements',
+        values: [
+          {
+            $type: 'zeebe:calledElement',
+            processId: 'called-element-test',
+            propagateAllChildVariables: 'false',
+          },
+          {
+            $children: [
+              {
+                $type: 'zeebe:input',
+                source: '= "test1"',
+                target: 'localVariable1',
+              },
+              {
+                $type: 'zeebe:input',
+                source: '= "test2"',
+                target: 'localVariable2',
+              },
+              {
+                $type: 'zeebe:output',
+                source: '= 2',
+                target: 'outputTest',
+              },
+            ],
+            $type: 'zeebe:ioMapping',
+          },
+        ],
+      },
+      id: 'Activity_0qtp1k6',
+    },
+    Event_0bonl61: {
+      $type: 'bpmn:EndEvent',
+      id: 'Event_0bonl61',
+    },
+    StartEvent_1: {
+      $type: 'bpmn:StartEvent',
+      id: 'StartEvent_1',
+    },
+  };
+
+  const Wrapper = ({children}: {children: React.ReactNode}) => {
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch business objects successfully', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    const {result} = renderHook(() => useBusinessObjects(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(businessObjects);
+  });
+
+  it('should handle server error while fetching business objects', async () => {
+    mockFetchProcessDefinitionXml().withServerError();
+
+    const {result} = renderHook(() => useBusinessObjects(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('should handle network error while fetching business objects', async () => {
+    mockFetchProcessDefinitionXml().withNetworkError();
+
+    const {result} = renderHook(() => useBusinessObjects(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+
+  it('should handle empty data', async () => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+
+    const {result} = renderHook(() => useBusinessObjects(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).not.toBeDefined();
+  });
+
+  it('should handle loading state', async () => {
+    mockFetchProcessDefinitionXml().withDelay(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    const {result} = renderHook(() => useBusinessObjects(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+  });
+});

--- a/operate/client/src/modules/queries/processDefinitions/useBusinessObjects.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useBusinessObjects.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {
+  ParsedXmlData,
+  useProcessDefinitionXml,
+} from './useProcessDefinitionXml';
+import {isFlowNode} from 'modules/utils/flowNodes';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
+
+function businessObjectsParser({diagramModel}: ParsedXmlData): BusinessObjects {
+  const businessObjects = Object.entries(diagramModel.elementsById).reduce(
+    (flowNodes, [flowNodeId, businessObject]) => {
+      if (isFlowNode(businessObject)) {
+        return {...flowNodes, [flowNodeId]: businessObject};
+      } else {
+        return flowNodes;
+      }
+    },
+    {},
+  );
+
+  return businessObjects;
+}
+
+const useBusinessObjects = () => {
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+
+  return useProcessDefinitionXml<BusinessObjects>({
+    processDefinitionKey,
+    select: businessObjectsParser,
+    enabled: !!processDefinitionKey,
+  });
+};
+
+export {businessObjectsParser, useBusinessObjects};

--- a/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessDefinitionXml.ts
@@ -33,7 +33,7 @@ async function processDefinitionParser(data: string): Promise<ParsedXmlData> {
   return {xml: data, diagramModel, selectableFlowNodes};
 }
 
-function useProcessDefinitionXml<T extends ParsedXmlData = ParsedXmlData>({
+function useProcessDefinitionXml<T = ParsedXmlData>({
   processDefinitionKey,
   select,
   enabled = true,

--- a/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
+++ b/operate/client/src/modules/queries/processDefinitions/useProcessInstanceXml.ts
@@ -11,7 +11,7 @@ import {
   useProcessDefinitionXml,
 } from './useProcessDefinitionXml';
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
-import {isFlowNode} from 'modules/utils/flowNodes';
+import {businessObjectsParser} from './useBusinessObjects';
 
 type ExtendedParsedXmlData = ParsedXmlData & {
   businessObjects: {[key: string]: BusinessObject};
@@ -22,16 +22,11 @@ function processInstanceXmlParser({
   diagramModel,
   selectableFlowNodes,
 }: ParsedXmlData) {
-  const businessObjects = Object.entries(diagramModel.elementsById).reduce(
-    (flowNodes, [flowNodeId, businessObject]) => {
-      if (isFlowNode(businessObject)) {
-        return {...flowNodes, [flowNodeId]: businessObject};
-      } else {
-        return flowNodes;
-      }
-    },
-    {},
-  );
+  const businessObjects = businessObjectsParser({
+    xml,
+    diagramModel,
+    selectableFlowNodes,
+  });
 
   return {
     xml,

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
@@ -23,7 +23,7 @@ import {NetworkReconnectionHandler} from '../networkReconnectionHandler';
 import {isFlowNode} from 'modules/utils/flowNodes';
 import {modificationsStore} from '../modifications';
 import {processInstanceDetailsStatisticsStore} from '../processInstanceDetailsStatistics';
-import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {BusinessObject, BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
 import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
@@ -80,7 +80,7 @@ class ProcessInstanceDetailsDiagram extends NetworkReconnectionHandler {
     );
   }
 
-  get businessObjects(): {[flowNodeId: string]: BusinessObject} {
+  get businessObjects(): BusinessObjects {
     if (this.state.diagramModel === null) {
       return {};
     }

--- a/operate/client/src/modules/types/bpmn-js.d.ts
+++ b/operate/client/src/modules/types/bpmn-js.d.ts
@@ -92,6 +92,8 @@ declare module 'bpmn-js/lib/NavigatedViewer' {
     targetRef?: BusinessObject;
   };
 
+  export type BusinessObjects = {[flowNodeId: string]: BusinessObject};
+
   export type BpmnElement = {
     id: string;
     type: ElementType;

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -6,14 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
 import {modificationsStore} from 'modules/stores/modifications';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {tracking} from 'modules/tracking';
 
 const finishMovingToken = (
   affectedTokenCount: number,
   visibleAffectedTokenCount: number,
+  businessObjects: BusinessObjects,
   targetFlowNodeId?: string,
 ) => {
   tracking.track({
@@ -32,13 +33,8 @@ const finishMovingToken = (
     sourceFlowNodeIdForMoveOperation !== null
   ) {
     if (sourceFlowNodeInstanceKeyForMoveOperation === null) {
-      // TODO: [OPERATE-V2-MIGRATION] After migrating processInstanceDetailsDiagramStore to a query,
-      // consider passing the resolved sourceFlowNode as a parameter to finishMovingToken
-      // instead of accessing it directly from processInstanceDetailsDiagramStore.businessObjects.
       newScopeCount = isMultiInstance(
-        processInstanceDetailsDiagramStore.businessObjects[
-          sourceFlowNodeIdForMoveOperation
-        ],
+        businessObjects[sourceFlowNodeIdForMoveOperation],
       )
         ? 1
         : affectedTokenCount;

--- a/operate/client/src/modules/utils/statistics/flownodeInstance.test.tsx
+++ b/operate/client/src/modules/utils/statistics/flownodeInstance.test.tsx
@@ -11,32 +11,58 @@ import {renderHook} from '@testing-library/react';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {getStatisticsByFlowNode} from './flownodeInstances';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {mockProcessWithInputOutputMappingsXML} from 'modules/testUtils';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
 
 describe('getStatisticsByFlowNode', () => {
+  const businessObjects: BusinessObjects = {
+    StartEvent_1: {
+      $type: 'bpmn:StartEvent',
+      id: 'StartEvent_1',
+      name: 'Start Event',
+    },
+    Activity_0qtp1k6: {
+      $type: 'bpmn:UserTask',
+      id: 'Activity_0qtp1k6',
+      name: 'User Task',
+    },
+    Event_0bonl61: {
+      id: 'Event_0bonl61',
+      name: 'End Event',
+      $type: 'bpmn:EndEvent',
+      $parent: {
+        id: 'Process_1',
+        $type: 'bpmn:Process',
+        name: 'Process 1',
+      },
+    },
+  };
+
   const Wrapper = ({children}: {children: React.ReactNode}) => {
     useEffect(() => {
       return () => {
-        processInstanceDetailsDiagramStore.reset();
         modificationsStore.reset();
       };
     }, []);
 
     return (
-      <QueryClientProvider client={getMockQueryClient()}>
-        {children}
-      </QueryClientProvider>
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
     );
   };
 
   beforeEach(async () => {
     jest.clearAllMocks();
-
-    mockFetchProcessXML().withSuccess(mockProcessWithInputOutputMappingsXML);
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
   });
 
   it('should return statistics for valid flow nodes', () => {
@@ -57,9 +83,12 @@ describe('getStatisticsByFlowNode', () => {
       },
     ];
 
-    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => getStatisticsByFlowNode(data, businessObjects),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(result.current).toEqual({
       StartEvent_1: {
@@ -99,9 +128,12 @@ describe('getStatisticsByFlowNode', () => {
       },
     ];
 
-    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => getStatisticsByFlowNode(data, businessObjects),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(result.current).toEqual({
       StartEvent_1: {
@@ -128,9 +160,12 @@ describe('getStatisticsByFlowNode', () => {
       },
     ];
 
-    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => getStatisticsByFlowNode(data, businessObjects),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(result.current).toEqual({
       StartEvent_1: {
@@ -155,9 +190,12 @@ describe('getStatisticsByFlowNode', () => {
       },
     ];
 
-    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => getStatisticsByFlowNode(data, businessObjects),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(result.current).toEqual({
       Event_0bonl61: {
@@ -182,9 +220,12 @@ describe('getStatisticsByFlowNode', () => {
       },
     ];
 
-    const {result} = renderHook(() => getStatisticsByFlowNode(data), {
-      wrapper: Wrapper,
-    });
+    const {result} = renderHook(
+      () => getStatisticsByFlowNode(data, businessObjects),
+      {
+        wrapper: Wrapper,
+      },
+    );
 
     expect(result.current).toEqual({});
   });

--- a/operate/client/src/modules/utils/statistics/flownodeInstances.ts
+++ b/operate/client/src/modules/utils/statistics/flownodeInstances.ts
@@ -7,24 +7,23 @@
  */
 
 import {ProcessDefinitionStatistic} from '@vzeta/camunda-api-zod-schemas/operate';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {isProcessEndEvent} from 'modules/bpmn-js/utils/isProcessEndEvent';
 import {modificationsStore} from 'modules/stores/modifications';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 type Statistic = ProcessDefinitionStatistic & {
   filteredActive: number;
   completedEndEvents: number;
 };
 
-const getStatisticsByFlowNode = (data: ProcessDefinitionStatistic[]) => {
+const getStatisticsByFlowNode = (
+  data: ProcessDefinitionStatistic[],
+  businessObjects?: BusinessObjects,
+) => {
   return data.reduce<{
     [key: string]: Omit<Statistic, 'flowNodeId'>;
   }>((statistics, {flowNodeId: id, active, incidents, completed, canceled}) => {
-    // TODO: [OPERATE-V2-MIGRATION] After migrating processInstanceDetailsDiagramStore to a query,
-    // consider passing the resolved flowNode as a parameter to getStatisticsByFlowNode
-    // instead of accessing it directly from processInstanceDetailsDiagramStore.businessObjects.
-    const businessObject =
-      processInstanceDetailsDiagramStore.businessObjects[id];
+    const businessObject = businessObjects?.[id];
 
     if (businessObject === undefined) {
       return statistics;


### PR DESCRIPTION
## Description

As we migrated statistics stores to use tanstack query (Milestone 1), we've introduced dependencies on `processInstanceDetailsDiagramStore` which is itself being removed (Milestone 0).
As a result, Milestone 0 work has become more complex. This PR is removing dependencies from utils and updating tests.

I also refactored the business objects logic into a new hook

## Related issues

related to #30591