### PR TITLE
feat: include binary resources when reconstructing deployments

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -321,10 +321,12 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
       case ProcessResource(final var process) -> {
         final var metadata = deploymentRecord.processesMetadata().add();
         resourceUtil.applyProcessMetadata(process, metadata);
+        process.addToDeployment(deploymentRecord);
       }
       case FormResource(final var form) -> {
         final var metadata = deploymentRecord.formMetadata().add();
         resourceUtil.applyFormMetadata(form, metadata);
+        form.addToDeployment(deploymentRecord);
       }
       case DecisionRequirementsResource(
               final var deploymentKey,
@@ -332,6 +334,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
               final var decisions) -> {
         final var requirementsMetadata = deploymentRecord.decisionRequirementsMetadata().add();
         resourceUtil.applyDecisionRequirementsMetadata(decisionRequirements, requirementsMetadata);
+        decisionRequirements.addToDeployment(deploymentRecord);
         decisions.forEach(
             decision -> {
               final var decisionMetadata = deploymentRecord.decisionsMetadata().add();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributor.java
@@ -32,16 +32,15 @@ public final class DeploymentRedistributor
 
     final var previousDeploymentKey = progress.getDeploymentKey();
 
-    // TODO: Rehydrate the deployment record with all referenced resources
+    // Note: at this stage the deployment contains already the binary resources
     final var deployment = deploymentState.nextDeployment(previousDeploymentKey);
     if (deployment == null) {
       return List.of();
     }
     final var deploymentKey = deployment.getDeploymentKey();
 
-    // TODO: Should also contain all the resources within the deployment, i.e. processes etc.
-    final var resources =
-        Set.<RedistributableResource>of(new RedistributableResource.Deployment(deploymentKey));
+    final Set<RedistributableResource> resources =
+        Set.of(new RedistributableResource.Deployment(deploymentKey));
 
     return List.of(
         new Redistribution<>(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.engine.state.immutable.DeployableResource;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -20,7 +21,8 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
-public final class PersistedDecisionRequirements extends UnpackedObject implements DbValue {
+public final class PersistedDecisionRequirements extends UnpackedObject
+    implements DbValue, DeployableResource {
 
   private final StringProperty decisionRequirementsIdProp =
       new StringProperty("decisionRequirementsId");
@@ -90,16 +92,18 @@ public final class PersistedDecisionRequirements extends UnpackedObject implemen
     return decisionRequirementsKeyProp.getValue();
   }
 
-  public DirectBuffer getResourceName() {
-    return resourceNameProp.getValue();
-  }
-
   public DirectBuffer getChecksum() {
     return checksumProp.getValue();
   }
 
+  @Override
   public DirectBuffer getResource() {
     return resourceProp.getValue();
+  }
+
+  @Override
+  public DirectBuffer getResourceName() {
+    return resourceNameProp.getValue();
   }
 
   public String getTenantId() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.engine.state.immutable.DeployableResource;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -21,7 +22,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public final class PersistedForm extends UnpackedObject implements DbValue {
+public final class PersistedForm extends UnpackedObject implements DbValue, DeployableResource {
   private static final long NO_DEPLOYMENT_KEY = -1L;
 
   private final StringProperty formIdProp = new StringProperty("formId");
@@ -79,12 +80,14 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     return formKeyProp.getValue();
   }
 
-  public DirectBuffer getResourceName() {
-    return resourceNameProp.getValue();
-  }
-
+  @Override
   public DirectBuffer getResource() {
     return resourceProp.getValue();
+  }
+
+  @Override
+  public DirectBuffer getResourceName() {
+    return resourceNameProp.getValue();
   }
 
   public DirectBuffer getChecksum() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.deployment;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.engine.state.immutable.DeployableResource;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
@@ -20,7 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
 
-public final class PersistedProcess extends UnpackedObject implements DbValue {
+public final class PersistedProcess extends UnpackedObject implements DbValue, DeployableResource {
   private static final long NO_DEPLOYMENT_KEY = -1L;
   private final IntegerProperty versionProp = new IntegerProperty("version", -1);
   private final LongProperty keyProp = new LongProperty("key", -1L);
@@ -76,12 +77,14 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
     return bpmnProcessIdProp.getValue();
   }
 
-  public DirectBuffer getResourceName() {
-    return resourceNameProp.getValue();
-  }
-
+  @Override
   public DirectBuffer getResource() {
     return resourceProp.getValue();
+  }
+
+  @Override
+  public DirectBuffer getResourceName() {
+    return resourceNameProp.getValue();
   }
 
   public PersistedProcessState getState() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeployableResource.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeployableResource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import org.agrona.DirectBuffer;
+
+/** A record that contain a resource that can be added to a {@link DeploymentRecord */
+public interface DeployableResource {
+  DirectBuffer getResource();
+
+  DirectBuffer getResourceName();
+
+  default void addToDeployment(final DeploymentRecord deploymentRecord) {
+    final var resourceRecord = deploymentRecord.resources().add();
+    resourceRecord.setResource(getResource()).setResourceName(getResourceName());
+  }
+}


### PR DESCRIPTION
## Description
When reconstructing a deployment, attach the binary resources directly.
They are already available from `PersistedProcess`, `PersistedForm` and `PersistedDecisionRequirement`.
## Related issues

closes #31030 
