### PR TITLE
[Backport stable/8.6] feat: do not include the entire record byte array in the toString

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -56,6 +56,16 @@ public record ReplicatableJournalRecord(
 
   @Override
   public String toString() {
+    final var recordToString =
+        serializedJournalRecord != null
+            ? "{rawToString="
+                + serializedJournalRecord
+                + ", length="
+                + serializedJournalRecord.length
+                + ", hashCode="
+                + Arrays.hashCode(serializedJournalRecord)
+                + "}"
+            : "null";
     return "ReplicatableJournalRecord{"
         + "term="
         + term
@@ -63,13 +73,8 @@ public record ReplicatableJournalRecord(
         + index
         + ", checksum="
         + checksum
-        + ", serializedJournalRecord={rawToString="
-        + serializedJournalRecord
-        + ", length="
-        + serializedJournalRecord.length
-        + ", hashCode="
-        + Arrays.hashCode(serializedJournalRecord)
-        + "}"
+        + ", serializedJournalRecord="
+        + recordToString
         + '}';
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -63,8 +63,13 @@ public record ReplicatableJournalRecord(
         + index
         + ", checksum="
         + checksum
-        + ", serializedJournalRecord="
-        + Arrays.toString(serializedJournalRecord)
+        + ", serializedJournalRecord={rawToString="
+        + serializedJournalRecord
+        + ", length="
+        + serializedJournalRecord.length
+        + ", hashCode="
+        + Arrays.hashCode(serializedJournalRecord)
+        + "}"
         + '}';
   }
 


### PR DESCRIPTION
# Description
Backport of #31032 to `stable/8.6`.

relates to 