### PR TITLE
fix: grpcs was not configurable on sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -173,6 +173,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -45,6 +45,8 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
   private final List<AsyncExecChainHandler> chainHandlers;
   private final CamundaClientExecutorService zeebeClientExecutorService;
   private final CredentialsProvider credentialsProvider;
+  private final String gatewayAddress;
+  private final boolean plaintext;
 
   public CamundaClientConfigurationImpl(
       final CamundaClientProperties camundaClientProperties,
@@ -59,6 +61,8 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
     this.chainHandlers = chainHandlers;
     this.zeebeClientExecutorService = zeebeClientExecutorService;
     this.credentialsProvider = credentialsProvider;
+    gatewayAddress = composeGatewayAddress();
+    plaintext = composePlaintext();
   }
 
   private static <T> T propertyOrDefault(final T property, final T defaultValue) {
@@ -70,7 +74,7 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public String getGatewayAddress() {
-    return propertyOrDefault(composeGatewayAddress(), DEFAULT.getGatewayAddress());
+    return propertyOrDefault(gatewayAddress, DEFAULT.getGatewayAddress());
   }
 
   @Override
@@ -143,7 +147,7 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return propertyOrDefault(composePlaintext(), DEFAULT.isPlaintextConnectionEnabled());
+    return propertyOrDefault(plaintext, DEFAULT.isPlaintextConnectionEnabled());
   }
 
   @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -265,8 +265,8 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
   private boolean composePlaintext() {
     final String protocol = getGrpcAddress().getScheme();
     return switch (protocol) {
-      case "http" -> true;
-      case "https" -> false;
+      case "http", "grpc" -> true;
+      case "https", "grpcs" -> false;
       default ->
           throw new IllegalStateException(
               String.format("Unrecognized zeebe protocol '%s'", protocol));

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationImplTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationImplTest.java
@@ -25,9 +25,12 @@ import io.camunda.spring.client.configuration.CamundaClientConfigurationImpl;
 import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.properties.CamundaClientProperties;
 import io.grpc.ClientInterceptor;
+import java.net.URI;
 import java.util.List;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class CamundaClientConfigurationImplTest {
   private static CamundaClientConfigurationImpl configuration(
@@ -70,5 +73,22 @@ public class CamundaClientConfigurationImplTest {
     final CredentialsProvider credentialsProvider1 = configuration.getCredentialsProvider();
     final CredentialsProvider credentialsProvider2 = configuration.getCredentialsProvider();
     assertThat(credentialsProvider1).isSameAs(credentialsProvider2);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"http, true", "https, false", "grpc, true", "grpcs, false"})
+  void shouldConfigurePlaintextAndGatewayAddress(final String protocol, final boolean plaintext) {
+    final CamundaClientProperties properties = properties();
+    properties.setGrpcAddress(URI.create(String.format("%s://some-host:21500", protocol)));
+    final CamundaClientConfigurationImpl configuration =
+        configuration(
+            properties,
+            jsonMapper(),
+            List.of(),
+            List.of(),
+            executorService(),
+            credentialsProvider());
+    assertThat(configuration.isPlaintextConnectionEnabled()).isEqualTo(plaintext);
+    assertThat(configuration.getGatewayAddress()).isEqualTo("some-host:21500");
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes a problem where an URL like `grpcs://your-host:26500` could not be used as `camunda.client.grpc-address` because the protocol was not handled properly.

Context: https://camunda.slack.com/archives/CKZK2E7RP/p1744312026338319

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
