### PR TITLE
Feat/31169 bo e2e test for modify process instance

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
@@ -66,7 +66,7 @@ public class BatchOperationMigrateProcessInstanceTest {
     final var targetProcessDefinitionKey =
         deployProcessFromClasspath(client, "process/migration-process_v2.bpmn");
 
-    IntStream.range(0, 10)
+    IntStream.range(0, 20)
         .forEach(
             i -> {
               final var processInstanceKey =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationModifyProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationModifyProcessInstanceTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.filter;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1.CreateBatchOperationCommandStep3;
+import io.camunda.client.api.command.CreateBatchOperationCommandStep1.ProcessInstanceModificationStep;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchOperationModifyProcessInstanceTest {
+
+  static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  static final List<Long> PROCESS_INSTANCES_PATH1 = new ArrayList<>();
+  static final List<Long> PROCESS_INSTANCES_PATH2 = new ArrayList<>();
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  public static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+    final List<String> processes =
+        List.of("multi_instance_subprocess.bpmn", "service_tasks_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, DEPLOYED_PROCESSES.size());
+
+    // start some random process instances we want to not match the filter
+    IntStream.range(0, 10).forEach(i -> startProcessInstance(camundaClient, "service_tasks_v1"));
+
+    // start some process instances for one path
+    IntStream.range(0, 10)
+        .forEach(
+            i -> {
+              final var processInstance =
+                  startProcessInstance(
+                      camundaClient,
+                      "multi_instance_subprocess",
+                      "{\"variables\": [\"foo\", \"bar\"], \"foo\": 1}");
+              PROCESS_INSTANCES_PATH1.add(processInstance.getProcessInstanceKey());
+            });
+
+    // start some process instances for another path
+    IntStream.range(0, 10)
+        .forEach(
+            i -> {
+              final var processInstance =
+                  startProcessInstance(
+                      camundaClient,
+                      "multi_instance_subprocess",
+                      "{\"variables\": [\"foo\", \"bar\"], \"foo\": 2}");
+              PROCESS_INSTANCES_PATH2.add(processInstance.getProcessInstanceKey());
+            });
+
+    waitForProcessInstancesToStart(camundaClient, 30);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+    PROCESS_INSTANCES_PATH1.clear();
+    PROCESS_INSTANCES_PATH2.clear();
+  }
+
+  @Test
+  void shouldModifyProcessInstancesWithBatch() {
+    final var allProcessInstances = new ArrayList<Long>();
+    allProcessInstances.addAll(PROCESS_INSTANCES_PATH1);
+    allProcessInstances.addAll(PROCESS_INSTANCES_PATH2);
+
+    // when
+    final var batchOperationKey =
+        modifyProcessInstance(
+            b ->
+                b.addMoveInstruction("userTaskE", "userTaskF")
+                    .filter(f -> f.processDefinitionId("multi_instance_subprocess")));
+    // then
+    shouldCompleteBatchOperation(batchOperationKey);
+    batchOperationHasItemsWithState(
+        batchOperationKey, BatchOperationItemState.COMPLETED, allProcessInstances);
+
+    for (final long itemKey : allProcessInstances) {
+      processInstanceHasActiveUserTasks(camundaClient, itemKey, Map.of("userTaskF", 2L));
+    }
+  }
+
+  @Test
+  void shouldModifyProcessInstancesWithMultipleBatches() {
+    // given
+    final var processInstanceKey1 = PROCESS_INSTANCES_PATH1.get(0);
+    final var processInstanceKey2 = PROCESS_INSTANCES_PATH1.get(1);
+
+    // when
+    final var batchOperationKey1 =
+        modifyProcessInstance(
+            b ->
+                b.addMoveInstruction("userTaskE", "userTaskF")
+                    .filter(f -> f.processInstanceKey(processInstanceKey1)));
+    final var batchOperationKey2 =
+        modifyProcessInstance(
+            b ->
+                b.addMoveInstruction("userTaskC", "userTaskD")
+                    .filter(f -> f.processInstanceKey(processInstanceKey1)));
+    final var batchOperationKey3 =
+        modifyProcessInstance(
+            b ->
+                b.addMoveInstruction("userTaskE", "userTaskF")
+                    .filter(f -> f.processInstanceKey(processInstanceKey2)));
+
+    // then
+    shouldCompleteBatchOperation(batchOperationKey1);
+    shouldCompleteBatchOperation(batchOperationKey2);
+    shouldCompleteBatchOperation(batchOperationKey3);
+
+    batchOperationHasItemsWithState(
+        batchOperationKey1, BatchOperationItemState.COMPLETED, List.of(processInstanceKey1));
+    batchOperationHasItemsWithState(
+        batchOperationKey1, BatchOperationItemState.COMPLETED, List.of(processInstanceKey1));
+    batchOperationHasItemsWithState(
+        batchOperationKey1, BatchOperationItemState.COMPLETED, List.of(processInstanceKey2));
+
+    processInstanceHasActiveUserTasks(
+        camundaClient, processInstanceKey1, Map.of("userTaskD", 1L, "userTaskF", 2L));
+    processInstanceHasActiveUserTasks(camundaClient, processInstanceKey2, Map.of("userTaskF", 2L));
+  }
+
+  @Test
+  void shouldModifyProcessInstancesWithBatchFail() {
+    // when
+    final var batchOperationKey =
+        modifyProcessInstance(
+            b ->
+                b.addMoveInstruction("userTaskA", "userTaskB")
+                    .addMoveInstruction("userTaskC", "FAIL")
+                    .addMoveInstruction("userTaskE", "userTaskF")
+                    .filter(f -> f.processDefinitionId("multi_instance_subprocess")));
+
+    // then
+    shouldCompleteBatchOperation(batchOperationKey);
+    batchOperationHasItemsWithState(
+        batchOperationKey, BatchOperationItemState.FAILED, PROCESS_INSTANCES_PATH1);
+    batchOperationHasItemsWithState(
+        batchOperationKey, BatchOperationItemState.COMPLETED, PROCESS_INSTANCES_PATH2);
+
+    // and
+    for (final long itemKey : PROCESS_INSTANCES_PATH2) {
+      processInstanceHasActiveUserTasks(
+          camundaClient,
+          itemKey,
+          Map.of(
+              "userTaskB", 1L,
+              "userTaskF", 2L));
+    }
+  }
+
+  public long modifyProcessInstance(
+      final Function<
+              ProcessInstanceModificationStep<ProcessInstanceFilter>,
+              CreateBatchOperationCommandStep3<ProcessInstanceFilter>>
+          commandBuilder) {
+    return commandBuilder
+        .apply(camundaClient.newCreateBatchOperationCommand().modifyProcessInstance())
+        .send()
+        .join()
+        .getBatchOperationKey();
+  }
+
+  public void shouldCompleteBatchOperation(final long batchOperationKey) {
+    await("should complete batch operation")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getEndDate()).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+            });
+  }
+
+  public void batchOperationHasItemsWithState(
+      final long batchOperationKey,
+      final BatchOperationItemState state,
+      final List<Long> failedItemKeys) {
+    final var itemsObj =
+        camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
+
+    final var filteredItems =
+        itemsObj.items().stream().filter(i -> i.getStatus() == state).toList();
+    assertThat(filteredItems).hasSize(failedItemKeys.size());
+    assertThat(filteredItems.stream().map(BatchOperationItem::getKey))
+        .hasSize(failedItemKeys.size());
+  }
+
+  public void processInstanceHasActiveUserTasks(
+      final CamundaClient client,
+      final Long processInstanceKey,
+      final Map<String, Long> userTaskCounts) {
+    flowNodeInstanceExistAndMatches(
+        client,
+        f ->
+            f.processInstanceKey(processInstanceKey)
+                .state(ElementInstanceState.ACTIVE)
+                .type(ElementInstanceType.USER_TASK),
+        f -> {
+          final var elementIdCounts =
+              f.stream()
+                  .collect(
+                      Collectors.groupingBy(ElementInstance::getElementId, Collectors.counting()));
+          assertThat(elementIdCounts).containsAllEntriesOf(userTaskCounts);
+        });
+  }
+
+  public void flowNodeInstanceExistAndMatches(
+      final CamundaClient client,
+      final Consumer<ElementInstanceFilter> filter,
+      final Consumer<List<ElementInstance>> asserter) {
+    await()
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  client.newElementInstanceSearchRequest().filter(filter).send().join().items();
+              asserter.accept(result);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleMa
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableRoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableTenantRecordValue;
@@ -632,6 +634,49 @@ public class RecordFixtures {
         .withValue(
             ImmutableProcessInstanceMigrationRecordValue.builder()
                 .from((ImmutableProcessInstanceMigrationRecordValue) recordValueRecord.getValue())
+                .withProcessInstanceKey(processInstanceKey)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getBatchOperationModifyProcessInstanceRecord(
+      final Long processInstanceKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_MODIFICATION);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(ProcessInstanceModificationIntent.MODIFIED)
+        .withKey(processInstanceKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .withValue(
+            ImmutableProcessInstanceModificationRecordValue.builder()
+                .from(
+                    (ImmutableProcessInstanceModificationRecordValue) recordValueRecord.getValue())
+                .withProcessInstanceKey(processInstanceKey)
+                .build())
+        .build();
+  }
+
+  protected static ImmutableRecord<RecordValue> getFailedBatchOperationModifyProcessInstanceRecord(
+      final Long processInstanceKey, final Long batchOperationKey, final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_MODIFICATION);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(ProcessInstanceModificationIntent.MODIFY)
+        .withRejectionType(RejectionType.INVALID_STATE)
+        .withKey(processInstanceKey)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withOperationReference(batchOperationKey)
+        .withValue(
+            ImmutableProcessInstanceModificationRecordValue.builder()
+                .from(
+                    (ImmutableProcessInstanceModificationRecordValue) recordValueRecord.getValue())
                 .withProcessInstanceKey(processInstanceKey)
                 .build())
         .build();

--- a/qa/acceptance-tests/src/test/resources/process/multi_instance_subprocess.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/multi_instance_subprocess.bpmn
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0jnkxay" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="multi_instance_subprocess" name="MultiInstance subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_01h019c</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_01h019c" sourceRef="StartEvent_1" targetRef="Gateway_0di87lz" />
+    <bpmn:userTask id="userTaskC" name="C">
+      <bpmn:incoming>Flow_1gqyehp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1p0c3i6</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1p0c3i6" sourceRef="userTaskC" targetRef="userTaskD" />
+    <bpmn:userTask id="userTaskD" name="D">
+      <bpmn:incoming>Flow_1p0c3i6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qi0qq6</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_1r71uoa">
+      <bpmn:incoming>Flow_136nv6v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0qi0qq6" sourceRef="userTaskD" targetRef="Gateway_1n7p724" />
+    <bpmn:sequenceFlow id="Flow_1h48f0w" sourceRef="Gateway_0di87lz" targetRef="Gateway_1wwmgvc" />
+    <bpmn:parallelGateway id="Gateway_0di87lz">
+      <bpmn:incoming>Flow_01h019c</bpmn:incoming>
+      <bpmn:outgoing>Flow_1h48f0w</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08mqnul</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:subProcess id="subprocess" name="Multi instance subprocess">
+      <bpmn:incoming>Flow_08mqnul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yrc2ni</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=variables" inputElement="variable" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_02eg68l">
+        <bpmn:outgoing>Flow_1rlbq9a</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1rlbq9a" sourceRef="Event_02eg68l" targetRef="userTaskE" />
+      <bpmn:userTask id="userTaskE" name="E">
+        <bpmn:incoming>Flow_1rlbq9a</bpmn:incoming>
+        <bpmn:outgoing>Flow_1cbp7l0</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_1cbp7l0" sourceRef="userTaskE" targetRef="userTaskF" />
+      <bpmn:userTask id="userTaskF" name="F">
+        <bpmn:incoming>Flow_1cbp7l0</bpmn:incoming>
+        <bpmn:outgoing>Flow_07uv78l</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="Event_1kb2995">
+        <bpmn:incoming>Flow_07uv78l</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_07uv78l" sourceRef="userTaskF" targetRef="Event_1kb2995" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_08mqnul" sourceRef="Gateway_0di87lz" targetRef="subprocess" />
+    <bpmn:exclusiveGateway id="Gateway_1n7p724">
+      <bpmn:incoming>Flow_0qi0qq6</bpmn:incoming>
+      <bpmn:incoming>Flow_0yrc2ni</bpmn:incoming>
+      <bpmn:incoming>Flow_01kwxj6</bpmn:incoming>
+      <bpmn:outgoing>Flow_136nv6v</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_136nv6v" sourceRef="Gateway_1n7p724" targetRef="Event_1r71uoa" />
+    <bpmn:sequenceFlow id="Flow_0yrc2ni" sourceRef="subprocess" targetRef="Gateway_1n7p724" />
+    <bpmn:exclusiveGateway id="Gateway_1wwmgvc" default="Flow_1hb4p0z">
+      <bpmn:incoming>Flow_1h48f0w</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gqyehp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1hb4p0z</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1gqyehp" sourceRef="Gateway_1wwmgvc" targetRef="userTaskC">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo = 1</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1hb4p0z" sourceRef="Gateway_1wwmgvc" targetRef="userTaskA" />
+    <bpmn:sequenceFlow id="Flow_17v4any" sourceRef="userTaskA" targetRef="userTaskB" />
+    <bpmn:sequenceFlow id="Flow_01kwxj6" sourceRef="userTaskB" targetRef="Gateway_1n7p724" />
+    <bpmn:userTask id="userTaskA" name="A">
+      <bpmn:incoming>Flow_1hb4p0z</bpmn:incoming>
+      <bpmn:outgoing>Flow_17v4any</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="userTaskB" name="B">
+      <bpmn:incoming>Flow_17v4any</bpmn:incoming>
+      <bpmn:outgoing>Flow_01kwxj6</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multi_instance_subprocess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ddxjir_di" bpmnElement="userTaskC">
+        <dc:Bounds x="440" y="207" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1r71uoa_di" bpmnElement="Event_1r71uoa">
+        <dc:Bounds x="1042" y="229" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15f2v10_di" bpmnElement="Gateway_0di87lz">
+        <dc:Bounds x="235" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wwmgvc_di" bpmnElement="Gateway_1wwmgvc" isMarkerVisible="true">
+        <dc:Bounds x="340" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1n7p724_di" bpmnElement="Gateway_1n7p724" isMarkerVisible="true">
+        <dc:Bounds x="945" y="222" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1spzz3i_di" bpmnElement="userTaskD">
+        <dc:Bounds x="680" y="207" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mynacg_di" bpmnElement="userTaskA">
+        <dc:Bounds x="440" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s65f9w_di" bpmnElement="userTaskB">
+        <dc:Bounds x="680" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wsqsac_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="310" y="320" width="630" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02eg68l_di" bpmnElement="Event_02eg68l">
+        <dc:Bounds x="350" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1013iuc_di" bpmnElement="userTaskE">
+        <dc:Bounds x="440" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yyus7u_di" bpmnElement="userTaskF">
+        <dc:Bounds x="680" y="380" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kb2995_di" bpmnElement="Event_1kb2995">
+        <dc:Bounds x="842" y="402" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rlbq9a_di" bpmnElement="Flow_1rlbq9a">
+        <di:waypoint x="386" y="420" />
+        <di:waypoint x="440" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cbp7l0_di" bpmnElement="Flow_1cbp7l0">
+        <di:waypoint x="540" y="420" />
+        <di:waypoint x="680" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07uv78l_di" bpmnElement="Flow_07uv78l">
+        <di:waypoint x="780" y="420" />
+        <di:waypoint x="842" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01h019c_di" bpmnElement="Flow_01h019c">
+        <di:waypoint x="188" y="247" />
+        <di:waypoint x="235" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gqyehp_di" bpmnElement="Flow_1gqyehp">
+        <di:waypoint x="390" y="247" />
+        <di:waypoint x="440" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1p0c3i6_di" bpmnElement="Flow_1p0c3i6">
+        <di:waypoint x="540" y="247" />
+        <di:waypoint x="680" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_136nv6v_di" bpmnElement="Flow_136nv6v">
+        <di:waypoint x="995" y="247" />
+        <di:waypoint x="1042" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h48f0w_di" bpmnElement="Flow_1h48f0w">
+        <di:waypoint x="285" y="247" />
+        <di:waypoint x="340" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08mqnul_di" bpmnElement="Flow_08mqnul">
+        <di:waypoint x="260" y="272" />
+        <di:waypoint x="260" y="420" />
+        <di:waypoint x="310" y="420" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hb4p0z_di" bpmnElement="Flow_1hb4p0z">
+        <di:waypoint x="365" y="222" />
+        <di:waypoint x="365" y="120" />
+        <di:waypoint x="440" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qi0qq6_di" bpmnElement="Flow_0qi0qq6">
+        <di:waypoint x="780" y="247" />
+        <di:waypoint x="945" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yrc2ni_di" bpmnElement="Flow_0yrc2ni">
+        <di:waypoint x="940" y="420" />
+        <di:waypoint x="970" y="420" />
+        <di:waypoint x="970" y="272" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01kwxj6_di" bpmnElement="Flow_01kwxj6">
+        <di:waypoint x="780" y="120" />
+        <di:waypoint x="970" y="120" />
+        <di:waypoint x="970" y="222" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17v4any_di" bpmnElement="Flow_17v4any">
+        <di:waypoint x="540" y="120" />
+        <di:waypoint x="680" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -26,7 +26,7 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
 
   @Override
   public void execute(final long itemKey, final PersistedBatchOperation batchOperation) {
-    LOGGER.info("Cancelling process instance with key '{}'", itemKey);
+    LOGGER.trace("Cancelling process instance with key '{}'", itemKey);
 
     final var command = new ProcessInstanceRecord();
     command.setProcessInstanceKey(itemKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
@@ -31,7 +31,7 @@ public class MigrateProcessInstanceBatchOperationExecutor implements BatchOperat
 
   @Override
   public void execute(final long processInstanceKey, final PersistedBatchOperation batchOperation) {
-    LOGGER.info("Migrate process instance with key '{}'", processInstanceKey);
+    LOGGER.trace("Migrate process instance with key '{}'", processInstanceKey);
 
     final var migrationPlan = batchOperation.getMigrationPlan();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
@@ -68,7 +68,7 @@ public class ModifyProcessInstanceBatchOperationExecutor implements BatchOperati
       elementInstances.addAll(elementInstanceState.getChildren(elementInstance.getKey()));
     }
 
-    LOGGER.info("Modifying process instance with key '{}'", processInstanceKey);
+    LOGGER.trace("Modifying process instance with key '{}'", processInstanceKey);
     commandWriter.appendFollowUpCommand(
         processInstanceKey,
         ProcessInstanceModificationIntent.MODIFY,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
@@ -34,13 +34,13 @@ public class ResolveIncidentBatchOperationExecutor implements BatchOperationExec
   public void execute(final long itemKey, final PersistedBatchOperation batchOperation) {
     final var incident = incidentState.getIncidentRecord(itemKey);
     if (incidentState.isJobIncident(incident)) {
-      LOGGER.info("Increasing retries for job with key '{}'", incident.getJobKey());
+      LOGGER.trace("Increasing retries for job with key '{}'", incident.getJobKey());
       final var jobRecord = new JobRecord().setRetries(1);
       commandWriter.appendFollowUpCommand(
           incident.getJobKey(), JobIntent.UPDATE_RETRIES, jobRecord);
     }
 
-    LOGGER.info("Resolving incident with key '{}'", itemKey);
+    LOGGER.trace("Resolving incident with key '{}'", itemKey);
     final var command = new IncidentRecord();
     commandWriter.appendFollowUpCommand(
         itemKey, IncidentIntent.RESOLVE, command, batchOperation.getKey());

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -35,6 +35,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.BatchOperationLifecycle
 import io.camunda.exporter.rdbms.handlers.batchoperation.IncidentBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancellationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -232,6 +233,10 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         new ProcessInstanceMigrationBatchOperationExportHandler(
+            rdbmsWriter.getBatchOperationWriter()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        new ProcessInstanceModificationBatchOperationExportHandler(
             rdbmsWriter.getBatchOperationWriter()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+
+/** This aggregates the batch operation status of process instance modify tasks */
+public class ProcessInstanceModificationBatchOperationExportHandler
+    extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceModificationRecordValue> {
+
+  public ProcessInstanceModificationBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter) {
+    super(batchOperationWriter);
+  }
+
+  @Override
+  long getItemKey(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
+  protected boolean isCompleted(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFIED);
+  }
+
+  @Override
+  protected boolean isFailed(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFY)
+        && record.getRejectionType() != RejectionType.NULL_VAL;
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces the Exporter logic and a concluding E2E test for the MODIFY_PROCESS_INSTANCE batch operation:
- extend RDBMS exporter code to monitor the batch operation items
- add an E2E test for MODIFY_PROCESS_INSTANCE

## Related issues

closes #31169
