### PR TITLE
refactor: remove getFlowNodeName dependency from modifications store

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -1317,7 +1317,7 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('Activity_0qtp1k6');
+      modificationsStore.cancelAllTokens('Activity_0qtp1k6', {});
     });
 
     expect(
@@ -1553,7 +1553,7 @@ describe('VariablePanel', () => {
     expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('Activity_0qtp1k6');
+      modificationsStore.cancelAllTokens('Activity_0qtp1k6', {});
     });
 
     await waitFor(() => {
@@ -1591,10 +1591,14 @@ describe('VariablePanel', () => {
     expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('Activity_0qtp1k6');
+      modificationsStore.cancelAllTokens('Activity_0qtp1k6', {});
     });
 
-    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    await waitFor(
+      () =>
+        expect(screen.queryByTestId('edit-variable-value')).not
+          .toBeInTheDocument,
+    );
   });
 
   it('should display readonly state for existing node if cancel modification is applied on the flow node and one new token is added', async () => {
@@ -1651,7 +1655,7 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('Activity_0qtp1k6');
+      modificationsStore.cancelAllTokens('Activity_0qtp1k6', {});
     });
 
     await waitFor(() =>

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -1084,7 +1084,7 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 1, 1);
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
     expect(
@@ -1401,7 +1401,7 @@ describe('VariablePanel', () => {
     expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 1, 1);
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
     await waitFor(() =>
@@ -1465,7 +1465,7 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 0, 0);
+      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
     });
 
     expect(
@@ -1646,7 +1646,7 @@ describe('VariablePanel', () => {
     expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 0, 0);
+      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
     });
 
     await waitFor(() => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/index.test.tsx
@@ -107,7 +107,7 @@ describe('<ModificationIcons />', () => {
       screen.queryByTitle('This flow node instance is planned to be canceled'),
     ).not.toBeInTheDocument();
 
-    act(() => modificationsStore.cancelAllTokens('user_task'));
+    act(() => modificationsStore.cancelAllTokens('user_task', {}));
 
     expect(
       screen.getByTitle('This flow node instance is planned to be canceled'),
@@ -134,7 +134,9 @@ describe('<ModificationIcons />', () => {
       },
     );
 
-    act(() => modificationsStore.cancelToken('user_task', 'some-flow-node-id'));
+    act(() =>
+      modificationsStore.cancelToken('user_task', 'some-flow-node-id', {}),
+    );
 
     expect(
       screen.getByTitle('This flow node instance is planned to be canceled'),
@@ -162,7 +164,11 @@ describe('<ModificationIcons />', () => {
     );
 
     act(() =>
-      modificationsStore.cancelToken('user_task', 'some-other-flow-node-id'),
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-other-flow-node-id',
+        {},
+      ),
     );
 
     expect(
@@ -191,7 +197,11 @@ describe('<ModificationIcons />', () => {
     );
 
     act(() =>
-      modificationsStore.cancelToken('user_task', 'some-parent-flow-node-id'),
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-parent-flow-node-id',
+        {},
+      ),
     );
 
     expect(
@@ -223,6 +233,7 @@ describe('<ModificationIcons />', () => {
       modificationsStore.cancelToken(
         'user_task',
         'some-second-parent-flow-node-id',
+        {},
       ),
     );
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
@@ -110,7 +110,7 @@ describe('<ModificationIcons />', () => {
       screen.queryByTitle('This flow node instance is planned to be canceled'),
     ).not.toBeInTheDocument();
 
-    act(() => modificationsStore.cancelAllTokens('user_task'));
+    act(() => modificationsStore.cancelAllTokens('user_task', {}));
 
     expect(
       screen.getByTitle('This flow node instance is planned to be canceled'),
@@ -133,7 +133,9 @@ describe('<ModificationIcons />', () => {
       },
     );
 
-    act(() => modificationsStore.cancelToken('user_task', 'some-flow-node-id'));
+    act(() =>
+      modificationsStore.cancelToken('user_task', 'some-flow-node-id', {}),
+    );
 
     expect(
       screen.getByTitle('This flow node instance is planned to be canceled'),
@@ -157,7 +159,11 @@ describe('<ModificationIcons />', () => {
     );
 
     act(() =>
-      modificationsStore.cancelToken('user_task', 'some-other-flow-node-id'),
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-other-flow-node-id',
+        {},
+      ),
     );
 
     expect(
@@ -182,7 +188,11 @@ describe('<ModificationIcons />', () => {
     );
 
     act(() =>
-      modificationsStore.cancelToken('user_task', 'some-parent-flow-node-id'),
+      modificationsStore.cancelToken(
+        'user_task',
+        'some-parent-flow-node-id',
+        {},
+      ),
     );
 
     expect(
@@ -210,6 +220,7 @@ describe('<ModificationIcons />', () => {
       modificationsStore.cancelToken(
         'user_task',
         'some-second-parent-flow-node-id',
+        {},
       ),
     );
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/index.test.tsx
@@ -12,6 +12,9 @@ import {mockStartNode, mockStartEventBusinessObject} from './index.setup';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
 import {MOCK_TIMESTAMP} from 'modules/utils/date/__mocks__/formatDate';
 import {useEffect} from 'react';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
@@ -21,7 +24,13 @@ jest.mock('modules/feature-flags', () => ({
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => flowNodeTimeStampStore.reset, []);
 
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value={'123'}>
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
 describe('<Bar />', () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -222,8 +222,12 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
           ) : undefined;
         }}
         onSelect={() => {
-          if (modificationsStore.state.status === 'adding-token') {
+          if (
+            modificationsStore.state.status === 'adding-token' &&
+            processInstanceXmlData?.businessObjects
+          ) {
             modificationsStore.finishAddingToken(
+              processInstanceXmlData.businessObjects,
               flowNodeInstance.flowNodeId,
               flowNodeInstance.id,
             );

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
@@ -170,7 +170,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
 
     act(() => {
       modificationsStore.enableModificationMode();
-      modificationsStore.cancelAllTokens('peterJoin');
+      modificationsStore.cancelAllTokens('peterJoin', {});
     });
 
     expect(

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationsWithAncestorSelection.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationsWithAncestorSelection.test.tsx
@@ -106,10 +106,10 @@ describe.skip('FlowNodeInstancesTree - modifications with ancestor selection', (
 
     act(() => {
       modificationsStore.startAddingToken('user_task');
-      modificationsStore.finishAddingToken('inner_sub_process', '2_2');
+      modificationsStore.finishAddingToken({}, 'inner_sub_process', '2_2');
 
       modificationsStore.startAddingToken('user_task');
-      modificationsStore.finishAddingToken('inner_sub_process', '2_2');
+      modificationsStore.finishAddingToken({}, 'inner_sub_process', '2_2');
     });
 
     mockFetchFlowNodeInstances().withSuccess(
@@ -200,10 +200,10 @@ describe.skip('FlowNodeInstancesTree - modifications with ancestor selection', (
 
     act(() => {
       modificationsStore.startAddingToken('user_task');
-      modificationsStore.finishAddingToken('parent_sub_process', '2');
+      modificationsStore.finishAddingToken({}, 'parent_sub_process', '2');
 
       modificationsStore.startAddingToken('user_task');
-      modificationsStore.finishAddingToken('parent_sub_process', '2');
+      modificationsStore.finishAddingToken({}, 'parent_sub_process', '2');
     });
 
     mockFetchFlowNodeInstances().withSuccess(
@@ -367,12 +367,14 @@ describe.skip('FlowNodeInstancesTree - modifications with ancestor selection', (
     act(() => {
       modificationsStore.startAddingToken('user_task');
       modificationsStore.finishAddingToken(
+        {},
         'nested_sub_process',
         processInstanceId,
       );
 
       modificationsStore.startAddingToken('user_task');
       modificationsStore.finishAddingToken(
+        {},
         'nested_sub_process',
         processInstanceId,
       );
@@ -548,6 +550,7 @@ describe.skip('FlowNodeInstancesTree - modifications with ancestor selection', (
     act(() => {
       modificationsStore.startAddingToken('user_task');
       modificationsStore.finishAddingToken(
+        {},
         'nested_sub_process',
         processInstanceId,
       );

--- a/operate/client/src/App/ProcessInstance/LastModification/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/LastModification/index.test.tsx
@@ -108,7 +108,7 @@ describe('LastModification', () => {
     expect(screen.getByText(/Add "service-task-1"/)).toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('service-task-2');
+      modificationsStore.cancelAllTokens('service-task-2', {});
     });
 
     expect(

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
@@ -205,7 +205,7 @@ describe('Modification Summary Modal', () => {
 
     act(() => {
       modificationsStore.removeLastModification();
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1');
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1', {});
     });
 
     expect(
@@ -228,6 +228,7 @@ describe('Modification Summary Modal', () => {
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
         newScopeCount: 1,
+        businessObjects: {},
       });
     });
 
@@ -288,8 +289,8 @@ describe('Modification Summary Modal', () => {
     );
 
     act(() => {
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1');
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-2');
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1', {});
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-2', {});
     });
 
     await waitFor(() =>
@@ -323,6 +324,7 @@ describe('Modification Summary Modal', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     modificationsStore.addMoveModification({
@@ -332,6 +334,7 @@ describe('Modification Summary Modal', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     const {user} = render(
@@ -488,7 +491,7 @@ describe('Modification Summary Modal', () => {
         },
       });
 
-      modificationsStore.cancelAllTokens('multi-instance-subprocess');
+      modificationsStore.cancelAllTokens('multi-instance-subprocess', {});
     });
 
     render(<ModificationSummaryModal open setOpen={() => {}} />, {
@@ -649,7 +652,7 @@ describe('Modification Summary Modal', () => {
     ).not.toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('taskA');
+      modificationsStore.cancelAllTokens('taskA', {});
     });
 
     expect(
@@ -659,7 +662,7 @@ describe('Modification Summary Modal', () => {
     ).not.toBeInTheDocument();
 
     act(() => {
-      modificationsStore.cancelAllTokens('taskB');
+      modificationsStore.cancelAllTokens('taskB', {});
     });
 
     expect(
@@ -743,7 +746,7 @@ describe('Modification Summary Modal', () => {
     expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
 
     act(() => {
-      modificationsStore.cancelAllTokens('taskA');
+      modificationsStore.cancelAllTokens('taskA', {});
     });
 
     expect(

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/v2/index.test.tsx
@@ -224,7 +224,7 @@ describe('Modification Summary Modal', () => {
 
     act(() => {
       modificationsStore.removeLastModification();
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1');
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1', {});
     });
 
     expect(
@@ -247,6 +247,7 @@ describe('Modification Summary Modal', () => {
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
         newScopeCount: 1,
+        businessObjects: {},
       });
     });
 
@@ -307,8 +308,8 @@ describe('Modification Summary Modal', () => {
     );
 
     act(() => {
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1');
-      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-2');
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-1', {});
+      modificationsStore.cancelToken('flow-node-1', 'some-instance-key-2', {});
     });
 
     await waitFor(() =>
@@ -342,6 +343,7 @@ describe('Modification Summary Modal', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     modificationsStore.addMoveModification({
@@ -351,6 +353,7 @@ describe('Modification Summary Modal', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     const {user} = render(
@@ -510,6 +513,7 @@ describe('Modification Summary Modal', () => {
         flowNodeId: 'multi-instance-subprocess',
         affectedTokenCount: 7,
         visibleAffectedTokenCount: 7,
+        businessObjects: {},
       });
     });
 
@@ -682,6 +686,7 @@ describe('Modification Summary Modal', () => {
         flowNodeId: 'service-task-2',
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
+        businessObjects: {},
       });
     });
 
@@ -696,6 +701,7 @@ describe('Modification Summary Modal', () => {
         flowNodeId: 'service-task-3',
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
+        businessObjects: {},
       });
     });
 
@@ -783,7 +789,7 @@ describe('Modification Summary Modal', () => {
     expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
 
     act(() => {
-      modificationsStore.cancelAllTokens('taskA');
+      modificationsStore.cancelAllTokens('taskA', {});
     });
 
     expect(

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -125,12 +125,11 @@ const ModificationDropdown: React.FC<Props> = observer(
                                 scopeId: generateUniqueID(),
                                 flowNode: {
                                   id: flowNodeId,
-                                  name:
-                                    getFlowNodeName({
-                                      businessObjects:
-                                        processDefinitionData?.businessObjects,
-                                      flowNodeId,
-                                    }) ?? '',
+                                  name: getFlowNodeName({
+                                    businessObjects:
+                                      processDefinitionData?.businessObjects,
+                                    flowNodeId,
+                                  }),
                                 },
                                 affectedTokenCount: 1,
                                 visibleAffectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -150,7 +150,8 @@ const ModificationDropdown: React.FC<Props> = observer(
                     )}
 
                     {availableModifications.includes('cancel-instance') &&
-                      !isNil(flowNodeInstanceId) && (
+                      !isNil(flowNodeInstanceId) &&
+                      processDefinitionData?.businessObjects && (
                         <Button
                           kind="ghost"
                           title="Cancel selected instance in this flow node"
@@ -165,6 +166,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                             modificationsStore.cancelToken(
                               flowNodeId,
                               flowNodeInstanceId,
+                              processDefinitionData.businessObjects,
                             );
                             flowNodeSelectionStore.clearSelection();
                           }}
@@ -173,25 +175,29 @@ const ModificationDropdown: React.FC<Props> = observer(
                         </Button>
                       )}
 
-                    {availableModifications.includes('cancel-all') && (
-                      <Button
-                        kind="ghost"
-                        title="Cancel all running flow node instances in this flow node"
-                        aria-label="Cancel all running flow node instances in this flow node"
-                        size="sm"
-                        renderIcon={Error}
-                        onClick={() => {
-                          tracking.track({
-                            eventName: 'cancel-token',
-                          });
+                    {availableModifications.includes('cancel-all') &&
+                      processDefinitionData?.businessObjects && (
+                        <Button
+                          kind="ghost"
+                          title="Cancel all running flow node instances in this flow node"
+                          aria-label="Cancel all running flow node instances in this flow node"
+                          size="sm"
+                          renderIcon={Error}
+                          onClick={() => {
+                            tracking.track({
+                              eventName: 'cancel-token',
+                            });
 
-                          modificationsStore.cancelAllTokens(flowNodeId);
-                          flowNodeSelectionStore.clearSelection();
-                        }}
-                      >
-                        Cancel all
-                      </Button>
-                    )}
+                            modificationsStore.cancelAllTokens(
+                              flowNodeId,
+                              processDefinitionData.businessObjects,
+                            );
+                            flowNodeSelectionStore.clearSelection();
+                          }}
+                        >
+                          Cancel all
+                        </Button>
+                      )}
 
                     {availableModifications.includes('move-instance') &&
                       !isNil(flowNodeInstanceId) && (

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -127,8 +127,8 @@ const ModificationDropdown: React.FC<Props> = observer(
                                   id: flowNodeId,
                                   name:
                                     getFlowNodeName({
-                                      diagramModel:
-                                        processDefinitionData?.diagramModel,
+                                      businessObjects:
+                                        processDefinitionData?.businessObjects,
                                       flowNodeId,
                                     }) ?? '',
                                 },

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
@@ -70,7 +70,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+    expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
     expect(screen.getByText(/Move/)).toBeInTheDocument();
     expect(screen.getByText(/Add/)).toBeInTheDocument();
   });
@@ -210,7 +210,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB');
+      modificationsStore.cancelAllTokens('TaskB', {});
 
       act(() => {
         flowNodeSelectionStore.selectFlowNode({
@@ -265,7 +265,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB');
+      modificationsStore.cancelAllTokens('TaskB', {});
 
       act(() => {
         flowNodeSelectionStore.selectFlowNode({

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
@@ -152,11 +152,10 @@ const ModificationDropdown: React.FC<Props> = observer(
                                   scopeId: generateUniqueID(),
                                   flowNode: {
                                     id: flowNodeId,
-                                    name:
-                                      getFlowNodeName({
-                                        businessObjects,
-                                        flowNodeId,
-                                      }) ?? '',
+                                    name: getFlowNodeName({
+                                      businessObjects,
+                                      flowNodeId,
+                                    }),
                                   },
                                   affectedTokenCount: 1,
                                   visibleAffectedTokenCount: 1,

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
@@ -176,7 +176,8 @@ const ModificationDropdown: React.FC<Props> = observer(
                       )}
 
                     {availableModifications.includes('cancel-instance') &&
-                      !isNil(flowNodeInstanceId) && (
+                      !isNil(flowNodeInstanceId) &&
+                      businessObjects && (
                         <Button
                           kind="ghost"
                           title="Cancel selected instance in this flow node"
@@ -191,6 +192,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                             modificationsStore.cancelToken(
                               flowNodeId,
                               flowNodeInstanceId,
+                              businessObjects,
                             );
                             flowNodeSelectionStore.clearSelection();
                           }}
@@ -199,29 +201,31 @@ const ModificationDropdown: React.FC<Props> = observer(
                         </Button>
                       )}
 
-                    {availableModifications.includes('cancel-all') && (
-                      <Button
-                        kind="ghost"
-                        title="Cancel all running flow node instances in this flow node"
-                        aria-label="Cancel all running flow node instances in this flow node"
-                        size="sm"
-                        renderIcon={Error}
-                        onClick={() => {
-                          tracking.track({
-                            eventName: 'cancel-token',
-                          });
+                    {availableModifications.includes('cancel-all') &&
+                      businessObjects && (
+                        <Button
+                          kind="ghost"
+                          title="Cancel all running flow node instances in this flow node"
+                          aria-label="Cancel all running flow node instances in this flow node"
+                          size="sm"
+                          renderIcon={Error}
+                          onClick={() => {
+                            tracking.track({
+                              eventName: 'cancel-token',
+                            });
 
-                          cancelAllTokens(
-                            flowNodeId,
-                            totalRunningInstances ?? 0,
-                            totalRunningInstancesVisible ?? 0,
-                          );
-                          flowNodeSelectionStore.clearSelection();
-                        }}
-                      >
-                        Cancel all
-                      </Button>
-                    )}
+                            cancelAllTokens(
+                              flowNodeId,
+                              totalRunningInstances ?? 0,
+                              totalRunningInstancesVisible ?? 0,
+                              businessObjects,
+                            );
+                            flowNodeSelectionStore.clearSelection();
+                          }}
+                        >
+                          Cancel all
+                        </Button>
+                      )}
 
                     {availableModifications.includes('move-instance') &&
                       !isNil(flowNodeInstanceId) && (

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.tsx
@@ -154,8 +154,7 @@ const ModificationDropdown: React.FC<Props> = observer(
                                     id: flowNodeId,
                                     name:
                                       getFlowNodeName({
-                                        diagramModel:
-                                          processDefinitionData?.diagramModel,
+                                        businessObjects,
                                         flowNodeId,
                                       }) ?? '',
                                   },

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -71,7 +71,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+    expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
     expect(screen.getByText(/Move/)).toBeInTheDocument();
     expect(screen.getByText(/Add/)).toBeInTheDocument();
   });
@@ -217,7 +217,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB');
+      modificationsStore.cancelAllTokens('TaskB', {});
 
       act(() => {
         flowNodeSelectionStore.selectFlowNode({
@@ -274,7 +274,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB');
+      modificationsStore.cancelAllTokens('TaskB', {});
 
       act(() => {
         flowNodeSelectionStore.selectFlowNode({

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -204,28 +204,36 @@ const TopPanel: React.FC = observer(() => {
           isOpen={incidentsStore.state.isIncidentBarOpen}
         />
       )}
-      {modificationsStore.state.status === 'moving-token' && (
-        <ModificationInfoBanner
-          text="Select the target flow node in the diagram"
-          button={{
-            onClick: () => modificationsStore.finishMovingToken(),
-            label: 'Discard',
-          }}
-        />
-      )}
+      {modificationsStore.state.status === 'moving-token' &&
+        processDefinitionData?.businessObjects && (
+          <ModificationInfoBanner
+            text="Select the target flow node in the diagram"
+            button={{
+              onClick: () =>
+                modificationsStore.finishMovingToken(
+                  processDefinitionData.businessObjects,
+                ),
+              label: 'Discard',
+            }}
+          />
+        )}
       {modificationsStore.isModificationModeEnabled &&
         flowNodeSelectionStore.selectedRunningInstanceCount > 1 && (
           <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
         )}
-      {modificationsStore.state.status === 'adding-token' && (
-        <ModificationInfoBanner
-          text="Flow node has multiple parent scopes. Please select parent node from Instance History to Add."
-          button={{
-            onClick: () => modificationsStore.finishAddingToken(),
-            label: 'Discard',
-          }}
-        />
-      )}
+      {modificationsStore.state.status === 'adding-token' &&
+        processDefinitionData?.businessObjects && (
+          <ModificationInfoBanner
+            text="Flow node has multiple parent scopes. Please select parent node from Instance History to Add."
+            button={{
+              onClick: () =>
+                modificationsStore.finishAddingToken(
+                  processDefinitionData.businessObjects,
+                ),
+              label: 'Discard',
+            }}
+          />
+        )}
       <DiagramPanel>
         <DiagramShell status={getStatus()}>
           {processDefinitionData?.xml !== undefined && (
@@ -242,9 +250,15 @@ const TopPanel: React.FC = observer(() => {
                   : undefined
               }
               onFlowNodeSelection={(flowNodeId, isMultiInstance) => {
-                if (modificationsStore.state.status === 'moving-token') {
+                if (
+                  modificationsStore.state.status === 'moving-token' &&
+                  processDefinitionData?.businessObjects
+                ) {
                   flowNodeSelectionStore.clearSelection();
-                  modificationsStore.finishMovingToken(flowNodeId);
+                  modificationsStore.finishMovingToken(
+                    processDefinitionData.businessObjects,
+                    flowNodeId,
+                  );
                 } else {
                   if (modificationsStore.state.status !== 'adding-token') {
                     flowNodeSelectionStore.selectFlowNode({

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
@@ -259,15 +259,17 @@ const TopPanel: React.FC = observer(() => {
         getSelectedRunningInstanceCount(totalRunningInstances || 0) > 1 && (
           <ModificationInfoBanner text="Flow node has multiple instances. To select one, use the instance history tree below." />
         )}
-      {modificationsStore.state.status === 'adding-token' && (
-        <ModificationInfoBanner
-          text="Flow node has multiple parent scopes. Please select parent node from Instance History to Add."
-          button={{
-            onClick: () => modificationsStore.finishAddingToken(),
-            label: 'Discard',
-          }}
-        />
-      )}
+      {modificationsStore.state.status === 'adding-token' &&
+        businessObjects && (
+          <ModificationInfoBanner
+            text="Flow node has multiple parent scopes. Please select parent node from Instance History to Add."
+            button={{
+              onClick: () =>
+                modificationsStore.finishAddingToken(businessObjects),
+              label: 'Discard',
+            }}
+          />
+        )}
       <DiagramPanel>
         <DiagramShell status={getStatus()}>
           {processDefinitionData?.xml !== undefined && businessObjects && (

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
@@ -32,11 +32,11 @@ const BatchModificationNotification: React.FC<Props> = observer(
         sourceFlowNodeId,
       );
     const sourceFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: sourceFlowNodeId,
     });
     const targetFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: targetFlowNodeId,
     });
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
@@ -48,7 +48,7 @@ const BatchModificationNotification: React.FC<Props> = observer(
           kind="info"
           title=""
           subtitle={
-            sourceFlowNodeName === undefined || targetFlowNodeName === undefined
+            sourceFlowNodeName === '' || targetFlowNodeName === ''
               ? 'Please select where you want to move the selected instances on the diagram.'
               : `Modification scheduled: Move ${pluralSuffix(
                   instancesCount,

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -35,12 +35,12 @@ const BatchModificationNotification: React.FC<Props> = observer(
     );
 
     const sourceFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: sourceFlowNodeId,
     });
 
     const targetFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: targetFlowNodeId,
     });
 

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -52,7 +52,7 @@ const BatchModificationNotification: React.FC<Props> = observer(
           kind="info"
           title=""
           subtitle={
-            sourceFlowNodeName === undefined || targetFlowNodeName === undefined
+            sourceFlowNodeName === '' || targetFlowNodeName === ''
               ? 'Please select where you want to move the selected instances on the diagram.'
               : `Modification scheduled: Move ${pluralSuffix(
                   instancesCount,

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -186,7 +186,8 @@ const DiagramPanel: React.FC = observer(() => {
                       selectedFlowNodeId !== undefined &&
                       isMoveModificationTarget(
                         getFlowNode({
-                          diagramModel: processDefinition.data?.diagramModel,
+                          businessObjects:
+                            processDefinition.data?.diagramModel.elementsById,
                           flowNodeId: selectedFlowNodeId,
                         }),
                       ),

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -174,7 +174,8 @@ const DiagramPanel: React.FC = observer(() => {
                       selectedFlowNodeId !== undefined &&
                       isMoveModificationTarget(
                         getFlowNode({
-                          diagramModel: processDefinition.data?.diagramModel,
+                          businessObjects:
+                            processDefinition.data?.diagramModel.elementsById,
                           flowNodeId: selectedFlowNodeId,
                         }),
                       ),

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -41,11 +41,11 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       processDefinitionKey,
     });
     const sourceFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: sourceFlowNodeId,
     });
     const targetFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: targetFlowNodeId ?? undefined,
     });
     const instancesCount =

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
@@ -41,11 +41,11 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
       processDefinitionKey,
     });
     const sourceFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: sourceFlowNodeId,
     });
     const targetFlowNodeName = getFlowNodeName({
-      diagramModel: processDefinitionData?.diagramModel,
+      businessObjects: processDefinitionData?.diagramModel.elementsById,
       flowNodeId: targetFlowNodeId ?? undefined,
     });
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
@@ -13,6 +13,7 @@ import {processInstancesSelectionStore} from 'modules/stores/processInstancesSel
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {BatchModificationFooter} from '..';
+import {MemoryRouter} from 'react-router-dom';
 
 jest.mock('modules/hooks/useCallbackPrompt', () => {
   return {
@@ -46,7 +47,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
     });
 
     return (
-      <>
+      <MemoryRouter>
         {children}
         <button
           onClick={processInstancesSelectionStore.selectAllProcessInstances}
@@ -67,7 +68,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
         >
           select target flow node
         </button>
-      </>
+      </MemoryRouter>
     );
   },
 );

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
@@ -50,7 +50,7 @@ const MoveAction: React.FC = observer(() => {
 
   const businessObject: BusinessObject | null = flowNodeId
     ? (getFlowNode({
-        diagramModel: processDefinitionData?.diagramModel,
+        businessObjects: processDefinitionData?.diagramModel.elementsById,
         flowNodeId,
       }) ?? null)
     : null;

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/mocks.tsx
@@ -12,6 +12,7 @@ import {processStatisticsStore} from 'modules/stores/processStatistics/processSt
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter} from 'react-router-dom';
 
 type Props = {
   children?: React.ReactNode;
@@ -27,31 +28,35 @@ const Wrapper = ({children}: Props) => {
   });
 
   return (
-    <QueryClientProvider client={getMockQueryClient()}>
-      {children}
-      <button
-        onClick={() => processInstanceMigrationStore.setCurrentStep('summary')}
-      >
-        Summary
-      </button>
-      <button
-        onClick={() =>
-          processInstanceMigrationStore.setCurrentStep('elementMapping')
-        }
-      >
-        Element Mapping
-      </button>
-      <button
-        onClick={() => {
-          processInstanceMigrationStore.updateFlowNodeMapping({
-            sourceId: 'ServiceTask_0kt6c5i',
-            targetId: 'ServiceTask_0kt6c5i',
-          });
-        }}
-      >
-        map elements
-      </button>
-    </QueryClientProvider>
+    <MemoryRouter>
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+        <button
+          onClick={() =>
+            processInstanceMigrationStore.setCurrentStep('summary')
+          }
+        >
+          Summary
+        </button>
+        <button
+          onClick={() =>
+            processInstanceMigrationStore.setCurrentStep('elementMapping')
+          }
+        >
+          Element Mapping
+        </button>
+        <button
+          onClick={() => {
+            processInstanceMigrationStore.updateFlowNodeMapping({
+              sourceId: 'ServiceTask_0kt6c5i',
+              targetId: 'ServiceTask_0kt6c5i',
+            });
+          }}
+        >
+          map elements
+        </button>
+      </QueryClientProvider>
+    </MemoryRouter>
   );
 };
 

--- a/operate/client/src/modules/stores/flowNodeSelection.test.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.test.ts
@@ -610,7 +610,7 @@ describe('stores/flowNodeSelection', () => {
     );
 
     // cancel all tokens
-    modificationsStore.cancelAllTokens('userTask');
+    modificationsStore.cancelAllTokens('userTask', {});
 
     flowNodeSelectionStore.setSelection({
       flowNodeId: 'userTask',
@@ -633,9 +633,9 @@ describe('stores/flowNodeSelection', () => {
     modificationsStore.removeLastModification();
 
     // cancel all tokens one by one
-    modificationsStore.cancelToken('userTask', '2251799813689409');
-    modificationsStore.cancelToken('userTask', '2251799813689410');
-    modificationsStore.cancelToken('userTask', '2251799813689411');
+    modificationsStore.cancelToken('userTask', '2251799813689409', {});
+    modificationsStore.cancelToken('userTask', '2251799813689410', {});
+    modificationsStore.cancelToken('userTask', '2251799813689411', {});
 
     flowNodeSelectionStore.setSelection({
       flowNodeId: 'userTask',
@@ -662,7 +662,7 @@ describe('stores/flowNodeSelection', () => {
     modificationsStore.removeLastModification();
 
     // cancel one token
-    modificationsStore.cancelToken('userTask', '2251799813689409');
+    modificationsStore.cancelToken('userTask', '2251799813689409', {});
 
     flowNodeSelectionStore.setSelection({
       flowNodeId: 'userTask',
@@ -725,6 +725,7 @@ describe('stores/flowNodeSelection', () => {
       affectedTokenCount: 3,
       visibleAffectedTokenCount: 3,
       newScopeCount: 3,
+      businessObjects: {},
     });
 
     flowNodeSelectionStore.setSelection({
@@ -755,6 +756,7 @@ describe('stores/flowNodeSelection', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
     modificationsStore.addMoveModification({
       sourceFlowNodeId: 'userTask',
@@ -763,6 +765,7 @@ describe('stores/flowNodeSelection', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
     modificationsStore.addMoveModification({
       sourceFlowNodeId: 'userTask',
@@ -771,6 +774,7 @@ describe('stores/flowNodeSelection', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     flowNodeSelectionStore.setSelection({
@@ -804,6 +808,7 @@ describe('stores/flowNodeSelection', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     flowNodeSelectionStore.setSelection({

--- a/operate/client/src/modules/stores/modificationRules.test.ts
+++ b/operate/client/src/modules/stores/modificationRules.test.ts
@@ -145,7 +145,7 @@ describe('stores/modificationRules', () => {
     ]);
 
     // cancel all instances
-    modificationsStore.cancelAllTokens('service-task-2');
+    modificationsStore.cancelAllTokens('service-task-2', {});
     expect(modificationRulesStore.canBeModified).toBe(true);
     expect(modificationRulesStore.canBeCanceled).toBe(false);
     expect(modificationRulesStore.availableModifications).toEqual(['add']);
@@ -172,7 +172,7 @@ describe('stores/modificationRules', () => {
     });
 
     // cancel one of the instances
-    modificationsStore.cancelToken('service-task-2', 'some-instance-key-1');
+    modificationsStore.cancelToken('service-task-2', 'some-instance-key-1', {});
     expect(modificationRulesStore.canBeModified).toBe(true);
     expect(modificationRulesStore.canBeCanceled).toBe(true);
     expect(modificationRulesStore.availableModifications).toEqual([
@@ -203,7 +203,7 @@ describe('stores/modificationRules', () => {
     ]);
 
     // cancel the other instance
-    modificationsStore.cancelToken('service-task-2', 'some-instance-key-2');
+    modificationsStore.cancelToken('service-task-2', 'some-instance-key-2', {});
     expect(modificationRulesStore.canBeModified).toBe(true);
     expect(modificationRulesStore.canBeCanceled).toBe(false);
     expect(modificationRulesStore.availableModifications).toEqual([]);

--- a/operate/client/src/modules/stores/modifications.test.ts
+++ b/operate/client/src/modules/stores/modifications.test.ts
@@ -168,7 +168,7 @@ describe('stores/modifications', () => {
     });
 
     expect(modificationsStore.state.modifications.length).toEqual(1);
-    modificationsStore.cancelAllTokens('service-task-2');
+    modificationsStore.cancelAllTokens('service-task-2', {});
 
     expect(modificationsStore.state.modifications.length).toEqual(2);
 
@@ -393,7 +393,7 @@ describe('stores/modifications', () => {
       },
     });
 
-    modificationsStore.cancelAllTokens('service-task-2');
+    modificationsStore.cancelAllTokens('service-task-2', {});
 
     expect(modificationsStore.lastModification).toEqual({
       payload: {
@@ -456,7 +456,7 @@ describe('stores/modifications', () => {
       },
     });
 
-    modificationsStore.cancelAllTokens('service-task-2');
+    modificationsStore.cancelAllTokens('service-task-2', {});
 
     modificationsStore.addModification({
       type: 'token',
@@ -496,7 +496,7 @@ describe('stores/modifications', () => {
       },
     });
 
-    modificationsStore.cancelAllTokens('multi-instance-subprocess');
+    modificationsStore.cancelAllTokens('multi-instance-subprocess', {});
 
     expect(modificationsStore.modificationsByFlowNode).toEqual({
       'service-task-1': {
@@ -597,7 +597,7 @@ describe('stores/modifications', () => {
       modificationsStore.hasPendingCancelOrMoveModification('service-task-1'),
     ).toBe(false);
 
-    modificationsStore.cancelAllTokens('service-task-1');
+    modificationsStore.cancelAllTokens('service-task-1', {});
 
     expect(
       modificationsStore.hasPendingCancelOrMoveModification('service-task-1'),
@@ -648,7 +648,7 @@ describe('stores/modifications', () => {
       'StartEvent_1',
     );
 
-    modificationsStore.finishMovingToken('end-event');
+    modificationsStore.finishMovingToken({}, 'end-event');
 
     expect(modificationsStore.modificationsByFlowNode).toEqual({
       StartEvent_1: {
@@ -681,7 +681,7 @@ describe('stores/modifications', () => {
     );
     await processInstanceDetailsStatisticsStore.fetchFlowNodeStatistics(1);
     modificationsStore.startMovingToken('multi-instance-service-task');
-    modificationsStore.finishMovingToken('service-task-7');
+    modificationsStore.finishMovingToken({}, 'service-task-7');
 
     expect(modificationsStore.modificationsByFlowNode).toEqual({
       'multi-instance-service-task': {
@@ -1140,7 +1140,7 @@ describe('stores/modifications', () => {
         },
       },
     });
-    modificationsStore.cancelAllTokens('flow_node_2');
+    modificationsStore.cancelAllTokens('flow_node_2', {});
 
     modificationsStore.addModification({
       type: 'token',
@@ -1291,7 +1291,7 @@ describe('stores/modifications', () => {
       },
     });
 
-    modificationsStore.cancelToken('flow_node_5', 'some_instance_key');
+    modificationsStore.cancelToken('flow_node_5', 'some_instance_key', {});
     modificationsStore.addMoveModification({
       sourceFlowNodeId: 'flow_node_6',
       sourceFlowNodeInstanceKey: 'some_instance_key_2',
@@ -1299,6 +1299,7 @@ describe('stores/modifications', () => {
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
       newScopeCount: 1,
+      businessObjects: {},
     });
 
     modificationsStore.addModification({
@@ -1512,6 +1513,7 @@ describe('stores/modifications', () => {
     );
 
     modificationsStore.finishAddingToken(
+      {},
       'multi-instance-subprocess',
       'some-instance-key',
     );

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -253,9 +253,11 @@ class Modifications {
           scopeId: generateUniqueID(),
           flowNode: {
             id: this.state.sourceFlowNodeIdForAddOperation,
-            name: processInstanceDetailsDiagramStore.getFlowNodeName(
-              this.state.sourceFlowNodeIdForAddOperation,
-            ),
+            name:
+              getFlowNodeName({
+                businessObjects,
+                flowNodeId: this.state.sourceFlowNodeIdForAddOperation,
+              }) ?? '',
           },
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
@@ -812,16 +814,16 @@ class Modifications {
         operation: 'MOVE_TOKEN',
         flowNode: {
           id: sourceFlowNodeId,
-          name: processInstanceDetailsDiagramStore.getFlowNodeName(
-            sourceFlowNodeId,
-          ),
+          name:
+            getFlowNodeName({businessObjects, flowNodeId: sourceFlowNodeId}) ??
+            '',
         },
         flowNodeInstanceKey: sourceFlowNodeInstanceKey,
         targetFlowNode: {
           id: targetFlowNodeId,
-          name: processInstanceDetailsDiagramStore.getFlowNodeName(
-            targetFlowNodeId,
-          ),
+          name:
+            getFlowNodeName({businessObjects, flowNodeId: targetFlowNodeId}) ??
+            '',
         },
         affectedTokenCount,
         visibleAffectedTokenCount,

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -771,7 +771,7 @@ class Modifications {
         operation: 'CANCEL_TOKEN',
         flowNode: {
           id: flowNodeId,
-          name: getFlowNodeName({businessObjects, flowNodeId}) ?? '',
+          name: getFlowNodeName({businessObjects, flowNodeId}),
         },
         flowNodeInstanceKey,
         affectedTokenCount,
@@ -832,16 +832,18 @@ class Modifications {
         operation: 'MOVE_TOKEN',
         flowNode: {
           id: sourceFlowNodeId,
-          name:
-            getFlowNodeName({businessObjects, flowNodeId: sourceFlowNodeId}) ??
-            '',
+          name: getFlowNodeName({
+            businessObjects,
+            flowNodeId: sourceFlowNodeId,
+          }),
         },
         flowNodeInstanceKey: sourceFlowNodeInstanceKey,
         targetFlowNode: {
           id: targetFlowNodeId,
-          name:
-            getFlowNodeName({businessObjects, flowNodeId: targetFlowNodeId}) ??
-            '',
+          name: getFlowNodeName({
+            businessObjects,
+            flowNodeId: targetFlowNodeId,
+          }),
         },
         affectedTokenCount,
         visibleAffectedTokenCount,

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -19,6 +19,9 @@ import {
 import {logger} from 'modules/logger';
 import {tracking} from 'modules/tracking';
 import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
+import {getFlowNodeName} from 'modules/utils/flowNodes';
+import {getFlowNodesInBetween} from 'modules/utils/processInstanceDetailsDiagram';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 
 type FlowNodeModificationPayload =
   | {
@@ -174,12 +177,13 @@ class Modifications {
   generateScopeIdsInBetween = (
     targetFlowNodeId: string,
     ancestorFlowNodeId: string,
+    businessObjects: BusinessObjects,
   ) => {
-    const flowNodesInBetween =
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        targetFlowNodeId,
-        ancestorFlowNodeId,
-      );
+    const flowNodesInBetween = getFlowNodesInBetween(
+      businessObjects,
+      targetFlowNodeId,
+      ancestorFlowNodeId,
+    );
 
     return flowNodesInBetween.reduce<{[flowNodeId: string]: string}>(
       (flowNodeScopes, flowNodeId) => {
@@ -190,7 +194,10 @@ class Modifications {
     );
   };
 
-  finishMovingToken = (targetFlowNodeId?: string) => {
+  finishMovingToken = (
+    businessObjects: BusinessObjects,
+    targetFlowNodeId?: string,
+  ) => {
     tracking.track({
       eventName: 'move-token',
     });
@@ -213,9 +220,7 @@ class Modifications {
             this.state.sourceFlowNodeIdForMoveOperation,
           );
         newScopeCount = isMultiInstance(
-          processInstanceDetailsDiagramStore.businessObjects[
-            this.state.sourceFlowNodeIdForMoveOperation
-          ],
+          businessObjects[this.state.sourceFlowNodeIdForMoveOperation],
         )
           ? 1
           : affectedTokenCount;
@@ -229,6 +234,7 @@ class Modifications {
         affectedTokenCount,
         visibleAffectedTokenCount,
         newScopeCount,
+        businessObjects,
       });
     }
 
@@ -238,6 +244,7 @@ class Modifications {
   };
 
   finishAddingToken = (
+    businessObjects: BusinessObjects,
     ancestorElementId?: string,
     ancestorElementInstanceKey?: string,
   ) => {
@@ -246,7 +253,7 @@ class Modifications {
       ancestorElementId !== undefined &&
       this.state.sourceFlowNodeIdForAddOperation !== null
     ) {
-      modificationsStore.addModification({
+      this.addModification({
         type: 'token',
         payload: {
           operation: 'ADD_TOKEN',
@@ -265,9 +272,10 @@ class Modifications {
             instanceKey: ancestorElementInstanceKey,
             flowNodeId: ancestorElementId,
           },
-          parentScopeIds: modificationsStore.generateScopeIdsInBetween(
+          parentScopeIds: this.generateScopeIdsInBetween(
             this.state.sourceFlowNodeIdForAddOperation,
             ancestorElementId,
+            businessObjects,
           ),
         },
       });
@@ -749,11 +757,13 @@ class Modifications {
     flowNodeInstanceKey,
     affectedTokenCount,
     visibleAffectedTokenCount,
+    businessObjects,
   }: {
     flowNodeId: string;
     flowNodeInstanceKey?: string;
     affectedTokenCount: number;
     visibleAffectedTokenCount: number;
+    businessObjects: BusinessObjects;
   }) => {
     modificationsStore.addModification({
       type: 'token',
@@ -761,7 +771,7 @@ class Modifications {
         operation: 'CANCEL_TOKEN',
         flowNode: {
           id: flowNodeId,
-          name: processInstanceDetailsDiagramStore.getFlowNodeName(flowNodeId),
+          name: getFlowNodeName({businessObjects, flowNodeId}) ?? '',
         },
         flowNodeInstanceKey,
         affectedTokenCount,
@@ -770,16 +780,21 @@ class Modifications {
     });
   };
 
-  cancelToken = (flowNodeId: string, flowNodeInstanceKey: string) => {
+  cancelToken = (
+    flowNodeId: string,
+    flowNodeInstanceKey: string,
+    businessObjects: BusinessObjects,
+  ) => {
     this.addCancelModification({
       flowNodeId,
       flowNodeInstanceKey,
       affectedTokenCount: 1,
       visibleAffectedTokenCount: 1,
+      businessObjects,
     });
   };
 
-  cancelAllTokens = (flowNodeId: string) => {
+  cancelAllTokens = (flowNodeId: string, businessObjects: BusinessObjects) => {
     this.addCancelModification({
       flowNodeId,
       affectedTokenCount:
@@ -790,6 +805,7 @@ class Modifications {
         processInstanceDetailsStatisticsStore.getTotalRunningInstancesVisibleForFlowNode(
           flowNodeId,
         ),
+      businessObjects,
     });
   };
 
@@ -800,6 +816,7 @@ class Modifications {
     newScopeCount,
     affectedTokenCount,
     visibleAffectedTokenCount,
+    businessObjects,
   }: {
     sourceFlowNodeId: string;
     sourceFlowNodeInstanceKey?: string;
@@ -807,6 +824,7 @@ class Modifications {
     newScopeCount: number;
     affectedTokenCount: number;
     visibleAffectedTokenCount: number;
+    businessObjects: BusinessObjects;
   }) => {
     modificationsStore.addModification({
       type: 'token',

--- a/operate/client/src/modules/utils/flowNodes/index.ts
+++ b/operate/client/src/modules/utils/flowNodes/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {BusinessObject, BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {DiagramModel} from 'bpmn-moddle';
 
 export function isFlowNode(businessObject: BusinessObject) {
@@ -14,23 +14,23 @@ export function isFlowNode(businessObject: BusinessObject) {
 }
 
 export function getFlowNode({
-  diagramModel,
+  businessObjects,
   flowNodeId,
 }: {
-  diagramModel?: DiagramModel;
+  businessObjects?: BusinessObjects;
   flowNodeId?: string;
 }) {
-  return flowNodeId ? diagramModel?.elementsById[flowNodeId] : undefined;
+  return flowNodeId ? businessObjects?.[flowNodeId] : undefined;
 }
 
 export function getFlowNodeName({
-  diagramModel,
+  businessObjects,
   flowNodeId,
 }: {
-  diagramModel?: DiagramModel;
+  businessObjects?: BusinessObjects;
   flowNodeId?: string;
 }) {
-  return getFlowNode({diagramModel, flowNodeId})?.name ?? flowNodeId;
+  return getFlowNode({businessObjects, flowNodeId})?.name ?? flowNodeId;
 }
 
 export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {

--- a/operate/client/src/modules/utils/flowNodes/index.ts
+++ b/operate/client/src/modules/utils/flowNodes/index.ts
@@ -30,7 +30,7 @@ export function getFlowNodeName({
   businessObjects?: BusinessObjects;
   flowNodeId?: string;
 }) {
-  return getFlowNode({businessObjects, flowNodeId})?.name ?? flowNodeId;
+  return getFlowNode({businessObjects, flowNodeId})?.name ?? flowNodeId ?? '';
 }
 
 export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {

--- a/operate/client/src/modules/utils/modification.test.ts
+++ b/operate/client/src/modules/utils/modification.test.ts
@@ -48,12 +48,14 @@ describe('cancelAllTokens', () => {
       flowNodeId,
       totalRunningInstancesForFlowNode,
       totalRunningInstancesVisibleForFlowNode,
+      {},
     );
 
     expect(modificationsStore.addCancelModification).toHaveBeenCalledWith({
       flowNodeId,
       affectedTokenCount: totalRunningInstancesForFlowNode,
       visibleAffectedTokenCount: totalRunningInstancesVisibleForFlowNode,
+      businessObjects: {},
     });
   });
 });
@@ -108,6 +110,7 @@ describe('finishMovingToken', () => {
       affectedTokenCount: 5,
       visibleAffectedTokenCount: 3,
       newScopeCount: 5,
+      businessObjects,
     });
   });
 

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -18,11 +18,13 @@ const cancelAllTokens = (
   flowNodeId: string,
   totalRunningInstancesForFlowNode: number,
   totalRunningInstancesVisibleForFlowNode: number,
+  businessObjects: BusinessObjects,
 ) => {
   modificationsStore.addCancelModification({
     flowNodeId,
     affectedTokenCount: totalRunningInstancesForFlowNode,
     visibleAffectedTokenCount: totalRunningInstancesVisibleForFlowNode,
+    businessObjects,
   });
 };
 
@@ -63,6 +65,7 @@ const finishMovingToken = (
       affectedTokenCount,
       visibleAffectedTokenCount,
       newScopeCount,
+      businessObjects,
     });
   }
 

--- a/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
+++ b/operate/client/src/modules/utils/processInstanceDetailsDiagram.ts
@@ -74,4 +74,4 @@ const getFlowNodeParents = (
   return getFlowNodesInBetween(businessObjects, flowNodeId, bpmnProcessId);
 };
 
-export {getFlowNodeParents, hasMultipleScopes};
+export {getFlowNodeParents, hasMultipleScopes, getFlowNodesInBetween};


### PR DESCRIPTION
## Description

This PR removes the getFlowNodeName (from processInstanceDetailsDiagramStore) dependency from modifications store. This was used to resolve the flow node name by id. Instead the businessObjects object is passed around to allow the name resolving.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591
