### PR TITLE
refactor: remove getFlowNodeParents dep from modifications store

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
@@ -33,6 +33,8 @@ import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/proces
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
+import {generateParentScopeIds} from 'modules/utils/modifications';
 
 describe('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {
@@ -83,8 +85,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'peterJoin', name: 'Peter Join'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('peterJoin'),
+          parentScopeIds: generateParentScopeIds({}, 'peterJoin'),
         },
       });
       modificationsStore.addModification({
@@ -95,8 +96,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'peterJoin', name: 'Peter Join'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('peterJoin'),
+          parentScopeIds: generateParentScopeIds({}, 'peterJoin'),
         },
       });
     });
@@ -193,7 +193,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
     expect(screen.queryByTestId('warning-icon')).not.toBeInTheDocument();
   });
 
-  it('should create new parent scopes for a new palceholder if there are no running scopes', async () => {
+  it('should create new parent scopes for a new placeholder if there are no running scopes', async () => {
     mockFetchProcessInstance().withSuccess({
       ...multiInstanceProcessInstance,
       bpmnProcessId: 'nested_sub_process',
@@ -275,8 +275,10 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'user_task', name: 'User Task'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('user_task'),
+          parentScopeIds: generateParentScopeIds(
+            mockNestedSubProcessBusinessObjects,
+            'user_task',
+          ),
         },
       });
       modificationsStore.addModification({
@@ -287,8 +289,10 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'user_task', name: 'User Task'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('user_task'),
+          parentScopeIds: generateParentScopeIds(
+            mockNestedSubProcessBusinessObjects,
+            'user_task',
+          ),
         },
       });
     });
@@ -479,8 +483,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'user_task', name: 'User Task'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('user_task'),
+          parentScopeIds: generateParentScopeIds({}, 'user_task'),
         },
       });
       modificationsStore.addModification({
@@ -491,8 +494,7 @@ describe('FlowNodeInstancesTree - Modification placeholders', () => {
           flowNode: {id: 'user_task', name: 'User Task'},
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
-          parentScopeIds:
-            modificationsStore.generateParentScopeIds('user_task'),
+          parentScopeIds: generateParentScopeIds({}, 'user_task'),
         },
       });
     });

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/index.tsx
@@ -30,6 +30,7 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {getFlowNodeName} from 'modules/utils/flowNodes';
 import {getParentElement} from 'modules/bpmn-js/utils/getParentElement';
+import {generateParentScopeIds} from 'modules/utils/modifications';
 
 type Props = {
   selectedFlowNodeRef?: SVGSVGElement;
@@ -94,59 +95,58 @@ const ModificationDropdown: React.FC<Props> = observer(
                     </SelectedInstanceCount>
                   )}
                   <Stack gap={2}>
