### PR TITLE
Add E2E coverage for Identity Users page and operations

### DIFF
--- a/identity/client/e2e/pages/Header.ts
+++ b/identity/client/e2e/pages/Header.ts
@@ -1,28 +1,18 @@
 import { Page, Locator } from "@playwright/test";
 
-export class Common {
-  private page: Page;
+export class Header {
   readonly openSettingsButton: Locator;
   readonly logoutButton: Locator;
 
   constructor(page: Page) {
-    this.page = page;
     this.openSettingsButton = page.getByRole("button", {
       name: "Open Settings",
     });
     this.logoutButton = page.getByRole("button", { name: "Log out" });
   }
 
-  clickOpenSettingsButton() {
-    return this.openSettingsButton.click();
-  }
-
-  clickLogoutButton() {
-    return this.logoutButton.click();
-  }
-
   async logout() {
-    await this.clickOpenSettingsButton();
-    await this.clickLogoutButton();
+    await this.openSettingsButton.click();
+    await this.logoutButton.click();
   }
 }

--- a/identity/client/e2e/pages/LoginPage.ts
+++ b/identity/client/e2e/pages/LoginPage.ts
@@ -9,7 +9,7 @@
 import { Page, Locator } from "@playwright/test";
 import { Paths } from "../utils/paths";
 
-export class Login {
+export class LoginPage {
   private page: Page;
   readonly usernameInput: Locator;
   readonly passwordInput: Locator;

--- a/identity/client/e2e/pages/Users.ts
+++ b/identity/client/e2e/pages/Users.ts
@@ -1,19 +1,126 @@
 import { Page, Locator } from "@playwright/test";
 
 export class Users {
+  readonly usersList: Locator;
   readonly createUserButton: Locator;
-  readonly editUserButton: Locator;
-  readonly deleteFirstUserButton: Locator;
+  readonly editUserButton: (rowName?: string) => Locator;
+  readonly deleteUserButton: (rowName?: string) => Locator;
+  readonly createUserModal: Locator;
+  readonly closeCreateUserModal: Locator;
+  readonly createUsernameField: Locator;
+  readonly createNameField: Locator;
+  readonly createEmailField: Locator;
+  readonly createPasswordField: Locator;
+  readonly createRepeatPasswordField: Locator;
+  readonly createUserModalCancelButton: Locator;
+  readonly createUserModalCreateButton: Locator;
+  readonly editUserModal: Locator;
+  readonly closeEditUserModal: Locator;
+  readonly editNameField: Locator;
+  readonly editEmailField: Locator;
+  readonly editNewPasswordField: Locator;
+  readonly editRepeatPasswordField: Locator;
+  readonly editUserModalCancelButton: Locator;
+  readonly editUserModalUpdateButton: Locator;
+  readonly deleteUserModal: Locator;
+  readonly closeDeleteUserModal: Locator;
+  readonly deleteUserModalCancelButton: Locator;
+  readonly deleteUserModalDeleteButton: Locator;
 
   constructor(page: Page) {
+    // List page
+    this.usersList = page.getByRole("table");
     this.createUserButton = page.getByRole("button", {
+      name: /create user/i,
+    });
+    this.editUserButton = (rowName) =>
+      this.usersList
+        .getByRole("row", { name: rowName })
+        .getByLabel(/edit user/i);
+    this.deleteUserButton = (rowName) =>
+      this.usersList.getByRole("row", { name: rowName }).getByLabel("Delete");
+
+    // Create user modal
+    this.createUserModal = page.getByRole("dialog", {
       name: "Create user",
     });
-    this.editUserButton = page.getByRole("button", {
-      name: "Edit user",
+    this.closeCreateUserModal = this.createUserModal.getByRole("button", {
+      name: "Close",
     });
-    this.deleteFirstUserButton = page
-      .getByRole("button", { name: "Delete" })
-      .first();
+    this.createUsernameField = this.createUserModal.getByRole("textbox", {
+      name: "Username",
+    });
+    this.createNameField = this.createUserModal.getByRole("textbox", {
+      name: "Name",
+      exact: true,
+    });
+    this.createEmailField = this.createUserModal.getByRole("textbox", {
+      name: "Email",
+    });
+    this.createPasswordField = this.createUserModal.getByRole("textbox", {
+      name: "Password",
+      exact: true,
+    });
+    this.createRepeatPasswordField = this.createUserModal.getByRole("textbox", {
+      name: /repeat password/i,
+      exact: true,
+    });
+    this.createUserModalCancelButton = this.createUserModal.getByRole(
+      "button",
+      {
+        name: "Cancel",
+      },
+    );
+    this.createUserModalCreateButton = this.createUserModal.getByRole(
+      "button",
+      {
+        name: /create user/i,
+      },
+    );
+
+    // Edit user modal
+    this.editUserModal = page.getByRole("dialog", { name: /edit user/i });
+    this.closeEditUserModal = this.editUserModal.getByRole("button", {
+      name: "Close",
+    });
+    this.editNameField = this.editUserModal.getByRole("textbox", {
+      name: /name/i,
+      exact: true,
+    });
+    this.editEmailField = this.editUserModal.getByRole("textbox", {
+      name: /email/i,
+    });
+    this.editNewPasswordField = this.editUserModal.getByRole("textbox", {
+      name: /new password/i,
+      exact: true,
+    });
+    this.editRepeatPasswordField = this.editUserModal.getByRole("textbox", {
+      name: /repeat password/i,
+      exact: true,
+    });
+    this.editUserModalCancelButton = this.editUserModal.getByRole("button", {
+      name: "Cancel",
+    });
+    this.editUserModalUpdateButton = this.editUserModal.getByRole("button", {
+      name: /update user/i,
+    });
+
+    // Delete user modal
+    this.deleteUserModal = page.getByRole("dialog", { name: /delete user/i });
+    this.closeDeleteUserModal = this.deleteUserModal.getByRole("button", {
+      name: "Close",
+    });
+    this.deleteUserModalCancelButton = this.deleteUserModal.getByRole(
+      "button",
+      {
+        name: "Cancel",
+      },
+    );
+    this.deleteUserModalDeleteButton = this.deleteUserModal.getByRole(
+      "button",
+      {
+        name: /delete user/i,
+      },
+    );
   }
 }

--- a/identity/client/e2e/pages/Users.ts
+++ b/identity/client/e2e/pages/Users.ts
@@ -1,0 +1,19 @@
+import { Page, Locator } from "@playwright/test";
+
+export class Users {
+  readonly createUserButton: Locator;
+  readonly editUserButton: Locator;
+  readonly deleteFirstUserButton: Locator;
+
+  constructor(page: Page) {
+    this.createUserButton = page.getByRole("button", {
+      name: "Create user",
+    });
+    this.editUserButton = page.getByRole("button", {
+      name: "Edit user",
+    });
+    this.deleteFirstUserButton = page
+      .getByRole("button", { name: "Delete" })
+      .first();
+  }
+}

--- a/identity/client/e2e/pages/UsersPage.ts
+++ b/identity/client/e2e/pages/UsersPage.ts
@@ -1,6 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
 import { Page, Locator } from "@playwright/test";
 
-export class Users {
+export class UsersPage {
   readonly usersList: Locator;
   readonly createUserButton: Locator;
   readonly editUserButton: (rowName?: string) => Locator;

--- a/identity/client/e2e/tests/login.spec.ts
+++ b/identity/client/e2e/tests/login.spec.ts
@@ -7,9 +7,10 @@
  */
 
 import { expect } from "@playwright/test";
-import { loginTest as test } from "../text-fixtures";
+import { test } from "../text-fixtures";
 import { Paths } from "../utils/paths";
 import { relativizePath } from "../utils/relativizePaths";
+import { LOGIN_CREDENTIALS } from "../utils/constants";
 
 test.beforeEach(async ({ loginPage }) => {
   await loginPage.navigateToLogin();
@@ -35,22 +36,16 @@ test.describe("login page", () => {
   });
 
   test("Log in with valid user account", async ({ loginPage, page }) => {
-    await loginPage.login({
-      username: "demo",
-      password: "demo",
-    });
+    await loginPage.login(LOGIN_CREDENTIALS);
 
     await expect(page).toHaveURL(relativizePath(Paths.users()));
   });
 
-  test("Log out", async ({ loginPage, commonPage, page }) => {
-    await loginPage.login({
-      username: "demo",
-      password: "demo",
-    });
+  test("Log out", async ({ loginPage, header, page }) => {
+    await loginPage.login(LOGIN_CREDENTIALS);
 
     await expect(page).toHaveURL(relativizePath(Paths.users()));
-    await commonPage.logout();
+    await header.logout();
     await expect(page).toHaveURL(
       `${relativizePath(Paths.login())}?next=/identity/`,
     );
@@ -63,10 +58,7 @@ test.describe("login page", () => {
       `${relativizePath(Paths.login())}?next=/identity${Paths.users()}`,
     );
 
-    await loginPage.login({
-      username: "demo",
-      password: "demo",
-    });
+    await loginPage.login(LOGIN_CREDENTIALS);
 
     await expect(page).toHaveURL(relativizePath(Paths.users()));
   });

--- a/identity/client/e2e/tests/users.spec.ts
+++ b/identity/client/e2e/tests/users.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { expect } from "@playwright/test";
+import { test } from "../text-fixtures";
+import { Paths } from "../utils/paths";
+import { relativizePath } from "../utils/relativizePaths";
+import { LOGIN_CREDENTIALS } from "../utils/constants";
+
+test.beforeEach(async ({ loginPage, page }) => {
+  await loginPage.navigateToLogin();
+  await loginPage.login(LOGIN_CREDENTIALS);
+  await expect(page).toHaveURL(relativizePath(Paths.users()));
+});
+
+test.describe.only("users CRUD", () => {
+  test("creates an user", async ({ usersPage }) => {
+    await usersPage.createUserButton.click();
+  });
+  // @TODO: fill form fields
+  // @TODO: click create user button
+  // @TODO: await for user to be created
+  // @TODO: refresh page
+  // @TODO: check for new user on list
+});

--- a/identity/client/e2e/tests/users.spec.ts
+++ b/identity/client/e2e/tests/users.spec.ts
@@ -12,19 +12,114 @@ import { Paths } from "../utils/paths";
 import { relativizePath } from "../utils/relativizePaths";
 import { LOGIN_CREDENTIALS } from "../utils/constants";
 
-test.beforeEach(async ({ loginPage, page }) => {
+const NEW_USER = {
+  username: "testuser",
+  name: "Test User",
+  email: "testuser@camunda.com",
+  password: "testpassword",
+};
+
+const EDITED_USER = {
+  name: "Edited User",
+  email: "editeduser@camunda.com",
+  password: "editedtestpassword",
+};
+
+test.beforeEach(async ({ page, loginPage }) => {
   await loginPage.navigateToLogin();
   await loginPage.login(LOGIN_CREDENTIALS);
   await expect(page).toHaveURL(relativizePath(Paths.users()));
 });
 
-test.describe.only("users CRUD", () => {
-  test("creates an user", async ({ usersPage }) => {
+test.describe.serial("users CRUD", () => {
+  test("creates an user", async ({ page, usersPage }) => {
+    await expect(
+      usersPage.usersList.getByRole("cell", { name: "demo@demo.com" }),
+    ).toBeVisible();
+    await expect(
+      usersPage.usersList.getByRole("cell", { name: NEW_USER.email }),
+    ).not.toBeVisible();
+
     await usersPage.createUserButton.click();
+    await expect(usersPage.createUserModal).toBeVisible();
+    await usersPage.createUsernameField.fill(NEW_USER.username);
+    await usersPage.createNameField.fill(NEW_USER.name);
+    await usersPage.createEmailField.fill(NEW_USER.email);
+    await usersPage.createPasswordField.fill(NEW_USER.password);
+    await usersPage.createRepeatPasswordField.fill(NEW_USER.password);
+    await usersPage.createUserModalCreateButton.click();
+    await expect(usersPage.createUserModal).not.toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          await page.reload();
+          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
+          const isVisible = await usersPage.usersList
+            .getByRole("cell", { name: NEW_USER.email })
+            .isVisible();
+          return isVisible;
+        },
+        {
+          timeout: 10000,
+        },
+      )
+      .toBeTruthy();
   });
-  // @TODO: fill form fields
-  // @TODO: click create user button
-  // @TODO: await for user to be created
-  // @TODO: refresh page
-  // @TODO: check for new user on list
+
+  test("edits an user", async ({ page, usersPage }) => {
+    await expect(
+      usersPage.usersList.getByRole("cell", { name: NEW_USER.email }),
+    ).toBeVisible();
+
+    await usersPage.editUserButton(NEW_USER.email).click();
+    await expect(usersPage.editUserModal).toBeVisible();
+    await usersPage.editNameField.fill(EDITED_USER.name);
+    await usersPage.editEmailField.fill(EDITED_USER.email);
+    await usersPage.editUserModalUpdateButton.click();
+    await expect(usersPage.editUserModal).not.toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          await page.reload();
+          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
+          const isVisible = await usersPage.usersList
+            .getByRole("cell", { name: EDITED_USER.email })
+            .isVisible();
+          return isVisible;
+        },
+        {
+          timeout: 10000,
+        },
+      )
+      .toBeTruthy();
+  });
+
+  test("deletes an user", async ({ page, usersPage }) => {
+    await expect(
+      usersPage.usersList.getByRole("cell", { name: EDITED_USER.email }),
+    ).toBeVisible();
+
+    await usersPage.deleteUserButton(EDITED_USER.email).click();
+    await expect(usersPage.deleteUserModal).toBeVisible();
+    await usersPage.deleteUserModalDeleteButton.click();
+    await expect(usersPage.deleteUserModal).not.toBeVisible();
+
+    await expect
+      .poll(
+        async () => {
+          await page.reload();
+          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
+          const isVisible = await usersPage.usersList
+            .getByRole("cell", { name: EDITED_USER.email })
+            .isVisible();
+          return isVisible;
+        },
+        {
+          timeout: 10000,
+        },
+      )
+      .toBeFalsy();
+  });
 });

--- a/identity/client/e2e/tests/users.spec.ts
+++ b/identity/client/e2e/tests/users.spec.ts
@@ -11,6 +11,7 @@ import { test } from "../text-fixtures";
 import { Paths } from "../utils/paths";
 import { relativizePath } from "../utils/relativizePaths";
 import { LOGIN_CREDENTIALS } from "../utils/constants";
+import { waitForItemInList } from "../utils/waitForItemInList";
 
 const NEW_USER = {
   username: "testuser",
@@ -32,7 +33,7 @@ test.beforeEach(async ({ page, loginPage }) => {
 });
 
 test.describe.serial("users CRUD", () => {
-  test("creates an user", async ({ page, usersPage }) => {
+  test("creates a user", async ({ page, usersPage }) => {
     await expect(
       usersPage.usersList.getByRole("cell", { name: "demo@demo.com" }),
     ).toBeVisible();
@@ -50,24 +51,14 @@ test.describe.serial("users CRUD", () => {
     await usersPage.createUserModalCreateButton.click();
     await expect(usersPage.createUserModal).not.toBeVisible();
 
-    await expect
-      .poll(
-        async () => {
-          await page.reload();
-          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
-          const isVisible = await usersPage.usersList
-            .getByRole("cell", { name: NEW_USER.email })
-            .isVisible();
-          return isVisible;
-        },
-        {
-          timeout: 10000,
-        },
-      )
-      .toBeTruthy();
+    const item = usersPage.usersList.getByRole("cell", {
+      name: NEW_USER.email,
+    });
+
+    await waitForItemInList(page, item);
   });
 
-  test("edits an user", async ({ page, usersPage }) => {
+  test("edits a user", async ({ page, usersPage }) => {
     await expect(
       usersPage.usersList.getByRole("cell", { name: NEW_USER.email }),
     ).toBeVisible();
@@ -79,24 +70,14 @@ test.describe.serial("users CRUD", () => {
     await usersPage.editUserModalUpdateButton.click();
     await expect(usersPage.editUserModal).not.toBeVisible();
 
-    await expect
-      .poll(
-        async () => {
-          await page.reload();
-          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
-          const isVisible = await usersPage.usersList
-            .getByRole("cell", { name: EDITED_USER.email })
-            .isVisible();
-          return isVisible;
-        },
-        {
-          timeout: 10000,
-        },
-      )
-      .toBeTruthy();
+    const item = usersPage.usersList.getByRole("cell", {
+      name: EDITED_USER.email,
+    });
+
+    await waitForItemInList(page, item);
   });
 
-  test("deletes an user", async ({ page, usersPage }) => {
+  test("deletes a user", async ({ page, usersPage }) => {
     await expect(
       usersPage.usersList.getByRole("cell", { name: EDITED_USER.email }),
     ).toBeVisible();
@@ -121,5 +102,11 @@ test.describe.serial("users CRUD", () => {
         },
       )
       .toBeFalsy();
+
+    const item = usersPage.usersList.getByRole("cell", {
+      name: EDITED_USER.email,
+    });
+
+    await waitForItemInList(page, item, false);
   });
 });

--- a/identity/client/e2e/text-fixtures.ts
+++ b/identity/client/e2e/text-fixtures.ts
@@ -9,22 +9,17 @@
 import { test as base } from "@playwright/test";
 import { Header } from "./pages/Header";
 import { LoginPage } from "./pages/LoginPage";
-import { Users } from "./pages/Users";
+import { UsersPage } from "./pages/UsersPage";
+import { createFixture } from "./utils/createFixture";
 
-type PlaywrightFixtures = {
+type Fixtures = {
   header: Header;
   loginPage: LoginPage;
-  usersPage: Users;
+  usersPage: UsersPage;
 };
 
-export const test = base.extend<PlaywrightFixtures>({
-  header: async ({ page }, use) => {
-    await use(new Header(page));
-  },
-  loginPage: async ({ page }, use) => {
-    await use(new LoginPage(page));
-  },
-  usersPage: async ({ page }, use) => {
-    await use(new Users(page));
-  },
+export const test = base.extend<Fixtures>({
+  header: createFixture(Header),
+  loginPage: createFixture(LoginPage),
+  usersPage: createFixture(UsersPage),
 });

--- a/identity/client/e2e/text-fixtures.ts
+++ b/identity/client/e2e/text-fixtures.ts
@@ -7,20 +7,24 @@
  */
 
 import { test as base } from "@playwright/test";
-import { Login } from "./pages/Login";
-import { Common } from "./pages/CommonPage";
+import { Header } from "./pages/Header";
+import { LoginPage } from "./pages/LoginPage";
+import { Users } from "./pages/Users";
 
-type Fixture = {
-  resetData: () => Promise<void>;
-  loginPage: Login;
-  commonPage: Common;
+type PlaywrightFixtures = {
+  header: Header;
+  loginPage: LoginPage;
+  usersPage: Users;
 };
 
-export const loginTest = base.extend<Fixture>({
-  commonPage: async ({ page }, use) => {
-    await use(new Common(page));
+export const test = base.extend<PlaywrightFixtures>({
+  header: async ({ page }, use) => {
+    await use(new Header(page));
   },
   loginPage: async ({ page }, use) => {
-    await use(new Login(page));
+    await use(new LoginPage(page));
+  },
+  usersPage: async ({ page }, use) => {
+    await use(new Users(page));
   },
 });

--- a/identity/client/e2e/utils/constants.ts
+++ b/identity/client/e2e/utils/constants.ts
@@ -6,6 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const URL_API_PATTERN = /^.*\/(v2).*$/i;
+export const URL_API_PATTERN = /^.*\/(v2).*$/i;
 
-export { URL_API_PATTERN };
+export const LOGIN_CREDENTIALS = { username: "demo", password: "demo" };

--- a/identity/client/e2e/utils/createFixture.ts
+++ b/identity/client/e2e/utils/createFixture.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export function createFixture(Constructor) {
+  return async ({ page }, use) => {
+    await use(new Constructor(page));
+  };
+}

--- a/identity/client/e2e/utils/waitForItemInList.ts
+++ b/identity/client/e2e/utils/waitForItemInList.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { expect, Locator, Page } from "@playwright/test";
+
+export const waitForItemInList = async (
+  page: Page,
+  item: Locator,
+  shouldBeVisible: boolean = true,
+  timeout: number = 10000,
+) => {
+  const poll = expect.poll(
+    async () => {
+      await page.reload();
+      await page.getByRole("table").waitFor();
+      const isVisible = await item.isVisible();
+
+      return isVisible;
+    },
+    {
+      timeout,
+    },
+  );
+
+  if (shouldBeVisible) {
+    return await poll.toBeTruthy();
+  }
+
+  return await poll.toBeFalsy();
+};


### PR DESCRIPTION
## Description

Add E2E coverage for Identity Users page and operations. 
More details on parent issue - #30950


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30950
