### PR TITLE
feat: add RSS and NMT metrics via JFR

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics;
+
+import io.camunda.application.commons.metrics.jfr.NativeMemoryMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Objects;
+import jdk.jfr.consumer.RecordingStream;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Allows registering and tracking metrics based on JFR events. Although there should be no overhead
+ * according to the JVM, we still allow disabling this via an experimental flag {@code
+ * camunda.flags.jfr.metrics = false}.
+ *
+ * <p>Defaults to being enabled.
+ *
+ * <p>NOTE: the stream is not closed, as this is a singleton component; it will live until the
+ * application is closed. Since it's not using a daemon thread, this will not prevent the
+ * application from stopping.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "camunda.flags.jfr",
+    name = "metrics",
+    havingValue = "true",
+    matchIfMissing = true)
+@Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+public final class JfrMetricRecorder {
+  private final RecordingStream jfrStream;
+  private final MeterRegistry registry;
+
+  @Autowired
+  public JfrMetricRecorder(final MeterRegistry registry) {
+    this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
+    jfrStream = new RecordingStream();
+    jfrStream.setMaxSize(8 * 1024 * 1024);
+  }
+
+  @EventListener(classes = {ApplicationStartedEvent.class})
+  public void onStart(final ApplicationStartedEvent ignored) {
+    new NativeMemoryMetrics().registerEvents(jfrStream, registry);
+    jfrStream.startAsync();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/JfrMetricRecorder.java
@@ -27,15 +27,11 @@ import org.springframework.stereotype.Component;
  * <p>Defaults to being enabled.
  *
  * <p>NOTE: the stream is not closed, as this is a singleton component; it will live until the
- * application is closed. Since it's not using a daemon thread, this will not prevent the
- * application from stopping.
+ * application is closed. Since it's using a daemon thread, this will not prevent the application
+ * from stopping.
  */
 @Component
-@ConditionalOnProperty(
-    prefix = "camunda.flags.jfr",
-    name = "metrics",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnProperty(prefix = "camunda.flags.jfr", name = "metrics", havingValue = "true")
 @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
 public final class JfrMetricRecorder {
   private final RecordingStream jfrStream;

--- a/dist/src/main/java/io/camunda/application/commons/metrics/MetricRegistration.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/MetricRegistration.java
@@ -5,18 +5,18 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.shared;
+package io.camunda.application.commons.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import jdk.jfr.consumer.RecordingStream;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 public final class MetricRegistration implements MeterBinder {
-
   @SuppressWarnings("NullableProblems")
   @Override
   public void bindTo(final MeterRegistry registry) {

--- a/dist/src/main/java/io/camunda/application/commons/metrics/MetricRegistration.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/MetricRegistration.java
@@ -12,7 +12,6 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.netty4.NettyAllocatorMetrics;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import jdk.jfr.consumer.RecordingStream;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)

--- a/dist/src/main/java/io/camunda/application/commons/metrics/PrometheusConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/PrometheusConfiguration.java
@@ -10,10 +10,12 @@ package io.camunda.application.commons.metrics;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.ConditionalOnEnabledMetricsExport;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MetricsConfiguration implements BeanPostProcessor {
+@ConditionalOnEnabledMetricsExport("prometheus")
+public class PrometheusConfiguration implements BeanPostProcessor {
 
   /** Configure PrometheusMeterRegistry if it's configured */
   @Override

--- a/dist/src/main/java/io/camunda/application/commons/metrics/jfr/NativeMemoryMetrics.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/jfr/NativeMemoryMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics.jfr;
+
+import static io.camunda.application.commons.metrics.jfr.NativeMemoryMetricsDoc.NMT_USAGE;
+import static io.camunda.application.commons.metrics.jfr.NativeMemoryMetricsDoc.NMT_USAGE_TOTAL;
+import static io.camunda.application.commons.metrics.jfr.NativeMemoryMetricsDoc.RSS;
+import static io.camunda.application.commons.metrics.jfr.NativeMemoryMetricsDoc.RSS_PEAK;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
+
+/**
+ * Tracks RSS and native memory usage (as provided by the JVM's Native Memory Tracking) capabilities
+ * and registers equivalent gauges to Micrometer.
+ *
+ * <p>See {@link NativeMemoryMetricsDoc} for documentation.
+ *
+ * <p>Note that the native memory metrics are only available if NMT is enabled via {@code
+ * -XX:NativeMemoryTracking} (e.g. {@code -XX:NativeMemoryTracking=summary}).
+ */
+public final class NativeMemoryMetrics {
+  private final MemoryUsage residentSetSize = new MemoryUsage();
+  private final ConcurrentMap<String, NativeMemoryUsage> nativeMemoryUsage =
+      new ConcurrentHashMap<>();
+  private final NativeMemoryUsage nativeMemoryUsageTotal = new NativeMemoryUsage();
+
+  public void registerEvents(final RecordingStream stream, final MeterRegistry registry) {
+    stream.enable(RSS.getJfrEventName()).withoutStackTrace();
+    stream.onEvent(RSS.getJfrEventName(), residentSetSize::onEvent);
+    residentSetSize.register(registry);
+
+    stream.enable(NMT_USAGE_TOTAL.getJfrEventName()).withoutStackTrace();
+    stream.onEvent(NMT_USAGE_TOTAL.getJfrEventName(), nativeMemoryUsageTotal::onEvent);
+    nativeMemoryUsageTotal.register(NMT_USAGE_TOTAL, registry);
+
+    stream.enable(NMT_USAGE.getJfrEventName()).withoutStackTrace();
+    stream.onEvent(
+        NMT_USAGE.getJfrEventName(),
+        event ->
+            nativeMemoryUsage
+                .computeIfAbsent(event.getString("type"), type -> registerNmtGauge(type, registry))
+                .onEvent(event));
+  }
+
+  private NativeMemoryUsage registerNmtGauge(final String type, final MeterRegistry registry) {
+    final var usage = new NativeMemoryUsage();
+    usage.register(
+        NMT_USAGE,
+        registry,
+        Tag.of(NativeMemoryMetricsDoc.NativeMemoryUsageKeys.TYPE.asString(), type));
+
+    return usage;
+  }
+
+  private record MemoryUsage(AtomicLong size, AtomicLong peak) {
+    private MemoryUsage() {
+      this(new AtomicLong(), new AtomicLong());
+    }
+
+    private void onEvent(final RecordedEvent event) {
+      size.set(event.getLong("size"));
+      peak.set(event.getLong("peak"));
+    }
+
+    private void register(final MeterRegistry registry) {
+      Gauge.builder(RSS.getName(), size, AtomicLong::get)
+          .description(RSS.getDescription())
+          .baseUnit("bytes")
+          .register(registry);
+      Gauge.builder(RSS_PEAK.getName(), peak, AtomicLong::get)
+          .description(RSS_PEAK.getDescription())
+          .baseUnit("bytes")
+          .register(registry);
+    }
+  }
+
+  private record NativeMemoryUsage(AtomicLong reserved, AtomicLong committed) {
+    private NativeMemoryUsage() {
+      this(new AtomicLong(), new AtomicLong());
+    }
+
+    private void onEvent(final RecordedEvent event) {
+      reserved.set(event.getLong("reserved"));
+      committed.set(event.getLong("committed"));
+    }
+
+    private void register(
+        final NativeMemoryMetricsDoc doc, final MeterRegistry registry, final Tag... tags) {
+      Gauge.builder(doc.getName(), reserved, AtomicLong::get)
+          .description(doc.getDescription())
+          .baseUnit("bytes")
+          .tags(List.of(tags))
+          .register(registry);
+      Gauge.builder(doc.getName(), committed, AtomicLong::get)
+          .description(doc.getDescription())
+          .baseUnit("bytes")
+          .tags(List.of(tags))
+          .register(registry);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/metrics/jfr/NativeMemoryMetricsDoc.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/jfr/NativeMemoryMetricsDoc.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics.jfr;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/** Documentation for metrics related to memory tracking which includes native memory. */
+@SuppressWarnings("NullableProblems")
+public enum NativeMemoryMetricsDoc implements ExtendedMeterDocumentation {
+  /** The current resident set size as observed by the JVM */
+  RSS {
+    @Override
+    public String getDescription() {
+      return "The current resident set size as observed by the JVM";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.memory.rss";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getJfrEventName() {
+      return "jdk.ResidentSetSize";
+    }
+  },
+
+  /** The current resident set size as observed by the JVM */
+  RSS_PEAK {
+    @Override
+    public String getDescription() {
+      return "The peak resident set size as observed so far by the JVM";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.memory.rss.peak";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getJfrEventName() {
+      return "jdk.ResidentSetSize";
+    }
+  },
+
+  /** The reserved and committed memory usage of native memory usage, split by type */
+  NMT_USAGE {
+    @Override
+    public String getDescription() {
+      return "The reserved and committed memory usage of native memory usage, split by type";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.memory.nmt";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return NativeMemoryUsageKeys.values();
+    }
+
+    @Override
+    public String getJfrEventName() {
+      return "jdk.NativeMemoryUsage";
+    }
+  },
+
+  /** The total reserved and committed memory usage of native memory usage */
+  NMT_USAGE_TOTAL {
+    @Override
+    public String getDescription() {
+      return "The total reserved and committed memory usage of native memory usage";
+    }
+
+    @Override
+    public String getName() {
+      return "camunda.memory.nmt.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {NativeMemoryUsageKeys.RESERVED, NativeMemoryUsageKeys.COMMITTED};
+    }
+
+    @Override
+    public String getJfrEventName() {
+      return "jdk.NativeMemoryUsageTotal";
+    }
+  };
+
+  public abstract String getJfrEventName();
+
+  @SuppressWarnings("NullableProblems")
+  public enum NativeMemoryUsageKeys implements KeyName {
+    /**
+     * The specific native memory type; this can be things like "Heap", but also "Code", "GC",
+     * "Compiler", etc.
+     *
+     * <p>See: <a
+     * href="https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr007.html">Oracle
+     * documentation</a> on this
+     */
+    TYPE {
+      @Override
+      public String asString() {
+        return "type";
+      }
+    },
+
+    RESERVED {
+      @Override
+      public String asString() {
+        return "reserved";
+      }
+    },
+
+    COMMITTED {
+      @Override
+      public String asString() {
+        return "committed";
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a basic framework to report metrics via JFR, which includes RSS and potentially NMT.

Motivation is tracking native memory usage, which is painful to do via the `jcmd` utility.

While JFR works OOTB, you will need to enable NMT to get some metrics, e.g. `-XX:NativeMemoryTracking=summary` or something.

Although JFR is not supposed to have much overhead, I still added a flag to allow disabling this.

This was done very quickly, so can probably be improved :)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
