### PR TITLE
Feature/25360 complete job

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /** The injected context for a process test. */
@@ -101,8 +102,17 @@ public interface CamundaProcessTestContext {
    * <p>This mock allows simulating job processing behavior, such as completing jobs, throwing BPMN
    * errors, or handling jobs with custom logic.
    *
-   * @param jobId the job type to mock, matching the `zeebeJobType` in the BPMN model.
+   * @param jobType the job type to mock, matching the `zeebeJobType` in the BPMN model.
    * @return a {@see JobWorkerMock} instance for configuring the mock behavior.
    */
-  JobWorkerMock mockJobWorker(final String jobId);
+  JobWorkerMock mockJobWorker(final String jobType);
+
+  void completeJob(final String jobType);
+
+  void completeJob(final String jobType, final Map<String, Object> variables);
+
+  void throwBpmnErrorFromJob(final String jobType, final String errorCode);
+
+  void throwBpmnErrorFromJob(
+      final String jobType, final String errorCode, final Map<String, Object> variables);
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -137,6 +137,72 @@ public class CamundaProcessTestContextIT {
     CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
   }
 
+  @Test
+  void shouldCompleteJob() {
+    // Given
+    final long processDefinitionKey = deployProcessModel();
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // When
+    processTestContext.completeJob("test");
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
+  }
+
+  @Test
+  void shouldCompleteJobWithVariables() {
+    // Given
+    final long processDefinitionKey = deployProcessModel();
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("abc", 123);
+
+    // When
+    processTestContext.completeJob("test", variables);
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("success-end");
+    CamundaAssert.assertThat(processInstanceEvent).hasVariables(variables);
+  }
+
+  @Test
+  void shouldThrowBpmnErrorFromJob() {
+    // Given
+    final long processDefinitionKey = deployProcessModel();
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // When
+    processTestContext.throwBpmnErrorFromJob("test", "bpmn-error");
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("error-end");
+  }
+
+  @Test
+  void shouldThrowBpmnErrorFromJobWithVariables() {
+    // Given
+    final long processDefinitionKey = deployProcessModel();
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("abc", 123);
+
+    // When
+    processTestContext.throwBpmnErrorFromJob("test", "bpmn-error", variables);
+
+    // Then
+    CamundaAssert.assertThat(processInstanceEvent).isCompleted();
+    CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("error-end");
+    CamundaAssert.assertThat(processInstanceEvent).hasVariables(variables);
+  }
+
   /**
    * Deploys a process model and waits until it is accessible via the API.
    *


### PR DESCRIPTION
## Description

Enhanced CamundaProcessTestContext Functionality:  
- Added support for job completion with and without variables (completeJob).
- Added support for throwing BPMN errors with and without variables (throwBpmnErrorFromJob).

Added comprehensive test cases to validate the behavior:
- Job completion with and without variables.
- Throwing BPMN errors with and without variables.

## Related issues

depends on #19262 
closes #25360
