### PR TITLE
fix: update entry message urls and apis for c8run

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,10 +1,12 @@
 -------------------------------------------
 Access each component at the following urls:
 
-Operate:                     http://localhost:{{.ServerPort}}/operate
-Tasklist:                    http://localhost:{{.ServerPort}}/tasklist
-Zeebe Cluster Endpoint:      http://localhost:26500
-Inbound Connectors Endpoint: http://localhost:8085
+Camunda 8 API:      http://localhost:8080/v2/
+Inbound Connectors: http://localhost:8085/
+Operate API:        http://localhost:8081/
+Optimize API:       http://localhost:8083/
+Tasklist API:       http://localhost:8082/
+Zeebe API (gRPC):   http://localhost:26500/
 
 Camunda metrics endpoint:    http://localhost:9600/actuator/prometheus
 

--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,7 +1,7 @@
 -------------------------------------------
 Access each component at the following urls:
 
-Camunda 8 API:      http://localhost:8080/v2/
+Camunda 8 API:      http://localhost:{{.ServerPort}}/v2/
 Inbound Connectors: http://localhost:8085/
 Operate API:        http://localhost:8081/
 Optimize API:       http://localhost:8083/

--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,14 +1,14 @@
 -------------------------------------------
 Access each component at the following urls:
 
-Camunda 8 API:      http://localhost:{{.ServerPort}}/v2/
-Inbound Connectors: http://localhost:8085/
-Operate API:        http://localhost:8081/
-Optimize API:       http://localhost:8083/
-Tasklist API:       http://localhost:8082/
-Zeebe API (gRPC):   http://localhost:26500/
+Camunda 8 API:            http://localhost:{{.ServerPort}}/v2/
+Inbound Connectors:       http://localhost:8085/
+Operate API:              http://localhost:8081/
+Optimize API:             http://localhost:8083/
+Tasklist API:             http://localhost:8082/
+Zeebe API (gRPC):         http://localhost:26500/
 
-Camunda metrics endpoint:    http://localhost:9600/actuator/prometheus
+Camunda metrics endpoint: http://localhost:9600/actuator/prometheus
 
 When using the Desktop Modeler, Authentication may be set to None.
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

closes https://github.com/camunda/camunda/issues/30779#issuecomment-2804491735

update entry message of c8run with latest endpoints and apis (valid for 8.7 and 8.8)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
