### PR TITLE
refactor: store mapping role membership decoupled from mapping state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -352,9 +352,14 @@ public final class AuthorizationCheckBehavior {
                       request.getResourceType(),
                       request.getPermissionType())
                   .forEach(stream);
-              getAuthorizedResourceIdentifiersForOwnerKeys(
+              getAuthorizedResourceIdentifiersForOwners(
                       AuthorizationOwnerType.ROLE,
-                      mapping.getRoleKeysList(),
+                      membershipState.getMemberships(
+                          EntityType.MAPPING,
+                          // TODO: Use mappingId instead of mappingKey when roles and mappings are
+                          //   id-based
+                          String.valueOf(mapping.getMappingKey()),
+                          RelationType.ROLE),
                       request.getResourceType(),
                       request.getPermissionType())
                   .forEach(stream);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -270,12 +270,9 @@ public final class IdentitySetupInitializeProcessor
 
     final var isAlreadyAssigned =
         switch (entityType) {
-          case USER ->
+          case USER, MAPPING ->
               membershipState.hasRelation(
-                  EntityType.USER,
-                  Long.toString(entityKey),
-                  RelationType.ROLE,
-                  Long.toString(roleKey));
+                  entityType, Long.toString(entityKey), RelationType.ROLE, Long.toString(roleKey));
           default -> roleState.getEntityType(roleKey, entityKey).isPresent();
         };
     if (isAlreadyAssigned) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -140,12 +140,17 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
               .setEntityId(mapping.getMappingId())
               .setEntityType(EntityType.MAPPING));
     }
-    for (final var roleKey : mapping.getRoleKeysList()) {
+    for (final var roleId :
+        membershipState.getMemberships(
+            EntityType.MAPPING, mapping.getMappingId(), RelationType.ROLE)) {
       stateWriter.appendFollowUpEvent(
-          roleKey,
+          // TODO: Use the role id instead of the key.
+          Long.parseLong(roleId),
           RoleIntent.ENTITY_REMOVED,
           new RoleRecord()
-              .setRoleKey(roleKey)
+              // TODO: Use the role id instead of the key.
+              .setRoleId(roleId)
+              .setRoleKey(Long.parseLong(roleId))
               .setEntityKey(mappingKey)
               .setEntityType(EntityType.MAPPING));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -140,17 +140,17 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
               .setEntityId(mapping.getMappingId())
               .setEntityType(EntityType.MAPPING));
     }
