### PR TITLE
test: unskip v2 tests

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -46,6 +46,11 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const getOperationSpy = jest.spyOn(operationApi, 'getOperation');
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: false,
+}));
+
 jest.mock('modules/stores/notifications', () => ({
   notificationsStore: {
     displayNotification: jest.fn(() => () => {}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -94,14 +94,14 @@ describe('VariablePanel', () => {
   beforeEach(() => {
     const statistics = [
       {
-        flowNodeId: 'TEST_FLOW_NODE',
+        elementId: 'TEST_FLOW_NODE',
         active: 0,
         canceled: 0,
         incidents: 0,
         completed: 1,
       },
       {
-        flowNodeId: 'Activity_0qtp1k6',
+        elementId: 'Activity_0qtp1k6',
         active: 0,
         canceled: 0,
         incidents: 1,
@@ -1468,11 +1468,9 @@ describe('VariablePanel', () => {
       cancelAllTokens('Activity_0qtp1k6', 0, 0);
     });
 
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('button', {name: /add variable/i}),
-      ).not.toBeInTheDocument(),
-    );
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
 
     expect(
       screen.getByText('The Flow Node has no Variables'),
@@ -1580,14 +1578,14 @@ describe('VariablePanel', () => {
     const mockData: GetProcessInstanceStatisticsResponseBody = {
       items: [
         {
-          flowNodeId: 'TEST_FLOW_NODE',
+          elementId: 'TEST_FLOW_NODE',
           active: 0,
           canceled: 0,
           incidents: 0,
           completed: 1,
         },
         {
-          flowNodeId: 'Activity_0qtp1k6',
+          elementId: 'Activity_0qtp1k6',
           active: 2,
           canceled: 0,
           incidents: 0,
@@ -1709,14 +1707,14 @@ describe('VariablePanel', () => {
   it('should display correct state for a flow node that has only one finished token on it', async () => {
     const statistics = [
       {
-        flowNodeId: 'StartEvent_1',
+        elementId: 'StartEvent_1',
         active: 1,
         canceled: 0,
         incidents: 0,
         completed: 0,
       },
       {
-        flowNodeId: 'Activity_0qtp1k6',
+        elementId: 'Activity_0qtp1k6',
         active: 0,
         canceled: 0,
         incidents: 0,

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/v2/index.test.tsx
@@ -7,21 +7,40 @@
  */
 
 import {act, render, screen} from 'modules/testing-library';
-import {Bar} from './index';
-import {mockStartNode, mockStartEventBusinessObject} from './index.setup';
+import {Bar} from '../index';
+import {mockStartNode, mockStartEventBusinessObject} from '../index.setup';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
 import {MOCK_TIMESTAMP} from 'modules/utils/date/__mocks__/formatDate';
 import {useEffect} from 'react';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {Paths} from 'modules/Routes';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: false,
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
 }));
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
-  useEffect(() => flowNodeTimeStampStore.reset, []);
+  useEffect(() => {
+    return () => {
+      flowNodeTimeStampStore.reset();
+    };
+  }, []);
 
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
 describe('<Bar />', () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -97,7 +97,7 @@ describe('Modification Dropdown', () => {
     modificationsStore.enableModificationMode();
   });
 
-  it.skip('should not render dropdown when no flow node is selected', async () => {
+  it('should not render dropdown when no flow node is selected', async () => {
     renderPopover();
 
     await waitFor(() =>
@@ -355,7 +355,7 @@ describe('Modification Dropdown', () => {
     expect(screen.getByText(/Move/)).toBeInTheDocument();
   });
 
-  it.skip('should not support move operation for sub processes', async () => {
+  it('should not support move operation for sub processes', async () => {
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('diagramForModifications.bpmn'),
@@ -389,7 +389,7 @@ describe('Modification Dropdown', () => {
     expect(screen.getByText(/Cancel/)).toBeInTheDocument();
   });
 
-  it.skip('should display spinner when loading meta data', async () => {
+  it('should display spinner when loading meta data', async () => {
     init(statisticsData);
 
     renderPopover();

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
@@ -78,7 +78,7 @@ describe('selectedRunningInstanceCount', () => {
     );
   });
 
-  it.skip('should not render when there are no running instances selected', async () => {
+  it('should not render when there are no running instances selected', async () => {
     modificationsStore.enableModificationMode();
 
     renderPopover();
@@ -104,7 +104,7 @@ describe('selectedRunningInstanceCount', () => {
     ).not.toBeInTheDocument();
   });
 
-  it.skip('should render when there are running instances selected', async () => {
+  it('should render when there are running instances selected', async () => {
     modificationsStore.enableModificationMode();
 
     renderPopover();


### PR DESCRIPTION
## Description

As we migrated the components away from the FI statistics store + XML diagram store, we ran into unstable tests setup and have skipped tests along the way. Now that the stores are more stable, this PR unskips all the remaining tests in v2 components. 

I'm also fixing/updating the Variables test with the changes from statistics and XML queries.

## Related issues

related to #30785
