### PR TITLE
feat: batch operation migrate process instances rest

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
@@ -18,5 +18,6 @@ package io.camunda.client.api.search.enums;
 public enum BatchOperationType {
   PROCESS_CANCELLATION,
   RESOLVE_INCIDENT,
+  MIGRATE_PROCESS_INSTANCE,
   UNKNOWN_ENUM_VALUE;
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8056,6 +8056,7 @@ components:
       enum:
       - PROCESS_CANCELLATION
       - RESOLVE_INCIDENT
+      - MIGRATE_PROCESS_INSTANCE
     BatchOperationCreatedResult:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1647,6 +1647,42 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /process-instances/batch-operations/migration:
+    post:
+      tags:
+        - Process instance
+      operationId: migrateProcessInstancesBatchOperation
+      summary: Create a batch operation to migrate process instances
+      description: |
+        Migrate multiple instances of process instances.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessInstanceMigrationBatchOperationInstruction"
+      responses:
+        "202":
+          description: The batch operation request was accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchOperationCreatedResult"
+        "400":
+          description: >
+            The process instance batch operation failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /process-instances/{processInstanceKey}/migration:
     post:
       tags:
@@ -7834,8 +7870,20 @@ components:
             The unique identifier of the created process instance; to be used wherever a request
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: string
+    ProcessInstanceMigrationBatchOperationInstruction:
+      type: object
+      properties:
+        filter:
+          $ref: "#/components/schemas/ProcessInstanceFilter"
+        migrationPlan:
+          $ref: "#/components/schemas/ProcessInstanceMigrationInstruction"
+      required:
+        - filter
+        - migrationPlan
     ProcessInstanceMigrationInstruction:
       type: object
+      description: |
+        The migration instructions describe how to migrate a process instance from one process definition to another.
       properties:
         mappingInstructions:
           description: Element mappings from the source process instance to the target process instance.

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
@@ -11,6 +11,7 @@ import io.camunda.search.filter.FilterBase;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
@@ -46,6 +47,12 @@ public class BrokerCreateBatchOperationRequest
 
   public BrokerCreateBatchOperationRequest setFilter(final FilterBase filter) {
     requestDto.setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)));
+    return this;
+  }
+
+  public BrokerCreateBatchOperationRequest setMigrationPlan(
+      final BatchOperationProcessInstanceMigrationPlan migrationPlan) {
+    requestDto.setMigrationPlan(migrationPlan);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
@@ -23,18 +24,22 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
   public static final String PROP_BATCH_OPERATION_TYPE = "batchOperationType";
   public static final String PROP_ENTITY_FILTER = "entityFilter";
+  public static final String PROP_MIGRATION_PLAN = "migrationPlan";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>(PROP_BATCH_OPERATION_TYPE, BatchOperationType.class);
   private final BinaryProperty entityFilterProp =
       new BinaryProperty(PROP_ENTITY_FILTER, new UnsafeBuffer());
+  private final ObjectProperty<BatchOperationProcessInstanceMigrationPlan> migrationPlanProp =
+      new ObjectProperty<>(PROP_MIGRATION_PLAN, new BatchOperationProcessInstanceMigrationPlan());
 
   public BatchOperationCreationRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp)
         .declareProperty(batchOperationTypeProp)
-        .declareProperty(entityFilterProp);
+        .declareProperty(entityFilterProp)
+        .declareProperty(migrationPlanProp);
   }
 
   @Override
