### PR TITLE
Feat/30741 e2e batch operation resolve incident

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -102,6 +102,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     switch (type) {
       case PROCESS_CANCELLATION:
         return "/process-instances/batch-operations/cancellation";
+      case RESOLVE_INCIDENT:
+        return "/process-instances/batch-operations/incident-resolution";
       default:
         throw new IllegalArgumentException("Unsupported batch operation type: " + type);
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchResolveIncidentTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchResolveIncidentTest {
+
+  static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  static final List<Long> ACTIVE_INCIDENTS = new ArrayList<>();
+  private static final int AMOUNT_OF_INCIDENTS = 3;
+
+  private static CamundaClient camundaClient;
+
+  private static Incident incident;
+
+  @BeforeAll
+  public static void beforeAll() {
+
+    final var processes =
+        List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+
+    startProcessInstance(camundaClient, "service_tasks_v1");
+    startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}");
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
+    startProcessInstance(camundaClient, "incident_process_v1");
+
+    waitForProcessInstancesToStart(camundaClient, 5);
+    waitUntilProcessInstanceHasIncidents(camundaClient, AMOUNT_OF_INCIDENTS);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
+
+    ACTIVE_INCIDENTS.addAll(
+        camundaClient.newIncidentSearchRequest().send().join().items().stream()
+            .map(Incident::getIncidentKey)
+            .toList());
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+    ACTIVE_INCIDENTS.clear();
+  }
+
+  @Test
+  void shouldResolveIncidentsWithBatch() throws InterruptedException {
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .resolveIncident()
+            .filter(new ProcessInstanceFilterImpl())
+            .send()
+            .join();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // then
+    assertThat(result).isNotNull();
+    //    assertThat(result.getBatchOperationKey()).isNotNull();
+
+    // and
+    Awaitility.await("should complete batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient
+                      .newBatchOperationGetRequest(result.getBatchOperationKey())
+                      .send()
+                      .join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getEndDate()).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+            });
+
+    waitUntilIncidentsAreResolved(camundaClient, ACTIVE_INCIDENTS.size());
+
+    // and
+    final var itemsObj =
+        camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getKey).toList();
+
+    assertThat(itemsObj.items()).hasSize(3);
+    assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
+        .containsExactly(BatchOperationItemState.COMPLETED);
+    assertThat(itemKeys).containsExactlyInAnyOrder(ACTIVE_INCIDENTS.toArray(Long[]::new));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -14,7 +14,9 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifec
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifecyclePausedRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifecycleResumeRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationProcessCancelledRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationResolveIncidentRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getFailedBatchOperationProcessCancelledRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getFailedBatchOperationResolveIncidentRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
@@ -211,6 +213,56 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationCreatedRecord);
     exporter.export(batchOperationChunkRecord);
     exporter.export(processFailedCancelledRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
+    assertThat(batchOperation.operationsFailedCount()).isEqualTo(1);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
+  }
+
+  @Test
+  public void shouldMonitorResolveIncidentBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
+    final var incidentKey = 1L;
+    final var incidentResolvedRecord =
+        getBatchOperationResolveIncidentRecord(incidentKey, batchOperationKey, 3L);
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationChunkRecord);
+    exporter.export(incidentResolvedRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
+    assertThat(batchOperation.operationsFailedCount()).isEqualTo(0);
+    assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
+  }
+
+  @Test
+  public void shouldMonitorFailedResolveIncidentBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
+    final var incidentKey = 1L;
+    final var resolveIncidentFailedRecord =
+        getFailedBatchOperationResolveIncidentRecord(incidentKey, batchOperationKey, 3L);
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationChunkRecord);
+    exporter.export(resolveIncidentFailedRecord);
 
     // then
     final var batchOperation =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -561,4 +561,33 @@ public class RecordFixtures {
                 .build())
         .build();
   }
+
+  protected static ImmutableRecord<RecordValue> getBatchOperationResolveIncidentRecord(
+      final Long incidentKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.INCIDENT);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(IncidentIntent.RESOLVED)
+        .withKey(incidentKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getFailedBatchOperationResolveIncidentRecord(
+      final Long incidentKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.INCIDENT);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(IncidentIntent.RESOLVE)
+        .withRejectionType(RejectionType.INVALID_STATE)
+        .withKey(incidentKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .build();
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -21,6 +21,7 @@ import io.camunda.exporter.rdbms.handlers.FlowNodeExportHandler;
 import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceIncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.FormExportHandler;
 import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
+import io.camunda.exporter.rdbms.handlers.IncidentBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.IncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.JobExportHandler;
 import io.camunda.exporter.rdbms.handlers.MappingExportHandler;
@@ -223,5 +224,8 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.PROCESS_INSTANCE,
         new ProcessInstanceBatchOperationExportHandler(rdbmsWriter.getBatchOperationWriter()));
+    builder.withHandler(
+        ValueType.INCIDENT,
+        new IncidentBatchOperationExportHandler(rdbmsWriter.getBatchOperationWriter()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentBatchOperationExportHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+
+/** This aggregates the batch operation status of incident management tasks */
+public class IncidentBatchOperationExportHandler
+    implements RdbmsExportHandler<IncidentRecordValue> {
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public IncidentBatchOperationExportHandler(final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<IncidentRecordValue> record) {
+    return record.getOperationReference() != operationReferenceNullValue()
+        && (isIncidentResolved(record) || isFailed(record));
+  }
+
+  @Override
+  public void export(final Record<IncidentRecordValue> record) {
+    if (isIncidentResolved(record)) {
+      batchOperationWriter.updateItem(
+          record.getOperationReference(), record.getKey(), BatchOperationItemState.COMPLETED);
+    } else if (isFailed(record)) {
+      batchOperationWriter.updateItem(
+          record.getOperationReference(), record.getKey(), BatchOperationItemState.FAILED);
+    }
+  }
+
+  private boolean isIncidentResolved(final Record<IncidentRecordValue> record) {
+    return record.getIntent().equals(IncidentIntent.RESOLVED);
+  }
+
+  private boolean isFailed(final Record<IncidentRecordValue> record) {
+    return record.getIntent().equals(IncidentIntent.RESOLVE) && record.getRejectionType() != null;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandler.java
@@ -17,15 +17,20 @@ import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.util.DateUtil;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class IncidentExportHandler implements RdbmsExportHandler<IncidentRecordValue> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentExportHandler.class);
+
+  private static final Set<Intent> INCIDENT_INTENTS =
+      Set.of(IncidentIntent.CREATED, IncidentIntent.RESOLVED, IncidentIntent.MIGRATED);
 
   private final IncidentWriter incidentWriter;
 
@@ -35,7 +40,8 @@ public class IncidentExportHandler implements RdbmsExportHandler<IncidentRecordV
 
   @Override
   public boolean canExport(final Record<IncidentRecordValue> record) {
-    return record.getValueType() == ValueType.INCIDENT;
+    return record.getValueType() == ValueType.INCIDENT
+        && INCIDENT_INTENTS.contains(record.getIntent());
   }
 
   @Override


### PR DESCRIPTION
## Description

- Adds a new E2E-Test for the new batch operation RESOLVE_INCIDENT
- Fix: The exporter had to be extended to actually monitor resolve-incident records which are part of a batch operation

## Related issues

closes #30741 
