### PR TITLE
test: create SchemaManagerConcurrencyIT

### DIFF
--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -138,6 +138,12 @@
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -90,10 +90,10 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     } catch (final ElasticsearchException elsEx) {
       if ("resource_already_exists_exception".equals(elsEx.error().type())) {
         // we can ignore already exists exceptions
-        // as this means the index was created by another exporter on a different partition
+        // as this means the index was created by another instance
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will continue, likely was created by different partition (exporter).",
+                "Expected to create index [%s], but already exist. Will continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, elsEx);
         return;

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -97,10 +97,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
     } catch (final OpenSearchException ose) {
       if ("resource_already_exists_exception".equals(ose.error().type())) {
         // we can ignore already exists exceptions
-        // as this means the index was created by another exporter on a different partition
+        // as this means the index was created by another instance
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will continue, likely was created by different partition (exporter).",
+                "Expected to create index [%s], but already exist. Will continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, ose);
         return;

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.search.schema.SchemaTestUtil.validateMappings;
+import static io.camunda.search.schema.utils.SchemaTestUtil.validateMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.*;
@@ -19,6 +19,7 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
@@ -9,6 +9,7 @@ package io.camunda.search.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Test;

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.schema.exceptions.IndexSchemaValidationException;
+import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
 import java.io.IOException;
 import java.util.Collections;

--- a/schema-manager/src/test/java/io/camunda/search/schema/OpensearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/OpensearchEngineClientIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.CONFIG_PREFIX;
+import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
+import static io.camunda.search.schema.utils.SchemaTestUtil.mappingsMatch;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
+import io.camunda.search.schema.utils.SchemaTestUtil;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.dynamic.loading.ClassReloadingStrategy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DisabledIfSystemProperty(
+    named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+    matches = "^(?=\\s*\\S).*$",
+    disabledReason = "Excluding from AWS OS IT CI")
+@ExtendWith(SchemaManagerITInvocationProvider.class)
+public class SchemaManagerConcurrencyIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaManagerConcurrencyIT.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(30);
+  private IndexDescriptor index;
+  private IndexTemplateDescriptor indexTemplate;
+  private final MethodInterceptor methodInterceptor = new MethodInterceptor(SchemaManager.class);
+
+  @AfterEach
+  public void reset() {
+    methodInterceptor.reset();
+  }
+
+  @BeforeEach
+  public void before() throws IOException {
+    indexTemplate =
+        SchemaTestUtil.mockIndexTemplate(
+            "index_name",
+            "test*",
+            "template_alias",
+            Collections.emptyList(),
+            CONFIG_PREFIX + "-template_name",
+            "/mappings.json");
+
+    index =
+        SchemaTestUtil.mockIndex(
+            CONFIG_PREFIX + "-qualified_name", "alias", "index_name", "/mappings.json");
+
+    when(indexTemplate.getFullQualifiedName()).thenReturn(CONFIG_PREFIX + "-qualified_name");
+  }
+
+  @TestTemplate
+  void shouldConcurrentlyCreateSchemaWithSuccess(
+      final SearchEngineConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
+    // given
+    final var exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+    final var schemaManager1 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+    final var schemaManager2 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+
+    // when
+    methodInterceptor.applyPostMethodAdvice("getMissingIndices");
+    // Start schemaManager1 in a separate thread (it will pause after `getMissingIndices()`)
+    final Thread thread1 =
+        new Thread(
+            collectExceptions(
+                exceptions,
+                () -> {
+                  PostMethodPauseAdvice.setPauseForCurrentThread();
+                  schemaManager1.startup();
+                }),
+            "schema-manager-1");
+    thread1.start();
+    // Start schemaManager2 that should execute while schemaManager1 is paused
+    final Thread thread2 =
+        new Thread(
+            collectExceptions(exceptions, () -> schemaManager2.startup()), "schema-manager-2");
+    thread2.start();
+    thread2.join(TIMEOUT);
+    // unpause schemaManager1
+    PostMethodPauseAdvice.unpauseAll();
+    thread1.join(TIMEOUT);
+
+    // then
+    assertThat(exceptions).isEmpty();
+    // assert that both schema managers detected missing index
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, List.class)).hasSize(1);
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, List.class)).hasSize(1);
+    // assert that the schema was correctly created
+    final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    final var retrievedIndexTemplate =
+        clientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings.json")).isTrue();
+    assertThat(
+            mappingsMatch(
+                retrievedIndexTemplate.at("/index_template/template/mappings"), "/mappings.json"))
+        .isTrue();
+  }
+
+  @TestTemplate
+  void shouldConcurrentlyUpdateSchemaWithSuccess(
+      final SearchEngineConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
+    // given
+    final var exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+    final var schemaManager1 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+    final var schemaManager2 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+    schemaManager1.startup(); // initial schema creation
+    // set the mappings to a different file
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+
+    // when
+    methodInterceptor.applyPostMethodAdvice("validateIndices");
+    // Start schemaManager1 in a separate thread (it will pause after `validateIndices()`)
+    final Thread thread1 =
+        new Thread(
+            collectExceptions(
+                exceptions,
+                () -> {
+                  PostMethodPauseAdvice.setPauseForCurrentThread();
+                  schemaManager1.startup();
+                }),
+            "schema-manager-1");
+    thread1.start();
+    // Start schemaManager2 that should execute while schemaManager1 is paused
+    final Thread thread2 =
+        new Thread(
+            collectExceptions(exceptions, () -> schemaManager2.startup()), "schema-manager-2");
+    thread2.start();
+    thread2.join(TIMEOUT);
+    // unpause schemaManager1
+    PostMethodPauseAdvice.unpauseAll();
+    thread1.join(TIMEOUT);
+
+    // then
+    assertThat(exceptions).isEmpty();
+    // assert that both schema managers detected a diff in the index mapping
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, Map.class)).hasSize(1);
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, Map.class)).hasSize(1);
+    // assert that the schema was correctly updated
+    final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    final var retrievedIndexTemplate =
+        clientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
+        .isTrue();
+    assertThat(
+            mappingsMatch(
+                retrievedIndexTemplate.at("/index_template/template/mappings"),
+                "/mappings-added-property.json"))
+        .isTrue();
+  }
+
+  @TestTemplate
+  void shouldNotErrorIfOldSchemaManagerStartsWhileNewSchemaManagerHasAlreadyStarted(
+      final SearchEngineConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
+    // given
+    final var updatedSchemaManager =
+        createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+    final var oldSchemaManager = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
+    oldSchemaManager.startup(); // initial schema creation
+
+    // when
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+
+    updatedSchemaManager.startup();
+
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings.json");
+
+    oldSchemaManager.startup();
+
+    // then
+    final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    final var retrievedIndexTemplate =
+        clientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+
+    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
+        .isTrue();
+    assertThat(
+            mappingsMatch(
+                retrievedIndexTemplate.at("/index_template/template/mappings"),
+                "/mappings-added-property.json"))
+        .isTrue();
+  }
+
+  private Runnable collectExceptions(final List<Throwable> exceptions, final Runnable runnable) {
+    return () -> {
+      try {
+        runnable.run();
+      } catch (final Throwable t) {
+        LOGGER.error("Exception in thread {}", Thread.currentThread().getName(), t);
+        exceptions.add(t);
+      }
+    };
+  }
+
+  static class PostMethodPauseAdvice {
+    static final Semaphore SEMAPHORE = new Semaphore(0);
+    static ThreadLocal<Boolean> pauseCurrentThread = ThreadLocal.withInitial(() -> false);
+    static final ConcurrentMap<Thread, Object> RETURNED_VALUES = new ConcurrentHashMap<>();
+
+    @Advice.OnMethodExit
+    public static void onExit(@Advice.Return final Object returnedObject)
+        throws InterruptedException {
+      RETURNED_VALUES.put(Thread.currentThread(), returnedObject);
+      if (pauseCurrentThread.get()) {
+        SEMAPHORE.acquire(); // wait for unpauseAll signal
+      }
+      pauseCurrentThread.set(false);
+    }
+
+    static void setPauseForCurrentThread() {
+      pauseCurrentThread.set(true);
+    }
+
+    static void unpauseAll() {
+      while (SEMAPHORE.hasQueuedThreads()) {
+        SEMAPHORE.release();
+      }
+    }
+
+    static <T> T getReturnedValueBeforePause(final Thread thread, final Class<T> clazz) {
+      return clazz.cast(RETURNED_VALUES.get(thread));
+    }
+
+    static void reset() {
+      unpauseAll();
+      RETURNED_VALUES.clear();
+      pauseCurrentThread = ThreadLocal.withInitial(() -> false);
+    }
+  }
+
+  static class MethodInterceptor {
+
+    private final Class<?> targetClass;
+
+    public MethodInterceptor(final Class<?> targetClass) {
+      this.targetClass = targetClass;
+    }
+
+    public void applyPostMethodAdvice(final String pauseMethodName) {
+      new ByteBuddy()
+          .redefine(targetClass)
+          .visit(Advice.to(PostMethodPauseAdvice.class).on(named(pauseMethodName)))
+          .make()
+          .load(targetClass.getClassLoader(), ClassReloadingStrategy.fromInstalledAgent());
+    }
+
+    public void reset() {
+      new ByteBuddy()
+          .redefine(targetClass)
+          .make()
+          .load(targetClass.getClassLoader(), ClassReloadingStrategy.fromInstalledAgent());
+      PostMethodPauseAdvice.reset();
+    }
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/retry/RetryDecorator.java
@@ -97,7 +97,7 @@ public class RetryDecorator {
         .onRetry(
             event ->
                 LOG.warn(
-                    "Retrying operation for `{}`: attempt {}",
+                    "Retrying operation for '{}': attempt {}",
                     message,
                     event.getNumberOfRetryAttempts()));
     return retry;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`SchemaManagerConcurrencyIT` to test some concurrent situations where 
- 2 schema managers are simultaneously creating the schema
- 2 schema managers are simultaneously updating the schema (index mapping)
- old schema manager (with old index mapping) executing aftera newer schema manager (with newer schema manager) has completed: this test was moved from `SchemaManagerIT`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/28897
