### PR TITLE
[Backport stable/8.7] fix: grpcs was not configurable on sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -182,6 +182,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -47,6 +47,8 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   private final List<AsyncExecChainHandler> chainHandlers;
   private final ZeebeClientExecutorService zeebeClientExecutorService;
   private final CredentialsProvider credentialsProvider;
+  private final String gatewayAddress;
+  private final boolean plaintext;
 
   @Autowired
   public ZeebeClientConfigurationImpl(
@@ -62,11 +64,13 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
     this.chainHandlers = chainHandlers;
     this.zeebeClientExecutorService = zeebeClientExecutorService;
     this.credentialsProvider = credentialsProvider;
+    gatewayAddress = composeGatewayAddress();
+    plaintext = composePlaintext();
   }
 
   @Override
   public String getGatewayAddress() {
-    return ofNullable(composeGatewayAddress()).orElse(DEFAULT.getGatewayAddress());
+    return ofNullable(gatewayAddress).orElse(DEFAULT.getGatewayAddress());
   }
 
   @Override
@@ -136,7 +140,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return composePlaintext();
+    return plaintext;
   }
 
   @Override
@@ -258,8 +262,8 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   private boolean composePlaintext() {
     final String protocol = getGrpcAddress().getScheme();
     return switch (protocol) {
-      case "http" -> true;
-      case "https" -> false;
+      case "http", "grpc" -> true;
+      case "https", "grpcs" -> false;
       default ->
           throw new IllegalStateException(
               String.format("Unrecognized zeebe protocol '%s'", protocol));

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplTest.java
@@ -25,9 +25,12 @@ import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationImpl
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.grpc.ClientInterceptor;
+import java.net.URI;
 import java.util.List;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class ZeebeClientConfigurationImplTest {
   private static ZeebeClientConfigurationImpl configuration(
@@ -70,5 +73,24 @@ public class ZeebeClientConfigurationImplTest {
     final CredentialsProvider credentialsProvider1 = configuration.getCredentialsProvider();
     final CredentialsProvider credentialsProvider2 = configuration.getCredentialsProvider();
     assertThat(credentialsProvider1).isSameAs(credentialsProvider2);
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {"http, true", "https, false", "grpc, true", "grpcs, false"})
+  void shouldConfigurePlaintextAndGatewayAddress(final String protocol, final boolean plaintext) {
+    final CamundaClientProperties properties = properties();
+    properties
+        .getZeebe()
+        .setGrpcAddress(URI.create(String.format("%s://some-host:21500", protocol)));
+    final ZeebeClientConfigurationImpl configuration =
+        configuration(
+            properties,
+            jsonMapper(),
+            List.of(),
+            List.of(),
+            executorService(),
+            credentialsProvider());
+    assertThat(configuration.isPlaintextConnectionEnabled()).isEqualTo(plaintext);
+    assertThat(configuration.getGatewayAddress()).isEqualTo("some-host:21500");
   }
 }


### PR DESCRIPTION
# Description
Backport of #30959 to `stable/8.7`.

relates to 