### PR TITLE
[Backport stable/8.6] ci: Fix potential globbing issue in analyze-test-runs

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -57,8 +57,7 @@ runs:
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
         {
           echo 'FLAKY_TESTS<<EOF'
-            # echo ${flakyTests[*]}
-            echo $flakyTests
+          echo "$flakyTests"
           echo EOF
         } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Description
Backport of #31044 to `stable/8.6`.

relates to 