### PR TITLE
Feat/29884 bo modify process instance in engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -165,7 +165,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
         () -> !batchOperationState.exists(batchOperation.getKey());
 
     return switch (batchOperation.getBatchOperationType()) {
-      case CANCEL_PROCESS_INSTANCE, MIGRATE_PROCESS_INSTANCE ->
+      case CANCEL_PROCESS_INSTANCE, MIGRATE_PROCESS_INSTANCE, MODIFY_PROCESS_INSTANCE ->
           entityKeyProvider.fetchProcessInstanceKeys(
               batchOperation.getEntityFilter(ProcessInstanceFilter.class), abortCondition);
       case RESOLVE_INCIDENT ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.CancelProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.MigrateProcessInstanceBatchOperationExecutor;
+import io.camunda.zeebe.engine.processing.batchoperation.handlers.ModifyProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ResolveIncidentBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -46,7 +47,10 @@ public final class BatchOperationSetupProcessors {
                 writers.command(), processingState.getIncidentState()),
             BatchOperationType.MIGRATE_PROCESS_INSTANCE,
             new MigrateProcessInstanceBatchOperationExecutor(
-                writers.command(), processingState.getBatchOperationState()));
+                writers.command(), processingState.getBatchOperationState()),
+            BatchOperationType.MODIFY_PROCESS_INSTANCE,
+            new ModifyProcessInstanceBatchOperationExecutor(
+                writers.command(), processingState.getElementInstanceState()));
 
     typedRecordProcessors
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation.handlers;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.ProcessInstanceModificationMoveInstructionValue;
+import java.util.ArrayDeque;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ModifyProcessInstanceBatchOperationExecutor implements BatchOperationExecutor {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ModifyProcessInstanceBatchOperationExecutor.class);
+
+  final TypedCommandWriter commandWriter;
+  private final ElementInstanceState elementInstanceState;
+
+  public ModifyProcessInstanceBatchOperationExecutor(
+      final TypedCommandWriter commandWriter, final ElementInstanceState elementInstanceState) {
+    this.commandWriter = commandWriter;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void execute(final long processInstanceKey, final PersistedBatchOperation batchOperation) {
+
+    final var moveInstructions =
+        batchOperation.getModificationPlan().getMoveInstructions().stream()
+            .collect(
+                Collectors.toMap(
+                    ProcessInstanceModificationMoveInstructionValue::getSourceElementId,
+                    ProcessInstanceModificationMoveInstructionValue::getTargetElementId));
+
+    final var command = new ProcessInstanceModificationRecord();
+    command.setProcessInstanceKey(processInstanceKey);
+
+    // avoid stackoverflow using a queue to iterate over the descendants instead of recursion
+    final var elementInstances =
+        new ArrayDeque<>(elementInstanceState.getChildren(processInstanceKey));
+    while (!elementInstances.isEmpty()) {
+      final var elementInstance = elementInstances.poll();
+
+      if (moveInstructions.containsKey(elementInstance.getValue().getElementId())) {
+        final var activateInstruction =
+            new ProcessInstanceModificationActivateInstruction()
+                .setElementId(moveInstructions.get(elementInstance.getValue().getElementId()))
+                .setAncestorScopeKey(elementInstance.getParentKey());
+        final var terminateInstruction =
+            new ProcessInstanceModificationTerminateInstruction()
+                .setElementInstanceKey(elementInstance.getKey());
+
+        command.addActivateInstruction(activateInstruction);
+        command.addTerminateInstruction(terminateInstruction);
+      }
+
+      elementInstances.addAll(elementInstanceState.getChildren(elementInstance.getKey()));
+    }
+
+    LOGGER.info("Modifying process instance with key '{}'", processInstanceKey);
+    commandWriter.appendFollowUpCommand(
+        processInstanceKey,
+        ProcessInstanceModificationIntent.MODIFY,
+        command,
+        batchOperation.getKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationProcessInstanceMigrationPlanValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.BatchOperationProcessInstanceModificationPlanValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.Comparator;
 import org.agrona.DirectBuffer;
@@ -34,16 +36,19 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");
   private final ObjectProperty<BatchOperationProcessInstanceMigrationPlan> migrationPlanProp =
       new ObjectProperty<>("migrationPlan", new BatchOperationProcessInstanceMigrationPlan());
+  private final ObjectProperty<BatchOperationProcessInstanceModificationPlan> modificationPlanProp =
+      new ObjectProperty<>("modificationPlan", new BatchOperationProcessInstanceModificationPlan());
   private final ArrayProperty<LongValue> chunkKeysProp =
       new ArrayProperty<>("chunkKeys", LongValue::new);
 
   public PersistedBatchOperation() {
-    super(6);
+    super(7);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
         .declareProperty(entityFilterProp)
         .declareProperty(migrationPlanProp)
+        .declareProperty(modificationPlanProp)
         .declareProperty(chunkKeysProp);
   }
 
@@ -52,6 +57,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     setBatchOperationType(record.getBatchOperationType());
     setEntityFilter(record.getEntityFilterBuffer());
     setMigrationPlan(record.getMigrationPlan());
+    setModificationPlan(record.getModificationPlan());
     return this;
   }
 
@@ -99,6 +105,16 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public PersistedBatchOperation setStatus(final BatchOperationStatus status) {
     statusProp.setValue(status);
+    return this;
+  }
+
+  public BatchOperationProcessInstanceModificationPlan getModificationPlan() {
+    return modificationPlanProp.getValue();
+  }
+
+  public PersistedBatchOperation setModificationPlan(
+      final BatchOperationProcessInstanceModificationPlanValue modificationPlan) {
+    modificationPlanProp.getValue().wrap(modificationPlan);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Set;
+import org.junit.Test;
+
+public final class ModifyProcessInstanceBatchExecutorTest extends AbstractBatchOperationTest {
+
+  @Test
+  public void shouldModifyProcessInstance() {
+    // given
+    // create a process with two user tasks
+    final long processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .startEvent()
+                    .userTask("userTaskA")
+                    .userTask("userTaskB")
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId("process").create();
+
+    // wait for the user task to exist
+    RecordingExporter.jobRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(JobIntent.CREATED)
+        .getFirst();
+
+    // then start the batch where we modify the process instance and move the token the userTaskB
+    final var batchOperationKey =
+        createNewModifyProcessInstanceBatchOperation(
+            Set.of(processInstanceKey), "userTaskA", "userTaskB");
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a modified event
+    assertThat(
+            RecordingExporter.processInstanceModificationRecords()
+                .withRecordKey(processInstanceKey))
+        .extracting(Record::getIntent)
+        .containsSequence(ProcessInstanceModificationIntent.MODIFIED);
+  }
+
+  @Test
+  public void shouldModifyProcessInstanceFail() {
+    // given
+    // create a process with two user tasks
+    final long processDefinitionKey =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .startEvent()
+                    .userTask("userTaskA")
+                    .userTask("userTaskB")
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0)
+            .getProcessDefinitionKey();
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId("process").create();
+
+    // wait for the user task to exist
+    RecordingExporter.jobRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(JobIntent.CREATED)
+        .getFirst();
+
+    // then start the batch where we modify the process instance and move the token the userTaskB
+    final var batchOperationKey =
+        createNewModifyProcessInstanceBatchOperation(
+            Set.of(processInstanceKey), "userTaskA", "userTaskC");
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a modified event
+    assertThat(
+            RecordingExporter.processInstanceModificationRecords()
+                .withRecordKey(processInstanceKey)
+                .onlyCommandRejections())
+        .extracting(Record::getIntent)
+        .containsSequence(ProcessInstanceModificationIntent.MODIFY);
+  }
+
+  @Test
+  public void shouldModifyProcessInstanceFailNoProcessInstance() {
+    // given
+    // nothing
+
+    // then start the batch where we modify the non-existing process instance
+    final var batchOperationKey =
+        createNewModifyProcessInstanceBatchOperation(Set.of(42L), "userTaskA", "userTaskC");
+
+    // then we have executed and completed event
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyEvents())
+        .extracting(Record::getIntent)
+        .containsSequence(
+            BatchOperationExecutionIntent.EXECUTED, BatchOperationExecutionIntent.COMPLETED);
+
+    // and a follow op up command to execute again
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommands())
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationExecutionIntent.EXECUTE);
+
+    // and we have a modified event
+    assertThat(
+            RecordingExporter.processInstanceModificationRecords()
+                .withRecordKey(42L)
+                .onlyCommandRejections())
+        .extracting(Record::getIntent)
+        .containsSequence(ProcessInstanceModificationIntent.MODIFY);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -97,6 +98,12 @@ public final class BatchOperationClient {
     public BatchOperationCreationClient withMigrationPlan(
         final BatchOperationProcessInstanceMigrationPlanValue migrationPlan) {
       batchOperationCreationRecord.setMigrationPlan(migrationPlan);
+      return this;
+    }
+
+    public BatchOperationCreationClient withModificationPlan(
+        final BatchOperationProcessInstanceModificationPlan modificationPlan) {
+      batchOperationCreationRecord.setModificationPlan(modificationPlan);
       return this;
     }
 


### PR DESCRIPTION
## Description

This PR implements the MODIFY_PROCESS_INSTANCE batch operation type in the engine:
- store the modificationPlan
- load the correct items
- add a batchOperationExecutor to create the actual modification command

## Related issues

closes #29708 
