### PR TITLE
[Backport stable/8.7] fix: when there is a leader transition client requests were never completed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
@@ -84,4 +84,18 @@ public abstract class RaftException extends RuntimeException {
       super(RaftError.Type.CONFIGURATION_ERROR, throwable, message, args);
     }
   }
+
+  public static class AppendFailureException extends RaftException {
+
+    private final long index;
+
+    public AppendFailureException(final long index, final String message) {
+      super(RaftError.Type.COMMAND_FAILURE, message);
+      this.index = index;
+    }
+
+    public long getIndex() {
+      return index;
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -19,6 +19,7 @@ package io.atomix.raft.roles;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.RaftMember;
@@ -1049,20 +1050,6 @@ final class LeaderAppender {
 
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
-  }
-
-  static class AppendFailureException extends Throwable {
-
-    private final long index;
-
-    public AppendFailureException(final long index, final String message) {
-      super(message);
-      this.index = index;
-    }
-
-    public long getIndex() {
-      return index;
-    }
   }
 
   /** Timestamped completable future. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -857,10 +857,10 @@ final class LeaderAppender {
     open = false;
     metrics.close();
     completeCommits(raft.getCommitIndex());
-    appendFutures
-        .values()
-        .forEach(
-            future -> future.completeExceptionally(new IllegalStateException("Inactive state")));
+    appendFutures.forEach(
+        (index, future) ->
+            future.completeExceptionally(
+                new AppendFailureException(index, "Leader stepping down")));
     heartbeatFutures.forEach(
         future ->
             future.completeExceptionally(
@@ -1049,6 +1049,20 @@ final class LeaderAppender {
 
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
+  }
+
+  static class AppendFailureException extends Throwable {
+
+    private final long index;
+
+    public AppendFailureException(final long index, final String message) {
+      super(message);
+      this.index = index;
+    }
+
+    public long getIndex() {
+      return index;
+    }
   }
 
   /** Timestamped completable future. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
@@ -767,8 +768,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             }
           } else {
             long index = -1L;
-            if (commitError
-                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+            if (commitError instanceof final AppendFailureException appendFailureException) {
               index = appendFailureException.getIndex();
             }
             appendListener.onCommitError(index, commitError);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -766,7 +766,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               appendListener.onCommit(commitIndex, committedPosition);
             }
           } else {
-            final var index = (commitIndex != null) ? commitIndex : committedPosition;
+            long index = -1L;
+            if (commitError
+                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+              index = appendFailureException.getIndex();
+            }
             appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
             log.error("Failed to replicate entry: {}", commitIndex, commitError);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.impl.LogCompactor;
@@ -301,8 +302,8 @@ public class LeaderRoleTest {
     leaderRole.stop().join();
 
     // then
-    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
-    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(caughtError.get()).isInstanceOf(AppendFailureException.class);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -44,6 +44,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -93,6 +94,8 @@ public class LeaderRoleTest {
     when(context.getLog()).thenReturn(log);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
+    when(persistedSnapshotStore.purgePendingSnapshots())
+        .thenReturn(CompletableActorFuture.completed(null));
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());
     when(context.getStorage())
@@ -274,6 +277,31 @@ public class LeaderRoleTest {
     verify(log, timeout(1000)).append(any(RaftLogEntry.class));
     verify(context, timeout(1000)).transition(Role.FOLLOWER);
 
+    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldCallOnCommitErrorWhenSteppingDown() throws InterruptedException {
+    // given
+    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+          @Override
+          public void onCommitError(final long index, final Throwable error) {
+
+            caughtError.set(error);
+            latch.countDown();
+          }
+        };
+    leaderRole.appendEntry(2, 3, data, listener);
+
+    // when
+    leaderRole.stop().join();
+
+    // then
+    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
     assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
   }
 


### PR DESCRIPTION
# Description
Backport of #31033 to `stable/8.7`.

relates to #27852 #30790