### PR TITLE
refactor: migrate tasklist e2e public start form tests to core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/fixtures.ts
+++ b/qa/core-application-e2e-test-suite/fixtures.ts
@@ -17,6 +17,7 @@ import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
 import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
+import {PublicFormsPage} from '@pages/PublicFormsPage';
 import {sleep} from 'utils/sleep';
 
 type PlaywrightFixtures = {
@@ -31,6 +32,7 @@ type PlaywrightFixtures = {
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
   tasklistProcessesPage: TasklistProcessesPage;
+  publicFormsPage: PublicFormsPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -81,6 +83,9 @@ const test = base.extend<PlaywrightFixtures>({
 
       await sleep(1000);
     });
+  },
+  publicFormsPage: async ({page}, use) => {
+    await use(new PublicFormsPage(page));
   },
 });
 

--- a/qa/core-application-e2e-test-suite/pages/PublicFormsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/PublicFormsPage.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Page, Locator} from '@playwright/test';
+
+class PublicFormsPage {
+  private page: Page;
+  readonly nameInput: Locator;
+  readonly emailInput: Locator;
+  readonly submitButton: Locator;
+  readonly successMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.nameInput = page.getByLabel('Name');
+    this.emailInput = page.getByLabel('Email');
+    this.submitButton = page.getByRole('button', {name: 'Submit'});
+    this.successMessage = page.getByRole('heading', {
+      name: 'Success!',
+    });
+  }
+
+  async goToPublicForm(bpmnProcessId: string) {
+    await this.page.goto(`/new/${bpmnProcessId}`);
+  }
+}
+export {PublicFormsPage};

--- a/qa/core-application-e2e-test-suite/resources/subscribeForm.form
+++ b/qa/core-application-e2e-test-suite/resources/subscribeForm.form
@@ -1,0 +1,35 @@
+{
+  "components": [
+    {
+      "text": "# Subscribe to newsletter",
+      "type": "text",
+      "layout": {
+        "row": "Row_0jjnqip",
+        "columns": null
+      },
+      "id": "Field_1xn41dw"
+    },
+    {
+      "label": "Name",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_15ghdy6",
+        "columns": null
+      },
+      "id": "Field_0ibsmz4",
+      "key": "field_1lfayry"
+    },
+    {
+      "label": "Email",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_1klibf9",
+        "columns": null
+      },
+      "id": "Field_0msuoi3",
+      "key": "field_1prtdvl"
+    }
+  ],
+  "type": "default",
+  "id": "subscribe"
+}

--- a/qa/core-application-e2e-test-suite/resources/subscribeFormProcess.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/subscribeFormProcess.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pg20dm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="a3b2585" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="subscribeFormProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="subscribe" />
+        <zeebe:properties>
+          <zeebe:property name="publicAccess" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_15vkolf" sourceRef="StartEvent_1" targetRef="task" />
+    <bpmn:sequenceFlow id="Flow_1i3gdwk" sourceRef="task" targetRef="Event_07rdhb7" />
+    <bpmn:endEvent id="Event_07rdhb7">
+      <bpmn:incoming>Flow_1i3gdwk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="task" name="task">
+      <bpmn:incoming>Flow_15vkolf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1i3gdwk</bpmn:outgoing>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="subscribeFormProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07rdhb7_di" bpmnElement="Event_07rdhb7">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06qd63g_di" bpmnElement="task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_15vkolf_di" bpmnElement="Flow_15vkolf">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i3gdwk_di" bpmnElement="Flow_1i3gdwk">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+
+test.describe('public start process', () => {
+  test('should submit form', async ({makeAxeBuilder, publicFormsPage}) => {
+    await deploy([
+      './resources/subscribeFormProcess.bpmn',
+      './resources/subscribeForm.form',
+    ]);
+    await publicFormsPage.goToPublicForm('subscribeFormProcess');
+
+    await expect(publicFormsPage.nameInput).toBeVisible();
+
+    const results = await makeAxeBuilder().analyze();
+
+    expect(results.violations).toHaveLength(0);
+    expect(results.passes.length).toBeGreaterThan(0);
+
+    await publicFormsPage.nameInput.fill('Joe Doe');
+    await publicFormsPage.emailInput.fill('joe@doe.com');
+    await publicFormsPage.submitButton.click();
+
+    await expect(publicFormsPage.successMessage).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR migrates the **public-start-form.spec** tests from the `tasklist-e2e` test suite to the `core-application-e2e` test suite. The goal is to centralize test coverage under one suite for better maintainability and consistency across core applications. No functional changes to the login behavior have been introduced — only test structure and location have been updated.

❗ The migrated tests will remain in the `tasklist-e2e` test suite for now. They will be removed in a separate PR once the `core-application-e2e` test suite is considered mature and fully stable.


**Note:**  
Test run passed locally.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues


related to #30910 
