### PR TITLE
[Backport stable/8.6] test: assert that correlationKey is not associated to partition 1

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -11,9 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
@@ -65,6 +67,13 @@ public class PersistedClusterTopologyTest {
     //                                        |                            |
     //                                        |----------------------------|
     //
+    final var correlationkey = "foobar";
+
+    // the partition for the correlation key should not equal 1, which is the only partition
+    // available after the restart
+    assertThat(
+            SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(correlationkey), 3))
+        .isNotEqualTo(1);
 
     final var processDefinition =
         Bpmn.createExecutableProcess("catch_event")
@@ -75,7 +84,9 @@ public class PersistedClusterTopologyTest {
                 "boundary_catch",
                 bi ->
                     bi.message(
-                        bm -> bm.name("catch_event_message").zeebeCorrelationKey("=\"foo\"")))
+                        bm ->
+                            bm.name("catch_event_message")
+                                .zeebeCorrelationKey("=\"" + correlationkey + "\"")))
             .endEvent()
             .done();
 
@@ -103,7 +114,7 @@ public class PersistedClusterTopologyTest {
     client
         .newPublishMessageCommand()
         .messageName("catch_event_message")
-        .correlationKey("foo")
+        .correlationKey(correlationkey)
         .send()
         .join();
 


### PR DESCRIPTION
# Description
Backport of #30967 to `stable/8.6`.

relates to #30377 #29612