### PR TITLE
[Backport stable/8.5]  fix: when there is a leader transition client requests were never completed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
@@ -84,4 +84,18 @@ public abstract class RaftException extends RuntimeException {
       super(RaftError.Type.CONFIGURATION_ERROR, throwable, message, args);
     }
   }
+
+  public static class AppendFailureException extends RaftException {
+
+    private final long index;
+
+    public AppendFailureException(final long index, final String message) {
+      super(RaftError.Type.COMMAND_FAILURE, message);
+      this.index = index;
+    }
+
+    public long getIndex() {
+      return index;
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -854,10 +854,10 @@ final class LeaderAppender {
     open = false;
     metrics.close();
     completeCommits(raft.getCommitIndex());
-    appendFutures
-        .values()
-        .forEach(
-            future -> future.completeExceptionally(new IllegalStateException("Inactive state")));
+    appendFutures.forEach(
+        (index, future) ->
+            future.completeExceptionally(
+                new AppendFailureException(index, "Leader stepping down")));
     heartbeatFutures.forEach(
         future ->
             future.completeExceptionally(
@@ -1046,6 +1046,20 @@ final class LeaderAppender {
 
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
+  }
+
+  static class AppendFailureException extends Throwable {
+
+    private final long index;
+
+    public AppendFailureException(final long index, final String message) {
+      super(message);
+      this.index = index;
+    }
+
+    public long getIndex() {
+      return index;
+    }
   }
 
   /** Timestamped completable future. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -19,6 +19,7 @@ package io.atomix.raft.roles;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.RaftMember;
@@ -1046,20 +1047,6 @@ final class LeaderAppender {
 
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
-  }
-
-  static class AppendFailureException extends Throwable {
-
-    private final long index;
-
-    public AppendFailureException(final long index, final String message) {
-      super(message);
-      this.index = index;
-    }
-
-    public long getIndex() {
-      return index;
-    }
   }
 
   /** Timestamped completable future. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
@@ -767,8 +768,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             }
           } else {
             long index = -1L;
-            if (commitError
-                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+            if (commitError instanceof final AppendFailureException appendFailureException) {
               index = appendFailureException.getIndex();
             }
             appendListener.onCommitError(index, commitError);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -737,14 +737,15 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   private void replicate(final IndexedRaftLogEntry indexed, final AppendListener appendListener) {
     raft.checkThread();
     final var appendEntriesFuture = appender.appendEntries(indexed.index());
+    final var committedPosition =
+        indexed.isApplicationEntry() ? indexed.getApplicationEntry().highestPosition() : -1;
 
     if (indexed.isApplicationEntry()) {
       // We have some services which are waiting for the application records, especially position
       // to be committed. This is our glue code to notify them, instead of
       // passing the complete object (IndexedRaftLogEntry) threw the listeners and
       // keep them in heap until they are committed. This had the risk of going out of OOM
-      // if records can't be committed, see https://github.com/camunda/zeebe/issues/14275
-      final var committedPosition = indexed.getApplicationEntry().highestPosition();
+      // if records can't be committed, see https://github.com/camunda/camunda/issues/14275
       appendEntriesFuture.whenCompleteAsync(
           (commitIndex, commitError) -> {
             if (isRunning() && commitError == null) {
@@ -756,17 +757,17 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
     appendEntriesFuture.whenCompleteAsync(
         (commitIndex, commitError) -> {
-          if (!isRunning()) {
-            return;
-          }
 
           // have the state machine apply the index which should do nothing but ensures it keeps
           // up to date with the latest entries, so it can handle configuration and initial
           // entries properly on fail over
           if (commitError == null) {
-            appendListener.onCommit(commitIndex);
+            if (isRunning()) {
+              appendListener.onCommit(commitIndex);
+            }
           } else {
-            appendListener.onCommitError(commitIndex, commitError);
+            final var index = (commitIndex != null) ? commitIndex : committedPosition;
+            appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
             log.error("Failed to replicate entry: {}", commitIndex, commitError);
           }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -766,7 +766,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
               appendListener.onCommit(commitIndex);
             }
           } else {
-            final var index = (commitIndex != null) ? commitIndex : committedPosition;
+            long index = -1L;
+            if (commitError
+                instanceof final LeaderAppender.AppendFailureException appendFailureException) {
+              index = appendFailureException.getIndex();
+            }
             appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
             log.error("Failed to replicate entry: {}", commitIndex, commitError);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.raft.RaftException.AppendFailureException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.impl.LogCompactor;
@@ -301,8 +302,8 @@ public class LeaderRoleTest {
     leaderRole.stop().join();
 
     // then
-    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
-    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(caughtError.get()).isInstanceOf(AppendFailureException.class);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -16,6 +16,7 @@
 package io.atomix.raft.roles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.answerVoid;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
@@ -26,9 +27,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.raft.RaftException.AppendFailureException;
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftException;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.impl.LogCompactor;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
@@ -47,13 +51,16 @@ import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -62,8 +69,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+@AutoCloseResources
 public class LeaderRoleTest {
 
+  @AutoCloseResource SingleThreadContext threadContext;
   private LeaderRole leaderRole;
   private RaftContext context;
   private RaftLog log;
@@ -81,7 +90,7 @@ public class LeaderRoleTest {
     when(context.getReplicationMetrics()).thenReturn(mock(RaftReplicationMetrics.class));
     when(context.getLogCompactor()).thenReturn(logCompactor);
 
-    final SingleThreadContext threadContext = new SingleThreadContext("leader");
+    threadContext = new SingleThreadContext("leader");
     when(context.getThreadContext()).thenReturn(threadContext);
 
     log = mock(RaftLog.class);
@@ -104,8 +113,12 @@ public class LeaderRoleTest {
 
     leaderRole = new LeaderRole(context);
     // since we mock RaftContext we should simulate leader close on transition
-    doAnswer(i -> leaderRole.stop().join()).when(context).transition(Role.FOLLOWER);
+    doAnswer(answerVoid(ignored -> leaderRole.stop().join()))
+        .when(context)
+        .transition(Role.FOLLOWER);
     when(context.getMembershipService()).thenReturn(mock(ClusterMembershipService.class));
+    when(context.getLeader())
+        .thenReturn(new DefaultRaftMember(MemberId.from("0"), Type.ACTIVE, Instant.now()));
   }
 
   @Test
@@ -287,8 +300,18 @@ public class LeaderRoleTest {
     final AtomicReference<Throwable> caughtError = new AtomicReference<>();
     final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
     final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch writeLatch = new CountDownLatch(1);
+    // because RETURN_DEEP_STUBS is set on the context, it returns a default value
+    // each of these methods must be stubbed
+    when(context.getCommitIndex()).thenReturn(0L);
+    when(context.getCluster().getReplicationTargets()).thenReturn(Set.of());
     final AppendListener listener =
         new AppendListener() {
+          @Override
+          public void onWrite(final IndexedRaftLogEntry indexed) {
+            writeLatch.countDown();
+          }
+
           @Override
           public void onCommitError(final long index, final Throwable error) {
 
@@ -297,13 +320,15 @@ public class LeaderRoleTest {
           }
         };
     leaderRole.appendEntry(2, 3, data, listener);
+    // wait before the event has been written before stopping
+    assertThat(writeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 
     // when
     leaderRole.stop().join();
 
     // then
     assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-    assertThat(caughtError.get()).isInstanceOf(AppendFailureException.class);
+    assertThat(caughtError.get()).isInstanceOf(RaftException.class);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -44,6 +44,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -93,6 +94,8 @@ public class LeaderRoleTest {
     when(context.getLog()).thenReturn(log);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
+    when(persistedSnapshotStore.purgePendingSnapshots())
+        .thenReturn(CompletableActorFuture.completed(null));
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());
     when(context.getStorage())
@@ -274,6 +277,31 @@ public class LeaderRoleTest {
     verify(log, timeout(1000)).append(any(RaftLogEntry.class));
     verify(context, timeout(1000)).transition(Role.FOLLOWER);
 
+    assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void shouldCallOnCommitErrorWhenSteppingDown() throws InterruptedException {
+    // given
+    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+          @Override
+          public void onCommitError(final long index, final Throwable error) {
+
+            caughtError.set(error);
+            latch.countDown();
+          }
+        };
+    leaderRole.appendEntry(2, 3, data, listener);
+
+    // when
+    leaderRole.stop().join();
+
+    // then
+    assertThat(latch.await(100, TimeUnit.SECONDS)).isTrue();
     assertThat(caughtError.get()).isInstanceOf(RuntimeException.class);
   }
 


### PR DESCRIPTION
# Description
Backport of #31141 to `stable/8.5`.

relates to #31033 #27852