### PR TITLE
refactor: migrate processes-page tests from HTO to core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/fixtures.ts
+++ b/qa/core-application-e2e-test-suite/fixtures.ts
@@ -16,9 +16,12 @@ import {OperateProcessesPage} from '@pages/OperateProcessesPage';
 import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
+import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
+import {sleep} from 'utils/sleep';
 
 type PlaywrightFixtures = {
   makeAxeBuilder: () => AxeBuilder;
+  resetData: () => Promise<void>;
   operateLoginPage: OperateLoginPage;
   operateHomePage: OperateHomePage;
   taskListLoginPage: TaskListLoginPage;
@@ -27,6 +30,7 @@ type PlaywrightFixtures = {
   operateProcessInstancePage: OperateProcessInstancePage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
+  tasklistprocessesPage: TasklistProcessesPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -65,6 +69,18 @@ const test = base.extend<PlaywrightFixtures>({
   },
   tasklistHeader: async ({page}, use) => {
     await use(new TasklistHeader(page));
+  },
+  tasklistprocessesPage: async ({page}, use) => {
+    await use(new TasklistProcessesPage(page));
+  },
+  resetData: async ({baseURL}, use) => {
+    await use(async () => {
+      await fetch(`${baseURL}../v1/external/devUtil/recreateData`, {
+        method: 'POST',
+      });
+
+      await sleep(1000);
+    });
   },
 });
 

--- a/qa/core-application-e2e-test-suite/fixtures.ts
+++ b/qa/core-application-e2e-test-suite/fixtures.ts
@@ -30,7 +30,7 @@ type PlaywrightFixtures = {
   operateProcessInstancePage: OperateProcessInstancePage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
-  tasklistprocessesPage: TasklistProcessesPage;
+  tasklistProcessesPage: TasklistProcessesPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -70,7 +70,7 @@ const test = base.extend<PlaywrightFixtures>({
   tasklistHeader: async ({page}, use) => {
     await use(new TasklistHeader(page));
   },
-  tasklistprocessesPage: async ({page}, use) => {
+  tasklistProcessesPage: async ({page}, use) => {
     await use(new TasklistProcessesPage(page));
   },
   resetData: async ({baseURL}, use) => {

--- a/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -160,15 +160,9 @@ class TaskDetailsPage {
     await this.decrementButton.click();
   }
 
-  async fillDate(date: string): Promise<void> {
-    await this.dateInput.click();
-    await this.dateInput.fill(date);
-    await this.dateInput.press('Enter');
-  }
-
-  async enterTime(time: string): Promise<void> {
-    await this.timeInput.click();
-    await this.page.getByText(time).click();
+  async fillDatetimeField(name: string, value: string) {
+    await this.page.getByRole('textbox', {name}).fill(value);
+    await this.page.getByRole('textbox', {name}).press('Enter');
   }
 
   async checkCheckbox(): Promise<void> {
@@ -177,6 +171,11 @@ class TaskDetailsPage {
 
   async selectDropdownValue(value: string): Promise<void> {
     await this.selectDropdown.click();
+    await this.page.getByText(value).click();
+  }
+
+  async selectDropdownOption(label: string, value: string) {
+    await this.page.getByText(label).click();
     await this.page.getByText(value).click();
   }
 
@@ -246,6 +245,16 @@ class TaskDetailsPage {
     await expect(this.page.getByTitle(variableName + ' Value')).toHaveValue(
       variableValue,
     );
+  }
+  async forEachDynamicListItem(
+    locator: Locator,
+    fn: (value: Locator, index: number, array: Locator[]) => Promise<void>,
+  ) {
+    const elements = await locator.all();
+
+    for (const element of elements) {
+      await fn(element, elements.indexOf(element), elements);
+    }
   }
 }
 export {TaskDetailsPage};

--- a/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -251,7 +251,11 @@ class TaskDetailsPage {
     fn: (value: Locator, index: number, array: Locator[]) => Promise<void>,
   ) {
     const elements = await locator.all();
-
+    if (elements.length === 0) {
+      throw new Error(
+        'No elements found for provided locator in the dynamic list',
+      );
+    }
     for (const element of elements) {
       await fn(element, elements.indexOf(element), elements);
     }

--- a/qa/core-application-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -12,7 +12,6 @@ class TasklistProcessesPage {
   private page: Page;
   readonly continueButton: Locator;
   readonly cancelButton: Locator;
-  readonly modaLStartProcessButton: Locator;
   readonly startProcessButton: Locator;
   readonly docsLink: Locator;
   readonly searchProcessesInput: Locator;
@@ -24,9 +23,6 @@ class TasklistProcessesPage {
     this.continueButton = page.getByRole('button', {name: 'Continue'});
     this.cancelButton = page.getByRole('button', {name: 'Cancel'});
     this.startProcessButton = page.getByRole('button', {name: 'Start process'});
-    this.modaLStartProcessButton = this.page
-      .getByLabel('Start process processWithStartNodeFormDeployed')
-      .getByRole('button', {name: 'Start process'});
     this.docsLink = page.getByRole('link', {name: 'here'});
     this.searchProcessesInput = page.getByPlaceholder('Search processes');
     this.processTile = page.getByTestId('process-tile');
@@ -44,5 +40,16 @@ class TasklistProcessesPage {
     await this.searchProcessesInput.fill(process);
     await this.searchProcessesInput.press('Enter');
   }
+
+  async getModalStartProcessButton(processName: string): Promise<Locator> {
+    return this.page
+      .getByLabel(`Start process ${processName}`)
+      .getByRole('button', {name: 'Start process'});
+  }
+
+  async clickStartProcessButton(processName: string): Promise<void> {
+    await (await this.getModalStartProcessButton(processName)).click();
+  }
 }
+
 export {TasklistProcessesPage};

--- a/qa/core-application-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Page, Locator} from '@playwright/test';
+
+class TasklistProcessesPage {
+  private page: Page;
+  readonly continueButton: Locator;
+  readonly cancelButton: Locator;
+  readonly modaLStartProcessButton: Locator;
+  readonly startProcessButton: Locator;
+  readonly docsLink: Locator;
+  readonly searchProcessesInput: Locator;
+  readonly processTile: Locator;
+  readonly tasksTab: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.continueButton = page.getByRole('button', {name: 'Continue'});
+    this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+    this.startProcessButton = page.getByRole('button', {name: 'Start process'});
+    this.modaLStartProcessButton = this.page
+      .getByLabel('Start process processWithStartNodeFormDeployed')
+      .getByRole('button', {name: 'Start process'});
+    this.docsLink = page.getByRole('link', {name: 'here'});
+    this.searchProcessesInput = page.getByPlaceholder('Search processes');
+    this.processTile = page.getByTestId('process-tile');
+    this.tasksTab = page.getByRole('link', {name: 'Tasks'});
+  }
+
+  async goto() {
+    await this.page.goto('/processes', {
+      waitUntil: 'load',
+    });
+  }
+
+  public async searchForProcess(process: string) {
+    await this.searchProcessesInput.click();
+    await this.searchProcessesInput.fill(process);
+    await this.searchProcessesInput.press('Enter');
+  }
+}
+export {TasklistProcessesPage};

--- a/qa/core-application-e2e-test-suite/resources/create_invoice.form
+++ b/qa/core-application-e2e-test-suite/resources/create_invoice.form
@@ -1,0 +1,246 @@
+{
+  "components": [
+    {
+      "components": [
+        {
+          "text": "### Invoice",
+          "type": "text",
+          "id": "Heading_0",
+          "layout": {
+            "row": "Row_0fp5znu",
+            "columns": null
+          }
+        }
+      ],
+      "showOutline": false,
+      "label": "",
+      "type": "group",
+      "layout": {
+        "row": "row_0",
+        "columns": null
+      },
+      "id": "Field_1ll8pgn"
+    },
+    {
+      "components": [
+        {
+          "type": "textfield",
+          "id": "Textfield_1",
+          "label": "Client Name",
+          "validate": {
+            "minLength": 2,
+            "maxLength": 50,
+            "required": true
+          },
+          "key": "name",
+          "layout": {
+            "row": "Row_18tb43e",
+            "columns": null
+          }
+        },
+        {
+          "label": "Client Address",
+          "type": "textarea",
+          "layout": {
+            "row": "Row_053xglo",
+            "columns": null
+          },
+          "id": "Field_0e9lblu",
+          "key": "address",
+          "validate": {
+            "required": true
+          }
+        }
+      ],
+      "showOutline": false,
+      "label": "Billed to",
+      "type": "group",
+      "layout": {
+        "row": "Row_0o7mon1",
+        "columns": null
+      },
+      "id": "Field_0g2mpc9",
+      "path": "client"
+    },
+    {
+      "components": [
+        {
+          "subtype": "date",
+          "dateLabel": "Invoice Date",
+          "type": "datetime",
+          "id": "Date_4",
+          "validate": {
+            "required": true
+          },
+          "key": "invoiceDate",
+          "layout": {
+            "row": "Row_0pc7qah",
+            "columns": null
+          }
+        },
+        {
+          "subtype": "date",
+          "dateLabel": "Due Date",
+          "type": "datetime",
+          "id": "Date_5",
+          "validate": {
+            "required": true
+          },
+          "key": "dueDate",
+          "layout": {
+            "row": "Row_0pc7qah",
+            "columns": null
+          }
+        },
+        {
+          "values": [
+            {
+              "label": "USD - United States Dollar",
+              "value": "USD"
+            },
+            {
+              "label": "EUR - Euro",
+              "value": "EUR"
+            }
+          ],
+          "label": "Currency",
+          "type": "select",
+          "layout": {
+            "row": "Row_1fv40q7",
+            "columns": null
+          },
+          "id": "Field_0nz4fgu",
+          "key": "currency",
+          "defaultValue": "USD"
+        },
+        {
+          "type": "textfield",
+          "id": "Textfield_3",
+          "label": "Invoice Number",
+          "validate": {
+            "minLength": 1,
+            "maxLength": 10,
+            "required": true
+          },
+          "key": "invoiceNumber",
+          "layout": {
+            "row": "Row_0rugl5w",
+            "columns": null
+          }
+        },
+        {
+          "label": "Reference #",
+          "type": "textfield",
+          "layout": {
+            "row": "Row_0rugl5w",
+            "columns": null
+          },
+          "id": "Field_1l6w9gw",
+          "key": "referenceNumber"
+        }
+      ],
+      "showOutline": false,
+      "label": "Invoice Details",
+      "type": "group",
+      "layout": {
+        "row": "Row_0o7mon1",
+        "columns": null
+      },
+      "id": "Field_1g6x01a"
+    },
+    {
+      "components": [
+        {
+          "type": "textfield",
+          "id": "Textfield_7",
+          "label": "Item Name",
+          "validate": {
+            "minLength": 2,
+            "maxLength": 50,
+            "required": true
+          },
+          "key": "itemName",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 6
+          }
+        },
+        {
+          "type": "number",
+          "id": "Number_9",
+          "label": "Unit Price",
+          "decimalDigits": 2,
+          "defaultValue": 0,
+          "validate": {
+            "min": 0,
+            "max": 1000,
+            "step": 0.5,
+            "required": true
+          },
+          "key": "unitPrice",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 4
+          },
+          "appearance": {
+            "prefixAdorner": "=currency"
+          }
+        },
+        {
+          "type": "number",
+          "id": "Number_8",
+          "label": "Quantity",
+          "decimalDigits": 2,
+          "defaultValue": 1,
+          "validate": {
+            "min": 1,
+            "max": 100,
+            "step": 1,
+            "required": true
+          },
+          "key": "quantity",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 4
+          },
+          "increment": "1"
+        },
+        {
+          "text": "{{currency}} {{this.unitPrice * this.quantity}}",
+          "label": "Text view",
+          "type": "text",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": null
+          },
+          "id": "Field_1cyz9yt"
+        }
+      ],
+      "showOutline": false,
+      "isRepeating": true,
+      "allowAddRemove": true,
+      "defaultRepetitions": 1,
+      "label": "Items",
+      "type": "dynamiclist",
+      "layout": {
+        "row": "Row_1k6j1pw",
+        "columns": null
+      },
+      "id": "Field_104boo3",
+      "path": "items",
+      "verticalAlignment": "end"
+    },
+    {
+      "content": "<style>\n    .invoice-total {\n      border: 1px solid #ccc;\n      padding: 10px;\n      max-width: 300px;\n      margin-left: auto;\n      text-align: right;\n    }\n</style>\n\n\n<div class=\"invoice-total\">\n    <h4>Invoice Total</h4>\n    <p>Subtotal: {{currency}} {{sum(items[unitPrice * quantity])}}</p>\n    <p>Tax (10%): {{currency}} {{floor(sum(items[unitPrice * quantity]) * 0.1, 2)}}</p>\n    <hr>\n    <p>Total: {{currency}} {{floor(sum(items[unitPrice * quantity ]) * 1.1, 2)}}</p>\n</div>\n",
+      "label": "HTML",
+      "type": "html",
+      "layout": {
+        "row": "Row_0cd4anm",
+        "columns": null
+      },
+      "id": "Field_0nl093o"
+    }
+  ],
+  "id": "Form_Invoice",
+  "type": "default"
+}

--- a/qa/core-application-e2e-test-suite/resources/processWithStartNodeFormDeployed.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/processWithStartNodeFormDeployed.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7640587b-ab4b-4660-8e4e-4064a21c9626">
+  <bpmn:process id="processWithStartNodeFormDeployed" name="processWithStartNodeFormDeployed" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="Form_Invoice" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0d7gldh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0d7gldh" sourceRef="StartEvent_1" targetRef="processStartedByForm_user_task" />
+    <bpmn:endEvent id="Event_1cu4vf1">
+      <bpmn:incoming>Flow_1g7mhgj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1g7mhgj" sourceRef="processStartedByForm_user_task" targetRef="Event_1cu4vf1" />
+    <bpmn:userTask id="processStartedByForm_user_task" name="processStartedByForm_user_task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0d7gldh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g7mhgj</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithStartNodeFormDeployed">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cu4vf1_di" bpmnElement="Event_1cu4vf1">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14rkwl1_di" bpmnElement="processStartedByForm_user_task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0d7gldh_di" bpmnElement="Flow_0d7gldh">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g7mhgj_di" bpmnElement="Flow_1g7mhgj">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_process.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_process.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="a790e7ab-0639-412e-a17c-7823129f4511">
+  <bpmn:process id="User_Process" name="User_Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06a3ybp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_06a3ybp" sourceRef="StartEvent_1" targetRef="User_Task" />
+    <bpmn:endEvent id="End_Event">
+      <bpmn:incoming>Flow_1xn2vgi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xn2vgi" sourceRef="User_Task" targetRef="End_Event" />
+    <bpmn:userTask id="User_Task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06a3ybp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xn2vgi</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="User_Process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10qqfb6_di" bpmnElement="End_Event">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kuvhuk_di" bpmnElement="User_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06a3ybp_di" bpmnElement="Flow_06a3ybp">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xn2vgi_di" bpmnElement="Flow_1xn2vgi">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/tests/tasklist/login.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/login.spec.ts
@@ -97,7 +97,9 @@ test.describe.parallel('Login Tests', () => {
     taskPanelPage,
   }) => {
     await page.goto('tasklist/123');
-    await expect(taskPanelPage.taskListPageBanner).toBeVisible();
+    await expect(taskPanelPage.taskListPageBanner).toBeVisible({
+      timeout: 60000,
+    });
     await taskListLoginPage.login('demo', 'demo');
     await expect(page).toHaveURL('/tasklist/123');
 

--- a/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -31,40 +31,40 @@ test.describe('process page', () => {
   test('process page navigation', async ({
     tasklistHeader,
     page,
-    tasklistprocessesPage,
+    tasklistProcessesPage,
   }) => {
     await tasklistHeader.processesTab.click();
     await expect(page).toHaveURL('/tasklist/processes');
     await expect(page.getByText('Start your process on demand')).toBeVisible();
-    await tasklistprocessesPage.cancelButton.click();
+    await tasklistProcessesPage.cancelButton.click();
     await expect(page.getByText('Welcome to Tasklist')).toBeVisible();
 
     await tasklistHeader.processesTab.click();
-    await tasklistprocessesPage.continueButton.click();
+    await tasklistProcessesPage.continueButton.click();
     await expect(page.getByText('Search processes')).toBeVisible();
   });
 
   test('process searching', async ({
     page,
     tasklistHeader,
-    tasklistprocessesPage,
+    tasklistProcessesPage,
   }) => {
     await tasklistHeader.processesTab.click();
     await expect(page).toHaveURL('/tasklist/processes');
-    await tasklistprocessesPage.continueButton.click();
+    await tasklistProcessesPage.continueButton.click();
 
-    await tasklistprocessesPage.searchForProcess('fake_process');
+    await tasklistProcessesPage.searchForProcess('fake_process');
     await expect(
       page.getByText('We could not find any process with that name'),
     ).toBeVisible();
 
-    await tasklistprocessesPage.searchForProcess('User_Process');
+    await tasklistProcessesPage.searchForProcess('User_Process');
     await expect(
       page.getByText('We could not find any process with that name'),
     ).toBeHidden();
 
-    await expect(tasklistprocessesPage.processTile).toHaveCount(1);
-    await expect(tasklistprocessesPage.processTile).toContainText(
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1);
+    await expect(tasklistProcessesPage.processTile).toContainText(
       'User_Process',
     );
   });
@@ -72,42 +72,42 @@ test.describe('process page', () => {
   test('start process instance', async ({
     page,
     tasklistHeader,
-    tasklistprocessesPage,
+    tasklistProcessesPage,
     taskPanelPage,
   }) => {
     await tasklistHeader.processesTab.click();
     await expect(page).toHaveURL('/tasklist/processes');
-    await tasklistprocessesPage.continueButton.click();
+    await tasklistProcessesPage.continueButton.click();
 
-    await tasklistprocessesPage.searchForProcess('User_Process');
-    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
       timeout: 10000,
     });
 
-    await tasklistprocessesPage.startProcessButton.click();
+    await tasklistProcessesPage.startProcessButton.click();
     await expect(page.getByText('Process has started')).toBeVisible();
-    await expect(tasklistprocessesPage.startProcessButton).toBeHidden();
+    await expect(tasklistProcessesPage.startProcessButton).toBeHidden();
     await expect(page.getByText('Waiting for tasks...')).toBeVisible();
-    await expect(taskPanelPage.assignToMeButton).toBeVisible();
+    await expect(taskPanelPage.assignToMeButton).toBeVisible({timeout: 60000});
   });
 
   test('complete task started by process instance', async ({
     page,
     tasklistHeader,
-    tasklistprocessesPage,
+    tasklistProcessesPage,
     taskPanelPage,
   }) => {
     await tasklistHeader.processesTab.click();
     await expect(page).toHaveURL('/tasklist/processes');
-    await tasklistprocessesPage.continueButton.click();
+    await tasklistProcessesPage.continueButton.click();
 
-    await tasklistprocessesPage.searchForProcess('User_Process');
-    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
       timeout: 10000,
     });
 
-    await tasklistprocessesPage.startProcessButton.click();
-    await tasklistprocessesPage.tasksTab.click();
+    await tasklistProcessesPage.startProcessButton.click();
+    await tasklistProcessesPage.tasksTab.click();
 
     await taskPanelPage.openTask('User_Task');
 
@@ -120,21 +120,21 @@ test.describe('process page', () => {
     page,
     tasklistHeader,
     taskDetailsPage,
-    tasklistprocessesPage,
+    tasklistProcessesPage,
     taskPanelPage,
   }) => {
     await tasklistHeader.processesTab.click();
     await expect(page).toHaveURL('/tasklist/processes');
-    await tasklistprocessesPage.continueButton.click();
+    await tasklistProcessesPage.continueButton.click();
 
-    await tasklistprocessesPage.searchForProcess(
+    await tasklistProcessesPage.searchForProcess(
       'processWithStartNodeFormDeployed',
     );
-    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
       timeout: 30000,
     });
 
-    await tasklistprocessesPage.startProcessButton.click();
+    await tasklistProcessesPage.startProcessButton.click();
     await page.getByRole('textbox', {name: 'Client Name'}).fill('Jon');
     await page.getByRole('textbox', {name: 'Client Address'}).fill('Earth');
     await taskDetailsPage.fillDatetimeField('Invoice Date', '1/1/3000');
@@ -171,9 +171,11 @@ test.describe('process page', () => {
     await expect(page.getByText('EUR 231')).toBeVisible();
     await expect(page.getByText('EUR 264')).toBeVisible();
     await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
-    await tasklistprocessesPage.modaLStartProcessButton.click();
+    await tasklistProcessesPage.clickStartProcessButton(
+      'processWithStartNodeFormDeployed',
+    );
 
-    await tasklistprocessesPage.tasksTab.click();
+    await tasklistProcessesPage.tasksTab.click();
     await taskPanelPage.openTask('processStartedByForm_user_task');
     await expect(
       page.getByText('{"name":"jon","address":"earth"}'),

--- a/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/user_process.bpmn',
+    './resources/processWithStartNodeFormDeployed.bpmn',
+    './resources/create_invoice.form',
+  ]);
+  await sleep(2000);
+});
+
+test.beforeEach(async ({page, taskListLoginPage, taskPanelPage}) => {
+  await navigateToApp(page, 'tasklist');
+  await taskListLoginPage.login('demo', 'demo');
+  await expect(taskPanelPage.taskListPageBanner).toBeVisible();
+});
+
+test.describe('process page', () => {
+  test('process page navigation', async ({
+    tasklistHeader,
+    page,
+    tasklistprocessesPage,
+  }) => {
+    await tasklistHeader.processesTab.click();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await expect(page.getByText('Start your process on demand')).toBeVisible();
+    await tasklistprocessesPage.cancelButton.click();
+    await expect(page.getByText('Welcome to Tasklist')).toBeVisible();
+
+    await tasklistHeader.processesTab.click();
+    await tasklistprocessesPage.continueButton.click();
+    await expect(page.getByText('Search processes')).toBeVisible();
+  });
+
+  test('process searching', async ({
+    page,
+    tasklistHeader,
+    tasklistprocessesPage,
+  }) => {
+    await tasklistHeader.processesTab.click();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistprocessesPage.continueButton.click();
+
+    await tasklistprocessesPage.searchForProcess('fake_process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeVisible();
+
+    await tasklistprocessesPage.searchForProcess('User_Process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeHidden();
+
+    await expect(tasklistprocessesPage.processTile).toHaveCount(1);
+    await expect(tasklistprocessesPage.processTile).toContainText(
+      'User_Process',
+    );
+  });
+
+  test('start process instance', async ({
+    page,
+    tasklistHeader,
+    tasklistprocessesPage,
+    taskPanelPage,
+  }) => {
+    await tasklistHeader.processesTab.click();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistprocessesPage.continueButton.click();
+
+    await tasklistprocessesPage.searchForProcess('User_Process');
+    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+      timeout: 10000,
+    });
+
+    await tasklistprocessesPage.startProcessButton.click();
+    await expect(page.getByText('Process has started')).toBeVisible();
+    await expect(tasklistprocessesPage.startProcessButton).toBeHidden();
+    await expect(page.getByText('Waiting for tasks...')).toBeVisible();
+    await expect(taskPanelPage.assignToMeButton).toBeVisible();
+  });
+
+  test('complete task started by process instance', async ({
+    page,
+    tasklistHeader,
+    tasklistprocessesPage,
+    taskPanelPage,
+  }) => {
+    await tasklistHeader.processesTab.click();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistprocessesPage.continueButton.click();
+
+    await tasklistprocessesPage.searchForProcess('User_Process');
+    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+      timeout: 10000,
+    });
+
+    await tasklistprocessesPage.startProcessButton.click();
+    await tasklistprocessesPage.tasksTab.click();
+
+    await taskPanelPage.openTask('User_Task');
+
+    await taskPanelPage.assignToMeButton.click();
+    await taskPanelPage.completeTaskButton.click();
+    await expect(page.getByText('Task completed')).toBeVisible();
+  });
+
+  test('complete process with start node having deployed form', async ({
+    page,
+    tasklistHeader,
+    taskDetailsPage,
+    tasklistprocessesPage,
+    taskPanelPage,
+  }) => {
+    await tasklistHeader.processesTab.click();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistprocessesPage.continueButton.click();
+
+    await tasklistprocessesPage.searchForProcess(
+      'processWithStartNodeFormDeployed',
+    );
+    await expect(tasklistprocessesPage.processTile).toHaveCount(1, {
+      timeout: 30000,
+    });
+
+    await tasklistprocessesPage.startProcessButton.click();
+    await page.getByRole('textbox', {name: 'Client Name'}).fill('Jon');
+    await page.getByRole('textbox', {name: 'Client Address'}).fill('Earth');
+    await taskDetailsPage.fillDatetimeField('Invoice Date', '1/1/3000');
+    await taskDetailsPage.fillDatetimeField('Due Date', '1/2/3000');
+    await taskDetailsPage.selectDropdownOption(
+      'USD - United States Dollar',
+      'EUR - Euro',
+    );
+    await page.getByRole('textbox', {name: 'Invoice Number'}).fill('123');
+    await page.getByRole('button', {name: /add new/i}).click();
+
+    await taskDetailsPage.forEachDynamicListItem(
+      page.getByLabel('Item Name*'),
+      async (element, index) => {
+        await element.fill(`Laptop${index + 1}`);
+      },
+    );
+
+    await taskDetailsPage.forEachDynamicListItem(
+      page.getByLabel('Unit Price*'),
+      async (element, index) => {
+        await element.fill(`${index + 11}`);
+      },
+    );
+
+    await taskDetailsPage.forEachDynamicListItem(
+      page.getByLabel('Quantity*'),
+      async (element, index) => {
+        await element.clear();
+        await element.fill(`${index + 21}`);
+      },
+    );
+
+    await expect(page.getByText('EUR 231')).toBeVisible();
+    await expect(page.getByText('EUR 264')).toBeVisible();
+    await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
+    await tasklistprocessesPage.modaLStartProcessButton.click();
+
+    await tasklistprocessesPage.tasksTab.click();
+    await taskPanelPage.openTask('processStartedByForm_user_task');
+    await expect(
+      page.getByText('{"name":"jon","address":"earth"}'),
+    ).toBeVisible();
+    await expect(page.getByText('EUR')).toBeVisible();
+    await expect(page.getByText('3000-01-01')).toBeVisible();
+    await expect(page.getByText('3000-01-02')).toBeVisible();
+    await expect(page.getByText('123')).toBeVisible();
+    await expect(
+      page.getByText(
+        '[{"itemName":"laptop1","unitPrice":11,"quantity":21},{"itemName":"laptop2","unitPrice":12,"quantity":22}]',
+      ),
+    ).toBeVisible();
+    await taskPanelPage.assignToMeButton.click();
+    await taskPanelPage.completeTaskButton.click();
+    await expect(page.getByText('Task completed')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR migrates the **process-page.spec** tests from the `tasklist-e2e` test suite to the `core-application-e2e` test suite. The goal is to centralize test coverage under one suite for better maintainability and consistency across core applications. No functional changes to the login behavior have been introduced — only test structure and location have been updated.

❗ The migrated tests will remain in the `tasklist-e2e` test suite for now. They will be removed in a separate PR once the `core-application-e2e` test suite is considered mature and fully stable.


**Note:**  
Test run passed locally.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues


related to #30910 

