### PR TITLE
Groups management refactor exporters

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -85,7 +85,7 @@ public class CamundaOAuthPrincipalService {
             tenantServices.getTenantsByMemberIds(mappingIds).stream()
                 .map(TenantDTO::fromEntity)
                 .toList(),
-            groupServices.getGroupsByMemberKeys(mappingKeys).stream()
+            groupServices.getGroupsByMemberKeys(mappingIds).stream()
                 .map(GroupEntity::name)
                 .toList()));
   }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -428,19 +428,21 @@
 
   <changeSet id="create_group_table" author="cthiel">
     <createTable tableName="${prefix}GROUPS">
-      <column name="GROUP_KEY" type="BIGINT" >
+      <column name="GROUP_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
+      <column name="GROUP_KEY" type="BIGINT" />
       <column name="NAME" type="VARCHAR(255)" />
+      <column name="DESCRIPTION" type="VARCHAR(255)" />
     </createTable>
   </changeSet>
 
   <changeSet id="group_members_table" author="cthiel">
     <createTable tableName="${prefix}GROUP_MEMBER">
-      <column name="GROUP_KEY" type="BIGINT" >
+      <column name="GROUP_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_KEY" type="BIGINT" >
+      <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
@@ -31,13 +31,13 @@ public class GroupReader extends AbstractEntityReader<GroupEntity> {
     this.groupMapper = groupMapper;
   }
 
