### PR TITLE
test: use default values for history cleanup in MultiDbTest since we …

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -277,7 +277,7 @@ public class CamundaMultiDBExtension
         final var expectedDescriptors = new IndexDescriptors(testPrefix, false).all();
         setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
       }
-      case RDBMS -> multiDbConfigurator.configureRDBMSSupport();
+      case RDBMS -> multiDbConfigurator.configureRDBMSSupport(isHistoryRelatedTest);
       case AWS_OS -> {
         final var awsOSUrl = System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL);
         multiDbConfigurator.configureAWSOpenSearchSupport(awsOSUrl, testPrefix);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -234,7 +234,7 @@ public class MultiDbConfigurator {
         });
   }
 
-  public void configureRDBMSSupport() {
+  public void configureRDBMSSupport(final boolean retentionEnabled) {
     testApplication.withProperty("camunda.database.type", DatabaseType.RDBMS);
     testApplication.withProperty(
         "spring.datasource.url",
@@ -243,11 +243,14 @@ public class MultiDbConfigurator {
     testApplication.withProperty("spring.datasource.username", "sa");
     testApplication.withProperty("spring.datasource.password", "");
     testApplication.withProperty("zeebe.broker.exporters.rdbms.args.flushInterval", "PT0S");
-    testApplication.withProperty("zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", "PT2S");
     testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval", "PT2S");
+        "zeebe.broker.exporters.rdbms.args.defaultHistoryTTL", retentionEnabled ? "PT1S" : "PT1H");
     testApplication.withProperty(
-        "zeebe.broker.exporters.rdbms.args.maxHistoryCleanupInterval", "PT5S");
+        "zeebe.broker.exporters.rdbms.args.minHistoryCleanupInterval",
+        retentionEnabled ? "PT1S" : "PT1H");
+    testApplication.withProperty(
+        "zeebe.broker.exporters.rdbms.args.maxHistoryCleanupInterval",
+        retentionEnabled ? "PT5S" : "PT2H");
     testApplication.withExporter(
         "rdbms",
         cfg -> {


### PR DESCRIPTION
## Description

Currently history cleanup is configured to 2 seconds for rdbms. I think because of this, in some cases we already delete process instances before checking if the quantity is correct ... 

And we also don't need it since we use H2 database.

## Related issues

closes #30892 