@@ -68,6 +73,17 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
 
   public BatchOperationCreationRecord setEntityFilter(final DirectBuffer filterBuffer) {
     entityFilterProp.setValue(new UnsafeBuffer(filterBuffer));
+    return this;
+  }
+
+  @Override
+  public BatchOperationProcessInstanceMigrationPlanValue getMigrationPlan() {
+    return migrationPlanProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setMigrationPlan(
+      final BatchOperationProcessInstanceMigrationPlanValue migrationPlan) {
+    migrationPlanProp.getValue().wrap(migrationPlan);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationProcessInstanceMigrationPlan.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationProcessInstanceMigrationPlan.java
@@ -51,9 +51,6 @@ public final class BatchOperationProcessInstanceMigrationPlan extends ObjectValu
    */
   @Override
   public List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions() {
-    // we need to make a copy of each element in the ArrayProperty while iterating it because the
-    // inner values are updated during the iteration
-    // TODO: Is it for the batch operation case also needed to copy everything?
     return mappingInstructionsProperty.stream()
         .map(
             element -> {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationProcessInstanceMigrationPlan.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationProcessInstanceMigrationPlan.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationProcessInstanceMigrationPlanValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
+import java.util.List;
+
+public final class BatchOperationProcessInstanceMigrationPlan extends ObjectValue
+    implements BatchOperationProcessInstanceMigrationPlanValue {
+
+  private final LongProperty targetProcessDefinitionKeyProperty =
+      new LongProperty("targetProcessDefinitionKey", -1);
+  private final ArrayProperty<ProcessInstanceMigrationMappingInstruction>
+      mappingInstructionsProperty =
+          new ArrayProperty<>(
+              "mappingInstructions", ProcessInstanceMigrationMappingInstruction::new);
+
+  public BatchOperationProcessInstanceMigrationPlan() {
+    super(2);
+    declareProperty(targetProcessDefinitionKeyProperty)
+        .declareProperty(mappingInstructionsProperty);
+  }
+
+  @Override
+  public long getTargetProcessDefinitionKey() {
+    return targetProcessDefinitionKeyProperty.getValue();
+  }
+
+  public BatchOperationProcessInstanceMigrationPlan setTargetProcessDefinitionKey(
+      final long targetProcessDefinitionKey) {
+    targetProcessDefinitionKeyProperty.setValue(targetProcessDefinitionKey);
+    return this;
+  }
+
+  /**
+   * This method is expensive because it copies each element before returning it. It is recommended
+   * to use {@link #hasMappingInstructions()} before calling this.
+   *
+   * <p>{@inheritDoc}
+   */
+  @Override
+  public List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions() {
+    // we need to make a copy of each element in the ArrayProperty while iterating it because the
+    // inner values are updated during the iteration
+    // TODO: Is it for the batch operation case also needed to copy everything?
+    return mappingInstructionsProperty.stream()
+        .map(
+            element -> {
+              final var elementCopy = new ProcessInstanceMigrationMappingInstruction();
+              elementCopy.copy(element);
+              return (ProcessInstanceMigrationMappingInstructionValue) elementCopy;
+            })
+        .toList();
+  }
+
+  /** Returns true if this record has mapping instructions, otherwise false. */
+  @JsonIgnore
+  public boolean hasMappingInstructions() {
+    return !mappingInstructionsProperty.isEmpty();
+  }
+
+  public BatchOperationProcessInstanceMigrationPlan addMappingInstruction(
+      final ProcessInstanceMigrationMappingInstruction mappingInstruction) {
+    mappingInstructionsProperty.add().copy(mappingInstruction);
+    return this;
+  }
+
+  public BatchOperationProcessInstanceMigrationPlan wrap(
+      final BatchOperationProcessInstanceMigrationPlanValue record) {
+    setTargetProcessDefinitionKey(record.getTargetProcessDefinitionKey());
+    record
+        .getMappingInstructions()
+        .forEach(inst -> addMappingInstruction((ProcessInstanceMigrationMappingInstruction) inst));
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
@@ -17,6 +17,8 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -31,4 +33,26 @@ public interface BatchOperationCreationRecordValue extends BatchOperationRelated
    * @return filter to apply in the batch operation to select the entities to operate on (as JSON)
    */
   String getEntityFilter();
+
+  /**
+   * @return the migration plan, this is only used for {@link
+   *     BatchOperationType#MIGRATE_PROCESS_INSTANCE}
+   */
+  BatchOperationProcessInstanceMigrationPlanValue getMigrationPlan();
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableBatchOperationProcessInstanceMigrationPlanValue.Builder.class)
+  interface BatchOperationProcessInstanceMigrationPlanValue {
+
+    /**
+     * @return the key of the process definition to migrate to
+     */
+    long getTargetProcessDefinitionKey();
+
+    /**
+     * @return the mapping instructions, or an empty list if no instructions are available
+     */
+    List<ProcessInstanceMigrationMappingInstructionValue> getMappingInstructions();
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
@@ -17,5 +17,6 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum BatchOperationType {
   PROCESS_CANCELLATION,
+  MIGRATE_PROCESS_INSTANCE,
   RESOLVE_INCIDENT
 }


### PR DESCRIPTION
## Description

Adds a new endpoint + service method + mapper + docs for starting a batch operation (MIGRATE_PROCESS_INSTANCE) to migrate process instances based on a ProcessInstanceFilter and a migration plan.

Engine part will be an own follow-up PR.

## Related issues

closes #29709 
