### PR TITLE
refactor: allow filtering and sorting by groupId

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -51,6 +51,20 @@ public class GroupIT {
   }
 
   @TestTemplate
+  public void shouldSaveAndFindById(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final GroupReader groupReader = rdbmsService.getGroupReader();
+
+    final var group = GroupFixtures.createRandomized(b -> b);
+    createAndSaveGroup(rdbmsWriter, group);
+
+    final var instance = groupReader.findOne(group.groupId()).orElse(null);
+
+    compareGroups(instance, group);
+  }
+
+  @TestTemplate
   public void shouldSaveAndUpdate(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
@@ -51,6 +51,22 @@ public class GroupSortIT {
         Comparator.comparing(GroupEntity::groupKey).reversed());
   }
 
+  @TestTemplate
+  public void shouldSortByGroupIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.groupId().asc(),
+        Comparator.comparing(GroupEntity::groupId));
+  }
+
+  @TestTemplate
+  public void shouldSortByGroupIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.groupId().desc(),
+        Comparator.comparing(GroupEntity::groupId).reversed());
+  }
+
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<GroupSort>> sortBuilder,

--- a/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
@@ -29,6 +29,11 @@ public record GroupSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public Builder groupId() {
+      currentOrdering = new FieldSorting("groupId", null);
+      return this;
+    }
+
     public Builder name() {
       currentOrdering = new FieldSorting("name", null);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6264,6 +6264,7 @@ components:
           enum:
             - groupKey
             - name
+            - groupId
         order:
           $ref: "#/components/schemas/SortOrderEnum"
       required:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -944,6 +944,7 @@ public final class SearchQueryRequestMapper {
     } else {
       switch (field) {
         case GROUP_KEY -> builder.groupKey();
+        case GROUP_ID -> builder.groupId();
         case NAME -> builder.name();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -36,7 +36,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-@Disabled("Enable with https://github.com/camunda/camunda/issues/30285")
+@Disabled(
+    "Enable after https://github.com/camunda/camunda/issues/30010 and https://github.com/camunda/camunda/issues/30012")
 @WebMvcTest(value = GroupController.class)
 public class GroupQueryControllerTest extends RestControllerTest {
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow search layer to sort filter by `groupId`

## Related issues

closes #30285 
