### PR TITLE
refactor: normalize mapping tenant membership

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -460,18 +460,20 @@ public final class AuthorizationCheckBehavior {
     final var tenantsOfMapping =
         getPersistedMappings(command).stream()
             .flatMap(
-                mapping -> {
-                  final var tenantIds =
-                      new ArrayList<>(
-                          membershipState.getMemberships(
-                              EntityType.MAPPING, mapping.getMappingId(), RelationType.TENANT));
-                  final var groupIds =
-                      mapping.getGroupKeysList().stream()
-                          .map(key -> Long.toString(key))
-                          .collect(Collectors.toSet());
-                  tenantIds.addAll(getTenantIdsForGroups(groupIds));
-                  return tenantIds.stream();
-                })
+                mapping ->
+                    Stream.concat(
+                        membershipState
+                            .getMemberships(
+                                EntityType.MAPPING, mapping.getMappingId(), RelationType.TENANT)
+                            .stream(),
+                        mapping.getGroupKeysList().stream()
+                            .map(key -> Long.toString(key))
+                            .flatMap(
+                                groupId ->
+                                    membershipState
+                                        .getMemberships(
+                                            EntityType.GROUP, groupId, RelationType.TENANT)
+                                        .stream())))
             .toList();
     return tenantsOfMapping.isEmpty()
         ? AuthorizedTenants.DEFAULT_TENANTS

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -42,7 +42,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.util.Collections;
 import org.agrona.collections.MutableBoolean;
 
 @ExcludeAuthorizationCheck
@@ -293,14 +292,10 @@ public final class IdentitySetupInitializeProcessor
       final TenantRecord tenant, final String entityId, final EntityType entityType) {
     final var isAlreadyAssigned =
         switch (entityType) {
-          case USER ->
+          case USER, MAPPING ->
               membershipState.hasRelation(
-                  EntityType.USER, entityId, RelationType.TENANT, tenant.getTenantId());
-          default ->
-              tenantState
-                  .getEntitiesByType(tenant.getTenantId())
-                  .getOrDefault(entityType, Collections.emptyList())
-                  .contains(entityId);
+                  entityType, entityId, RelationType.TENANT, tenant.getTenantId());
+          default -> throw new IllegalArgumentException("Unsupported entity type: " + entityType);
         };
     if (isAlreadyAssigned) {
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -158,7 +158,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       createEntityNotExistRejectCommand(command, mappingId, EntityType.MAPPING, tenantId);
       return false;
     }
