### PR TITLE
[Backport stable/8.5] fix: when there is a leader transition client requests were never completed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -756,17 +756,21 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
     appendEntriesFuture.whenCompleteAsync(
         (commitIndex, commitError) -> {
-          if (!isRunning()) {
-            return;
-          }
 
           // have the state machine apply the index which should do nothing but ensures it keeps
           // up to date with the latest entries, so it can handle configuration and initial
           // entries properly on fail over
           if (commitError == null) {
+<<<<<<< HEAD
             appendListener.onCommit(commitIndex);
+=======
+            if (isRunning()) {
+              appendListener.onCommit(commitIndex, committedPosition);
+            }
+>>>>>>> bcf9b5fd (fix: when there is a leader transition client requests were never replied)
           } else {
-            appendListener.onCommitError(commitIndex, commitError);
+            final var index = (commitIndex != null) ? commitIndex : committedPosition;
+            appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
             log.error("Failed to replicate entry: {}", commitIndex, commitError);
           }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RaftCorruptedDataTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RaftCorruptedDataTest.class);
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  @DisplayName(
+      "When nodes with corrupted data forms a quorum, the remaining one should not delete its files")
+  public void upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption() throws Exception {
+    // given
+    // nodes 0, 1 experience corruption: all data is lost
+    final var servers = raftRule.getServers().toArray(RaftServer[]::new);
+    // name == memberId since the name is not specified
+    final var node0 = MemberId.from(servers[0].name());
+    final var node1 = MemberId.from(servers[1].name());
+    final var node2 = MemberId.from(servers[2].name());
+
+    raftRule.appendEntries(100);
+    raftRule.appendEntries(1);
+    Awaitility.await("commitIndex is > 0 on all nodes")
+        .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
+
+    final var commitIndex = servers[2].getContext().getCommitIndex();
+
+    for (final RaftServer server : servers) {
+      raftRule.shutdownServer(server);
+    }
+
+    raftRule.triggerDataLossOnNode(node0.id());
+    raftRule.triggerDataLossOnNode(node1.id());
+
+    // after shutdown the servers must be created from scratch with the same server name.
+    final var server0 = raftRule.createServer(node0);
+    final var server1 = raftRule.createServer(node1);
+
+    // bootstrap the nodes with data loss
+    CompletableFuture.allOf(
+            server0.bootstrap(node0, node1, node2), server1.bootstrap(node0, node1, node2))
+        .join();
+
+    // wait for the two corrupted nodes to form quorum
+    Awaitility.await("corrupted nodes form a quorum")
+        .until(() -> server0.isLeader() || server1.isLeader());
+    // when
+    // the node with up-to-date log joins the cluster
+    final var server2 = raftRule.createServer(node2);
+
+    // then
+    // trigger bootstrap async
+    server2.bootstrap(node0, node1, node2);
+
+    // node does not become follower - goes to inactive as it detects that it has longer log
+    Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole().equals(Role.INACTIVE));
+  }
+
+  @Test
+  @DisplayName(
+      "When nodes with corrupted data forms a quorum, the remaining one should not delete its files even if quorum term is > 1")
+  public void upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption2() throws Exception {
+    // given
+    // nodes 0, 1 experience corruption: all data is lost
+    final var servers = raftRule.getServers().toArray(RaftServer[]::new);
+    // name == memberId since the name is not specified
+    final var node0 = MemberId.from(servers[0].name());
+    final var node1 = MemberId.from(servers[1].name());
+    final var node2 = MemberId.from(servers[2].name());
+
+    raftRule.appendEntries(2000);
+    raftRule.appendEntries(1);
+    Awaitility.await("commitIndex is > 0 on all nodes")
+        .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
+
+    for (final RaftServer server : servers) {
+      raftRule.shutdownServer(server);
+    }
+
+    LOGGER.debug("All servers shut down");
+
+    raftRule.triggerDataLossOnNode(node0.id());
+    raftRule.triggerDataLossOnNode(node1.id());
+
+    LOGGER.debug("Data loss triggered on Broker-1/Broker-2");
+
+    // after shutdown the servers must be created from scratch with the same server name.
+    final var server0 = raftRule.createServer(node0);
+    final var server1 = raftRule.createServer(node1);
+
+    // bootstrap the nodes with data loss
+    CompletableFuture.allOf(
+            server0.bootstrap(node0, node1, node2), server1.bootstrap(node0, node1, node2))
+        .join();
+
+    // wait for the two corrupted nodes to form quorum
+    Awaitility.await("corrupted nodes form a quorum")
+        .until(() -> server0.isLeader() || server1.isLeader());
+    for (int i = 0; i < 1000; i++) {
+      //      raftRule.appendEntry();
+      Awaitility.await("entry is committed")
+          .untilAsserted(() -> assertThatNoException().isThrownBy(() -> raftRule.appendEntry()));
+    }
+
+    raftRule.restartLeader();
+
+    Awaitility.await("until the term is > 1")
+        .until(() -> raftRule.getLeader().get().getContext().getTerm() > 1);
+
+    // when
+    // the node with up-to-date log joins the cluster
+    final var server2 = raftRule.createServer(node2);
+
+    // then
+    // trigger bootstrap async
+    server2.bootstrap(node0, node1, node2);
+
+    raftRule.appendEntries(1);
+
+    // node does not become follower - goes to inactive as it detects that it has longer log
+    Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole() == Role.INACTIVE);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -44,6 +44,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -93,6 +94,8 @@ public class LeaderRoleTest {
     when(context.getLog()).thenReturn(log);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
+    when(persistedSnapshotStore.purgePendingSnapshots())
+        .thenReturn(CompletableActorFuture.completed(null));
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());
     when(context.getStorage())
@@ -274,6 +277,31 @@ public class LeaderRoleTest {
     verify(log, timeout(1000)).append(any(RaftLogEntry.class));
     verify(context, timeout(1000)).transition(Role.FOLLOWER);
 
+    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldCallOnCommitErrorWhenSteppingDown() throws InterruptedException {
+    // given
+    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+          @Override
+          public void onCommitError(final long index, final Throwable error) {
+
+            caughtError.set(error);
+            latch.countDown();
+          }
+        };
+    leaderRole.appendEntry(2, 3, data, listener);
+
+    // when
+    leaderRole.stop().join();
+
+    // then
+    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
     assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
   }
 


### PR DESCRIPTION
# Description
Backport of #31033 to `stable/8.5`.

relates to #27852 #30790