### PR TITLE
refactor: minor cleanup of snapshot director and migrator

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -31,8 +31,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 public final class AsyncSnapshotDirector extends Actor
@@ -264,39 +262,11 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   private ActorFuture<PersistedSnapshot> snapshot(final InProgressSnapshot inProgressSnapshot) {
-    final ActorFuture<Void> takeTransientSnapshotFuture = actor.createFuture();
-    final ActorFuture<Void> getLastWrittenPositionFuture = actor.createFuture();
-    final ActorFuture<Void> lastWrittenPositionCommittedFuture = actor.createFuture();
-    final ActorFuture<Void> journalFlushFuture = actor.createFuture();
-    final ActorFuture<PersistedSnapshot> snapshotPersistedFuture = actor.createFuture();
-
-    takeTransientSnapshot(inProgressSnapshot).onComplete(takeTransientSnapshotFuture);
-
-    takeTransientSnapshotFuture.onComplete(
-        proceed(
-            getLastWrittenPositionFuture::completeExceptionally,
-            () ->
-                getLastWrittenPosition(inProgressSnapshot)
-                    .onComplete(getLastWrittenPositionFuture)));
-
-    getLastWrittenPositionFuture.onComplete(
-        proceed(
-            lastWrittenPositionCommittedFuture::completeExceptionally,
-            () ->
-                waitUntilLastWrittenPositionIsCommitted(inProgressSnapshot)
-                    .onComplete(lastWrittenPositionCommittedFuture)));
-
-    lastWrittenPositionCommittedFuture.onComplete(
-        proceed(
-            journalFlushFuture::completeExceptionally,
-            () -> flushJournal().onComplete(journalFlushFuture)));
-
-    journalFlushFuture.onComplete(
-        proceed(
-            snapshotPersistedFuture::completeExceptionally,
-            () -> persistSnapshot(inProgressSnapshot).onComplete(snapshotPersistedFuture)));
-
-    return snapshotPersistedFuture;
+    return takeTransientSnapshot(inProgressSnapshot)
+        .andThen(() -> getLastWrittenPosition(inProgressSnapshot), actor)
+        .andThen(() -> waitUntilLastWrittenPositionIsCommitted(inProgressSnapshot), actor)
+        .andThen(this::flushJournal, actor)
+        .andThen(() -> persistSnapshot(inProgressSnapshot), actor);
   }
 
   private ActorFuture<Void> flushJournal() {
@@ -433,17 +403,6 @@ public final class AsyncSnapshotDirector extends Actor
     }
 
     ongoingSnapshotFuture = null;
