### PR TITLE
feat: batch operation migrate process instanves engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -61,9 +61,8 @@ public final class BatchOperationCreateProcessor
     LOGGER.debug("Processing new command with key '{}': {}", key, recordValue);
 
     final var recordWithKey = new BatchOperationCreationRecord();
+    recordWithKey.wrap(recordValue);
     recordWithKey.setBatchOperationKey(key);
-    recordWithKey.setBatchOperationType(recordValue.getBatchOperationType());
-    recordWithKey.setEntityFilter(command.getValue().getEntityFilterBuffer());
 
     stateWriter.appendFollowUpEvent(key, BatchOperationIntent.CREATED, recordWithKey);
     responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -165,7 +165,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
         () -> !batchOperationState.exists(batchOperation.getKey());
 
     return switch (batchOperation.getBatchOperationType()) {
-      case PROCESS_CANCELLATION ->
+      case PROCESS_CANCELLATION, MIGRATE_PROCESS_INSTANCE ->
           entityKeyProvider.fetchProcessInstanceKeys(
               batchOperation.getEntityFilter(ProcessInstanceFilter.class), abortCondition);
       case RESOLVE_INCIDENT ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.CancelProcessInstanceBatchOperationExecutor;
+import io.camunda.zeebe.engine.processing.batchoperation.handlers.MigrateProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveIncidentBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -42,7 +43,10 @@ public final class BatchOperationSetupProcessors {
             new CancelProcessInstanceBatchOperationExecutor(writers.command()),
             BatchOperationType.RESOLVE_INCIDENT,
             new ResolveIncidentBatchOperationExecutor(
-                writers.command(), processingState.getIncidentState()));
+                writers.command(), processingState.getIncidentState()),
+            BatchOperationType.MIGRATE_PROCESS_INSTANCE,
+            new MigrateProcessInstanceBatchOperationExecutor(
+                writers.command(), processingState.getBatchOperationState()));
 
     typedRecordProcessors
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.handlers;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MigrateProcessInstanceBatchOperationExecutor implements BatchOperationExecutor {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MigrateProcessInstanceBatchOperationExecutor.class);
+
+  final TypedCommandWriter commandWriter;
+  final BatchOperationState batchOperationState;
+
+  public MigrateProcessInstanceBatchOperationExecutor(
+      final TypedCommandWriter commandWriter, final BatchOperationState batchOperationState) {
+    this.commandWriter = commandWriter;
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void execute(final long processInstanceKey, final PersistedBatchOperation batchOperation) {
+    LOGGER.info("Migrate process instance with key '{}'", processInstanceKey);
+
+    final var migrationPlan = batchOperation.getMigrationPlan();
+
+    final var command = new ProcessInstanceMigrationRecord();
+    command.setProcessInstanceKey(processInstanceKey);
+    command.setTargetProcessDefinitionKey(migrationPlan.getTargetProcessDefinitionKey());
+    migrationPlan
+        .getMappingInstructions()
+        .forEach(
+            mappingInstruction -> {
+              command.addMappingInstruction(
+                  new ProcessInstanceMigrationMappingInstruction()
+                      .setSourceElementId(mappingInstruction.getSourceElementId())
+                      .setTargetElementId(mappingInstruction.getTargetElementId()));
+            });
+
+    commandWriter.appendFollowUpCommand(
+        processInstanceKey,
+        ProcessInstanceMigrationIntent.MIGRATE,
+        command,
+        batchOperation.getKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -13,9 +13,12 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationProcessInstanceMigrationPlanValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.Comparator;
 import org.agrona.DirectBuffer;
@@ -29,15 +32,18 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final EnumProperty<BatchOperationStatus> statusProp =
       new EnumProperty<>("status", BatchOperationStatus.class);
   private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");
+  private final ObjectProperty<BatchOperationProcessInstanceMigrationPlan> migrationPlanProp =
+      new ObjectProperty<>("migrationPlan", new BatchOperationProcessInstanceMigrationPlan());
   private final ArrayProperty<LongValue> chunkKeysProp =
       new ArrayProperty<>("chunkKeys", LongValue::new);
 
   public PersistedBatchOperation() {
-    super(5);
+    super(6);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
         .declareProperty(entityFilterProp)
+        .declareProperty(migrationPlanProp)
         .declareProperty(chunkKeysProp);
   }
 
@@ -45,6 +51,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     setKey(record.getBatchOperationKey());
     setBatchOperationType(record.getBatchOperationType());
     setEntityFilter(record.getEntityFilterBuffer());
+    setMigrationPlan(record.getMigrationPlan());
     return this;
   }
 
@@ -106,6 +113,16 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public <T> T getEntityFilter(final Class<T> clazz) {
     return MsgPackConverter.convertToObject(entityFilterProp.getValue(), clazz);
+  }
+
+  public BatchOperationProcessInstanceMigrationPlan getMigrationPlan() {
+    return migrationPlanProp.getValue();
+  }
+
+  public PersistedBatchOperation setMigrationPlan(
+      final BatchOperationProcessInstanceMigrationPlanValue migrationPlan) {
+    migrationPlanProp.getValue().wrap(migrationPlan);
+    return this;
   }
 
   public long nextChunkKey() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/MigrateProcessesBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/MigrateProcessesBatchExecutorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.test.util.collection.Maps;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public final class MigrateProcessesBatchExecutorTest extends AbstractBatchOperationTest {
+
+  @Test
+  public void shouldMigrateProcess() {
+    // given
+    // create a process with a user task a
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process").startEvent().userTask("userTaskA").done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+
+    // create another process with a user task b
+    final long processDefinitionKey2 =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2").startEvent().userTask("userTaskB").done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariables(Maps.of(entry("foo", "bar")))
+            .create();
+
+    // wait for the user task to exist
+    RecordingExporter.jobRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(JobIntent.CREATED)
+        .getFirst();
+
+    // then start the batch where we migrate to a target process definition with a user task b
+    final var batchOperationKey =
+        createNewMigrateProcessesBatchOperation(
+            Set.of(processInstanceKey), processDefinitionKey2, Map.of("userTaskA", "userTaskB"));
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a migrated event
+    assertThat(
+            RecordingExporter.processInstanceMigrationRecords().withRecordKey(processInstanceKey))
+        .extracting(Record::getIntent)
+        .containsSequence(ProcessInstanceMigrationIntent.MIGRATED);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationProcessInstanceMigrationPlanValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
@@ -90,6 +91,12 @@ public final class BatchOperationClient {
 
     public BatchOperationCreationClient withFilter(final DirectBuffer filter) {
       batchOperationCreationRecord.setEntityFilter(filter);
+      return this;
+    }
+
+    public BatchOperationCreationClient withMigrationPlan(
+        final BatchOperationProcessInstanceMigrationPlanValue migrationPlan) {
+      batchOperationCreationRecord.setMigrationPlan(migrationPlan);
       return this;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -90,4 +90,12 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public DirectBuffer getEntityFilterBuffer() {
     return entityFilterProp.getValue();
   }
+
+  public BatchOperationCreationRecord wrap(final BatchOperationCreationRecord record) {
+    batchOperationKeyProp.setValue(record.getBatchOperationKey());
+    batchOperationTypeProp.setValue(record.getBatchOperationType());
+    entityFilterProp.setValue(record.getEntityFilterBuffer());
+    migrationPlanProp.getValue().wrap(record.getMigrationPlan());
+    return this;
+  }
 }


### PR DESCRIPTION
## Description

This is the follow-up PR for https://github.com/camunda/camunda/pull/31017. 

* It extends the batch operation scheduler to also query keys for the new type (MIGRATE_PROCESS_INSTANCE)
* It extends the batch operation state to persist the new needed fields. (migration plan)
* It adds a new BatchOperationExecutor for migrate process instances
* Tests for all of those aspects. 

## Related issues

closes #29885 