-                    {availableModifications.includes('add') && (
-                      <Button
-                        kind="ghost"
-                        title="Add single flow node instance"
-                        aria-label="Add single flow node instance"
-                        size="sm"
-                        renderIcon={Add}
-                        onClick={() => {
-                          const parentElement = getParentElement(
-                            processDefinitionData?.businessObjects?.[
-                              flowNodeId
-                            ],
-                          );
-                          if (
-                            processInstanceDetailsDiagramStore.hasMultipleScopes(
-                              parentElement,
-                            )
-                          ) {
-                            modificationsStore.startAddingToken(flowNodeId);
-                          } else {
-                            tracking.track({
-                              eventName: 'add-token',
-                            });
+                    {availableModifications.includes('add') &&
+                      processDefinitionData?.businessObjects && (
+                        <Button
+                          kind="ghost"
+                          title="Add single flow node instance"
+                          aria-label="Add single flow node instance"
+                          size="sm"
+                          renderIcon={Add}
+                          onClick={() => {
+                            const parentElement = getParentElement(
+                              processDefinitionData.businessObjects[flowNodeId],
+                            );
+                            if (
+                              processInstanceDetailsDiagramStore.hasMultipleScopes(
+                                parentElement,
+                              )
+                            ) {
+                              modificationsStore.startAddingToken(flowNodeId);
+                            } else {
+                              tracking.track({
+                                eventName: 'add-token',
+                              });
 
-                            modificationsStore.addModification({
-                              type: 'token',
-                              payload: {
-                                operation: 'ADD_TOKEN',
-                                scopeId: generateUniqueID(),
-                                flowNode: {
-                                  id: flowNodeId,
-                                  name: getFlowNodeName({
-                                    businessObjects:
-                                      processDefinitionData?.businessObjects,
-                                    flowNodeId,
-                                  }),
-                                },
-                                affectedTokenCount: 1,
-                                visibleAffectedTokenCount: 1,
-                                parentScopeIds:
-                                  modificationsStore.generateParentScopeIds(
+                              modificationsStore.addModification({
+                                type: 'token',
+                                payload: {
+                                  operation: 'ADD_TOKEN',
+                                  scopeId: generateUniqueID(),
+                                  flowNode: {
+                                    id: flowNodeId,
+                                    name: getFlowNodeName({
+                                      businessObjects:
+                                        processDefinitionData.businessObjects,
+                                      flowNodeId,
+                                    }),
+                                  },
+                                  affectedTokenCount: 1,
+                                  visibleAffectedTokenCount: 1,
+                                  parentScopeIds: generateParentScopeIds(
+                                    processDefinitionData.businessObjects,
                                     flowNodeId,
                                   ),
-                              },
-                            });
-                          }
+                                },
+                              });
+                            }
 
-                          flowNodeSelectionStore.clearSelection();
-                        }}
-                      >
-                        Add
-                      </Button>
-                    )}
+                            flowNodeSelectionStore.clearSelection();
+                          }}
+                        >
+                          Add
+                        </Button>
+                      )}
 
                     {availableModifications.includes('cancel-instance') &&
                       !isNil(flowNodeInstanceId) &&

--- a/operate/client/src/modules/mocks/mockNestedSubProcessBusinessObjects.ts
+++ b/operate/client/src/modules/mocks/mockNestedSubProcessBusinessObjects.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
+
+const mockNestedSubProcessBusinessObjects: BusinessObjects = {
+  user_task: {
+    id: 'user_task',
+    name: '',
+    $type: 'bpmn:UserTask',
+    $parent: {
+      id: 'inner_sub_process',
+      name: '',
+      $type: 'bpmn:SubProcess',
+    },
+  },
+  inner_sub_process: {
+    id: 'inner_sub_process',
+    name: '',
+    $type: 'bpmn:SubProcess',
+    $parent: {
+      id: 'parent_sub_process',
+      name: '',
+      $type: 'bpmn:SubProcess',
+    },
+  },
+  parent_sub_process: {
+    id: 'parent_sub_process',
+    name: '',
+    $type: 'bpmn:SubProcess',
+    $parent: {
+      id: 'nested_sub_process',
+      name: '',
+      $type: 'bpmn:Process',
+      $parent: undefined,
+    },
+  },
+};
+
+export {mockNestedSubProcessBusinessObjects};

--- a/operate/client/src/modules/stores/modifications.test.ts
+++ b/operate/client/src/modules/stores/modifications.test.ts
@@ -20,6 +20,8 @@ import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {open} from 'modules/mocks/diagrams';
 import {processInstanceDetailsStore} from './processInstanceDetails';
 import {createInstance} from 'modules/testUtils';
+import {generateParentScopeIds} from 'modules/utils/modifications';
+import {mockNestedSubProcessBusinessObjects} from 'modules/mocks/mockNestedSubProcessBusinessObjects';
 
 type AddModificationPayload = Extract<
   FlowNodeModification['payload'],
@@ -821,32 +823,6 @@ describe('stores/modifications', () => {
     ]);
   });
 
