### PR TITLE
[stable/8.6] fix: removal of meter registry workaround

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
@@ -20,10 +20,6 @@ import io.camunda.zeebe.spring.client.actuator.MicrometerMetricsRecorder;
 import io.camunda.zeebe.spring.client.actuator.ZeebeClientHealthIndicator;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -41,25 +37,8 @@ import org.springframework.context.annotation.Lazy;
 public class ZeebeActuatorConfiguration {
   @Bean
   @ConditionalOnMissingBean
-  public MetricsRecorder micrometerMetricsRecorder(
-      final @Autowired @Lazy MeterRegistry meterRegistry) {
+  public MetricsRecorder micrometerMetricsRecorder(@Lazy final MeterRegistry meterRegistry) {
     return new MicrometerMetricsRecorder(meterRegistry);
-  }
-
-  /**
-   * Workaround to fix premature initialization of MeterRegistry that seems to happen here, see
-   * https://github.com/camunda-community-hub/spring-zeebe/issues/296
-   */
-  @Bean
-  InitializingBean forceMeterRegistryPostProcessor(
-      final @Autowired(required = false) @Qualifier("meterRegistryPostProcessor") BeanPostProcessor
-              meterRegistryPostProcessor,
-      final @Autowired(required = false) MeterRegistry registry) {
-    if (registry == null || meterRegistryPostProcessor == null) {
-      return () -> {};
-    } else {
-      return () -> meterRegistryPostProcessor.postProcessAfterInitialization(registry, "");
-    }
   }
 
   @Bean


### PR DESCRIPTION
## Description

Removal of code added to fix lack of general metrics, as it caused warnings from micrometer, see linked issue.

Original workaround got added with: https://github.com/camunda-community-hub/spring-zeebe/issues/296

However removing the `forceMeterRegistryPostProcessor` method now didn't cause default metrics to disappear anymore, like originally reported with https://github.com/camunda-community-hub/spring-zeebe/issues/296.

I verified this via this [draft](https://github.com/camunda/camunda-8-get-started-spring/pull/11) on the get started with spring example. The app logs were free of warnings and the standard metrics as well as the client metrics were available on the metrics / prometheus actuator endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30812
