### PR TITLE
test: refactor flaky test case

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSaasTest.java
@@ -50,7 +50,7 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
       "camunda.client.mode=saas",
       "camunda.client.cloud.cluster-id=12345",
       "camunda.client.cloud.region=bru-2",
-      "camunda.client.auth.client-id=my-client-id",
+      "camunda.client.auth.client-id=CredentialsProviderSaasTest-my-client-id",
       "camunda.client.auth.client-secret=my-client-secret"
     })
 @EnableConfigurationProperties({CamundaClientProperties.class})

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
@@ -45,7 +45,7 @@ import wiremock.com.fasterxml.jackson.databind.node.JsonNodeFactory;
     classes = {CredentialsProviderConfiguration.class},
     properties = {
       "camunda.client.mode=self-managed",
-      "camunda.client.auth.client-id=my-client-id",
+      "camunda.client.auth.client-id=CredentialsProviderSelfManagedTest-client-id",
       "camunda.client.auth.client-secret=my-client-secret"
     })
 @EnableConfigurationProperties({CamundaClientProperties.class})
@@ -80,6 +80,7 @@ public class CredentialsProviderSelfManagedTest {
 
   @Test
   void shouldHaveZeebeAuth() throws IOException {
+    // given
     final Map<String, String> headers = new HashMap<>();
     final String accessToken = "access-token";
     wm.stubFor(
@@ -92,10 +93,13 @@ public class CredentialsProviderSelfManagedTest {
                             .put("token_type", "bearer")
                             .put("expires_in", 300))));
 
+    // when
     credentialsProvider.applyCredentials(headers::put);
-    credentialsProvider.applyCredentials(headers::put);
+
+    // then
     assertThat(credentialsProvider).isExactlyInstanceOf(OAuthCredentialsProvider.class);
-    assertThat(headers).containsEntry("Authorization", "Bearer " + accessToken);
+    final var authorizationValue = headers.get("Authorization");
+    assertThat(authorizationValue).isEqualTo("Bearer " + accessToken);
     assertThat(headers).hasSize(1);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
@@ -98,8 +98,7 @@ public class CredentialsProviderSelfManagedTest {
 
     // then
     assertThat(credentialsProvider).isExactlyInstanceOf(OAuthCredentialsProvider.class);
-    final var authorizationValue = headers.get("Authorization");
-    assertThat(authorizationValue).isEqualTo("Bearer " + accessToken);
+    assertThat(headers).containsEntry("Authorization", "Bearer " + accessToken);
     assertThat(headers).hasSize(1);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The `clientId` is the same with multiple credentials tests in the Camunda Spring SDK ([src](https://github.com/camunda/camunda/blob/d5e476b70dfc2dd2e430200e3de5979bfa25871c/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java#L48)). 

The `credentialsCache` used by the `OAuthCredentialsProvider` in the tests (see [src](https://github.com/camunda/camunda/blob/d5e476b70dfc2dd2e430200e3de5979bfa25871c/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java#L98-L99)) may return a token from a different test that is run in parallel.

This PR sets a unique `clientId` to avoid getting tokens from the cache from other tests run in parallel.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #24824