-    if (mapping.get().getTenantIdsList().contains(tenantId)) {
+    if (membershipState.hasRelation(EntityType.MAPPING, mappingId, RelationType.TENANT, tenantId)) {
       createAlreadyAssignedRejectCommand(command, mappingId, EntityType.MAPPING, tenantId);
       return false;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -9,22 +9,16 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 
 public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
 
-  private final MutableTenantState tenantState;
-  private final MutableMappingState mappingState;
   private final MutableMembershipState membershipState;
 
   public TenantEntityAddedApplier(final MutableProcessingState state) {
-    tenantState = state.getTenantState();
-    mappingState = state.getMappingState();
     membershipState = state.getMembershipState();
   }
 
@@ -37,10 +31,6 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
               tenant.getEntityId(),
               RelationType.TENANT,
               tenant.getTenantId());
-      //      case MAPPING -> {
-      //        tenantState.addEntity(tenant);
-      //        mappingState.addTenant(tenant.getEntityId(), tenant.getTenantId());
-      //      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -31,16 +31,16 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
   @Override
   public void applyState(final long tenantKey, final TenantRecord tenant) {
     switch (tenant.getEntityType()) {
-      case USER, GROUP ->
+      case USER, GROUP, MAPPING ->
           membershipState.insertRelation(
               tenant.getEntityType(),
               tenant.getEntityId(),
               RelationType.TENANT,
               tenant.getTenantId());
-      case MAPPING -> {
-        tenantState.addEntity(tenant);
-        mappingState.addTenant(tenant.getEntityId(), tenant.getTenantId());
-      }
+      //      case MAPPING -> {
+      //        tenantState.addEntity(tenant);
+      //        mappingState.addTenant(tenant.getEntityId(), tenant.getTenantId());
+      //      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -9,29 +9,23 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 
 public class TenantEntityRemovedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
 
-  private final MutableTenantState tenantState;
-  private final MutableGroupState groupState;
   private final MutableMembershipState membershipState;
 
   public TenantEntityRemovedApplier(final MutableProcessingState state) {
-    tenantState = state.getTenantState();
-    groupState = state.getGroupState();
     membershipState = state.getMembershipState();
   }
 
   @Override
   public void applyState(final long tenantKey, final TenantRecord tenant) {
     switch (tenant.getEntityType()) {
-      case USER, GROUP ->
+      case USER, GROUP, MAPPING ->
           membershipState.deleteRelation(
               tenant.getEntityType(),
               tenant.getEntityId(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -127,18 +127,6 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void addTenant(final String mappingId, final String tenantId) {
-    this.mappingId.wrapString(mappingId);
-    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      persistedMapping.addTenantId(tenantId);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
   public void addGroup(final String mappingId, final long groupKey) {
     this.mappingId.wrapString(mappingId);
     final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
@@ -160,20 +148,6 @@ public class DbMappingState implements MutableMappingState {
       final List<Long> roleKeys = persistedMapping.getRoleKeysList();
       roleKeys.remove(roleKey);
       persistedMapping.setRoleKeysList(roleKeys);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
-  public void removeTenant(final long mappingKey, final String tenantId) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      final var tenantIds = persistedMapping.getTenantIdsList();
-      tenantIds.remove(tenantId);
-      persistedMapping.setTenantIdsList(tenantIds);
       mappingColumnFamily.update(claim, persistedMapping);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
-import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,19 +27,16 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
   private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
   private final ArrayProperty<LongValue> roleKeysProp =
       new ArrayProperty<>("roleKeys", LongValue::new);
-  private final ArrayProperty<StringValue> tenantIdsProp =
-      new ArrayProperty<>("tenantIds", StringValue::new);
   private final ArrayProperty<LongValue> groupKeysProp =
       new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedMapping() {
-    super(8);
+    super(7);
     declareProperty(mappingKeyProp)
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
         .declareProperty(roleKeysProp)
-        .declareProperty(tenantIdsProp)
         .declareProperty(groupKeysProp)
         .declareProperty(mappingIdProp);
   }
@@ -110,24 +106,6 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
 
   public PersistedMapping addRoleKey(final long roleKey) {
     roleKeysProp.add().setValue(roleKey);
-    return this;
-  }
-
-  public List<String> getTenantIdsList() {
-    return StreamSupport.stream(tenantIdsProp.spliterator(), false)
-        .map(StringValue::getValue)
-        .map(BufferUtil::bufferAsString)
-        .collect(Collectors.toList());
-  }
-
-  public PersistedMapping setTenantIdsList(final List<String> tenantIds) {
-    tenantIdsProp.reset();
-    tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
-    return this;
-  }
-
-  public PersistedMapping addTenantId(final String tenantId) {
-    tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
@@ -8,32 +8,10 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
 public interface TenantState {
-
-  /**
-   * Retrieves the entity type associated with the given tenant key and entity key.
-   *
-   * @param tenantId the id of the tenant
-   * @param entityId the id of the entity
-   * @return an {@link Optional} containing the {@link EntityType} if it exists, or an empty {@link
-   *     Optional} if not
-   */
-  Optional<EntityType> getEntityType(final String tenantId, final String entityId);
-
-  /**
-   * Retrieves all entities associated with a given tenant id, grouped by their entity type.
-   *
-   * @param tenantId the id of the tenant whose entities are being retrieved
-   * @return a {@link Map} where each key is an {@link EntityType} and the corresponding value is a
-   *     {@link List} of entity ids associated with that type
-   */
-  Map<EntityType, List<String>> getEntitiesByType(String tenantId);
 
   /**
    * Loops over all tenants and applies the provided callback. It stops looping over the tenants,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -18,13 +18,9 @@ public interface MutableMappingState extends MappingState {
 
   void addRole(final long mappingKey, final long roleKey);
 
-  void addTenant(final String mappingId, final String tenantId);
-
   void addGroup(final String mappingId, final long groupKey);
 
   void removeRole(final long mappingKey, final long roleKey);
-
-  void removeTenant(final long mappingKey, final String tenantId);
 
   void removeGroup(final String mappingId, final long groupKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTenantState.java
@@ -26,20 +26,6 @@ public interface MutableTenantState extends TenantState {
   void updateTenant(final TenantRecord updatedTenantRecord);
 
   /**
-   * Adds an entity to the specified tenant.
-   *
-   * @param tenantRecord the tenant record containing the tenant key and the entity to add
-   */
-  void addEntity(final TenantRecord tenantRecord);
-
-  /**
-   * Removes a specific entity from the given tenant.
-   *
-   * @param tenantRecord the tenant record containing the tenant id and the entity to add
-   */
-  void removeEntity(final TenantRecord tenantRecord);
-
-  /**
    * Deletes a tenant and all associated data from the state.
    *
    * @param tenantRecord the tenant record representing the tenant to delete

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -10,18 +10,10 @@ package io.camunda.zeebe.engine.state.tenant;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.DbCompositeKey;
-import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.engine.state.authorization.EntityTypeValue;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -31,25 +23,11 @@ public class DbTenantState implements MutableTenantState {
   private final PersistedTenant persistedTenant = new PersistedTenant();
   private final ColumnFamily<DbString, PersistedTenant> tenantsColumnFamily;
 
-  private final DbForeignKey<DbString> fkTenantId;
-  private final DbString entityId = new DbString();
-  private final EntityTypeValue entityType = new EntityTypeValue();
-  private final DbCompositeKey<DbForeignKey<DbString>, DbString> entityIdByTenantId;
-  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbString>, DbString>, EntityTypeValue>
-      entityByTenantColumnFamily;
-
   public DbTenantState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     tenantsColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.TENANTS, transactionContext, tenantId, new PersistedTenant());
-
-    fkTenantId = new DbForeignKey<>(tenantId, ZbColumnFamilies.TENANTS);
-
-    entityIdByTenantId = new DbCompositeKey<>(fkTenantId, entityId);
-    entityByTenantColumnFamily =
-        zeebeDb.createColumnFamily(
-            ZbColumnFamilies.ENTITY_BY_TENANT, transactionContext, entityIdByTenantId, entityType);
   }
 
   @Override
@@ -69,62 +47,9 @@ public class DbTenantState implements MutableTenantState {
   }
 
   @Override
-  public void addEntity(final TenantRecord tenantRecord) {
-    tenantId.wrapString(tenantRecord.getTenantId());
-    entityId.wrapString(tenantRecord.getEntityId());
-    entityType.setEntityType(tenantRecord.getEntityType());
-    entityByTenantColumnFamily.insert(entityIdByTenantId, entityType);
-  }
-
-  @Override
-  public void removeEntity(final TenantRecord tenantRecord) {
-    tenantId.wrapString(tenantRecord.getTenantId());
-    entityId.wrapString(tenantRecord.getEntityId());
-    entityByTenantColumnFamily.deleteExisting(entityIdByTenantId);
-  }
-
-  @Override
   public void delete(final TenantRecord tenantRecord) {
     tenantId.wrapString(tenantRecord.getTenantId());
-
-    entityByTenantColumnFamily.whileEqualPrefix(
-        fkTenantId,
-        (compositeKey, entityTypeValue) -> {
-          entityByTenantColumnFamily.deleteExisting(compositeKey);
-        });
-
     tenantsColumnFamily.deleteExisting(tenantId);
-  }
-
-  @Override
-  public Optional<EntityType> getEntityType(final String tenantId, final String entityId) {
-    this.tenantId.wrapString(tenantId);
-    this.entityId.wrapString(entityId);
-
-    final var entityTypeValue = entityByTenantColumnFamily.get(entityIdByTenantId);
-
-    if (entityTypeValue == null) {
-      return Optional.empty();
-    }
-
-    return Optional.of(entityTypeValue.getEntityType());
-  }
-
-  @Override
-  public Map<EntityType, List<String>> getEntitiesByType(final String tenantId) {
-    final Map<EntityType, List<String>> entitiesMap = new HashMap<>();
-    this.tenantId.wrapString(tenantId);
-
-    entityByTenantColumnFamily.whileEqualPrefix(
-        fkTenantId,
-        (compositeKey, entityTypeValue) -> {
-          final var entityType = entityTypeValue.getEntityType();
-          final var entityId = compositeKey.second().toString();
-          entitiesMap.putIfAbsent(entityType, new ArrayList<>());
-          entitiesMap.get(entityType).add(entityId);
-        });
-
-    return entitiesMap;
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -10,9 +10,11 @@ package io.camunda.zeebe.engine.state.appliers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
@@ -42,6 +44,7 @@ public class MappingAppliersTest {
   private MutableTenantState tenantState;
   private MutableGroupState groupState;
   private MutableAuthorizationState authorizationState;
+  private MutableMembershipState membershipState;
   private MappingDeletedApplier mappingDeletedApplier;
   private MappingUpdatedApplier mappingUpdatedApplier;
 
@@ -52,6 +55,7 @@ public class MappingAppliersTest {
     tenantState = processingState.getTenantState();
     authorizationState = processingState.getAuthorizationState();
     groupState = processingState.getGroupState();
+    membershipState = processingState.getMembershipState();
     mappingDeletedApplier = new MappingDeletedApplier(processingState.getMappingState());
     mappingUpdatedApplier = new MappingUpdatedApplier(processingState.getMappingState());
   }
@@ -144,7 +148,7 @@ public class MappingAppliersTest {
     // create tenant
     final long tenantKey = 3L;
     final var tenantId = "tenant";
-    mappingState.addTenant(mappingId, tenantId);
+    membershipState.insertRelation(EntityType.MAPPING, mappingId, RelationType.TENANT, tenantId);
     final var tenant =
         new TenantRecord()
             .setTenantId(tenantId)
@@ -152,7 +156,6 @@ public class MappingAppliersTest {
             .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     tenantState.createTenant(tenant);
-    tenantState.addEntity(tenant);
     // create group
     final var groupId = "1";
     final var groupKey = Long.parseLong(groupId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -99,9 +98,10 @@ public class TenantAppliersTest {
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantId, mappingId).get()).isEqualTo(EntityType.MAPPING);
-    final var persistedMapping = mappingState.get(mappingId).get();
-    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.MAPPING, mappingId, RelationType.TENANT, tenantId))
+        .isTrue();
   }
 
   @Test
@@ -182,8 +182,6 @@ public class TenantAppliersTest {
   }
 
   @Test
-  @Disabled(
-      "Disabled while mappings are not supported: https://github.com/camunda/camunda/issues/26981")
   void shouldRemoveEntityFromTenantWithTypeMapping() {
     // given
     final var mappingId = "mappingId";
@@ -200,17 +198,19 @@ public class TenantAppliersTest {
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // Ensure the mapping is associated with the tenant before removal
-    assertThat(tenantState.getEntityType(tenantId, mappingId).get()).isEqualTo(EntityType.MAPPING);
-    final var persistedMapping = mappingState.get(mappingId).get();
-    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.MAPPING, mappingId, RelationType.TENANT, tenantId))
+        .isTrue();
 
     // when
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantId, mappingId)).isEmpty();
-    final var updatedMapping = mappingState.get(mappingId).get();
-    assertThat(updatedMapping.getTenantIdsList()).isEmpty();
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.MAPPING, mappingId, RelationType.TENANT, tenantId))
+        .isFalse();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
-import io.camunda.zeebe.test.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -167,55 +166,6 @@ public class MappingStateTest {
     // then
     final var persistedMapping = mappingState.get(key).get();
     assertThat(persistedMapping.getRoleKeysList()).isEmpty();
-  }
-
-  @Test
-  void shouldAddTenant() {
-    // given
-    final long key = 1L;
-    final String claimName = "foo";
-    final String claimValue = "bar";
-    final String mappingId = Strings.newRandomValidIdentityId();
-    final var mapping =
-        new MappingRecord()
-            .setMappingId(mappingId)
-            .setMappingKey(key)
-            .setClaimName(claimName)
-            .setClaimValue(claimValue);
-    mappingState.create(mapping);
-    final var tenantId = "tenant";
-
-    // when
-    mappingState.addTenant(mappingId, tenantId);
-
-    // then
-    final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
-  }
-
-  @Test
-  void shouldRemoveTenant() {
-    // given
-    final long key = 1L;
-    final String claimName = "foo";
-    final String claimValue = "bar";
-    final String mappingId = Strings.newRandomValidIdentityId();
-    final var mapping =
-        new MappingRecord()
-            .setMappingId(mappingId)
-            .setMappingKey(key)
-            .setClaimName(claimName)
-            .setClaimValue(claimValue);
-    mappingState.create(mapping);
-    final var tenantId = "tenant";
-    mappingState.addTenant(mappingId, tenantId);
-
-    // when
-    mappingState.removeTenant(key, tenantId);
-
-    // then
-    final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getTenantIdsList()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
We now track mapping tenant membership in the generalized membership state instead of the `PersistedMapping` and `TenantState`.

closes #30457