### PR TITLE
fix: Quote changelog variable (#28426)

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -288,7 +288,7 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
           #
           echo 'CHANGELOG<<EOF' >> $GITHUB_OUTPUT
-          echo $changelog >> $GITHUB_OUTPUT
+          echo "$changelog" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
           # To show the changelog also as step summary


### PR DESCRIPTION
## Description

Quote changelog variable in order to preserve formatting and avoid [bash wildcard expansion](https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #28426 
