### PR TITLE
build: use public camunda-nexus to build Optimize

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -674,7 +674,7 @@
     <repository>
       <id>camunda-nexus</id>
       <name>Camunda Nexus</name>
-      <url>https://artifacts.camunda.com/artifactory/internal/</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
## Description

This PR fixes the case where requests to internal camunda-nexus return 401.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
