### PR TITLE
feat: Mock job workers

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.api;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
+import io.camunda.process.test.api.mock.JobWorkerMock;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
@@ -93,4 +94,15 @@ public interface CamundaProcessTestContext {
    * @param timeToAdd the duration to add to the current time
    */
   void increaseTime(final Duration timeToAdd);
+
+  /**
+   * Creates a mock job worker for the specified job type.
+   *
+   * <p>This mock allows simulating job processing behavior, such as completing jobs, throwing BPMN
+   * errors, or handling jobs with custom logic.
+   *
+   * @param jobId the job type to mock, matching the `zeebeJobType` in the BPMN model.
+   * @return a {@see JobWorkerMock} instance for configuring the mock behavior.
+   */
+  JobWorkerMock mockJobWorker(final String jobId);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/mock/JobWorkerMock.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/mock/JobWorkerMock.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.mock;
+
+import io.camunda.client.api.worker.JobHandler;
+import java.util.Map;
+
+/**
+ * Use this interface to mock job workers in your process tests.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ *   processTestContext.mockJobWorker("myworker").thenComplete();
+ * </pre>
+ */
+public interface JobWorkerMock {
+
+  /** Configures the mock worker to complete jobs without any variables. */
+  void thenComplete();
+
+  /**
+   * Configures the mock worker to complete jobs with the specified variables.
+   *
+   * @param variables the variables to include when completing the job.
+   */
+  void thenComplete(Map<String, Object> variables);
+
+  /**
+   * Configures the mock worker to throw a BPMN error with the specified error code.
+   *
+   * @param errorCode the error code to throw.
+   */
+  void thenThrowBpmnError(String errorCode);
+
+  /**
+   * Configures the mock worker to throw a BPMN error with the specified error code and variables.
+   *
+   * @param errorCode the error code to throw.
+   * @param variables the variables to include when throwing the error.
+   */
+  void thenThrowBpmnError(String errorCode, Map<String, Object> variables);
+
+  /**
+   * Configures the mock worker with a custom job handler.
+   *
+   * @param jobHandler the custom job handler to use for processing jobs.
+   */
+  void withHandler(JobHandler jobHandler);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -18,9 +18,11 @@ package io.camunda.process.test.impl.extension;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.api.mock.JobWorkerMock;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
+import io.camunda.process.test.impl.mock.JobWorkerMockImpl;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
@@ -111,5 +113,11 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public void increaseTime(final Duration timeToAdd) {
     camundaManagementClient.increaseTime(timeToAdd);
+  }
+
+  @Override
+  public JobWorkerMock mockJobWorker(final String jobId) {
+    final CamundaClient client = createClient();
+    return new JobWorkerMockImpl(jobId, client);
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/mock/JobWorkerMockImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.mock;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.process.test.api.mock.JobWorkerMock;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JobWorkerMockImpl implements JobWorkerMock {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JobWorkerMockImpl.class);
+
+  private final String jobType;
+  private final CamundaClient client;
+
+  /**
+   * Constructs a `JobWorkerMock` instance.
+   *
+   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
+   * @param client the Camunda client used to create the mock worker.
+   */
+  public JobWorkerMockImpl(final String jobType, final CamundaClient client) {
+    this.jobType = jobType;
+    this.client = client;
+  }
+
+  @Override
+  public void thenComplete() {
+    thenComplete(new HashMap<>());
+  }
+
+  @Override
+  public void thenComplete(final Map<String, Object> variables) {
+    withHandler(
+        (jobClient, job) -> {
+          jobClient.newCompleteCommand(job).variables(variables).send().join();
+          LOGGER.debug("Completed mocked job {} with variables {}", job.getKey(), variables);
+        });
+  }
+
+  @Override
+  public void thenThrowBpmnError(final String errorCode) {
+    thenThrowBpmnError(errorCode, new HashMap<>());
+  }
+
+  @Override
+  public void thenThrowBpmnError(final String errorCode, final Map<String, Object> variables) {
+    withHandler(
+        (jobClient, job) -> {
+          jobClient
+              .newThrowErrorCommand(job)
+              .errorCode(errorCode)
+              .variables(variables)
+              .send()
+              .join();
+          LOGGER.debug(
+              "Mocked job {} with variables {} threw a BPMN error with error code {}",
+              job.getKey(),
+              variables,
+              errorCode);
+        });
+  }
+
+  @Override
+  public void withHandler(final JobHandler jobHandler) {
+    client.newWorker().jobType(jobType).handler(jobHandler).open();
+    LOGGER.debug("Completed job with custom handler");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.extensions;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.CamundaAssert;
+import io.camunda.process.test.api.CamundaProcessTest;
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class CamundaProcessTestContextIT {
+  private static final int TIMEOUT = 40;
+  private CamundaProcessTestContext processTestContext;
+  private CamundaClient client;
+
+  @Test
+  void shouldThrowBpmnErrorWithoutVariables() {
+    // Given
+    processTestContext.mockJobWorker("test").thenThrowBpmnError("bpmn-error");
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("error-end");
+  }
+
+  @Test
+  void shouldThrowBpmnErrorWithVariables() {
+    // Given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("abc", 123);
+    processTestContext.mockJobWorker("test").thenThrowBpmnError("bpmn-error", variables);
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("error-end");
+    CamundaAssert.assertThat(processInstanceEvent).hasVariables(variables);
+  }
+
+  @Test
+  void shouldMockJobWorkerWithoutVariables() {
+    // Given
+    processTestContext.mockJobWorker("test").thenComplete();
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
+  }
+
+  @Test
+  void shouldMockJobWorkerWithVariables() {
+    // Given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("abc", 123);
+    processTestContext.mockJobWorker("test").thenComplete(variables);
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
+    CamundaAssert.assertThat(processInstanceEvent).hasVariables(variables);
+  }
+
+  @Test
+  void shouldMockJobWorkerWithJobHandlerBpmnError() {
+    // Given
+    processTestContext
+        .mockJobWorker("test")
+        .withHandler(
+            (jobClient, job) -> {
+              jobClient.newThrowErrorCommand(job).errorCode("bpmn-error").send().join();
+            });
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("error-end");
+  }
+
+  @Test
+  void shouldMockJobWorkerWithJobHandlerSuccess() {
+    // Given
+    processTestContext
+        .mockJobWorker("test")
+        .withHandler(
+            (jobClient, job) -> {
+              jobClient.newCompleteCommand(job).send().join();
+            });
+    final long processDefinitionKey = deployProcessModel();
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
+  }
+
+  /**
+   * Deploys a process model and waits until it is accessible via the API.
+   *
+   * @return the process definition key
+   */
+  private long deployProcessModel() {
+    final BpmnModelInstance processModel =
+        Bpmn.createExecutableProcess("test-process")
+            .startEvent()
+            .serviceTask("service-task-1")
+            .zeebeJobType("test")
+            .boundaryEvent("error-boundary-event")
+            .error("bpmn-error")
+            .endEvent("error-end")
+            .moveToActivity("service-task-1")
+            .endEvent("success-end")
+            .done();
+
+    final DeploymentEvent deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(processModel, "test-process.bpmn")
+            .send()
+            .join();
+    return deploymentEvent.getProcesses().stream().findFirst().get().getProcessDefinitionKey();
+  }
+}


### PR DESCRIPTION
## Description

The JobWorkerMock class provides methods to simulate job worker behavior for testing BPMN processes. It supports:

- Completing jobs (thenComplete with/without variables).
- Throwing BPMN errors (thenThrowBpmnError with/without variables).
- Custom job handling (withHandler for advanced logic).


## Related issues

closes #19262 
