### PR TITLE
Fix flaky test in retries logic (#31090)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -543,7 +543,7 @@ public class ProcessDefinitionStatisticsTest {
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient);
+      waitUntilJobWorkerHasFailedJob(camundaClient, 2);
 
       // when
       final var actual =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -530,20 +530,20 @@ public class ProcessDefinitionStatisticsTest {
   void shouldReturnStatisticsAndFilterByHasRetriesLeft() {
     // given
     final var processDefinitionKey =
-        TestHelper.deployResource(camundaClient, "process/service_tasks_v1.bpmn")
+        TestHelper.deployResource(camundaClient, "process/service_tasks_v2.bpmn")
             .getProcesses()
             .getFirst()
             .getProcessDefinitionKey();
-    TestHelper.startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}");
+    TestHelper.startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}");
 
     try (final JobWorker ignored =
         camundaClient
             .newWorker()
-            .jobType("taskA")
+            .jobType("taskC")
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient, 2);
+      waitUntilJobWorkerHasFailedJob(camundaClient, 1);
 
       // when
       final var actual =
@@ -554,11 +554,12 @@ public class ProcessDefinitionStatisticsTest {
               .join();
 
       // then
-      assertThat(actual).hasSize(2);
+      assertThat(actual).hasSize(3);
       assertThat(actual)
           .containsExactlyInAnyOrder(
-              new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 1L),
-              new ProcessElementStatisticsImpl("taskA", 1L, 0L, 0L, 0L));
+              new ProcessElementStatisticsImpl("startEvent", 0L, 0L, 0L, 1L),
+              new ProcessElementStatisticsImpl("exclusiveGateway", 0L, 0L, 0L, 1L),
+              new ProcessElementStatisticsImpl("taskC", 1L, 0L, 0L, 0L));
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -1566,11 +1566,11 @@ public class ProcessInstanceAndElementInstanceSearchTest {
     try (final JobWorker ignored =
         camundaClient
             .newWorker()
-            .jobType("taskA")
+            .jobType("taskC")
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient, 2);
+      waitUntilJobWorkerHasFailedJob(camundaClient, 1);
 
       // when
       final var result =
@@ -1581,10 +1581,10 @@ public class ProcessInstanceAndElementInstanceSearchTest {
               .join();
 
       // then
-      assertThat(result.items().size()).isEqualTo(2);
+      assertThat(result.items().size()).isEqualTo(1);
       assertThat(result.items())
           .extracting("processDefinitionId")
-          .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v1");
+          .containsExactlyInAnyOrder("service_tasks_v2");
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -1570,7 +1570,7 @@ public class ProcessInstanceAndElementInstanceSearchTest {
             .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
             .open()) {
 
-      waitUntilJobWorkerHasFailedJob(camundaClient);
+      waitUntilJobWorkerHasFailedJob(camundaClient, 2);
 
       // when
       final var result =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -268,7 +268,8 @@ public final class TestHelper {
             });
   }
 
-  public static void waitUntilJobWorkerHasFailedJob(final CamundaClient camundaClient) {
+  public static void waitUntilJobWorkerHasFailedJob(
+      final CamundaClient camundaClient, final int expectedProcesses) {
     await("should wait until the process instance has been updated to reflect retries left.")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .untilAsserted(
@@ -279,7 +280,7 @@ public final class TestHelper {
                       .filter(f -> f.hasRetriesLeft(true))
                       .send()
                       .join();
-              assertThat(result.items().size()).isGreaterThan(0);
+              assertThat(result.items().size()).isEqualTo(expectedProcesses);
             });
   }
 

--- a/qa/acceptance-tests/src/test/resources/process/service_tasks_v2.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/service_tasks_v2.bpmn
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
   <bpmn:process id="service_tasks_v2" name="Service tasks v2" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_nyzldfv">
+    <bpmn:startEvent id="startEvent">
       <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="StartEvent_nyzldfv" targetRef="exclusiveGateway" />
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="startEvent" targetRef="exclusiveGateway" />
     <bpmn:sequenceFlow id="SequenceFlow_06ytcxw" sourceRef="taskA" targetRef="taskB" />
     <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="taskB" targetRef="EndEvent_0szldfv" />
     <bpmn:endEvent id="EndEvent_0szldfv">
@@ -54,7 +54,7 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="service_tasks_v2">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_nyzldfv">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
         <dc:Bounds x="114" y="153" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="121" y="189" width="22" height="14" />


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This issue addresses a flaky test reported in [#31090](https://github.com/camunda/camunda/issues/31090).

### Root Cause:
The original `waitUntilJobWorkerHasFoundJob()` method waited for at least one process with a found job. However, the test logic assumes a specific number of such processes—two, in this case.

### Proposed Fix:
Introduce a new parameter to `waitUntilJobWorkerHasFoundJob(int expectedProcesses)` that allows specifying an exact number of expected process instances with found jobs. Update the test to call this method with 2.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31090 
