### PR TITLE
fix: Optimise heap used during file uploads to GCP

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
@@ -42,6 +42,8 @@ public class GcpDocumentStore implements DocumentStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcpDocumentStore.class);
 
+  private static final int UPLOAD_BUFFER_SIZE_BYTES = 256 * 1024;
+
   private static final String CONTENT_HASH_METADATA_KEY = "contentHash";
   private static final String METADATA_PROCESS_DEFINITION_ID = "camunda.processDefinitionId";
   private static final String METADATA_PROCESS_INSTANCE_KEY = "camunda.processInstanceKey";
@@ -160,7 +162,8 @@ public class GcpDocumentStore implements DocumentStore {
       hash =
           InputStreamHashCalculator.streamAndCalculateHash(
               request.contentInputStream(),
-              stream -> storage.createFrom(blobInfoBuilder.build(), stream));
+              stream ->
+                  storage.createFrom(blobInfoBuilder.build(), stream, UPLOAD_BUFFER_SIZE_BYTES));
 
       applyMetadata(blobInfoBuilder, request.metadata(), fileName, hash);
       storage.update(blobInfoBuilder.build());


### PR DESCRIPTION
## Description

See related task for issue details.

The Java client for GCP allocates by default 15MiB for a buffer that helps with the file upload to GCP storage. In our case of batch uploads, we have a few threads attempting uploads at the same time. For each files 15MiB were allocated just for this buffer, so the heap usage grew quickly and caused OOM errors on SaaS.

![Screenshot 2025-04-14 at 09 34 13](https://github.com/user-attachments/assets/308264d4-542c-4e7e-a8e3-6ab12200b8a6)

The fix was an adjustment of the buffer size: I changed the default size to 256KiB (minimum acceptable value). The uploads now take significantly less heap space. See screenshot below @ 13:53:00

![Screenshot 2025-04-14 at 13 53 09](https://github.com/user-attachments/assets/8bfeb054-3a90-4b8a-bb63-f00df8bb589b)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to #30930
