### PR TITLE
[Backport main] In operate's backup repositoryName and snapshotName are swapped

### DIFF
--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -78,5 +78,10 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -539,7 +539,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                 ? "until completion."
                 : "at most " + snapshotTimeout + " seconds.");
         if (isSnapshotFinishedWithinTimeout(
-            snapshotRequest.snapshotName(), snapshotRequest.repositoryName())) {
+            snapshotRequest.repositoryName(), snapshotRequest.snapshotName())) {
           onSuccess.run();
         } else {
           onFailure.run();


### PR DESCRIPTION
# Description
Backport of #30878 to `main`.
depends on #30849
