### PR TITLE
refactor: add mappingId property to MappingEntity

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MappingEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MappingEntityTransformer.java
@@ -18,7 +18,7 @@ public class MappingEntityTransformer
   public MappingEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.MappingEntity value) {
     return new MappingEntity(
-        value.getId(),
+        value.getMappingId(),
         value.getKey(),
         value.getClaimName(),
         value.getClaimValue(),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/MappingEntity.java
@@ -13,6 +13,7 @@ public class MappingEntity extends AbstractExporterEntity<MappingEntity> {
 
   public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
   private Long key;
+  private String mappingId;
   private String claimName;
   private String claimValue;
   private String name;
@@ -25,6 +26,15 @@ public class MappingEntity extends AbstractExporterEntity<MappingEntity> {
 
   public MappingEntity setKey(final Long mappingKey) {
     key = mappingKey;
+    return this;
+  }
+
+  public String getMappingId() {
+    return mappingId;
+  }
+
+  public MappingEntity setMappingId(final String mappingId) {
+    this.mappingId = mappingId;
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -60,7 +60,7 @@ public class MappingCreatedUpdatedHandler
     final MappingRecordValue value = record.getValue();
     entity
         .setKey(value.getMappingKey())
-        .setId(value.getMappingId())
+        .setMappingId(value.getMappingId())
         .setClaimName(value.getClaimName())
         .setClaimValue(value.getClaimValue())
         .setName(value.getName());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
@@ -54,7 +54,7 @@ public class MappingDeletedHandler implements ExportHandler<MappingEntity, Mappi
     final MappingRecordValue value = record.getValue();
     entity
         .setKey(value.getMappingKey())
-        .setId(value.getMappingId())
+        .setMappingId(value.getMappingId())
         .setClaimName(value.getClaimName())
         .setClaimValue(value.getClaimValue());
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
@@ -113,7 +113,7 @@ public class MappingCreatedUpdatedHandlerTest {
     assertThat(mappingEntity.getClaimName()).isEqualTo("updated-claim");
     assertThat(mappingEntity.getClaimValue()).isEqualTo("updated-value");
     assertThat(mappingEntity.getName()).isEqualTo("updated-name");
-    assertThat(mappingEntity.getId()).isEqualTo("updated-id");
+    assertThat(mappingEntity.getMappingId()).isEqualTo("updated-id");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds the mappingId field to the MappingEntity class and ensures it's correctly populated and exported to Elasticsearch. This makes it possible to query mappings by mappingId and aligns the entity with the API model.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31142

