### PR TITLE
fix: parse cookie name rather than value for tokenized sorting

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/AuthCookieService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/AuthCookieService.java
@@ -266,9 +266,7 @@ public class AuthCookieService {
             .filter(name -> name.getName().startsWith(OPTIMIZE_AUTHORIZATION_PREFIX))
             .sorted(
                 Comparator.comparingInt(
-                    s ->
-                        Integer.parseInt(
-                            s.getValue().substring(s.getValue().lastIndexOf('_') + 1))))
+                    s -> Integer.parseInt(s.getName().substring(s.getName().lastIndexOf('_') + 1))))
             .map(Cookie::getValue)
             .collect(Collectors.joining());
     if (!authCookieValues.isEmpty()) {


### PR DESCRIPTION
fixes issue whereby the cookie value was parsed for sort value rather than the cookie name suffix