### PR TITLE
[Backport stable/8.6] In operate's backup repositoryName and snapshotName are swapped

### DIFF
--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -409,6 +409,11 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -500,7 +500,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                     ? "until completion."
                     : "at most " + snapshotTimeout + " seconds."));
         if (isSnapshotFinishedWithinTimeout(
-            snapshotRequest.snapshotName(), snapshotRequest.repositoryName())) {
+            snapshotRequest.repositoryName(), snapshotRequest.snapshotName())) {
           onSuccess.run();
         } else {
           onFailure.run();

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -9,7 +9,6 @@ package io.camunda.operate.webapp.elasticsearch.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -24,8 +23,12 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.webapp.backup.BackupService.SnapshotRequest;
+import io.camunda.operate.webapp.backup.Metadata;
 import io.camunda.operate.webapp.management.dto.BackupStateDto;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -34,6 +37,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.awaitility.Awaitility;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
@@ -42,6 +47,7 @@ import org.elasticsearch.snapshots.SnapshotState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -52,7 +58,10 @@ public class ElasticsearchBackupRepositoryTest {
   private final String repositoryName = "repo1";
   private final long backupId = 555;
   private final String snapshotName = "camunda_operate_" + backupId + "_8.6_part_1_of_6";
-  @Mock private RestHighLevelClient esClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private RestHighLevelClient esClient;
+
   @Mock private SnapshotClient snapshotClient;
   @Mock private ObjectMapper objectMapper;
 
@@ -82,24 +91,47 @@ public class ElasticsearchBackupRepositoryTest {
   }
 
   @Test
-  public void testWaitingForSnapshotTillCompleted() {
+  public void testWaitingForSnapshotTillCompleted() throws IOException {
     final int timeout = 0;
 
+    final var snapshotInfos = new ArrayList<SnapshotInfo>();
+    for (int i = 0; i < 6; i++) {
+      final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+      when(snapshotInfo.state())
+          .thenReturn(SnapshotState.IN_PROGRESS)
+          .thenReturn(SnapshotState.IN_PROGRESS)
+          .thenReturn(SnapshotState.SUCCESS);
+      when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+      snapshotInfos.add(snapshotInfo);
+    }
+
     // mock calls to `findSnapshot` and `operateProperties`
-    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
-    when(snapshotInfo.state())
-        .thenReturn(SnapshotState.IN_PROGRESS)
-        .thenReturn(SnapshotState.IN_PROGRESS)
-        .thenReturn(SnapshotState.SUCCESS);
-    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
     when(operateProperties.getBackup().getSnapshotTimeout()).thenReturn(timeout);
-    doReturn(List.of(snapshotInfo)).when(backupRepository).findSnapshots(any(), any());
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    when(snapshotResponse.getSnapshots()).thenReturn(snapshotInfos);
+    when(esClient.snapshot().get(any(), any())).thenReturn(snapshotResponse);
+    final var captor = ArgumentCaptor.forClass(ActionListener.class);
+    when(esClient.snapshot().createAsync(any(), any(), any())).thenReturn(null);
 
-    final boolean finished =
-        backupRepository.isSnapshotFinishedWithinTimeout(repositoryName, snapshotName);
+    backupRepository.executeSnapshotting(
+        new SnapshotRequest(
+            repositoryName,
+            snapshotName,
+            List.of("index-example"),
+            new Metadata().setBackupId(backupId).setPartCount(1).setPartNo(1).setVersion("8.3.0")),
+        () -> {},
+        () -> {});
 
-    assertTrue(finished);
+    verify(esClient.snapshot()).createAsync(any(), any(), captor.capture());
+    captor.getValue().onFailure(new SocketTimeoutException());
     verify(backupRepository, times(3)).findSnapshots(repositoryName, backupId);
+
+    Awaitility.await("backup is completed")
+        .untilAsserted(
+            () -> {
+              final var response = backupRepository.getBackupState(repositoryName, backupId);
+              assertThat(response.getState()).isEqualTo(BackupStateDto.COMPLETED);
+            });
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #30878 to `stable/8.6`.

relates to 