### PR TITLE
refactor: change entitykey to entityid in role exporters

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -54,7 +54,9 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final Long userKey = storedUser.userKey();
 
-    final var roles = roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(userKey))));
+    // todo use username as memberId in https://github.com/camunda/camunda/issues/30111
+    final var roles =
+        roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(String.valueOf(userKey)))));
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -61,7 +61,7 @@ public class CamundaUserDetailsServiceTest {
     when(authorizationServices.getAuthorizedApplications(any()))
         .thenReturn(List.of("operate", "identity"));
     final RoleEntity adminRole = new RoleEntity(2L, "ADMIN");
-    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(100L)))))
+    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId("100")))))
         .thenReturn(List.of(adminRole));
 
     // when

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -419,7 +419,7 @@
       <column name="ROLE_KEY" type="BIGINT" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_KEY" type="BIGINT" >
+      <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -422,7 +422,9 @@
       <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_TYPE" type="VARCHAR(255)" />
+      <column name="ENTITY_TYPE" type="VARCHAR(255)" >
+        <constraints primaryKey="true"/>
+      </column>
     </createTable>
   </changeSet>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.read.domain.RoleDbQuery;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.columns.RoleSearchColumn;
 import io.camunda.db.rdbms.write.domain.RoleDbModel;
+import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -51,9 +52,6 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     return new RoleEntity(
         model.roleKey(),
         model.name(),
-        model.members().stream()
-            // todo, remove long parse in https://github.com/camunda/camunda/issues/30111
-            .map(dbModel -> Long.parseLong(dbModel.entityId()))
-            .collect(Collectors.toSet()));
+        model.members().stream().map(RoleMemberDbModel::entityId).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -11,7 +11,6 @@ import io.camunda.db.rdbms.read.domain.RoleDbQuery;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.columns.RoleSearchColumn;
 import io.camunda.db.rdbms.write.domain.RoleDbModel;