-    for (final var roleId :
+    for (final var roleKey :
         membershipState.getMemberships(
             EntityType.MAPPING, mapping.getMappingId(), RelationType.ROLE)) {
       stateWriter.appendFollowUpEvent(
           // TODO: Use the role id instead of the key.
-          Long.parseLong(roleId),
+          Long.parseLong(roleKey),
           RoleIntent.ENTITY_REMOVED,
           new RoleRecord()
               // TODO: Use the role id instead of the key.
-              .setRoleId(roleId)
-              .setRoleKey(Long.parseLong(roleId))
+              .setRoleId(roleKey)
+              .setRoleKey(Long.parseLong(roleKey))
               .setEntityKey(mappingKey)
               .setEntityType(EntityType.MAPPING));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -145,9 +145,9 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
 
   private boolean isEntityAssigned(final RoleRecord record) {
     return switch (record.getEntityType()) {
-      case USER ->
+      case USER, MAPPING ->
           membershipState.hasRelation(
-              EntityType.USER,
+              record.getEntityType(),
               Long.toString(record.getEntityKey()),
               RelationType.ROLE,
               Long.toString(record.getRoleKey()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -113,9 +113,9 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     final var record = command.getValue();
     final var isAssigned =
         switch (record.getEntityType()) {
-          case USER ->
+          case USER, MAPPING ->
               membershipState.hasRelation(
-                  EntityType.USER,
+                  record.getEntityType(),
                   // TODO: Use entity id instead of key
                   Long.toString(record.getEntityKey()),
                   RelationType.ROLE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
@@ -9,41 +9,30 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
-  private final MutableRoleState roleState;
-  private final MutableMappingState mappingState;
   private final MutableMembershipState membershipState;
 
   public RoleEntityAddedApplier(final MutableProcessingState state) {
-    roleState = state.getRoleState();
-    mappingState = state.getMappingState();
     membershipState = state.getMembershipState();
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     switch (value.getEntityType()) {
-      case USER ->
+      case USER, MAPPING ->
           membershipState.insertRelation(
-              EntityType.USER,
+              value.getEntityType(),
               // TODO: Use entity id instead of key
               Long.toString(value.getEntityKey()),
               RelationType.ROLE,
               // TODO: Use role id instead of key
               Long.toString(value.getRoleKey()));
-      case MAPPING -> {
-        roleState.addEntity(value);
-        mappingState.addRole(value.getEntityKey(), value.getRoleKey());
-      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
@@ -9,41 +9,30 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleEntityRemovedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
-  private final MutableRoleState roleState;
-  private final MutableMappingState mappingState;
   private final MutableMembershipState membershipState;
 
   public RoleEntityRemovedApplier(final MutableProcessingState state) {
-    roleState = state.getRoleState();
-    mappingState = state.getMappingState();
     membershipState = state.getMembershipState();
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     switch (value.getEntityType()) {
-      case USER ->
+      case USER, MAPPING ->
           membershipState.deleteRelation(
-              EntityType.USER,
+              value.getEntityType(),
               // TODO: Use entity id instead of key
               Long.toString(value.getEntityKey()),
               RelationType.ROLE,
               // TODO: Use role id instead of key
               Long.toString(value.getRoleKey()));
-      case MAPPING -> {
-        roleState.removeEntity(value.getRoleKey(), value.getEntityKey());
-        mappingState.removeRole(value.getEntityKey(), value.getRoleKey());
-      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -115,18 +115,6 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void addRole(final long mappingKey, final long roleKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      persistedMapping.addRoleKey(roleKey);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
   public void addGroup(final String mappingId, final long groupKey) {
     this.mappingId.wrapString(mappingId);
     final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
@@ -134,20 +122,6 @@ public class DbMappingState implements MutableMappingState {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);
       persistedMapping.addGroupKey(groupKey);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
-  public void removeRole(final long mappingKey, final long roleKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      final List<Long> roleKeys = persistedMapping.getRoleKeysList();
-      roleKeys.remove(roleKey);
-      persistedMapping.setRoleKeysList(roleKeys);
       mappingColumnFamily.update(claim, persistedMapping);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -25,18 +25,15 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
-  private final ArrayProperty<LongValue> roleKeysProp =
-      new ArrayProperty<>("roleKeys", LongValue::new);
   private final ArrayProperty<LongValue> groupKeysProp =
       new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedMapping() {
-    super(7);
+    super(6);
     declareProperty(mappingKeyProp)
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
-        .declareProperty(roleKeysProp)
         .declareProperty(groupKeysProp)
         .declareProperty(mappingIdProp);
   }
@@ -89,23 +86,6 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
 
   public PersistedMapping setMappingId(final String mappingId) {
     mappingIdProp.setValue(mappingId);
-    return this;
-  }
-
-  public List<Long> getRoleKeysList() {
-    return StreamSupport.stream(roleKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
-        .collect(Collectors.toList());
-  }
-
-  public PersistedMapping setRoleKeysList(final List<Long> roleKeys) {
-    roleKeysProp.reset();
-    roleKeys.forEach(roleKey -> roleKeysProp.add().setValue(roleKey));
-    return this;
-  }
-
-  public PersistedMapping addRoleKey(final long roleKey) {
-    roleKeysProp.add().setValue(roleKey);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,11 +16,7 @@ public interface MutableMappingState extends MappingState {
 
   void update(MappingRecord mappingRecord);
 
-  void addRole(final long mappingKey, final long roleKey);
-
   void addGroup(final String mappingId, final long groupKey);
-
-  void removeRole(final long mappingKey, final long roleKey);
 
   void removeGroup(final String mappingId, final long groupKey);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -137,14 +137,15 @@ public class MappingAppliersTest {
     mappingState.create(mappingRecord);
     // create role
     final long roleKey = 2L;
-    mappingState.addRole(mappingKey, roleKey);
     final var role =
         new RoleRecord()
             .setRoleKey(roleKey)
             .setEntityKey(mappingKey)
             .setEntityType(EntityType.MAPPING);
     roleState.create(role);
-    roleState.addEntity(role);
+    // TODO: Use role id instead of key
+    membershipState.insertRelation(
+        EntityType.MAPPING, mappingId, RelationType.ROLE, String.valueOf(roleKey));
     // create tenant
     final long tenantKey = 3L;
     final var tenantId = "tenant";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -84,30 +83,6 @@ public class RoleAppliersTest {
   }
 
   @Test
-  void shouldAddEntityToRoleWithTypeMapping() {
-    // given
-    final long entityKey = 1L;
-    mappingState.create(
-        new MappingRecord()
-            .setMappingKey(entityKey)
-            .setClaimName("claimName")
-            .setClaimValue("claimValue"));
-    final long roleKey = 11L;
-    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
-    roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
-
-    // when
-    roleEntityAddedApplier.applyState(roleKey, roleRecord);
-
-    // then
-    assertThat(roleState.getEntitiesByType(roleKey).get(EntityType.MAPPING))
-        .containsExactly(entityKey);
-    final var persistedMapping = mappingState.get(entityKey).get();
-    assertThat(persistedMapping.getRoleKeysList()).containsExactly(roleKey);
-  }
-
-  @Test
   void shouldDeleteRole() {
     // given
     final long roleKey = 11L;
@@ -168,30 +143,5 @@ public class RoleAppliersTest {
             membershipState.getMemberships(
                 EntityType.USER, Long.toString(userKey), RelationType.ROLE))
         .isEmpty();
-  }
-
-  @Test
-  void shouldRemoveEntityFromRoleWithTypeMapping() {
-    // given
-    final long entityKey = 1L;
-    mappingState.create(
-        new MappingRecord()
-            .setMappingKey(entityKey)
-            .setClaimName("claimName")
-            .setClaimValue("claimValue"));
-    final long roleKey = 11L;
-    mappingState.addRole(entityKey, 11L);
-    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
-    roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
-    roleState.addEntity(roleRecord);
-
-    // when
-    roleEntityRemovedApplier.applyState(roleKey, roleRecord);
-
-    // then
-    assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
-    final var persistedMapping = mappingState.get(entityKey).get();
-    assertThat(persistedMapping.getRoleKeysList()).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -130,45 +130,6 @@ public class MappingStateTest {
   }
 
   @Test
-  void shouldAddRole() {
-    // given
-    final long key = 1L;
-    final String claimName = "foo";
-    final String claimValue = "bar";
-    final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
-    mappingState.create(mapping);
-    final long roleKey = 1L;
-
-    // when
-    mappingState.addRole(key, roleKey);
-
-    // then
-    final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getRoleKeysList()).containsExactly(roleKey);
-  }
-
-  @Test
-  void shouldRemoveRole() {
-    // given
-    final long key = 1L;
-    final String claimName = "foo";
-    final String claimValue = "bar";
-    final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
-    mappingState.create(mapping);
-    final long roleKey = 1L;
-    mappingState.addRole(key, roleKey);
-
-    // when
-    mappingState.removeRole(key, roleKey);
-
-    // then
-    final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getRoleKeysList()).isEmpty();
-  }
-
-  @Test
   void shouldDeleteMapping() {
     // given
     final long key = 1L;


### PR DESCRIPTION
We now track mapping role membership in the generalized membership state instead of the PersistedMapping and RoleState.

depends on #31156
closes #30452
