### PR TITLE
[Backport stable/8.6] [Backport stable/8.7] fix: grpcs was not configurable on sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -182,6 +182,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -386,8 +386,8 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   private boolean composePlaintext() {
     final String protocol = getGrpcAddress().getScheme();
     return switch (protocol) {
-      case "http" -> true;
-      case "https" -> false;
+      case "http", "grpc" -> true;
+      case "https", "grpcs" -> false;
       default ->
           throw new IllegalStateException(
               String.format("Unrecognized zeebe protocol '%s'", protocol));


### PR DESCRIPTION
# Description
Backport of #30962 to `stable/8.6`.

relates to #30959