### PR TITLE
Unassign group from mapping rule

### DIFF
--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -141,10 +141,10 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
   }
 
   public CompletableFuture<GroupRecord> removeMember(
-      final String groupId, final String username, final EntityType memberType) {
+      final String groupId, final String entityId, final EntityType memberType) {
     return sendBrokerRequest(
         BrokerGroupMemberRequest.createRemoveRequest(groupId)
-            .setMemberId(username)
+            .setMemberId(entityId)
             .setMemberType(memberType));
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2828,6 +2828,44 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - Group
+      operationId: unassignMappingFromGroup
+      summary: Unassign a mapping rule from a group (Work-in-Progress)
+      description: |
+        Unassigns a mapping rule from a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The group ID.
+          schema:
+            type: string
+        - name: mappingId
+          in: path
+          required: true
+          description: The mapping rule ID.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The mapping rule was unassigned successfully from the group.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The group or mapping rule with the given ID was not found, or the mapping rule is not assigned to this group.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /groups/search:
     post:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -188,7 +188,8 @@ public class GroupController {
                 .assignMember(request.groupId(), request.entityId(), request.entityType()));
   }
 
-  public CompletableFuture<ResponseEntity<Object>> unassignMapping(final GroupMemberRequest request) {
+  public CompletableFuture<ResponseEntity<Object>> unassignMapping(
+      final GroupMemberRequest request) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
         () ->
             groupServices

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -101,6 +101,15 @@ public class GroupController {
                 .removeMember(groupId, username, EntityType.USER));
   }
 
+  @CamundaDeleteMapping(
+      path = "/{groupId}/mapping-rules/{mappingId}",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> unassignMappingToGroup(
+      @PathVariable final String groupId, @PathVariable final String mappingId) {
+    return RequestMapper.toGroupMemberRequest(groupId, mappingId, EntityType.MAPPING)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMapping);
+  }
+
   @CamundaGetMapping(path = "/{groupKey}/users")
   public ResponseEntity<UserSearchResult> usersByGroup(
       @PathVariable("groupKey") final long groupKey) {
@@ -177,5 +186,13 @@ public class GroupController {
             groupServices
                 .withAuthentication(RequestMapper.getAuthentication())
                 .assignMember(request.groupId(), request.entityId(), request.entityType()));
+  }
+
+  public CompletableFuture<ResponseEntity<Object>> unassignMapping(final GroupMemberRequest request) {
+    return RequestMapper.executeServiceMethodWithAcceptedResult(
+        () ->
+            groupServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .removeMember(request.groupId(), request.entityId(), request.entityType()));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -525,10 +525,7 @@ public class GroupControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
                     new BrokerRejection(
-                        RoleIntent.ENTITY_ADDED,
-                        1L,
-                        RejectionType.NOT_FOUND,
-                        "Mapping not found"))));
+                        RoleIntent.ENTITY_ADDED, 1L, RejectionType.NOT_FOUND, "Role not found"))));
 
     // when
     webClient
@@ -544,7 +541,7 @@ public class GroupControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidMappingIdWhenAddingToMapping() {
+  void shouldReturnErrorForProvidingInvalidMappingIdWhenAddingToRole() {
     // given
     final String groupId = Strings.newRandomValidIdentityId();
     final String mappingId = "mappingId!";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
-import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.concurrent.CompletableFuture;
@@ -497,7 +496,7 @@ public class GroupControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
                     new BrokerRejection(
-                        RoleIntent.ENTITY_ADDED,
+                        GroupIntent.ENTITY_ADDED,
                         1L,
                         RejectionType.NOT_FOUND,
                         "Mapping rule not found"))));
@@ -525,7 +524,10 @@ public class GroupControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
                     new BrokerRejection(
-                        RoleIntent.ENTITY_ADDED, 1L, RejectionType.NOT_FOUND, "Role not found"))));
+                        GroupIntent.ENTITY_ADDED,
+                        1L,
+                        RejectionType.NOT_FOUND,
+                        "Group not found"))));
 
     // when
     webClient
@@ -541,7 +543,7 @@ public class GroupControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnErrorForProvidingInvalidMappingIdWhenAddingToRole() {
+  void shouldReturnErrorForProvidingInvalidMappingIdWhenAddingToGroup() {
     // given
     final String groupId = Strings.newRandomValidIdentityId();
     final String mappingId = "mappingId!";
@@ -708,7 +710,7 @@ public class GroupControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
                     new BrokerRejection(
-                        RoleIntent.ENTITY_ADDED,
+                        GroupIntent.ENTITY_ADDED,
                         1L,
                         RejectionType.NOT_FOUND,
                         "Mapping not found"))));
@@ -736,7 +738,10 @@ public class GroupControllerTest extends RestControllerTest {
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
                     new BrokerRejection(
-                        RoleIntent.ENTITY_ADDED, 1L, RejectionType.NOT_FOUND, "Group not found"))));
+                        GroupIntent.ENTITY_ADDED,
+                        1L,
+                        RejectionType.NOT_FOUND,
+                        "Group not found"))));
 
     // when
     webClient


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a new endpoint to unassign a mapping rule from a group, the path is DELET /groups/{groupId}/mapping-rules/{mappingId}. Both of the path param are validated accordingly

## Related issues

closes #30048 

⚠️ this PR is based on https://github.com/camunda/camunda/pull/31144
