### PR TITLE
fix: when there is a leader transition client requests were never completed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
@@ -93,4 +93,18 @@ public abstract class RaftException extends RuntimeException {
       super(Type.COMMAND_FAILURE, message, args);
     }
   }
+
+  public static class AppendFailureException extends RaftException {
+
+    private final long index;
+
+    public AppendFailureException(final long index, final String message) {
+      super(Type.COMMAND_FAILURE, message);
+      this.index = index;
+    }
+
+    public long getIndex() {
+      return index;
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -19,6 +19,7 @@ package io.atomix.raft.roles;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.CommitFailedException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
@@ -1050,20 +1051,6 @@ final class LeaderAppender {
 
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
-  }
-
-  static class AppendFailureException extends Throwable {
-
-    private final long index;
-
-    public AppendFailureException(final long index, final String message) {
-      super(message);
-      this.index = index;
-    }
-
-    public long getIndex() {
-      return index;
-    }
   }
 
   /** Timestamped completable future. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
@@ -767,8 +768,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             }
           } else {
             long index = -1L;
-            if (commitError
-                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+            if (commitError instanceof final AppendFailureException appendFailureException) {
               index = appendFailureException.getIndex();
             }
             appendListener.onCommitError(index, commitError);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -766,7 +766,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               appendListener.onCommit(commitIndex, committedPosition);
             }
           } else {
-            final var index = (commitIndex != null) ? commitIndex : committedPosition;
+            long index = -1L;
+            if (commitError
+                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+              index = appendFailureException.getIndex();
+            }
             appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
             log.error("Failed to replicate entry: {}", commitIndex, commitError);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -91,8 +91,6 @@ public class RaftCorruptedDataTest {
     Awaitility.await("commitIndex is > 0 on all nodes")
         .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
 
-    final var commitIndex = servers[2].getContext().getCommitIndex();
-
     for (final RaftServer server : servers) {
       raftRule.shutdownServer(server);
     }
@@ -116,7 +114,12 @@ public class RaftCorruptedDataTest {
     // wait for the two corrupted nodes to form quorum
     Awaitility.await("corrupted nodes form a quorum")
         .until(() -> server0.isLeader() || server1.isLeader());
-    raftRule.appendEntries(1000);
+    for (int i = 0; i < 1000; i++) {
+      //      raftRule.appendEntry();
+      Awaitility.await("entry is committed")
+          .untilAsserted(() -> assertThatNoException().isThrownBy(() -> raftRule.appendEntry()));
+    }
+
     raftRule.restartLeader();
 
     Awaitility.await("until the term is > 1")

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.impl.LogCompactor;
@@ -301,8 +302,8 @@ public class LeaderRoleTest {
     leaderRole.stop().join();
 
     // then
-    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
-    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(caughtError.get()).isInstanceOf(AppendFailureException.class);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -44,6 +44,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -93,6 +94,8 @@ public class LeaderRoleTest {
     when(context.getLog()).thenReturn(log);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
+    when(persistedSnapshotStore.purgePendingSnapshots())
+        .thenReturn(CompletableActorFuture.completed(null));
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());
     when(context.getStorage())
@@ -274,6 +277,31 @@ public class LeaderRoleTest {
     verify(log, timeout(1000)).append(any(RaftLogEntry.class));
     verify(context, timeout(1000)).transition(Role.FOLLOWER);
 
+    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldCallOnCommitErrorWhenSteppingDown() throws InterruptedException {
+    // given
+    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+          @Override
+          public void onCommitError(final long index, final Throwable error) {
+
+            caughtError.set(error);
+            latch.countDown();
+          }
+        };
+    leaderRole.appendEntry(2, 3, data, listener);
+
+    // when
+    leaderRole.stop().join();
+
+    // then
+    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
     assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
@@ -15,6 +15,7 @@ import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftRule;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -88,14 +89,16 @@ public class RaftLeaderFlushErrorTest {
 
     // then
     assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
-        .isExactlyInstanceOf(AppendFailureException.class);
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(AppendFailureException.class);
 
     // when
     isFaulty.set(false);
     LOG.info("Leader flusher is not faulty anymore");
 
     assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
-        .isExactlyInstanceOf(AppendFailureException.class);
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(AppendFailureException.class);
 
     // then
     // await new leader

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
@@ -11,10 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.FaultyFlusherConfigurator;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftRule;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -88,14 +88,14 @@ public class RaftLeaderFlushErrorTest {
 
     // then
     assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
-        .isExactlyInstanceOf(TimeoutException.class);
+        .isExactlyInstanceOf(AppendFailureException.class);
 
     // when
     isFaulty.set(false);
     LOG.info("Leader flusher is not faulty anymore");
 
     assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
-        .isExactlyInstanceOf(TimeoutException.class);
+        .isExactlyInstanceOf(AppendFailureException.class);
 
     // then
     // await new leader


### PR DESCRIPTION
## Description
When there is a leader transition, the LeaderAppender is closed, which
in turn terminates all pending `appendFutures`.
However, in LeaderRole, the AppendListener would call commit error only
if the role was still running, which was not true when the leader was
stepping down.
Moreover, because the future was completed with an exception, the
commitIndex is null, which would throw an exception when is implicitly
converted to `long` (i.e. not boxed).

A new exception was added that embeds the index for which the append failed. This exception should be used when such an index is present, so that we can call the `appendListener` with the correct `commitIndex`.

:question: when no such index is present, the `commitIndex` used is `-1`, is that ok?


This fix was found after investigating  the flakyness of #27852 in CI:
- it happens only when the leader steps down because after 2-3 seconds of VM pause 
-  the leader thinks there is a network partition
- when there is a leader change all the client requests should be terminated exceptionally, but this does not happen
- the client never receives any error and waits for 30 seconds
- the assertions timeout first

## Related issues
relates #30790 
