### PR TITLE
refactor: remove defaults where possible

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -74,7 +74,7 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public String getGatewayAddress() {
-    return propertyOrDefault(gatewayAddress, DEFAULT.getGatewayAddress());
+    return gatewayAddress;
   }
 
   @Override
@@ -147,7 +147,7 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return propertyOrDefault(plaintext, DEFAULT.isPlaintextConnectionEnabled());
+    return plaintext;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes defaults where they are not required. This is the case as both properties are composed from `getGrpcAddress` which has a meaningful default.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
