### PR TITLE
feat: do not include the entire record byte array in the toString

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -56,6 +56,16 @@ public record ReplicatableJournalRecord(
 
   @Override
   public String toString() {
+    final var recordToString =
+        serializedJournalRecord != null
+            ? "{rawToString="
+                + serializedJournalRecord
+                + ", length="
+                + serializedJournalRecord.length
+                + ", hashCode="
+                + Arrays.hashCode(serializedJournalRecord)
+                + "}"
+            : "null";
     return "ReplicatableJournalRecord{"
         + "term="
         + term
@@ -63,13 +73,8 @@ public record ReplicatableJournalRecord(
         + index
         + ", checksum="
         + checksum
-        + ", serializedJournalRecord={rawToString="
-        + serializedJournalRecord
-        + ", length="
-        + serializedJournalRecord.length
-        + ", hashCode="
-        + Arrays.hashCode(serializedJournalRecord)
-        + "}"
+        + ", serializedJournalRecord="
+        + recordToString
         + '}';
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -63,8 +63,13 @@ public record ReplicatableJournalRecord(
         + index
         + ", checksum="
         + checksum
-        + ", serializedJournalRecord="
-        + Arrays.toString(serializedJournalRecord)
+        + ", serializedJournalRecord={rawToString="
+        + serializedJournalRecord
+        + ", length="
+        + serializedJournalRecord.length
+        + ", hashCode="
+        + Arrays.hashCode(serializedJournalRecord)
+        + "}"
         + '}';
   }
 


### PR DESCRIPTION
## Description
The entire record as a bytearray was included in the `toString`  of `ReplicatableJournalRecord`, but I don't think it's really necessary as it increases the log size quite a lot and makes impossible to look at the logs with *soft-wrap*. 

For debugging purposes I included the length of the bytearray and its hashcode, because the record equals and hashcode use valueEquality on the array. With that it should be useful to see if two records are identical (modulo collisions)

After the CI has run I'll update the size of the log files with this change

Results:
- Zeebe BigUnit test log file is 9MB instead of 20MB