### PR TITLE
test: add coverage for tenant membership resolution and request mapping

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -14,6 +14,7 @@ import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.service.TenantServices.TenantDTO;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -66,7 +67,11 @@ public class CamundaOidcUserServiceTest {
                 Set.of(5L, 7L),
                 Set.of("test-id", "test-id-2"),
                 new AuthenticationContext(
-                    null, List.of(roleR1), List.of("*"), new ArrayList<>(), new ArrayList<>())));
+                    null,
+                    List.of(roleR1),
+                    List.of("*"),
+                    List.of(new TenantDTO(1L, "tenant-1", "Tenant One", "desc")),
+                    new ArrayList<>())));
 
     // when
     final OidcUser oidcUser = camundaOidcUserService.loadUser(createOidcUserRequest(claims));
@@ -81,7 +86,9 @@ public class CamundaOidcUserServiceTest {
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.groups()).isEmpty();
-    assertThat(authenticationContext.tenants()).isEmpty();
+    assertThat(authenticationContext.tenants()).hasSize(1);
+    assertThat(authenticationContext.tenants().get(0).tenantId()).isEqualTo("tenant-1");
+
     assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
   }
 


### PR DESCRIPTION
## Description
Adds test cases for tenant resolution via mapping IDs in CamundaOAuthPrincipalServiceTest and CamundaOidcUserServiceTest

Verifies tenant propagation to AuthenticationContext

Covers RequestMapper logic for extracting authenticated tenant IDs

Adds authorization check test in TenantServiceTest

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes # 30709
