### PR TITLE
fix: use `id` field to reindex and delete batch operations

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -70,16 +70,15 @@ public class BatchOperationArchiverJob implements ArchiverJob {
     return CompletableFuture.completedFuture(0);
   }
 
-  private CompletableFuture<Integer> moveBatch(
-      final String finishDate, final List<String> processInstanceKeys) {
+  private CompletableFuture<Integer> moveBatch(final String finishDate, final List<String> ids) {
     return repository
         .moveDocuments(
             batchOperationTemplate.getFullQualifiedName(),
             batchOperationTemplate.getFullQualifiedName() + finishDate,
-            finishDate,
-            processInstanceKeys,
+            BatchOperationTemplate.ID,
+            ids,
             executor)
-        .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
+        .thenApplyAsync(ok -> ids.size(), executor);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -68,7 +68,7 @@ final class BatchOperationArchiverJobTest {
             new DocumentMove(
                 batchOperationTemplate.getFullQualifiedName(),
                 batchOperationTemplate.getFullQualifiedName() + "2024-01-01",
-                repository.batch.finishDate(),
+                BatchOperationTemplate.ID,
                 List.of("1", "2", "3"),
                 executor));
   }


### PR DESCRIPTION
## Description

Use `id` field to reindex and delete batch operations
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30877
