### PR TITLE
fix: Improve documentation on the batch file upload API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3091,8 +3091,21 @@ paths:
 
         The caller must provide a file name for each document, which will be used in case of a multi-status response
         to identify which documents failed to upload. The file name can be provided in the `Content-Disposition` header
-        of the file part or in the `fileName` field of the metadata part. If both are provided, the `fileName` field
-        takes precedence.
+        of the file part or in the `fileName` field of the metadata, which can be configured with
+        the `X-Document-Metadata` header for each file part. If both are provided, the `fileName` metadata field
+        takes precedence. For example, given the following headers for a file:
+        ```
+        Content-Disposition: form-data; name="files"; filename="bill.pdf"
+        X-Document-Metadata: {"fileName": "invoice.pdf", "size": 1234567}
+        ```
+
+        The filename will be `invoice.pdf`, but in the following example:
+        ```
+        Content-Disposition: form-data; name="files"; filename="bill.pdf"
+        X-Document-Metadata: {"size": 1234567}
+        ```
+
+        it would be `bill.pdf`.
 
         In case of a multi-status response, the response body will contain a list of `DocumentBatchProblemDetail` objects,
         each of which contains the file name of the document that failed to upload and the reason for the failure.


### PR DESCRIPTION
## Description

This is my attempt to improve the documentation of the batch file upload endpoint, in order to make it clearer that users can also specify filenames through metadata using the `X-Document-Metadata` header.

![Screenshot 2025-04-15 at 12 43 58](https://github.com/user-attachments/assets/2ba83601-0dfa-40c0-98b9-573972db66f3)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to #31027
