### PR TITLE
fix: fixed rdbms exporter for batch operation completed counts

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -28,9 +28,9 @@ public interface BatchOperationMapper {
 
   void incrementOperationsTotalCount(BatchOperationUpdateTotalCountDto dto);
 
-  void incrementFailedOperationsCount(Long batchOperationKey);
+  void incrementFailedOperationsCount(BatchOperationUpdateCountsDto dto);
 
-  void incrementCompletedOperationsCount(Long batchOperationKey);
+  void incrementCompletedOperationsCount(BatchOperationUpdateCountsDto dto);
 
   Long count(BatchOperationDbQuery query);
 
@@ -42,6 +42,8 @@ public interface BatchOperationMapper {
       long batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}
 
   record BatchOperationUpdateTotalCountDto(long batchOperationKey, int operationsTotalCount) {}
+
+  record BatchOperationUpdateCountsDto(long batchOperationKey, long itemKey) {}
 
   record BatchOperationItemsDto(Long batchOperationKey, Set<Long> items) {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemStatusUpdateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateCountsDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateTotalCountDto;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
@@ -88,7 +89,7 @@ public class BatchOperationWriter {
               WriteStatementType.UPDATE,
               batchOperationKey,
               "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementFailedOperationsCount",
-              batchOperationKey));
+              new BatchOperationUpdateCountsDto(batchOperationKey, itemKey)));
     } else if (state == BatchOperationItemState.COMPLETED) {
       executionQueue.executeInQueue(
           new QueueItem(
@@ -96,7 +97,7 @@ public class BatchOperationWriter {
               WriteStatementType.UPDATE,
               batchOperationKey,
               "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementCompletedOperationsCount",
-              batchOperationKey));
+              new BatchOperationUpdateCountsDto(batchOperationKey, itemKey)));
     }
   }
 

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -90,15 +90,27 @@
   </update>
 
   <update id="incrementFailedOperationsCount" parameterType="java.lang.Long">
-    UPDATE ${prefix}BATCH_OPERATION
+    UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + 1
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    AND EXISTS(
+      SELECT 1
+      FROM ${prefix}BATCH_OPERATION_ITEM i
+      WHERE i.BATCH_OPERATION_KEY = t.BATCH_OPERATION_KEY
+      AND i.ITEM_KEY = #{itemKey}
+    )
   </update>
 
   <update id="incrementCompletedOperationsCount" parameterType="java.lang.Long">
-    UPDATE ${prefix}BATCH_OPERATION
+    UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + 1
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+      AND EXISTS(
+      SELECT 1
+      FROM ${prefix}BATCH_OPERATION_ITEM i
+      WHERE i.BATCH_OPERATION_KEY = t.BATCH_OPERATION_KEY
+        AND i.ITEM_KEY = #{itemKey}
+    )
   </update>
 
   <select id="getItems"

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class BatchCancelProcessInstanceTest {
+public class BatchOperationCancelProcessInstanceTest {
 
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
@@ -126,6 +126,14 @@ public class BatchCancelProcessInstanceTest {
     for (final Long key : activeKeys) {
       waitForProcessInstanceToBeTerminated(camundaClient, key);
     }
+
+    final var batch =
+        camundaClient.newBatchOperationGetRequest(result.getBatchOperationKey()).send().join();
+    assertThat(batch).isNotNull();
+    assertThat(batch.getEndDate()).isNotNull();
+    assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+    assertThat(batch.getOperationsCompletedCount()).isEqualTo(3);
+    assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
 
     // and
     final var itemsObj =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
@@ -37,15 +37,13 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class BatchResolveIncidentTest {
+public class BatchOperationResolveIncidentTest {
 
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   static final List<Long> ACTIVE_INCIDENTS = new ArrayList<>();
   private static final int AMOUNT_OF_INCIDENTS = 3;
 
   private static CamundaClient camundaClient;
-
-  private static Incident incident;
 
   @BeforeAll
   public static void beforeAll() {
@@ -117,6 +115,14 @@ public class BatchResolveIncidentTest {
             });
 
     waitUntilIncidentsAreResolved(camundaClient, ACTIVE_INCIDENTS.size());
+
+    final var batch =
+        camundaClient.newBatchOperationGetRequest(result.getBatchOperationKey()).send().join();
+    assertThat(batch).isNotNull();
+    assertThat(batch.getEndDate()).isNotNull();
+    assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+    assertThat(batch.getOperationsCompletedCount()).isEqualTo(3);
+    assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
 
     // and
     final var itemsObj =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -536,6 +536,7 @@ public class RecordFixtures {
             ImmutableProcessInstanceRecordValue.builder()
                 .from((ImmutableProcessInstanceRecordValue) recordValueRecord.getValue())
                 .withBpmnElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
                 .withParentProcessInstanceKey(-1)
                 .build())
         .build();
@@ -558,6 +559,7 @@ public class RecordFixtures {
             ImmutableProcessInstanceRecordValue.builder()
                 .from((ImmutableProcessInstanceRecordValue) recordValueRecord.getValue())
                 .withBpmnElementType(BpmnElementType.PROCESS)
+                .withProcessInstanceKey(processInstanceKey)
                 .withParentProcessInstanceKey(-1)
                 .build())
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/IncidentBatchOperationExportHandler.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 
@@ -48,6 +49,7 @@ public class IncidentBatchOperationExportHandler
   }
 
   private boolean isFailed(final Record<IncidentRecordValue> record) {
-    return record.getIntent().equals(IncidentIntent.RESOLVE) && record.getRejectionType() != null;
+    return record.getIntent().equals(IncidentIntent.RESOLVE)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -60,6 +61,6 @@ public class ProcessInstanceBatchOperationExportHandler
 
   private boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceIntent.CANCEL)
-        && record.getRejectionType() != null;
+        && record.getRejectionType() != RejectionType.NULL_VAL;
   }
 }


### PR DESCRIPTION
## Description

This fixes wrong handling of `COMPLETED` and `FAILED` counts in the RDBMS exporter handler.
