### PR TITLE
fix: deduplicate optimize assignee operations

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/ZeebeProcessInstanceScriptFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/ZeebeProcessInstanceScriptFactory.java
@@ -88,7 +88,11 @@ public interface ZeebeProcessInstanceScriptFactory {
                 existingFlowNode.assigneeOperations = new ArrayList();
               }
               if (newFlowNode.assigneeOperations != null && !newFlowNode.assigneeOperations.isEmpty()) {
-                existingFlowNode.assigneeOperations.addAll(newFlowNode.assigneeOperations);
+                def newAssigneeOperations = Stream.of(newFlowNode.assigneeOperations)
+                  .filter(Objects::nonNull)
+                  .filter(newOperation -> !existingFlowNode.assigneeOperations.contains(newOperation))
+                  .collect(Collectors.toList());
+                existingFlowNode.assigneeOperations.addAll(newAssigneeOperations);
               }
               if (isUserTaskImport) {
                 existingFlowNode.assignee = newFlowNode.assignee;

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeUserTaskImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeUserTaskImportService.java
@@ -249,7 +249,12 @@ public class ZeebeUserTaskImportService
 
   private void updateUserTaskAssigneeOperations(
       final ZeebeUserTaskRecordDto zeebeUserTaskRecord, final FlowNodeInstanceDto flowNodeToAdd) {
-    flowNodeToAdd.getAssigneeOperations().add(createAssigneeOperationDto(zeebeUserTaskRecord));
+    final List<AssigneeOperationDto> assigneeOperations = flowNodeToAdd.getAssigneeOperations();
+    final AssigneeOperationDto newAssigneeOperation =
+        createAssigneeOperationDto(zeebeUserTaskRecord);
+    if (!assigneeOperations.contains(newAssigneeOperation)) {
+      assigneeOperations.add(newAssigneeOperation);
+    }
   }
 
   private AssigneeOperationDto createAssigneeOperationDto(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We found during testing that Optimize can create duplicate assignee operations, and this is not the intended behaviour. This PR fixes the scenario by simply deduplicating them on write

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
