### PR TITLE
fix: prevent showing forbidden page while loading identity

### DIFF
--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -15,6 +15,7 @@ import ErrorBoundary from "src/components/global/ErrorBoundary";
 import { useApi } from "src/utility/api";
 import { getAuthentication } from "src/utility/api/authentication";
 import ForbiddenComponent from "src/pages/forbidden/ForbiddenPage";
+import LateLoading from "src/components/layout/LateLoading";
 import { addHandler, removeHandler } from "src/utility/api/request";
 
 const GlobalStyle = createGlobalStyle`
@@ -64,7 +65,7 @@ const GridMainContent = styled.div`
 `;
 
 const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
-  const { data: camundaUser } = useApi(getAuthentication);
+  const { data: camundaUser, loading } = useApi(getAuthentication);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -82,6 +83,10 @@ const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
       removeHandler(handleResponse);
     };
   }, [navigate]);
+
+  if (loading) {
+    return <LateLoading />;
+  }
 
   if (
     !camundaUser?.authorizedApplications.includes("identity") &&

--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -7,13 +7,15 @@
  */
 
 import styled, { createGlobalStyle } from "styled-components";
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useEffect } from "react";
+import { useNavigate } from "react-router";
 import { g10, bodyShort01 } from "@carbon/elements";
 import AppHeader from "src/components/layout/AppHeader";
 import ErrorBoundary from "src/components/global/ErrorBoundary";
 import { useApi } from "src/utility/api";
 import { getAuthentication } from "src/utility/api/authentication";
 import ForbiddenComponent from "src/pages/forbidden/ForbiddenPage";
+import { addHandler, removeHandler } from "src/utility/api/request";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -63,6 +65,24 @@ const GridMainContent = styled.div`
 
 const AppContent: FC<{ children?: ReactNode }> = ({ children }) => {
   const { data: camundaUser } = useApi(getAuthentication);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleResponse = (response: Response) => {
+      if (
+        response.status === 401 &&
+        !window.location.pathname.includes("/login")
+      ) {
+        void navigate(`/login?next=${window.location.pathname}`);
+      }
+    };
+
+    addHandler(handleResponse);
+    return () => {
+      removeHandler(handleResponse);
+    };
+  }, [navigate]);
+
   if (
     !camundaUser?.authorizedApplications.includes("identity") &&
     !camundaUser?.authorizedApplications.includes("*")

--- a/identity/client/src/pages/forbidden/ForbiddenPage.tsx
+++ b/identity/client/src/pages/forbidden/ForbiddenPage.tsx
@@ -11,7 +11,7 @@ import { Link, Stack } from "@carbon/react";
 import { Launch } from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
 import { Description, Title, Grid, Content } from "./components";
-import forbiddenIcon from "src/assets/images/forbidden.svg";
+import ForbiddenIcon from "src/assets/images/forbidden.svg";
 
 const ForbiddenPage: FC = () => {
   const { t, Translate } = useTranslate();
@@ -19,7 +19,7 @@ const ForbiddenPage: FC = () => {
   return (
     <Grid>
       <Content gap={6}>
-        <img src={forbiddenIcon} alt="Forbidden" />
+        <ForbiddenIcon />
         <Stack gap={3}>
           <Title>{t("forbiddenPageTitle")}</Title>
           <Description>

--- a/identity/client/src/utility/auth/index.ts
+++ b/identity/client/src/utility/auth/index.ts
@@ -15,10 +15,6 @@ export function getLoginPath(next?: string) {
   return next ? `${LOGIN_PATH}?next=${next}` : LOGIN_PATH;
 }
 
-export function redirectToLogin() {
-  window.location.href = getLoginPath(window.location.pathname);
-}
-
 export function login(
   username: string,
   password: string,


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
The forbidden page appear due to two issues: 
1. Loading the current user to check if it is forbidden or not takes a bit of time and during that time, we do not display any loading state. So the forbidden page appears briefly until the user loads.

2. When redirecting to the /login page after receiving a 401 response, we issue a hard refresh, which takes a bit of time as well. During this time, the user info is not available, causing the forbidden page to appear.

I fixed the first issue by adding a loading state and second one by doing the redirection to `/login` in the front-end without a hard refresh


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29848
