### PR TITLE
feat: batch operation migrate process instances rdbms exporter + e2e test

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -36,6 +36,13 @@ public interface CreateBatchOperationCommandStep1 {
    */
   CreateBatchOperationCommandStep2<ProcessInstanceFilter> resolveIncident();
 
+  /**
+   * Defines the type of the batch operation to migrate process instances.
+   *
+   * @return the builder for this command
+   */
+  ProcessInstanceMigrationStep<ProcessInstanceFilter> migrateProcessInstance();
+
   interface CreateBatchOperationCommandStep2<E extends SearchRequestFilter> {
 
     /**
@@ -53,6 +60,17 @@ public interface CreateBatchOperationCommandStep1 {
      * @return the builder for fluent use
      */
     CreateBatchOperationCommandStep3<E> filter(Consumer<E> filter);
+  }
+
+  interface ProcessInstanceMigrationStep<E extends SearchRequestFilter>
+      extends CreateBatchOperationCommandStep2<E> {
+
+    ProcessInstanceMigrationStep<E> migrationPlan(MigrationPlan migrationPlan);
+
+    ProcessInstanceMigrationStep<E> addMappingInstruction(
+        String sourceElementId, String targetElementId);
+
+    ProcessInstanceMigrationStep<E> targetProcessDefinitionKey(long targetProcessDefinitionKey);
   }
 
   interface CreateBatchOperationCommandStep3<E extends SearchRequestFilter>

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -22,7 +22,9 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1.CreateBatchOperationCommandStep2;
 import io.camunda.client.api.command.CreateBatchOperationCommandStep1.CreateBatchOperationCommandStep3;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1.ProcessInstanceMigrationStep;
 import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.request.SearchRequestBuilders;
@@ -32,6 +34,9 @@ import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateBatchOperationResponseImpl;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceMigrationInstruction;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +45,9 @@ import java.util.function.Function;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
-    implements CreateBatchOperationCommandStep2<E>, CreateBatchOperationCommandStep3<E> {
+    implements ProcessInstanceMigrationStep<E>,
+        CreateBatchOperationCommandStep2<E>,
+        CreateBatchOperationCommandStep3<E> {
   private final HttpClient httpClient;
   private final JsonMapper jsonMapper;
   private final RequestConfig.Builder httpRequestConfig;
@@ -48,6 +55,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
   private final BatchOperationTypeEnum type;
   private final Function<Consumer<E>, E> filterFactory;
   private E filter;
+  private final ProcessInstanceMigrationInstruction migrationPlan =
+      new ProcessInstanceMigrationInstruction();
 
   public CreateBatchOperationCommandImpl(
       final HttpClient httpClient,
@@ -89,7 +98,7 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     final CreateBatchOperationResponseImpl response = new CreateBatchOperationResponseImpl();
     httpClient.post(
         getUrl(),
-        jsonMapper.toJson(provideSearchRequestProperty(filter)),
+        jsonMapper.toJson(getBody()),
         httpRequestConfig.build(),
         BatchOperationCreatedResult.class,
         response::setResponse,
@@ -103,9 +112,52 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
         return "/process-instances/batch-operations/cancellation";
       case RESOLVE_INCIDENT:
         return "/process-instances/batch-operations/incident-resolution";
+      case MIGRATE_PROCESS_INSTANCE:
+        return "/process-instances/batch-operations/migration";
       default:
         throw new IllegalArgumentException("Unsupported batch operation type: " + type);
     }
+  }
+
+  private Object getBody() {
+    if (type == BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE) {
+      return new ProcessInstanceMigrationBatchOperationInstruction()
+          .filter(provideSearchRequestProperty(filter))
+          .migrationPlan(migrationPlan);
+    } else {
+      return provideSearchRequestProperty(filter);
+    }
+  }
+
+  @Override
+  public ProcessInstanceMigrationStep<E> migrationPlan(final MigrationPlan migrationPlan) {
+    targetProcessDefinitionKey(migrationPlan.getTargetProcessDefinitionKey());
+    migrationPlan
+        .getMappingInstructions()
+        .forEach(
+            instruction ->
+                addMappingInstruction(
+                    instruction.getSourceElementId(), instruction.getTargetElementId()));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceMigrationStep<E> addMappingInstruction(
+      final String sourceElementId, final String targetElementId) {
+    Objects.requireNonNull(sourceElementId, "must specify a source element id");
+    Objects.requireNonNull(targetElementId, "must specify a target element id");
+    migrationPlan.addMappingInstructionsItem(
+        new MigrateProcessInstanceMappingInstruction()
+            .sourceElementId(sourceElementId)
+            .targetElementId(targetElementId));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceMigrationStep<E> targetProcessDefinitionKey(
+      final long targetProcessDefinitionKey) {
+    migrationPlan.targetProcessDefinitionKey(String.valueOf(targetProcessDefinitionKey));
+    return this;
   }
 
   public static class CreateBatchOperationCommandStep1Impl
@@ -135,6 +187,15 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
           httpClient,
           jsonMapper,
           BatchOperationTypeEnum.RESOLVE_INCIDENT,
+          SearchRequestBuilders::processInstanceFilter);
+    }
+
+    @Override
+    public ProcessInstanceMigrationStep<ProcessInstanceFilter> migrateProcessInstance() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
     }
   }

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -19,9 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.protocol.rest.MigrateProcessInstanceMappingInstruction;
 import io.camunda.client.protocol.rest.ProcessInstanceFilter;
+import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceMigrationInstruction;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public final class CreateBatchOperationTest extends ClientRestTest {
@@ -62,5 +66,38 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
     final ProcessInstanceFilter filter = gatewayService.getLastRequest(ProcessInstanceFilter.class);
     assertThat(filter.getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+  }
+
+  @Test
+  public void shouldSendProcessInstanceMigrationCommand() {
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .migrateProcessInstance()
+        .addMappingInstruction("source", "target")
+        .addMappingInstruction("source2", "target2")
+        .targetProcessDefinitionKey(1L)
+        .filter(filter -> filter.processDefinitionId("test-01"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/batch-operations/migration");
+
+    final ProcessInstanceMigrationBatchOperationInstruction lastRequest =
+        gatewayService.getLastRequest(ProcessInstanceMigrationBatchOperationInstruction.class);
+    assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+    final ProcessInstanceMigrationInstruction migrationPlan = lastRequest.getMigrationPlan();
+    assertThat(migrationPlan).isNotNull();
+    assertThat(migrationPlan.getTargetProcessDefinitionKey()).isEqualTo("1");
+    final List<MigrateProcessInstanceMappingInstruction> mappingInstructions =
+        migrationPlan.getMappingInstructions();
+    assertThat(mappingInstructions).hasSize(2);
+    assertThat(mappingInstructions.get(0).getSourceElementId()).isEqualTo("source");
+    assertThat(mappingInstructions.get(0).getTargetElementId()).isEqualTo("target");
+    assertThat(mappingInstructions.get(1).getSourceElementId()).isEqualTo("source2");
+    assertThat(mappingInstructions.get(1).getTargetElementId()).isEqualTo("target2");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
+import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.filter.VariableFilter;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import org.assertj.core.api.ThrowingConsumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchOperationMigrateProcessInstanceTest {
+
+  static final List<Long> PROCESS_INSTANCES = new ArrayList<>();
+
+  private static CamundaClient client;
+
+  @AfterAll
+  static void afterAll() {
+    PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldMigrateProcessInstancesWithBatch() {
+    // given
+    final long sourceProcessDefinitionKey =
+        deployProcessFromClasspath(client, "process/migration-process_v1.bpmn");
+    final var targetProcessDefinitionKey =
+        deployProcessFromClasspath(client, "process/migration-process_v2.bpmn");
+
+    IntStream.range(0, 10)
+        .forEach(
+            i -> {
+              final var processInstanceKey =
+                  startProcessInstance(client, sourceProcessDefinitionKey, Map.of("foo", "bar"));
+              PROCESS_INSTANCES.add(processInstanceKey);
+            });
+
+    waitForProcessInstancesToStart(client, PROCESS_INSTANCES.size());
+
+    // when
+    final var batchCreated =
+        batchMigrateProcessInstance(
+            client,
+            sourceProcessDefinitionKey,
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                .addMappingInstruction("taskA", "taskA2")
+                .addMappingInstruction("taskB", "taskB2")
+                .addMappingInstruction("taskC", "taskC2")
+                .build());
+
+    // then
+    Awaitility.await("should complete batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  client
+                      .newBatchOperationGetRequest(batchCreated.getBatchOperationKey())
+                      .send()
+                      .join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getEndDate()).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+              assertThat(batch.getOperationsTotalCount()).isEqualTo(PROCESS_INSTANCES.size());
+              assertThat(batch.getOperationsCompletedCount()).isEqualTo(PROCESS_INSTANCES.size());
+              assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+            });
+
+    Awaitility.await("should update batch operation items")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batchItems =
+                  client
+                      .newBatchOperationItemsGetRequest(batchCreated.getBatchOperationKey())
+                      .send()
+                      .join()
+                      .items();
+              assertThat(batchItems).isNotEmpty();
+              assertThat(batchItems).hasSize(PROCESS_INSTANCES.size());
+              assertThat(batchItems.stream().map(BatchOperationItem::getStatus).distinct().toList())
+                  .containsExactly(BatchOperationItemState.COMPLETED);
+            });
+
+    // and
+    for (final var processInstanceKey : PROCESS_INSTANCES) {
+      processInstanceExistAndMatches(
+          client,
+          f -> f.processInstanceKey(processInstanceKey).processDefinitionId("migration-process_v2"),
+          f -> assertThat(f).hasSize(1));
+      processInstanceHasUserTask(
+          client,
+          processInstanceKey,
+          userTask -> {
+            assertThat(userTask.getElementId()).isEqualTo("taskA2");
+            assertThat(userTask.getBpmnProcessId()).isEqualTo("migration-process_v2");
+            assertThat(userTask.getProcessDefinitionVersion()).isEqualTo(1);
+          });
+      processInstanceHasElementInstances(
+          client,
+          processInstanceKey,
+          Map.of(
+              "start", fni -> fni.getProcessDefinitionId().equals("migration-process_v1"),
+              "gateway1", fni -> fni.getProcessDefinitionId().equals("migration-process_v1"),
+              "taskA2", fni -> fni.getProcessDefinitionId().equals("migration-process_v2"),
+              "taskB2", fni -> fni.getProcessDefinitionId().equals("migration-process_v2")));
+      processInstanceHasVariables(
+          client, processInstanceKey, Map.of("foo", v -> v.getValue().equals("\"bar\"")));
+    }
+  }
+
+  public CreateBatchOperationResponse batchMigrateProcessInstance(
+      final CamundaClient client,
+      final long sourceProcessDefinitionKey,
+      final MigrationPlan migrationPlan) {
+    return client
+        .newCreateBatchOperationCommand()
+        .migrateProcessInstance()
+        .migrationPlan(migrationPlan)
+        .filter(new ProcessInstanceFilterImpl().processDefinitionKey(sourceProcessDefinitionKey))
+        .send()
+        .join();
+  }
+
+  public static Long deployProcessFromClasspath(
+      final CamundaClient client, final String classpath) {
+    final var deployment =
+        client.newDeployResourceCommand().addResourceFromClasspath(classpath).send().join();
+    final var event = deployment.getProcesses().getFirst();
+
+    // sync with exported database
+    processDefinitionExistAndMatches(
+        client,
+        f -> f.processDefinitionKey(event.getProcessDefinitionKey()),
+        f -> assertThat(f).hasSize(1));
+
+    return event.getProcessDefinitionKey();
+  }
+
+  //
+  // Query helpers
+  //
+  public void processInstanceHasUserTask(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final ThrowingConsumer<UserTask> assertions) {
+    userTaskExistAndMatches(
+        client,
+        f -> f.processInstanceKey(processInstanceKey),
+        f -> {
+          assertThat(f).hasSize(1);
+          assertThat(f.getFirst()).satisfies(assertions);
+        });
+  }
+
+  public void processInstanceHasElementInstances(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final Map<String, Predicate<ElementInstance>> flowNodeAssertions) {
+    flowNodeInstanceExistAndMatches(
+        client,
+        f -> f.processInstanceKey(processInstanceKey),
+        f -> {
+          assertThat(f).hasSize(flowNodeAssertions.size());
+          f.forEach(
+              fni -> assertThat(flowNodeAssertions.get(fni.getElementId()).test(fni)).isTrue());
+        });
+  }
+
+  public void processInstanceHasVariables(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final Map<String, Predicate<Variable>> assertions) {
+    variableExistAndMatches(
+        client,
+        f -> f.processInstanceKey(processInstanceKey),
+        list -> {
+          assertThat(list).hasSize(assertions.size());
+          list.forEach(v -> assertThat(assertions.get(v.getName()).test(v)).isTrue());
+        });
+  }
+
+  public void flowNodeInstanceExistAndMatches(
+      final CamundaClient client,
+      final Consumer<ElementInstanceFilter> filter,
+      final Consumer<List<ElementInstance>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newElementInstanceSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+
+  public void variableExistAndMatches(
+      final CamundaClient client,
+      final Consumer<VariableFilter> filter,
+      final Consumer<List<Variable>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newVariableSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+
+  public static void processDefinitionExistAndMatches(
+      final CamundaClient client,
+      final Consumer<ProcessDefinitionFilter> filter,
+      final Consumer<List<ProcessDefinition>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newProcessDefinitionSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+
+  public void processInstanceExistAndMatches(
+      final CamundaClient client,
+      final Consumer<ProcessInstanceFilter> filter,
+      final Consumer<List<ProcessInstance>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newProcessInstanceSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+
+  public void userTaskExistAndMatches(
+      final CamundaClient client,
+      final Consumer<UserTaskFilter> filter,
+      final Consumer<List<UserTask>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newUserTaskSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+
+  public static long startProcessInstance(
+      final CamundaClient client,
+      final long processDefinitionKey,
+      final Map<String, Object> variables) {
+    return client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(processDefinitionKey)
+        .variables(variables)
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationExecutionRe
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableRoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
@@ -591,6 +593,47 @@ public class RecordFixtures {
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
         .withOperationReference(batchOperationKey)
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getBatchOperationProcessMigratedRecord(
+      final Long processInstanceKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_MIGRATION);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+        .withKey(processInstanceKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .withValue(
+            ImmutableProcessInstanceMigrationRecordValue.builder()
+                .from((ImmutableProcessInstanceMigrationRecordValue) recordValueRecord.getValue())
+                .withProcessInstanceKey(processInstanceKey)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getFailedBatchOperationProcessMigratedRecord(
+      final Long processInstanceKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_MIGRATION);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .withRejectionType(RejectionType.INVALID_STATE)
+        .withKey(processInstanceKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .withValue(
+            ImmutableProcessInstanceMigrationRecordValue.builder()
+                .from((ImmutableProcessInstanceMigrationRecordValue) recordValueRecord.getValue())
+                .withProcessInstanceKey(processInstanceKey)
+                .build())
         .build();
   }
 }

--- a/qa/acceptance-tests/src/test/resources/log4j2-test.xml
+++ b/qa/acceptance-tests/src/test/resources/log4j2-test.xml
@@ -26,8 +26,9 @@
     <Logger name="io.atomix.raft" level="debug"/>
 
     <Logger name="org.apache.ibatis" level="debug"/>
-    <Logger name="io.camunda.db.rdbms" level="debug"/>
+    <Logger name="io.camunda.db.rdbms" level="info"/>
     <Logger name="io.camunda.exporter.rdbms" level="debug"/>
+    <Logger name="io.camunda.zeebe.engine.processing.batchoperation" level="trace"/>
     <Logger name="io.camunda.zeebe.gateway.rest" level="debug"/>
 
     <Root level="info">

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -160,13 +160,13 @@ public class RdbmsExporter {
   }
 
   private void updatePositionInBroker() {
-    LOG.debug("[RDBMS Exporter] Updating position to {} in broker", lastPosition);
+    LOG.trace("[RDBMS Exporter] Updating position to {} in broker", lastPosition);
     controller.updateLastExportedRecordPosition(lastPosition);
   }
 
   private void updatePositionInRdbms() {
     if (lastPosition > exporterRdbmsPosition.lastExportedPosition()) {
-      LOG.debug("[RDBMS Exporter] Updating position to {} in rdbms", lastPosition);
+      LOG.trace("[RDBMS Exporter] Updating position to {} in rdbms", lastPosition);
       exporterRdbmsPosition =
           new ExporterPositionModel(
               exporterRdbmsPosition.partitionId(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -34,6 +34,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationCreatedEx
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationLifecycleManagementExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.IncidentBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceBatchOperationCanceledExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -228,5 +229,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.INCIDENT,
         new IncidentBatchOperationExportHandler(rdbmsWriter.getBatchOperationWriter()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        new ProcessInstanceMigrationBatchOperationExportHandler(
+            rdbmsWriter.getBatchOperationWriter()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -33,7 +33,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationCompleted
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationCreatedExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationLifecycleManagementExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.IncidentBatchOperationExportHandler;
-import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceBatchOperationCanceledExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancellationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -224,7 +224,7 @@ public class RdbmsExporterWrapper implements Exporter {
     // Handlers per batch operation to track status
     builder.withHandler(
         ValueType.PROCESS_INSTANCE,
-        new ProcessInstanceBatchOperationCanceledExportHandler(
+        new ProcessInstanceCancellationBatchOperationExportHandler(
             rdbmsWriter.getBatchOperationWriter()));
     builder.withHandler(
         ValueType.INCIDENT,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -15,10 +15,10 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 
 /** This aggregates the batch operation status of process instance cancellations */
-public class ProcessInstanceBatchOperationCanceledExportHandler
+public class ProcessInstanceCancellationBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceRecordValue> {
 
-  public ProcessInstanceBatchOperationCanceledExportHandler(
+  public ProcessInstanceCancellationBatchOperationExportHandler(
       final BatchOperationWriter batchOperationWriter) {
     super(batchOperationWriter);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+
+/** This aggregates the batch operation status of process instance cancellations */
+public class ProcessInstanceMigrationBatchOperationExportHandler
+    extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceMigrationRecordValue> {
+
+  public ProcessInstanceMigrationBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter) {
+    super(batchOperationWriter);
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  boolean isCompleted(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
+  }
+
+  @Override
+  boolean isFailed(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATE)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}


### PR DESCRIPTION
## Description

This is the follow-up PR for https://github.com/camunda/camunda/pull/31162. 

* It adds a new rdbms export handler to track the status of process instance migrations which are related to a batch operation
* It extends the camunda client to be able to start a batch operation with the new type (MIGRATE_PROCESS_INSTANCE)
* It adds a Test for the rdbms exporter
* It adds an acceptance test for the new batch operation type

## Related issues

closes #31158
