### PR TITLE
refactor: align `includeEnabledRecords` after decision

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -62,7 +62,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   @Before
   public void beforeEach() {
     operateProperties.getImporter().setImportPositionUpdateInterval(5000);
-    CONFIG.setExportLegacyRecords(true);
+    CONFIG.setIncludeEnabledRecords(true);
     CONFIG.index.prefix = operateProperties.getZeebeElasticsearch().getPrefix();
     CONFIG.index.setNumberOfShards(1);
     CONFIG.index.setNumberOfReplicas(0);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -62,7 +62,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
   @Before
   public void beforeEach() {
     operateProperties.getImporter().setImportPositionUpdateInterval(1000);
-    CONFIG.setExportLegacyRecords(true);
+    CONFIG.setIncludeEnabledRecords(true);
     CONFIG.index.prefix = operateProperties.getZeebeOpensearch().getPrefix();
     CONFIG.index.setNumberOfShards(1);
     CONFIG.index.setNumberOfReplicas(0);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -75,7 +75,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   public void beforeEach() {
     tasklistProperties.getImporter().setImportPositionUpdateInterval(5000);
     CONFIG.index.prefix = tasklistProperties.getZeebeElasticsearch().getPrefix();
-    CONFIG.setExportLegacyRecords(true);
+    CONFIG.setIncludeEnabledRecords(true);
     CONFIG.index.setNumberOfShards(1);
     CONFIG.index.setNumberOfReplicas(0);
     CONFIG.index.createTemplate = true;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -78,7 +78,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   @BeforeEach
   public void beforeEach() throws IOException {
     tasklistProperties.getImporter().setImportPositionUpdateInterval(1000);
-    CONFIG.setExportLegacyRecords(true);
+    CONFIG.setIncludeEnabledRecords(true);
     CONFIG.url = tasklistProperties.getOpenSearch().getUrl();
     CONFIG.index.prefix = tasklistProperties.getZeebeOpenSearch().getPrefix();
     CONFIG.index.setNumberOfShards(1);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -368,15 +368,15 @@ public class ElasticsearchExporter implements Exporter {
   /**
    * Determine whether a record should be exported or not. For Camunda 8.8 we require Optimize
    * records to be exported, or if the configuration explicitly enables the export of all records
-   * {@link ElasticsearchExporterConfiguration#exportLegacyRecords}. For past versions, we continue
-   * to export all records.
+   * {@link ElasticsearchExporterConfiguration#includeEnabledRecords}. For past versions, we
+   * continue to export all records.
    *
    * @param record The record to check
    * @return Whether the record should be exported or not
    */
   private boolean shouldExportRecord(final Record<?> record) {
     final var recordVersion = getVersion(record.getBrokerVersion());
-    if (configuration.getIsExportLegacyRecords()
+    if (configuration.getIsIncludeEnabledRecords()
         || (recordVersion.major() == 8 && recordVersion.minor() < 8)) {
       return true;
     }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -29,7 +29,7 @@ public class ElasticsearchExporterConfiguration {
   public final RetentionConfiguration retention = new RetentionConfiguration();
   public final List<PluginConfiguration> interceptorPlugins = new ArrayList<>();
   private final AuthenticationConfiguration authentication = new AuthenticationConfiguration();
-  private boolean exportLegacyRecords = false;
+  private boolean includeEnabledRecords = false;
 
   public boolean hasAuthenticationPresent() {
     return getAuthentication().isPresent();
@@ -138,12 +138,12 @@ public class ElasticsearchExporterConfiguration {
     };
   }
 
-  public boolean getIsExportLegacyRecords() {
-    return exportLegacyRecords;
+  public boolean getIsIncludeEnabledRecords() {
+    return includeEnabledRecords;
   }
 
-  public void setExportLegacyRecords(final boolean exportLegacyRecords) {
-    this.exportLegacyRecords = exportLegacyRecords;
+  public void setIncludeEnabledRecords(final boolean includeEnabledRecords) {
+    this.includeEnabledRecords = includeEnabledRecords;
   }
 
   public static class IndexConfiguration {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -86,7 +86,7 @@ final class ElasticsearchExporterIT {
   @BeforeAll
   public void beforeAll() {
     config.url = CONTAINER.getHttpHostAddress();
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     config.index.setNumberOfShards(1);
     config.index.setNumberOfReplicas(1);
     config.index.createTemplate = true;
@@ -111,7 +111,7 @@ final class ElasticsearchExporterIT {
 
   @BeforeEach
   void cleanup() {
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     testClient.deleteIndices();
     exporter.configure(exporterTestContext);
   }
@@ -241,7 +241,7 @@ final class ElasticsearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
   void shouldExportOnlyRequiredRecords(final ValueType valueType) {
     // given
-    config.setExportLegacyRecords(false);
+    config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
 
@@ -277,7 +277,7 @@ final class ElasticsearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
   void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
     // given
-    config.setExportLegacyRecords(false);
+    config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterPluginTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterPluginTest.java
@@ -38,7 +38,7 @@ final class ElasticsearchExporterPluginTest {
     final var pluginConfig = new PluginConfiguration("test", TestPlugin.class.getName(), null);
     final var record =
         recordFactory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     config.interceptorPlugins.add(pluginConfig);
     config.url = "http://localhost:" + wmRuntimeInfo.getHttpPort();
     exporter.configure(context);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -201,7 +201,7 @@ final class ElasticsearchExporterTest {
     void shouldPutValueTypeTemplate(final ValueType valueType) {
       // given
       config.index.createTemplate = true;
-      config.setExportLegacyRecords(true);
+      config.setIncludeEnabledRecords(true);
       TestSupport.setIndexingForValueType(config.index, valueType, true);
       exporter.configure(context);
       exporter.open(controller);
@@ -240,7 +240,7 @@ final class ElasticsearchExporterTest {
     void shouldCreateAllTemplatesOnPreviousVersion(final ValueType valueType) {
       // given
       config.index.createTemplate = true;
-      config.setExportLegacyRecords(false);
+      config.setIncludeEnabledRecords(false);
       TestSupport.setIndexingForValueType(config.index, valueType, true);
       exporter.configure(context);
       exporter.open(controller);
@@ -414,7 +414,7 @@ final class ElasticsearchExporterTest {
 
     @BeforeEach
     void initExporter() {
-      config.setExportLegacyRecords(true);
+      config.setIncludeEnabledRecords(true);
       exporter.configure(context);
       exporter.open(controller);
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -134,15 +134,15 @@ public class OpensearchExporter implements Exporter {
   /**
    * Determine whether a record should be exported or not. For Camunda 8.8 we require Optimize
    * records to be exported, or if the configuration explicitly enables the export of all records
-   * {@link OpensearchExporterConfiguration#exportLegacyRecords}. For past versions, we continue to
-   * export all records.
+   * {@link OpensearchExporterConfiguration#includeEnabledRecords}. For past versions, we continue
+   * to export all records.
    *
    * @param record The record to check
    * @return Whether the record should be exported or not
    */
   private boolean shouldExportRecord(final Record<?> record) {
     final var recordVersion = getVersion(record.getBrokerVersion());
-    if (configuration.getIsExportLegacyRecords()
+    if (configuration.getIsIncludeEnabledRecords()
         || (recordVersion.major() == 8 && recordVersion.minor() < 8)) {
       return true;
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -30,7 +30,7 @@ public class OpensearchExporterConfiguration {
   public final RetentionConfiguration retention = new RetentionConfiguration();
   public final List<PluginConfiguration> interceptorPlugins = new ArrayList<>();
   private final AuthenticationConfiguration authentication = new AuthenticationConfiguration();
-  private boolean exportLegacyRecords = false;
+  private boolean includeEnabledRecords = false;
 
   public boolean hasAuthenticationPresent() {
     return getAuthentication().isPresent();
@@ -137,12 +137,12 @@ public class OpensearchExporterConfiguration {
     };
   }
 
-  public boolean getIsExportLegacyRecords() {
-    return exportLegacyRecords;
+  public boolean getIsIncludeEnabledRecords() {
+    return includeEnabledRecords;
   }
 
-  public void setExportLegacyRecords(final boolean exportLegacyRecords) {
-    this.exportLegacyRecords = exportLegacyRecords;
+  public void setIncludeEnabledRecords(final boolean includeEnabledRecords) {
+    this.includeEnabledRecords = includeEnabledRecords;
   }
 
   public static class IndexConfiguration {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -82,7 +82,7 @@ final class OpensearchExporterIT {
   @BeforeAll
   public void beforeAll() {
     config.url = CONTAINER.getHttpHostAddress();
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     config.index.setNumberOfShards(1);
     config.index.setNumberOfReplicas(1);
     config.index.createTemplate = true;
@@ -108,7 +108,7 @@ final class OpensearchExporterIT {
 
   @BeforeEach
   void cleanup() {
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     testClient.deleteIndices();
     testClient.deleteIndexTemplates();
     configureExporter(true);
@@ -318,7 +318,7 @@ final class OpensearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
   void shouldExportOnlyRequiredRecords(final ValueType valueType) {
     // given
-    config.setExportLegacyRecords(false);
+    config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
 
@@ -354,7 +354,7 @@ final class OpensearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
   void shouldExportRecordsOnPreviousVersion(final ValueType valueType) {
     // given
-    config.setExportLegacyRecords(false);
+    config.setIncludeEnabledRecords(false);
     exporter.configure(exporterTestContext);
     exporter.open(controller);
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterPluginTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterPluginTest.java
@@ -37,7 +37,7 @@ final class OpensearchExporterPluginTest {
     final var pluginConfig = new PluginConfiguration("test", TestPlugin.class.getName(), null);
     final var record =
         recordFactory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     config.interceptorPlugins.add(pluginConfig);
     config.url = "http://localhost:" + wmRuntimeInfo.getHttpPort();
     exporter.configure(context);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -70,7 +70,7 @@ final class OpensearchExporterTest {
   void shouldNotFailOnOpenIfOpensearchIsUnreachable() {
     // given
     final var exporter = new OpensearchExporter();
-    config.setExportLegacyRecords(true);
+    config.setIncludeEnabledRecords(true);
     exporter.configure(context);
 
     // when
@@ -300,7 +300,7 @@ final class OpensearchExporterTest {
     void shouldCreateAllTemplatesOnPreviousVersion(final ValueType valueType) {
       // given
       config.index.createTemplate = true;
-      config.setExportLegacyRecords(false);
+      config.setIncludeEnabledRecords(false);
       TestSupport.setIndexingForValueType(config.index, valueType, true);
       exporter.configure(context);
       exporter.open(controller);
@@ -445,7 +445,7 @@ final class OpensearchExporterTest {
 
     @BeforeEach
     void initExporter() {
-      config.setExportLegacyRecords(true);
+      config.setIncludeEnabledRecords(true);
       exporter.configure(context);
       exporter.open(controller);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Align exporter flag for excluding records from ES/OS Exporter according to the docs, ref: https://github.com/camunda/camunda-docs/pull/5479

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
