### PR TITLE
refactor: change batch operation executor handler to pass the state i…

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -89,7 +89,7 @@ public final class BatchOperationExecuteProcessor
     appendBatchOperationExecutionExecutingEvent(command.getValue(), Set.copyOf(entityKeys));
 
     final var handler = handlers.get(batchOperation.getBatchOperationType());
-    entityKeys.forEach(entityKey -> handler.handle(entityKey, batchKey));
+    entityKeys.forEach(entityKey -> handler.execute(entityKey, batchOperation));
 
     appendBatchOperationExecutionExecutedEvent(command.getValue(), Set.copyOf(entityKeys));
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/BatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/BatchOperationExecutor.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation.handlers;
 
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+
 public interface BatchOperationExecutor {
 
-  void handle(long entityKey, long batchOperationKey);
+  void execute(long itemKey, PersistedBatchOperation batchOperation);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation.handlers;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import org.slf4j.Logger;
@@ -24,12 +25,12 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
   }
 
   @Override
-  public void handle(final long processInstanceKey, final long batchOperationKey) {
-    LOGGER.info("Cancelling process instance with key '{}'", processInstanceKey);
+  public void execute(final long itemKey, final PersistedBatchOperation batchOperation) {
+    LOGGER.info("Cancelling process instance with key '{}'", itemKey);
 
     final var command = new ProcessInstanceRecord();
-    command.setProcessInstanceKey(processInstanceKey);
+    command.setProcessInstanceKey(itemKey);
     commandWriter.appendFollowUpCommand(
-        processInstanceKey, ProcessInstanceIntent.CANCEL, command, batchOperationKey);
+        itemKey, ProcessInstanceIntent.CANCEL, command, batchOperation.getKey());
   }
 }


### PR DESCRIPTION
Change batch operation executor handler to pass the state instead of just a key. That's needed for follow-up issues like the migrate and modify batch operations. (There we need the state in the handler)