### PR TITLE
fix: exclude completed non end events from stats

### DIFF
--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.test.tsx
@@ -40,7 +40,7 @@ describe('useProcessInstancesOverlayStatistics', () => {
     jest.clearAllMocks();
   });
 
-  it('should fetch process instances overlay statistics successfully', async () => {
+  it('should fetch process instances overlay statistics successfully excluding completed non-end events', async () => {
     const mockData = [
       {
         elementId: 'messageCatchEvent',
@@ -86,18 +86,6 @@ describe('useProcessInstancesOverlayStatistics', () => {
           left: 0,
         },
         type: 'statistics-canceled',
-      },
-      {
-        flowNodeId: 'messageCatchEvent',
-        payload: {
-          count: 4,
-          flowNodeState: 'completedEndEvents',
-        },
-        position: {
-          bottom: 1,
-          left: 17,
-        },
-        type: 'statistics-completedEndEvents',
       },
     ];
 

--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
@@ -30,18 +30,22 @@ const overlayPositions = {
   completedEndEvents: COMPLETED_END_EVENT_BADGE,
 };
 
-export function overlayParser(
+const overlayParser = (
   data: GetProcessDefinitionStatisticsResponseBody,
-): OverlayData[] {
+): OverlayData[] => {
   const flowNodeStates = flowNodeStatesParser(data);
 
-  return flowNodeStates.map(({flowNodeState, count, flowNodeId}) => ({
-    payload: {flowNodeState, count},
-    type: `statistics-${flowNodeState}`,
-    flowNodeId,
-    position: overlayPositions[flowNodeState],
-  }));
-}
+  return flowNodeStates
+    .filter(
+      (flowNodeData) => flowNodeData.flowNodeState !== 'completedEndEvents',
+    )
+    .map(({flowNodeState, count, flowNodeId}) => ({
+      payload: {flowNodeState, count},
+      type: `statistics-${flowNodeState}`,
+      flowNodeId,
+      position: overlayPositions[flowNodeState],
+    }));
+};
 
 function useProcessInstancesOverlayData(
   payload: GetProcessDefinitionStatisticsRequestBody,


### PR DESCRIPTION
## Description

This PR updates the frontend to exclude non end events from the diagram stats overlay data. I'm doing this by adding a filter on a flownode state we have specifically for this use case.

BEFORE:

![Screenshot 2568-04-17 at 14 44 17](https://github.com/user-attachments/assets/26131c9c-70c7-4d39-a74d-1ca491726036)


AFTER:

https://github.com/user-attachments/assets/363cd9c2-94ff-41c0-a4c4-6447da67a2bf

To test this locally, we must remove the [mock handler](https://github.com/camunda/camunda/blob/1bf368922e41181542bef8ddc8f97575b21dd9ab/operate/client/src/modules/mock-server/handlers.ts#L68-L69) and [enable this feature flag](https://github.com/camunda/camunda/blob/1bf368922e41181542bef8ddc8f97575b21dd9ab/operate/client/src/modules/feature-flags.ts#L11-L12)

## Related issues

related to #30906