-import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -52,6 +51,9 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     return new RoleEntity(
         model.roleKey(),
         model.name(),
-        model.members().stream().map(RoleMemberDbModel::entityKey).collect(Collectors.toSet()));
+        model.members().stream()
+            // todo, remove long parse in https://github.com/camunda/camunda/issues/30111
+            .map(dbModel -> Long.parseLong(dbModel.entityId()))
+            .collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
@@ -9,33 +9,33 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record RoleMemberDbModel(Long roleKey, Long entityKey, String entityType) {
+public record RoleMemberDbModel(Long roleKey, String entityId, String entityType) {
 
   // create builder implementing ObjectBuilder
   public static class Builder implements ObjectBuilder<RoleMemberDbModel> {
 
     private Long roleKey;
-    private Long entityKey;
+    private String entityId;
     private String entityType;
 
-    public Builder roleKey(Long roleKey) {
+    public Builder roleKey(final Long roleKey) {
       this.roleKey = roleKey;
       return this;
     }
 
-    public Builder entityKey(Long entityKey) {
-      this.entityKey = entityKey;
+    public Builder entityId(final String entityId) {
+      this.entityId = entityId;
       return this;
     }
 
-    public Builder entityType(String entityType) {
+    public Builder entityType(final String entityType) {
       this.entityType = entityType;
       return this;
     }
 
     @Override
     public RoleMemberDbModel build() {
-      return new RoleMemberDbModel(roleKey, entityKey, entityType);
+      return new RoleMemberDbModel(roleKey, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -23,7 +23,7 @@
     r.ROLE_KEY,
     r.NAME,
     rm.ROLE_KEY AS MEMBER_ROLE_KEY,
-    rm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
+    rm.ENTITY_ID AS MEMBER_ENTITY_ID,
     rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}ROLES r
     LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_KEY = rm.ROLE_KEY
@@ -47,7 +47,7 @@
       javaType="java.util.List">
       <constructor>
         <idArg column="MEMBER_ROLE_KEY" javaType="java.lang.Long"/>
-        <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_ENTITY_ID" javaType="java.lang.String"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>
     </collection>
@@ -80,8 +80,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_KEY, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{roleKey}, #{entityKey}, #{entityType})
+    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_KEY, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{roleKey}, #{entityId}, #{entityType})
   </insert>
 
   <delete
@@ -91,7 +91,7 @@
     DELETE
     FROM ${prefix}ROLE_MEMBER
     WHERE ROLE_KEY = #{roleKey}
-      AND ENTITY_KEY = #{entityKey}
+      AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -191,7 +191,7 @@ public class RoleIT {
     assertThat(instance).isNotNull();
     assertThat(instance)
         .usingRecursiveComparison()
-        .ignoringFields("assignedMemberKeys")
+        .ignoringFields("assignedMemberIds")
         .isEqualTo(role);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -407,14 +407,14 @@ class RdbmsExporterIT {
 
     // then
     final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
-    assertThat(updatedRole.assignedMemberKeys()).containsExactly(1337L);
+    assertThat(updatedRole.assignedMemberIds()).containsExactly("1337");
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, 1337L));
 
     // then
     final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
-    assertThat(deletedRole.assignedMemberKeys()).isEmpty();
+    assertThat(deletedRole.assignedMemberIds()).isEmpty();
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -9,8 +9,8 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -30,12 +30,12 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
         term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType()),
         filter.roleKey() == null ? null : term(RoleIndex.KEY, filter.roleKey()),
         filter.name() == null ? null : term(RoleIndex.NAME, filter.name()),
-        filter.memberKeys() == null
+        filter.memberIds() == null
             ? null
-            : filter.memberKeys().isEmpty()
+            : filter.memberIds().isEmpty()
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(RoleIndex.MEMBER_KEY, filter.memberKeys())));
+                    stringTerms(RoleIndex.MEMBER_ID, filter.memberIds())));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String name, Set<Long> assignedMemberKeys)
+public record RoleEntity(Long roleKey, String name, Set<String> assignedMemberIds)
     implements Serializable {
   public RoleEntity(final Long roleKey, final String name) {
     this(roleKey, name, Set.of());

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -10,15 +10,15 @@ package io.camunda.search.filter;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 
-public record RoleFilter(Long roleKey, String name, Set<Long> memberKeys) implements FilterBase {
+public record RoleFilter(Long roleKey, String name, Set<String> memberIds) implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).name(name).memberKeys(memberKeys);
+    return new Builder().roleKey(roleKey).name(name).memberIds(memberIds);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
     private Long roleKey;
     private String name;
-    private Set<Long> memberKeys;
+    private Set<String> memberIds;
 
     public Builder roleKey(final Long value) {
       roleKey = value;
@@ -30,18 +30,18 @@ public record RoleFilter(Long roleKey, String name, Set<Long> memberKeys) implem
       return this;
     }
 
-    public Builder memberKeys(final Set<Long> value) {
-      memberKeys = value;
+    public Builder memberIds(final Set<String> value) {
+      memberIds = value;
       return this;
     }
 
-    public Builder memberKey(final Long... values) {
-      return memberKeys(Set.of(values));
+    public Builder memberId(final String... values) {
+      return memberIds(Set.of(values));
     }
 
     @Override
     public RoleFilter build() {
-      return new RoleFilter(roleKey, name, memberKeys);
+      return new RoleFilter(roleKey, name, memberIds);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, RoleEntity> {
 
@@ -53,12 +54,17 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public SearchQueryResult<RoleEntity> getMemberRoles(final long memberKey, final RoleQuery query) {
+    // todo use memberId (String) in https://github.com/camunda/camunda/issues/30111
     return search(
-        query.toBuilder().filter(query.filter().toBuilder().memberKey(memberKey).build()).build());
+        query.toBuilder()
+            .filter(query.filter().toBuilder().memberId(String.valueOf(memberKey)).build())
+            .build());
   }
 
   public List<RoleEntity> getRolesByMemberKeys(final Set<Long> memberKeys) {
-    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberKeys(memberKeys))));
+    // todo use memberIds (String) in https://github.com/camunda/camunda/issues/30111
+    final var memberIds = memberKeys.stream().map(String::valueOf).collect(Collectors.toSet());
+    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds))));
   }
 
   public List<RoleEntity> findAll(final RoleQuery query) {

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -185,15 +185,17 @@ public class RoleServicesTest {
   }
 
   @Test
-  public void shouldGetAllRolesByMemberKey() {
+  public void shouldGetAllRolesByMemberId() {
     // given
     final var memberKey = 100L;
+    // todo use memberIds (String) in https://github.com/camunda/camunda/issues/30111
+    final var memberId = String.valueOf(memberKey);
     final var roleEntity = mock(RoleEntity.class);
-    when(client.findAllRoles(RoleQuery.of(q -> q.filter(f -> f.memberKey(memberKey)))))
+    when(client.findAllRoles(RoleQuery.of(q -> q.filter(f -> f.memberId(memberId)))))
         .thenReturn(List.of(roleEntity));
 
     // when
-    final var result = services.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(memberKey))));
+    final var result = services.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(memberId))));
 
     // then
     assertThat(result).isEqualTo(List.of(roleEntity));

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -19,7 +19,7 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
 
   public static final String KEY = "key";
   public static final String NAME = "name";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String MEMBER_ID = "memberId";
   public static final String JOIN = "join";
 
   public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -13,7 +13,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
   private Long key;
   private String name;
