### PR TITLE
ci: Fix potential globbing issue in analyze-test-runs

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -57,8 +57,7 @@ runs:
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
         {
           echo 'FLAKY_TESTS<<EOF'
-            # echo ${flakyTests[*]}
-            echo $flakyTests
+          echo "$flakyTests"
           echo EOF
         } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

chore(ci): Fix globbing issue in `analyze-test-runs` action.

Discovered this issue while working on https://github.com/camunda/camunda/issues/28426#issuecomment-2804487935, it's a same type of problem ([SC2086](https://www.shellcheck.net/wiki/SC2086))
In case the multi-line string here can take special globbing characters (like `*`) this may garbage the output.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