-  }
-
-  private BiConsumer<Void, Throwable> proceed(
-      final Consumer<Throwable> onError, final Runnable nextStep) {
-    return (ignore, error) -> {
-      if (error != null) {
-        onError.accept(error);
-      } else {
-        nextStep.run();
-      }
-    };
   }
 
   private static final class InProgressSnapshot {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -131,7 +131,6 @@ public final class AsyncSnapshotDirector extends Actor
    * Create an AsyncSnapshotDirector that can take snapshot when the StreamProcessor is in
    * continuous replay mode.
    *
-   * @param nodeId id of this broker
    * @param partitionId partition id
    * @param streamProcessor stream processor for the partition
    * @param stateController state controller that manages state
@@ -139,7 +138,6 @@ public final class AsyncSnapshotDirector extends Actor
    * @return snapshot director
    */
   public static AsyncSnapshotDirector ofReplayMode(
-      final int nodeId,
       final int partitionId,
       final StreamProcessor streamProcessor,
       final StateController stateController,
@@ -158,7 +156,6 @@ public final class AsyncSnapshotDirector extends Actor
    * Create an AsyncSnapshotDirector that can take snapshot when the StreamProcessor is in
    * processing mode
    *
-   * @param nodeId id of this broker
    * @param partitionId partition id
    * @param streamProcessor stream processor for the partition
    * @param stateController state controller that manages state
@@ -166,7 +163,6 @@ public final class AsyncSnapshotDirector extends Actor
    * @return snapshot director
    */
   public static AsyncSnapshotDirector ofProcessingMode(
-      final int nodeId,
       final int partitionId,
       final StreamProcessor streamProcessor,
       final StateController stateController,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -56,7 +56,6 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
       if (targetRole == Role.LEADER) {
         director =
             AsyncSnapshotDirector.ofProcessingMode(
-                context.getNodeId(),
                 context.getPartitionId(),
                 context.getStreamProcessor(),
                 context.getStateController(),
@@ -65,7 +64,6 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
       } else {
         director =
             AsyncSnapshotDirector.ofReplayMode(
-                context.getNodeId(),
                 context.getPartitionId(),
                 context.getStreamProcessor(),
                 context.getStateController(),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -107,7 +107,6 @@ public final class AsyncSnapshottingTest {
   private void createAsyncSnapshotDirectorOfProcessingMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofProcessingMode(
-            0,
             1,
             mockStreamProcessor,
             snapshotController,
@@ -119,7 +118,6 @@ public final class AsyncSnapshottingTest {
   private void createAsyncSnapshotDirectorOfReplayMode() {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofReplayMode(
-            0,
             1,
             mockStreamProcessor,
             snapshotController,
@@ -238,12 +236,7 @@ public final class AsyncSnapshottingTest {
 
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofProcessingMode(
-            0,
-            1,
-            mockStreamProcessor,
-            snapshotController,
-            Duration.ofMinutes(1),
-            () -> flushFuture);
+            1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1), () -> flushFuture);
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
     setCommitPosition(100L);
 
@@ -265,12 +258,7 @@ public final class AsyncSnapshottingTest {
 
     asyncSnapshotDirector =
         AsyncSnapshotDirector.ofReplayMode(
-            0,
-            1,
-            mockStreamProcessor,
-            snapshotController,
-            Duration.ofMinutes(1),
-            () -> flushFuture);
+            1, mockStreamProcessor, snapshotController, Duration.ofMinutes(1), () -> flushFuture);
     actorSchedulerRule.submitActor(asyncSnapshotDirector).join();
 
     // when

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -71,11 +71,6 @@ public class DbMigratorImpl implements DbMigrator {
   private int skippedMigrations = 0;
 
   public DbMigratorImpl(
-      final ClusterContext clusterContext, final MutableProcessingState processingState) {
-    this(true, new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS);
-  }
-
-  public DbMigratorImpl(
       final boolean versionCheckRestrictionEnabled,
       final ClusterContext clusterContext,
       final MutableProcessingState processingState) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -103,7 +103,7 @@ public class DbMigratorImpl implements DbMigrator {
   @Override
   public void runMigrations() {
     if (checkVersionCompatibility() instanceof Compatible.SameVersion) {
-      LOGGER.info("No migrations to run, snapshot is the same as current version");
+      LOGGER.debug("No migrations to run, snapshot is the same as current version");
       return;
     }
     logPreview(migrationTasks);
@@ -158,7 +158,7 @@ public class DbMigratorImpl implements DbMigrator {
       case final Compatible.SameVersion sameVersion ->
           LOGGER.trace("Snapshot is from the same version as the current version: {}", sameVersion);
       case final Compatible compatible ->
-          LOGGER.info("Snapshot is compatible with current version: {}", compatible);
+          LOGGER.debug("Snapshot is compatible with current version: {}", compatible);
     }
     return checkResult;
   }


### PR DESCRIPTION
This pull request includes changes to the `AsyncSnapshotDirector` class and related files to simplify the snapshotting process and remove unnecessary parameters and methods. The changes also include minor logging adjustments in the `DbMigratorImpl` class.

### Simplification of snapshotting process:

* [`zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java`](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL34-L35): Removed unnecessary `BiConsumer` and `Consumer` imports, and refactored the `snapshot` method to use `andThen` for chaining asynchronous operations. [[1]](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL34-L35) [[2]](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL267-R265) [[3]](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL438-L448)
* [`zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java`](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL136-L144): Removed the `nodeId` parameter from `ofReplayMode` and `ofProcessingMode` methods. [[1]](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL136-L144) [[2]](diffhunk://#diff-2968784688d8e18296bcdbc6953f81923d5d7ce547de52745746f155e5a23a0bL163-L171)

### Adjustments in related classes and tests:

* [`zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java`](diffhunk://#diff-b7b9b4f940f631cd7df7abc47f515e9eee4c4ad75777e2df5a6f67576c8ed1d3L59): Updated `transitionTo` method to remove the `nodeId` parameter when creating `AsyncSnapshotDirector`. [[1]](diffhunk://#diff-b7b9b4f940f631cd7df7abc47f515e9eee4c4ad75777e2df5a6f67576c8ed1d3L59) [[2]](diffhunk://#diff-b7b9b4f940f631cd7df7abc47f515e9eee4c4ad75777e2df5a6f67576c8ed1d3L68)
* [`zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java`](diffhunk://#diff-cef8676212db79479b848dca96c1d2fdffdfd73d4fd497e400a9a5190d5b98ddL110): Removed the `nodeId` parameter in test methods for creating `AsyncSnapshotDirector`. [[1]](diffhunk://#diff-cef8676212db79479b848dca96c1d2fdffdfd73d4fd497e400a9a5190d5b98ddL110) [[2]](diffhunk://#diff-cef8676212db79479b848dca96c1d2fdffdfd73d4fd497e400a9a5190d5b98ddL122) [[3]](diffhunk://#diff-cef8676212db79479b848dca96c1d2fdffdfd73d4fd497e400a9a5190d5b98ddL241-R239) [[4]](diffhunk://#diff-cef8676212db79479b848dca96c1d2fdffdfd73d4fd497e400a9a5190d5b98ddL268-R261)

### Logging adjustments:

* [`zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java`](diffhunk://#diff-e37e8d892811dfb0faecda12723ad46089fd8f190a55ad1c86e6048c58e28533L106-R101): Changed log level from `info` to `debug` for certain migration-related messages. [[1]](diffhunk://#diff-e37e8d892811dfb0faecda12723ad46089fd8f190a55ad1c86e6048c58e28533L106-R101) [[2]](diffhunk://#diff-e37e8d892811dfb0faecda12723ad46089fd8f190a55ad1c86e6048c58e28533L161-R156)