-  private Long memberKey;
+  private String memberId;
   private EntityJoinRelation<Long> join;
 
   public Long getKey() {
@@ -34,12 +34,12 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public Long getMemberKey() {
-    return memberKey;
+  public String getMemberId() {
+    return memberId;
   }
 
-  public RoleEntity setMemberKey(final Long memberKey) {
-    this.memberKey = memberKey;
+  public RoleEntity setMemberKey(final String memberId) {
+    this.memberId = memberId;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -55,7 +55,8 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     entity
-        .setMemberKey(record.getValue().getEntityKey())
+        // todo remove parsing in https://github.com/camunda/camunda/issues/30111
+        .setMemberKey(String.valueOf(record.getValue().getEntityKey()))
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(record.getValue().getRoleKey()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -54,7 +54,8 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleEntity, RoleR
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     entity
-        .setMemberKey(record.getValue().getEntityKey())
+        // todo remove parsing in https://github.com/camunda/camunda/issues/30111
+        .setMemberKey(String.valueOf(record.getValue().getEntityKey()))
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(record.getValue().getRoleKey()));
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -54,14 +54,16 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
           roleWriter.addMember(
               new RoleMemberDbModel.Builder()
                   .roleKey(value.getRoleKey())
-                  .entityKey(value.getEntityKey())
+                  // todo,remove parse in https://github.com/camunda/camunda/issues/30111
+                  .entityId(String.valueOf(value.getEntityKey()))
                   .entityType(value.getEntityType().name())
                   .build());
       case RoleIntent.ENTITY_REMOVED ->
           roleWriter.removeMember(
               new RoleMemberDbModel.Builder()
                   .roleKey(value.getRoleKey())
-                  .entityKey(value.getEntityKey())
+                  // todo,remove parse in https://github.com/camunda/camunda/issues/30111
+                  .entityId(String.valueOf(value.getEntityKey()))
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for role record", record.getIntent());


### PR DESCRIPTION
## Description

This PR refactors role exporters by replacing the usage of "entityKey" with "entityId" across the exporters, models, queries, and tests. Key changes include:

Updating database model records and builder methods to use entityId (as a String) instead of entityKey (as a Long).
Changing query filters and test assertions to use the new memberId naming convention.
Modifying test cases to reflect the updated naming and data type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31184 