-  it('should generate parent scope ids', async () => {
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({bpmnProcessId: 'nested_sub_process'}),
-    );
-    mockFetchProcessXML().withSuccess(mockNestedSubprocess);
-
-    await processInstanceDetailsDiagramStore.fetchProcessXml(
-      'processInstanceId',
-    );
-
-    expect(modificationsStore.generateParentScopeIds('user_task')).toEqual({
-      inner_sub_process: expect.any(String),
-      parent_sub_process: expect.any(String),
-    });
-
-    expect(
-      modificationsStore.generateParentScopeIds('inner_sub_process'),
-    ).toEqual({
-      parent_sub_process: expect.any(String),
-    });
-
-    expect(
-      modificationsStore.generateParentScopeIds('parent_sub_process'),
-    ).toEqual({});
-  });
-
   it('should not generate parent scope id twice', async () => {
     processInstanceDetailsStore.setProcessInstance(
       createInstance({bpmnProcessId: 'nested_sub_process'}),
@@ -865,7 +841,10 @@ describe('stores/modifications', () => {
         scopeId: 'random-scope-id-0',
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
-        parentScopeIds: modificationsStore.generateParentScopeIds('user_task'),
+        parentScopeIds: generateParentScopeIds(
+          mockNestedSubProcessBusinessObjects,
+          'user_task',
+        ),
       },
     });
     modificationsStore.addModification({
@@ -876,7 +855,10 @@ describe('stores/modifications', () => {
         scopeId: 'random-scope-id-1',
         affectedTokenCount: 1,
         visibleAffectedTokenCount: 1,
-        parentScopeIds: modificationsStore.generateParentScopeIds('user_task'),
+        parentScopeIds: generateParentScopeIds(
+          mockNestedSubProcessBusinessObjects,
+          'user_task',
+        ),
       },
     });
 

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/index.ts
@@ -127,37 +127,6 @@ class ProcessInstanceDetailsDiagram extends NetworkReconnectionHandler {
     return this.businessObjects[flowNodeId]?.name || flowNodeId;
   };
 
-  getFlowNodeParents = (flowNodeId: string): string[] => {
-    const bpmnProcessId =
-      processInstanceDetailsStore.state.processInstance?.bpmnProcessId;
-
-    if (bpmnProcessId === undefined) {
-      return [];
-    }
-
-    return this.getFlowNodesInBetween(flowNodeId, bpmnProcessId);
-  };
-
-  getFlowNodesInBetween = (
-    fromFlowNodeId: string,
-    toFlowNodeId: string,
-  ): string[] => {
-    const fromFlowNode =
-      processInstanceDetailsDiagramStore.businessObjects[fromFlowNodeId];
-
-    if (
-      fromFlowNode?.$parent === undefined ||
-      fromFlowNode.$parent.id === toFlowNodeId
-    ) {
-      return [];
-    }
-
-    return [
-      fromFlowNode.$parent.id,
-      ...this.getFlowNodesInBetween(fromFlowNode.$parent.id, toFlowNodeId),
-    ];
-  };
-
   hasMultipleScopes = (parentFlowNode?: BusinessObject): boolean => {
     if (parentFlowNode === undefined) {
       return false;

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
@@ -11,7 +11,6 @@ import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails
 import {createInstance, mockProcessXML} from 'modules/testUtils';
 import {waitFor} from 'modules/testing-library';
 import {modificationsStore} from 'modules/stores/modifications';
-import {mockNestedSubprocess} from 'modules/mocks/mockNestedSubprocess';
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {open} from 'modules/mocks/diagrams';
@@ -305,110 +304,6 @@ describe('stores/processInstanceDiagram', () => {
       'eventAttachedToEventbasedGateway1',
       'eventAttachedToEventbasedGateway2',
     ]);
-  });
-
-  it('should get flow node parents', async () => {
-    mockFetchProcessXML().withSuccess(mockNestedSubprocess);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: '123',
-        state: 'ACTIVE',
-        processId: '10',
-        bpmnProcessId: 'nested_sub_process',
-      }),
-    );
-
-    processInstanceDetailsDiagramStore.init();
-
-    await waitFor(() =>
-      expect(processInstanceDetailsDiagramStore.state.status).toEqual(
-        'fetched',
-      ),
-    );
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodeParents('user_task'),
-    ).toEqual(['inner_sub_process', 'parent_sub_process']);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodeParents(
-        'inner_sub_process',
-      ),
-    ).toEqual(['parent_sub_process']);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodeParents(
-        'parent_sub_process',
-      ),
-    ).toEqual([]);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodeParents('non_existing'),
-    ).toEqual([]);
-  });
-
-  it('should get flow nodes in between two flow nodes', async () => {
-    mockFetchProcessXML().withSuccess(mockNestedSubprocess);
-
-    processInstanceDetailsStore.setProcessInstance(
-      createInstance({
-        id: '123',
-        state: 'ACTIVE',
-        processId: '10',
-        bpmnProcessId: 'nested_sub_process',
-      }),
-    );
-
-    processInstanceDetailsDiagramStore.init();
-
-    await waitFor(() =>
-      expect(processInstanceDetailsDiagramStore.state.status).toEqual(
-        'fetched',
-      ),
-    );
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'user_task',
-        'nested_sub_process',
-      ),
-    ).toEqual(['inner_sub_process', 'parent_sub_process']);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'inner_sub_process',
-        'nested_sub_process',
-      ),
-    ).toEqual(['parent_sub_process']);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'parent_sub_process',
-        'nested_sub_process',
-      ),
-    ).toEqual([]);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'user_task',
-        'parent_sub_process',
-      ),
-    ).toEqual(['inner_sub_process']);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'inner_sub_process',
-        'parent_sub_process',
-      ),
-    ).toEqual([]);
-
-    expect(
-      processInstanceDetailsDiagramStore.getFlowNodesInBetween(
-        'user_task',
-        'inner_sub_process',
-      ),
-    ).toEqual([]);
   });
 
   it('should get has multiple scopes', async () => {


### PR DESCRIPTION
## Description

This PR removes the getFlowNodeParents (from processInstanceDetailsDiagramStore) dependency from modifications store.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