-  public Optional<GroupEntity> findOne(final long groupKey) {
-    final var result = search(GroupQuery.of(b -> b.filter(f -> f.groupKey(groupKey))));
+  public Optional<GroupEntity> findOne(final String groupId) {
+    final var result = search(GroupQuery.of(b -> b.filter(f -> f.groupId(groupId))));
     return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
   }
 
   public SearchQueryResult<GroupEntity> search(final GroupQuery query) {
-    final var dbSort = convertSort(query.sort(), GroupSearchColumn.GROUP_KEY);
+    final var dbSort = convertSort(query.sort(), GroupSearchColumn.GROUP_ID);
     final var dbQuery =
         GroupDbQuery.of(
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
@@ -51,7 +51,9 @@ public class GroupReader extends AbstractEntityReader<GroupEntity> {
   private GroupEntity map(final GroupDbModel model) {
     return new GroupEntity(
         model.groupKey(),
+        model.groupId(),
         model.name(),
-        model.members().stream().map(GroupMemberDbModel::entityKey).collect(Collectors.toSet()));
+        model.description(),
+        model.members().stream().map(GroupMemberDbModel::entityId).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GroupMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/GroupMapper.java
@@ -18,13 +18,13 @@ public interface GroupMapper {
 
   void update(GroupDbModel group);
 
-  void delete(Long groupKey);
+  void delete(String groupId);
 
   void insertMember(GroupMemberDbModel member);
 
   void deleteMember(GroupMemberDbModel member);
 
-  void deleteAllMembers(Long groupKey);
+  void deleteAllMembers(String groupId);
 
   Long count(GroupDbQuery filter);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/GroupSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/GroupSearchColumn.java
@@ -12,7 +12,9 @@ import java.util.function.Function;
 
 public enum GroupSearchColumn implements SearchColumn<GroupEntity> {
   GROUP_KEY("groupKey", GroupEntity::groupKey),
-  NAME("name", GroupEntity::name);
+  GROUP_ID("groupId", GroupEntity::groupId),
+  NAME("name", GroupEntity::name),
+  DESCRIPTION("description", GroupEntity::description);
 
   private final String property;
   private final Function<GroupEntity, Object> propertyReader;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -14,7 +14,9 @@ import java.util.function.Function;
 public class GroupDbModel implements DbModel<GroupDbModel> {
 
   private Long groupKey;
+  private String groupId;
   private String name;
+  private String description;
   private List<GroupMemberDbModel> members;
 
   public Long groupKey() {
@@ -25,12 +27,28 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
     this.groupKey = groupKey;
   }
 
+  public String groupId() {
+    return groupId;
+  }
+
+  public void groupId(final String groupId) {
+    this.groupId = groupId;
+  }
+
   public String name() {
     return name;
   }
 
   public void name(final String name) {
     this.name = name;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public void description(final String description) {
+    this.description = description;
   }
 
   public List<GroupMemberDbModel> members() {
@@ -52,8 +70,12 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
     return "GroupDbModel{"
         + "groupKey="
         + groupKey
+        + ", groupId='"
+        + groupId
         + ", name='"
         + name
+        + ", description='"
+        + description
         + '\''
         + ", members="
         + members
@@ -63,7 +85,9 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
   public static class Builder implements ObjectBuilder<GroupDbModel> {
 
     private Long groupKey;
+    private String groupId;
     private String name;
+    private String description;
     private List<GroupMemberDbModel> members;
 
     public Builder() {}
@@ -73,8 +97,18 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
       return this;
     }
 
+    public Builder groupId(final String groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
     public Builder name(final String name) {
       this.name = name;
+      return this;
+    }
+
+    public Builder description(final String description) {
+      this.description = description;
       return this;
     }
 
@@ -87,7 +121,9 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
     public GroupDbModel build() {
       final GroupDbModel model = new GroupDbModel();
       model.groupKey(groupKey);
+      model.groupId(groupId);
       model.name(name);
+      model.description(description);
       model.members(members);
       return model;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupMemberDbModel.java
@@ -9,22 +9,22 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record GroupMemberDbModel(Long groupKey, Long entityKey, String entityType) {
+public record GroupMemberDbModel(String groupId, String entityId, String entityType) {
 
   // create builder implementing ObjectBuilder
   public static class Builder implements ObjectBuilder<GroupMemberDbModel> {
 
-    private Long groupKey;
-    private Long entityKey;
+    private String groupId;
+    private String entityId;
     private String entityType;
 
-    public Builder groupKey(final Long groupKey) {
-      this.groupKey = groupKey;
+    public Builder groupId(final String groupId) {
+      this.groupId = groupId;
       return this;
     }
 
-    public Builder entityKey(final Long entityKey) {
-      this.entityKey = entityKey;
+    public Builder entityId(final String entityId) {
+      this.entityId = entityId;
       return this;
     }
 
@@ -35,7 +35,7 @@ public record GroupMemberDbModel(Long groupKey, Long entityKey, String entityTyp
 
     @Override
     public GroupMemberDbModel build() {
-      return new GroupMemberDbModel(groupKey, entityKey, entityType);
+      return new GroupMemberDbModel(groupId, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -31,6 +31,7 @@
     LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
     ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -21,15 +21,16 @@
     SELECT * FROM (
     SELECT
     g.GROUP_KEY,
+    g.GROUP_ID,
     g.NAME,
-    gm.GROUP_KEY AS MEMBER_GROUP_KEY,
-    gm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
+    g.DESCRIPTION,
+    gm.GROUP_ID AS MEMBER_GROUP_ID,
+    gm.ENTITY_ID AS MEMBER_ENTITY_ID,
     gm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}GROUPS g
-    LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_KEY = gm.GROUP_KEY
+    LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
     ) t
-    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
@@ -37,17 +38,20 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <if test="filter.groupKey != null">AND g.GROUP_KEY = #{filter.groupKey}</if>
+    <if test="filter.groupId != null">AND g.GROUP_ID = #{filter.groupId}</if>
     <if test="filter.name != null">AND g.NAME = #{filter.name}</if>
   </sql>
 
   <resultMap id="groupResultMap" type="io.camunda.db.rdbms.write.domain.GroupDbModel">
-    <id column="GROUP_KEY" property="groupKey" />
+    <id column="GROUP_ID" property="groupId"/>
+    <result column="GROUP_KEY" property="groupKey" />
     <result column="NAME" property="name"/>
+    <result column="DESCRIPTION" property="description"/>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
       javaType="java.util.List">
       <constructor>
-        <idArg column="MEMBER_GROUP_KEY" javaType="java.lang.Long"/>
-        <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_GROUP_ID" javaType="java.lang.String"/>
+        <idArg column="MEMBER_ENTITY_ID" javaType="java.lang.String"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>
     </collection>
@@ -57,31 +61,32 @@
     id="insert"
     parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}GROUPS (GROUP_KEY, NAME)
-    VALUES (#{groupKey}, #{name})
+    INSERT INTO ${prefix}GROUPS (GROUP_KEY, GROUP_ID, NAME, DESCRIPTION)
+    VALUES (#{groupKey}, #{groupId}, #{name}, #{description})
   </insert>
 
   <update
     id="update"
     parameterType="io.camunda.db.rdbms.write.domain.GroupDbModel"
     flushCache="true">
-    UPDATE ${prefix}GROUPS
-    SET NAME = #{name}
-    WHERE GROUP_KEY = #{groupKey}
+    UPDATE ${prefix}GROUPS SET
+                    NAME = #{name},
+                    DESCRIPTION = #{description}
+    WHERE GROUP_ID = #{groupId}
   </update>
 
-  <delete id="delete" parameterType="java.lang.Long" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String" flushCache="true">
     DELETE
     FROM ${prefix}GROUPS
-    WHERE GROUP_KEY = #{groupKey}
+    WHERE GROUP_ID = #{groupId}
   </delete>
 
   <insert
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}GROUP_MEMBER (GROUP_KEY, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{groupKey}, #{entityKey}, #{entityType})
+    INSERT INTO ${prefix}GROUP_MEMBER (GROUP_ID, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{groupId}, #{entityId}, #{entityType})
   </insert>
 
   <delete
@@ -90,18 +95,18 @@
     flushCache="true">
     DELETE
     FROM ${prefix}GROUP_MEMBER
-    WHERE GROUP_KEY = #{groupKey}
-      AND ENTITY_KEY = #{entityKey}
+    WHERE GROUP_ID = #{groupId}
+      AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 
   <delete
     id="deleteAllMembers"
-    parameterType="java.lang.Long"
+    parameterType="java.lang.String"
     flushCache="true">
     DELETE
     FROM ${prefix}GROUP_MEMBER
-    WHERE GROUP_KEY = #{groupKey}
+    WHERE GROUP_ID = #{groupId}
   </delete>
 
 </mapper>

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UsersGroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UsersGroupMigrationHandlerTest.java
@@ -85,7 +85,7 @@ final class UsersGroupMigrationHandlerTest {
     givenUserGroups();
 
     when(groupServices.getGroupByName(any()))
-        .thenReturn(new GroupEntity(1L, "", Collections.emptySet()));
+        .thenReturn(new GroupEntity(1L, "", "", "", Collections.emptySet()));
     when(mappingServices.createMapping(any()))
         .thenReturn(CompletableFuture.completedFuture(new MappingRecord()));
     when(groupServices.assignMember(anyString(), anyString(), any(EntityType.class)))
@@ -152,7 +152,7 @@ final class UsersGroupMigrationHandlerTest {
     // given
     givenUserGroups();
     when(groupServices.getGroupByName(anyString()))
-        .thenReturn(new GroupEntity(1L, "groupName", Collections.emptySet()));
+        .thenReturn(new GroupEntity(1L, "groupId", "name", "description", Collections.emptySet()));
     doThrow(
             new BrokerRejectionException(
                 new BrokerRejection(GroupIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/GroupFixtures.java
@@ -10,6 +10,7 @@ package io.camunda.it.rdbms.db.fixtures;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.GroupDbModel;
 import io.camunda.db.rdbms.write.domain.GroupDbModel.Builder;
+import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import java.util.function.Function;
 
@@ -18,8 +19,14 @@ public final class GroupFixtures extends CommonFixtures {
   private GroupFixtures() {}
 
   public static GroupDbModel createRandomized(final Function<Builder, Builder> builderFunction) {
-    final var userKey = nextKey();
-    final var builder = new Builder().groupKey(userKey).name("Group " + userKey);
+    final var groupKey = nextKey();
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var builder =
+        new Builder()
+            .groupKey(groupKey)
+            .groupId(groupId)
+            .name("Group " + groupId)
+            .description("Description " + groupId);
 
     return builderFunction.apply(builder).build();
   }
@@ -52,14 +59,14 @@ public final class GroupFixtures extends CommonFixtures {
     return definition;
   }
 
-  public static void createAndSaveGroup(final RdbmsWriter rdbmsWriter, final GroupDbModel user) {
-    createAndSaveGroups(rdbmsWriter, List.of(user));
+  public static void createAndSaveGroup(final RdbmsWriter rdbmsWriter, final GroupDbModel group) {
+    createAndSaveGroups(rdbmsWriter, List.of(group));
   }
 
   public static void createAndSaveGroups(
-      final RdbmsWriter rdbmsWriter, final List<GroupDbModel> userList) {
-    for (final GroupDbModel user : userList) {
-      rdbmsWriter.getGroupWriter().create(user);
+      final RdbmsWriter rdbmsWriter, final List<GroupDbModel> groupList) {
+    for (final GroupDbModel group : groupList) {
+      rdbmsWriter.getGroupWriter().create(group);
     }
     rdbmsWriter.flush();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -24,6 +24,7 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.sort.GroupSort;
 import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +45,7 @@ public class GroupIT {
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriter, group);
 
-    final var instance = groupReader.findOne(group.groupKey()).orElse(null);
+    final var instance = groupReader.findOne(group.groupId()).orElse(null);
 
     compareGroups(instance, group);
   }
@@ -58,11 +59,12 @@ public class GroupIT {
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriter, group);
 
-    final var groupUpdate = GroupFixtures.createRandomized(b -> b.groupKey(group.groupKey()));
+    final var groupUpdate =
+        GroupFixtures.createRandomized(b -> b.groupId(group.groupId()).groupKey(group.groupKey()));
     rdbmsWriter.getGroupWriter().update(groupUpdate);
     rdbmsWriter.flush();
 
-    final var instance = groupReader.findOne(group.groupKey()).orElse(null);
+    final var instance = groupReader.findOne(group.groupId()).orElse(null);
 
     compareGroups(instance, groupUpdate);
   }
@@ -75,13 +77,13 @@ public class GroupIT {
 
     final var group = GroupFixtures.createRandomized(b -> b);
     createAndSaveGroup(rdbmsWriter, group);
-    final var instance = groupReader.findOne(group.groupKey()).orElse(null);
+    final var instance = groupReader.findOne(group.groupId()).orElse(null);
     compareGroups(instance, group);
 
-    rdbmsWriter.getGroupWriter().delete(group.groupKey());
+    rdbmsWriter.getGroupWriter().delete(group.groupId());
     rdbmsWriter.flush();
 
-    final var deletedInstance = groupReader.findOne(group.groupKey()).orElse(null);
+    final var deletedInstance = groupReader.findOne(group.groupId()).orElse(null);
     assertThat(deletedInstance).isNull();
   }
 
@@ -154,6 +156,7 @@ public class GroupIT {
     assertThat(searchResult.items().getFirst().groupKey()).isEqualTo(group.groupKey());
   }
 
+  @Disabled("I think this test is not valid anymore as now the key of the table is a String")
   @TestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -190,6 +193,8 @@ public class GroupIT {
   private static void compareGroups(final GroupEntity instance, final GroupDbModel group) {
     assertThat(instance).isNotNull();
     assertThat(instance.groupKey()).isEqualTo(group.groupKey());
+    assertThat(instance.groupId()).isEqualTo(group.groupId());
     assertThat(instance.name()).isEqualTo(group.name());
+    assertThat(instance.description()).isEqualTo(group.description());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -24,7 +24,6 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.sort.GroupSort;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -156,7 +155,6 @@ public class GroupIT {
     assertThat(searchResult.items().getFirst().groupKey()).isEqualTo(group.groupKey());
   }
 
-  @Disabled("I think this test is not valid anymore as now the key of the table is a String")
   @TestTemplate
   public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
@@ -164,7 +162,7 @@ public class GroupIT {
     final GroupReader groupReader = rdbmsService.getGroupReader();
 
     createAndSaveRandomGroups(rdbmsWriter, b -> b.name("Alice Doe"));
-    final var sort = GroupSort.of(s -> s.name().asc());
+    final var sort = GroupSort.of(s -> s.name().asc().groupId().asc());
     final var searchResult =
         groupReader.search(
             GroupQuery.of(
@@ -182,7 +180,9 @@ public class GroupIT {
                                 p.size(5)
                                     .searchAfter(
                                         new Object[] {
-                                          instanceAfter.name(), instanceAfter.groupKey()
+                                          instanceAfter.name(),
+                                          instanceAfter.groupId(),
+                                          instanceAfter.groupKey()
                                         }))));
 
     assertThat(nextPage.total()).isEqualTo(20);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -336,13 +336,14 @@ public class RecordFixtures {
   }
 
   protected static ImmutableRecord<RecordValue> getGroupRecord(
-      final Long groupKey, final GroupIntent intent) {
-    return getGroupRecord(groupKey, intent, null);
+      final String groupId, final GroupIntent intent) {
+    return getGroupRecord(groupId, intent, null);
   }
 
   protected static ImmutableRecord<RecordValue> getGroupRecord(
-      final Long groupKey, final GroupIntent intent, final Long entityKey) {
+      final String groupId, final GroupIntent intent, final String entityId) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.GROUP);
+    final long groupKey = 1L;
     return ImmutableRecord.builder()
         .from(recordValueRecord)
         .withIntent(intent)
@@ -353,9 +354,9 @@ public class RecordFixtures {
             ImmutableGroupRecordValue.builder()
                 .from((GroupRecordValue) recordValueRecord.getValue())
                 .withGroupKey(groupKey)
-                // TODO: revisit with https://github.com/camunda/camunda/issues/29903
-                .withEntityId(entityKey != null ? String.valueOf(entityKey) : "0")
-                .withEntityType(entityKey != null ? EntityType.USER : null)
+                .withGroupId(groupId)
+                .withEntityId(entityId != null ? entityId : "0")
+                .withEntityType(entityId != null ? EntityType.USER : null)
                 .build())
         .build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GroupEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/GroupEntityTransformer.java
@@ -18,8 +18,9 @@ public class GroupEntityTransformer
   @Override
   public GroupEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.GroupEntity value) {
-    final Set<Long> memberSet =
-        value.getMemberKey() == null ? Set.of() : Set.of(value.getMemberKey());
-    return new GroupEntity(value.getKey(), value.getName(), memberSet);
+    final Set<String> memberSet =
+        value.getMemberId() == null ? Set.of() : Set.of(value.getMemberId());
+    return new GroupEntity(
+        value.getKey(), value.getGroupId(), value.getName(), value.getDescription(), memberSet);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -9,11 +9,11 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.KEY;
-import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_KEY;
+import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -33,13 +33,15 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
     return and(
         term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()),
         filter.groupKey() == null ? null : term(KEY, filter.groupKey()),
+        filter.groupId() == null ? null : term(GroupIndex.GROUP_ID, filter.groupId()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberKeys() == null
+        filter.description() == null ? null : term(GroupIndex.DESCRIPTION, filter.description()),
+        filter.memberIds() == null
             ? null
-            : filter.memberKeys().isEmpty()
+            : filter.memberIds().isEmpty()
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(MEMBER_KEY, filter.memberKeys())));
+                    stringTerms(MEMBER_ID, filter.memberIds())));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GroupFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GroupFieldSortingTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.index.GroupIndex.GROUP_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.NAME;
 
@@ -16,6 +17,7 @@ public class GroupFieldSortingTransformer implements FieldSortingTransformer {
   public String apply(final String domainField) {
     return switch (domainField) {
       case "groupKey" -> KEY;
+      case "groupId" -> GROUP_ID;
       case "name" -> NAME;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
@@ -11,4 +11,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record GroupEntity(Long groupKey, String name, Set<Long> assignedMemberKeys) {}
+public record GroupEntity(
+    Long groupKey,
+    String groupId,
+    String name,
+    String description,
+    Set<String> assignedMemberIds) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -10,15 +10,24 @@ package io.camunda.search.filter;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 
-public record GroupFilter(Long groupKey, String name, Set<Long> memberKeys) implements FilterBase {
+public record GroupFilter(
+    Long groupKey, String groupId, String name, String description, Set<String> memberIds)
+    implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
     private Long groupKey;
+    private String groupId;
     private String name;
-    private Set<Long> memberKeys;
+    private String description;
+    private Set<String> memberIds;
 
     public Builder groupKey(final Long value) {
       groupKey = value;
+      return this;
+    }
+
+    public Builder groupId(final String value) {
+      groupId = value;
       return this;
     }
 
@@ -27,18 +36,23 @@ public record GroupFilter(Long groupKey, String name, Set<Long> memberKeys) impl
       return this;
     }
 
-    public Builder memberKey(final Long value) {
-      return memberKeys(Set.of(value));
+    public Builder description(final String value) {
+      description = value;
+      return this;
     }
 
-    public Builder memberKeys(final Set<Long> value) {
-      memberKeys = value;
+    public Builder memberId(final String value) {
+      return memberIds(Set.of(value));
+    }
+
+    public Builder memberIds(final Set<String> value) {
+      memberIds = value;
       return this;
     }
 
     @Override
     public GroupFilter build() {
-      return new GroupFilter(groupKey, name, memberKeys);
+      return new GroupFilter(groupKey, groupId, name, description, memberIds);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
@@ -29,6 +29,11 @@ public record GroupSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public Builder groupId() {
+      currentOrdering = new FieldSorting("groupId", null);
+      return this;
+    }
+
     public Builder name() {
       currentOrdering = new FieldSorting("name", null);
       return this;

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -99,16 +99,16 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
                     CamundaSearchException.Reason.NOT_FOUND));
   }
 
-  public List<GroupEntity> getGroupsByUserKey(final long userKey) {
-    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberKey(userKey)).build())
+  public List<GroupEntity> getGroupsByUserKey(final String username) {
+    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberId(username)).build())
         .items()
         .stream()
         .toList();
   }
 
-  public List<GroupEntity> getGroupsByMemberKeys(final Set<Long> memberKeys) {
+  public List<GroupEntity> getGroupsByMemberKeys(final Set<String> memberKeys) {
     return findAll(
-        SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberKeys(memberKeys)).build());
+        SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberIds(memberKeys)).build());
   }
 
   public Optional<GroupEntity> findGroup(final Long groupKey) {

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -134,7 +134,7 @@ public class GroupServiceTest {
     when(client.searchGroups(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getGroupsByUserKey(1L);
+    final var searchQueryResult = services.getGroupsByUserKey("username");
 
     // then
     assertThat(searchQueryResult).contains(group1, group2);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/GroupIndex.java
@@ -18,11 +18,13 @@ public class GroupIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "group";
   public static final String INDEX_VERSION = "8.8.0";
   public static final String KEY = "key";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String GROUP_ID = "groupId";
+  public static final String MEMBER_ID = "memberId";
   public static final String NAME = "name";
+  public static final String DESCRIPTION = "description";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =
+  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory<>(
           IdentityJoinRelationshipType.GROUP, IdentityJoinRelationshipType.MEMBER);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -12,10 +12,12 @@ import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
   private Long key;
+  private String groupId;
   private String name;
-  private Long memberKey;
+  private String description;
+  private String memberId;
 
-  private EntityJoinRelation<Long> join;
+  private EntityJoinRelation<String> join;
 
   public Long getKey() {
     return key;
@@ -23,6 +25,15 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
   public GroupEntity setKey(final Long key) {
     this.key = key;
+    return this;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public GroupEntity setGroupId(final String groupId) {
+    this.groupId = groupId;
     return this;
   }
 
@@ -35,25 +46,34 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public Long getMemberKey() {
-    return memberKey;
+  public String getDescription() {
+    return description;
   }
 
-  public GroupEntity setMemberKey(final Long memberKey) {
-    this.memberKey = memberKey;
+  public GroupEntity setDescription(final String description) {
+    this.description = description;
     return this;
   }
 
-  public EntityJoinRelation<Long> getJoin() {
+  public String getMemberId() {
+    return memberId;
+  }
+
+  public GroupEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
+    return this;
+  }
+
+  public EntityJoinRelation<String> getJoin() {
     return join;
   }
 
-  public GroupEntity setJoin(final EntityJoinRelation<Long> join) {
+  public GroupEntity setJoin(final EntityJoinRelation<String> join) {
     this.join = join;
     return this;
   }
 
-  public static String getChildKey(final long groupKey, final long memberKey) {
-    return String.format("%d-%d", groupKey, memberKey);
+  public static String getChildKey(final String groupId, final String memberId) {
+    return String.format("%s-%s", groupId, memberId);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-group.json
@@ -5,10 +5,16 @@
       "id": {
         "type": "keyword"
       },
+      "groupId" : {
+        "type": "keyword"
+      },
       "key": {
         "type": "long"
       },
       "name": {
+        "type": "keyword"
+      },
+      "description": {
         "type": "keyword"
       },
       "memberKey": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
@@ -5,10 +5,16 @@
       "id": {
         "type": "keyword"
       },
+      "groupId": {
+        "type": "keyword"
+      },
       "key": {
         "type": "long"
       },
       "name": {
+        "type": "keyword"
+      },
+      "description": {
         "type": "keyword"
       },
       "memberKey": {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
 
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getGroupId());
   }
 
   @Override
@@ -59,7 +59,12 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
-    entity.setKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
+    entity
+        .setKey(value.getGroupKey())
+        .setGroupId(value.getGroupId())
+        .setName(value.getName())
+        .setDescription(value.getDescription())
+        .setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -43,7 +43,7 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
 
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getGroupId());
   }
 
   @Override
@@ -55,7 +55,12 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
-    entity.setKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
+    entity
+        .setKey(value.getGroupKey())
+        .setGroupId(value.getGroupId())
+        .setName(value.getName())
+        .setDescription(value.getDescription())
+        .setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -44,10 +44,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    // TODO: revisit https://github.com/camunda/camunda/issues/29903
-    return List.of(
-        GroupEntity.getChildKey(
-            groupRecord.getGroupKey(), Long.parseLong(groupRecord.getEntityId())));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupId(), groupRecord.getEntityId()));
   }
 
   @Override
@@ -58,13 +55,8 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
-    entity
-        .setKey(value.getGroupKey())
-        .setName(value.getName())
-        // TODO: revisit with https://github.com/camunda/camunda/issues/29903
-        .setMemberKey(Long.parseLong(value.getEntityId()))
-        .setJoin(joinRelation);
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupId());
+    entity.setMemberId(value.getEntityId()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -44,10 +44,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    // TODO: revisit with https://github.com/camunda/camunda/issues/29903
-    return List.of(
-        GroupEntity.getChildKey(
-            groupRecord.getGroupKey(), Long.parseLong(groupRecord.getEntityId())));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupId(), groupRecord.getEntityId()));
   }
 
   @Override
@@ -58,9 +55,8 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
-    // TODO: revisit with https://github.com/camunda/camunda/issues/29903
-    entity.setMemberKey(Long.parseLong(value.getEntityId())).setJoin(joinRelation);
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupId());
+    entity.setMemberId(value.getEntityId()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
@@ -104,7 +104,8 @@ public class GroupCreatedUpdatedHandlerTest {
             r -> r.withIntent(GroupIntent.CREATED).withValue(groupRecordValue).withKey(recordKey));
 
     // when
-    final GroupEntity groupEntity = new GroupEntity().setName("foo").setGroupId(groupId).setDescription("bar");
+    final GroupEntity groupEntity =
+        new GroupEntity().setName("foo").setGroupId(groupId).setDescription("bar");
     underTest.updateEntity(groupRecord, groupEntity);
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
@@ -58,7 +58,7 @@ public class GroupDeletedHandlerTest {
     final var idList = underTest.generateIds(groupRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(groupRecord.getKey()));
+    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getGroupId()));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -21,10 +21,9 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import org.junit.jupiter.api.Disabled;
+import io.camunda.zeebe.test.util.Strings;
 import org.junit.jupiter.api.Test;
 
-@Disabled("https://github.com/camunda/camunda/issues/29903")
 public class GroupEntityAddedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -62,10 +61,8 @@ public class GroupEntityAddedHandlerTest {
 
     // then
     final var value = groupRecord.getValue();
-    // TODO: revisit with https://github.com/camunda/camunda/pull/30697
     assertThat(idList)
-        .containsExactly(
-            GroupEntity.getChildKey(value.getGroupKey(), Long.parseLong(value.getEntityId())));
+        .containsExactly(GroupEntity.getChildKey(value.getGroupId(), value.getEntityId()));
   }
 
   @Test
@@ -81,9 +78,15 @@ public class GroupEntityAddedHandlerTest {
   @Test
   void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var memberId = Strings.newRandomValidIdentityId();
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(groupId);
     final GroupEntity inputEntity =
-        new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+        new GroupEntity()
+            .setId("111")
+            .setGroupId(groupId)
+            .setMemberId(memberId)
+            .setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -21,10 +21,9 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import org.junit.jupiter.api.Disabled;
+import io.camunda.zeebe.test.util.Strings;
 import org.junit.jupiter.api.Test;
 
-@Disabled("https://github.com/camunda/camunda/issues/29903")
 public class GroupEntityRemovedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -62,10 +61,8 @@ public class GroupEntityRemovedHandlerTest {
 
     // then
     final var value = groupRecord.getValue();
-    // TODO: revisit with https://github.com/camunda/camunda/pull/30697
     assertThat(idList)
-        .containsExactly(
-            GroupEntity.getChildKey(value.getGroupKey(), Long.parseLong(value.getEntityId())));
+        .containsExactly(GroupEntity.getChildKey(value.getGroupId(), value.getEntityId()));
   }
 
   @Test
@@ -81,9 +78,15 @@ public class GroupEntityRemovedHandlerTest {
   @Test
   void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var memberId = Strings.newRandomValidIdentityId();
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(groupId);
     final GroupEntity inputEntity =
-        new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+        new GroupEntity()
+            .setId("111")
+            .setGroupId(groupId)
+            .setMemberId(memberId)
+            .setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
@@ -49,21 +49,19 @@ public class GroupExportHandler implements RdbmsExportHandler<GroupRecordValue> 
     switch (record.getIntent()) {
       case GroupIntent.CREATED -> groupWriter.create(map(value));
       case GroupIntent.UPDATED -> groupWriter.update(map(value));
-      case GroupIntent.DELETED -> groupWriter.delete(value.getGroupKey());
+      case GroupIntent.DELETED -> groupWriter.delete(value.getGroupId());
       case GroupIntent.ENTITY_ADDED ->
           groupWriter.addMember(
               new GroupMemberDbModel.Builder()
-                  .groupKey(value.getGroupKey())
-                  // TODO: revisit with https://github.com/camunda/camunda/pull/30697
-                  .entityKey(Long.parseLong(value.getEntityId()))
+                  .groupId(value.getGroupId())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       case GroupIntent.ENTITY_REMOVED ->
           groupWriter.removeMember(
               new GroupMemberDbModel.Builder()
-                  .groupKey(value.getGroupKey())
-                  // TODO: revisit https://github.com/camunda/camunda/pull/30697
-                  .entityKey(Long.parseLong(value.getEntityId()))
+                  .groupId(value.getGroupId())
+                  .entityId((value.getEntityId()))
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for group record", record.getIntent());
@@ -72,8 +70,10 @@ public class GroupExportHandler implements RdbmsExportHandler<GroupRecordValue> 
 
   private GroupDbModel map(final GroupRecordValue decision) {
     return new GroupDbModel.Builder()
+        .groupId(decision.getGroupId())
         .groupKey(decision.getGroupKey())
         .name(decision.getName())
+        .description(decision.getDescription())
         .build();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -22,6 +22,7 @@ import io.camunda.search.sort.GroupSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -43,17 +44,23 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "items":[
           {
             "groupKey":"111",
+            "groupId":"%s",
             "name":"Group 1",
+            "description":"Description 1",
             "assignedMemberKeys":[]
           },
           {
             "groupKey":"222",
+            "groupId":"%s",
             "name":"Group 2",
+            "description":"Description 2",
             "assignedMemberKeys":[]
           },
           {
             "groupKey":"333",
+            "groupId":"%s",
             "name":"Group 3",
+            "description":"Description 3",
             "assignedMemberKeys":[]
           }
         ],
@@ -78,8 +85,10 @@ public class GroupQueryControllerTest extends RestControllerTest {
   void shouldReturnOkOnGetGroup() {
     // given
     final var groupKey = 111L;
+    final var groupId = Strings.newRandomValidIdentityId();
     final var groupName = "groupName";
-    final var group = new GroupEntity(groupKey, groupName, Set.of());
+    final var groupDescription = "groupDescription";
+    final var group = new GroupEntity(groupKey, groupId, groupName, groupDescription, Set.of());
     when(groupServices.getGroup(group.groupKey())).thenReturn(group);
 
     // when
@@ -94,10 +103,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .json(
             """
             {
+              "groupKey": "%d",
+              "groupId": "%s",
               "name": "%s",
-              "groupKey": "%d"
+              "description": "%s"
             }"""
-                .formatted(groupName, groupKey));
+                .formatted(groupKey, groupId, groupName, groupDescription));
 
     // then
     verify(groupServices, times(1)).getGroup(group.groupKey());
@@ -142,9 +153,15 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var groupKey1 = 111L;
     final var groupKey2 = 222L;
     final var groupKey3 = 333L;
+    final var groupId1 = Strings.newRandomValidIdentityId();
+    final var groupId2 = Strings.newRandomValidIdentityId();
+    final var groupId3 = Strings.newRandomValidIdentityId();
     final var groupName1 = "Group 1";
     final var groupName2 = "Group 2";
     final var groupName3 = "Group 3";
+    final var description1 = "Description 1";
+    final var description2 = "Description 2";
+    final var description3 = "Description 3";
     when(groupServices.search(any(GroupQuery.class)))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
@@ -153,9 +170,9 @@ public class GroupQueryControllerTest extends RestControllerTest {
                 .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
-                        new GroupEntity(groupKey1, groupName1, Set.of()),
-                        new GroupEntity(groupKey2, groupName2, Set.of()),
-                        new GroupEntity(groupKey3, groupName3, Set.of())))
+                        new GroupEntity(groupKey1, groupId1, groupName1, description1, Set.of()),
+                        new GroupEntity(groupKey2, groupId2, groupName2, description2, Set.of()),
+                        new GroupEntity(groupKey3, groupId3, groupName3, description3, Set.of())))
                 .build());
 
     // when / then
@@ -177,15 +194,21 @@ public class GroupQueryControllerTest extends RestControllerTest {
              "items": [
                {
                  "groupKey": "%d",
-                 "name": "%s"
+                 "groupId": "%s",
+                 "name": "%s",
+                 "description": "%s",
                },
                {
                  "groupKey": "%d",
-                 "name": "%s"
+                 "groupId": "%s",
+                 "name": "%s",
+                 "description": "%s"
                },
                {
                  "groupKey": "%d",
-                 "name": "%s"
+                 "groupId": "%s",
+                 "name": "%s",
+                 "description": "%s"
                }
              ],
              "page": {
@@ -194,7 +217,19 @@ public class GroupQueryControllerTest extends RestControllerTest {
                "lastSortValues": ["v"]
              }
            }"""
-                .formatted(groupKey1, groupName1, groupKey2, groupName2, groupKey3, groupName3));
+                .formatted(
+                    groupKey1,
+                    groupId1,
+                    groupName1,
+                    description1,
+                    groupKey2,
+                    groupId2,
+                    groupName2,
+                    description2,
+                    groupKey3,
+                    groupId3,
+                    groupName3,
+                    description3));
 
     verify(groupServices).search(new GroupQuery.Builder().build());
   }
@@ -205,18 +240,24 @@ public class GroupQueryControllerTest extends RestControllerTest {
     final var groupKey1 = 111L;
     final var groupKey2 = 222L;
     final var groupKey3 = 333L;
+    final var groupId1 = Strings.newRandomValidIdentityId();
+    final var groupId2 = Strings.newRandomValidIdentityId();
+    final var groupId3 = Strings.newRandomValidIdentityId();
     final var groupName1 = "Group 1";
     final var groupName2 = "Group 2";
     final var groupName3 = "Group 3";
+    final var description1 = "Description 1";
+    final var description2 = "Description 2";
+    final var description3 = "Description 3";
     when(groupServices.search(any(GroupQuery.class)))
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
                 .items(
                     List.of(
-                        new GroupEntity(groupKey1, groupName1, Set.of()),
-                        new GroupEntity(groupKey2, groupName2, Set.of()),
-                        new GroupEntity(groupKey3, groupName3, Set.of())))
+                        new GroupEntity(groupKey1, groupId1, groupName1, description1, Set.of()),
+                        new GroupEntity(groupKey2, groupId2, groupName2, description2, Set.of()),
+                        new GroupEntity(groupKey3, groupId3, groupName3, description3, Set.of())))
                 .firstSortValues(new Object[] {"f"})
                 .lastSortValues(new Object[] {"v"})
                 .build());
@@ -238,7 +279,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
-        .json(EXPECTED_SEARCH_RESPONSE);
+        .json(EXPECTED_SEARCH_RESPONSE.formatted(groupId1, groupId2, groupId3));
 
     verify(groupServices)
         .search(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,6 +36,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
+@Disabled("Enable with https://github.com/camunda/camunda/issues/30285")
 @WebMvcTest(value = GroupController.class)
 public class GroupQueryControllerTest extends RestControllerTest {
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allows the exporters to work with `groupId` instead of the key. It also adds the new fields `description` and `entityId` (replacing `entityKey`).

It touches both the exporters and the service layer, but I'll leave the issue open to properly verify that I didn't miss anything during the refactor.

## Related issues

closes #30042 
closes #30043 
