### PR TITLE
refactor: remove default from TypedRecordProcessor.processRecord

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
 
-  default void processRecord(final TypedRecord<T> record) {}
+  void processRecord(final TypedRecord<T> record);
 
   /**
    * Try to handle an error that occurred during processing.


### PR DESCRIPTION
## Description
I don't think that `processRecord` should have a `default` implementation because that method should (and is) always implemented.
If a noop implementation is needed we should create one, but it's not needed at the moment.

