### PR TITLE
fix: optimize FE console warnings

### DIFF
--- a/optimize/client/src/components/Analysis/BranchAnalysis/__snapshots__/Statistics.test.js.snap
+++ b/optimize/client/src/components/Analysis/BranchAnalysis/__snapshots__/Statistics.test.js.snap
@@ -14,7 +14,7 @@ exports[`should create two Charts 1`] = `
     </b>
      that passed the gateway 
     <i
-      class="gatewayName"
+      className="gatewayName"
       key="3"
     />
   </p>
@@ -31,7 +31,7 @@ exports[`should create two Charts 1`] = `
       </b>
        (33%) took the 
       <i
-        class="branchName"
+        className="branchName"
         key="2"
       />
        branch, 
@@ -42,7 +42,7 @@ exports[`should create two Charts 1`] = `
       </b>
        (300%) of those then continued to reach the end event 
       <i
-        class="endEventName"
+        className="endEventName"
         key="6"
       />
     </li>
@@ -56,7 +56,7 @@ exports[`should create two Charts 1`] = `
       </b>
        (67%) took the 
       <i
-        class="branchName"
+        className="branchName"
         key="2"
       />
        branch, 
@@ -67,7 +67,7 @@ exports[`should create two Charts 1`] = `
       </b>
        (100%) of those then continued to reach the end event 
       <i
-        class="endEventName"
+        className="endEventName"
         key="6"
       />
     </li>
@@ -75,7 +75,7 @@ exports[`should create two Charts 1`] = `
   <p>
     Distribution of instances at the gateway 
     <i
-      class="gatewayName"
+      className="gatewayName"
       key="1"
     />
     :
@@ -88,7 +88,7 @@ exports[`should create two Charts 1`] = `
   <p>
     Probability to reach the end event 
     <i
-      class="endEventName"
+      className="endEventName"
       key="1"
     />
      after taking a branch:
@@ -147,7 +147,7 @@ exports[`should show a summary after loading is complete 1`] = `
     </b>
      that passed the gateway 
     <i
-      class="gatewayName"
+      className="gatewayName"
       key="3"
     />
   </p>
@@ -164,7 +164,7 @@ exports[`should show a summary after loading is complete 1`] = `
       </b>
        (33%) took the 
       <i
-        class="branchName"
+        className="branchName"
         key="2"
       />
        branch, 
@@ -175,7 +175,7 @@ exports[`should show a summary after loading is complete 1`] = `
       </b>
        (300%) of those then continued to reach the end event 
       <i
-        class="endEventName"
+        className="endEventName"
         key="6"
       />
     </li>
@@ -189,7 +189,7 @@ exports[`should show a summary after loading is complete 1`] = `
       </b>
        (67%) took the 
       <i
-        class="branchName"
+        className="branchName"
         key="2"
       />
        branch, 
@@ -200,7 +200,7 @@ exports[`should show a summary after loading is complete 1`] = `
       </b>
        (100%) of those then continued to reach the end event 
       <i
-        class="endEventName"
+        className="endEventName"
         key="6"
       />
     </li>
@@ -208,7 +208,7 @@ exports[`should show a summary after loading is complete 1`] = `
   <p>
     Distribution of instances at the gateway 
     <i
-      class="gatewayName"
+      className="gatewayName"
       key="1"
     />
     :
@@ -221,7 +221,7 @@ exports[`should show a summary after loading is complete 1`] = `
   <p>
     Probability to reach the end event 
     <i
-      class="endEventName"
+      className="endEventName"
       key="1"
     />
      after taking a branch:

--- a/optimize/client/src/components/Home/AlertList.js
+++ b/optimize/client/src/components/Home/AlertList.js
@@ -145,7 +145,11 @@ const AlertList = ({collection, readOnly}) => {
         }
         isLoading={isLoading}
         headers={[t('common.name'), t('report.label'), t('common.condition'), t('alert.recipient')]}
-        bulkActions={!readOnly && [<BulkDeleter type="delete" deleteEntities={removeAlerts} />]}
+        bulkActions={
+          !readOnly && [
+            <BulkDeleter key="alertListBulkDeleter" type="delete" deleteEntities={removeAlerts} />,
+          ]
+        }
         onChange={syncAlerts}
         rows={
           !isLoading &&

--- a/optimize/client/src/components/Home/CollectionEnitiesList.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.js
@@ -118,6 +118,7 @@ export default function CollectionEnitiesList({
         bulkActions={
           hasEditRights && [
             <BulkDeleter
+              key="collectionBulkDeleter"
               type="delete"
               deleteEntities={async (selected) => await removeEntities(selected, collection)}
               checkConflicts={async (selected) => await checkConflicts(selected, collection)}
@@ -175,10 +176,9 @@ export default function CollectionEnitiesList({
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href =
-                      `api/export/${entityType}/json/${
-                        entity.id
-                      }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
+                    window.location.href = `api/export/${entityType}/json/${
+                      entity.id
+                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
                   },
                 }
               );

--- a/optimize/client/src/components/Home/Home.js
+++ b/optimize/client/src/components/Home/Home.js
@@ -151,6 +151,7 @@ export function Home({mightFail, user}) {
           bulkActions={
             isEditor && [
               <BulkDeleter
+                key="homeBulkDeleter"
                 type="delete"
                 deleteEntities={removeEntities}
                 checkConflicts={checkConflicts}
@@ -208,10 +209,9 @@ export function Home({mightFail, user}) {
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href =
-                      `api/export/${entityType}/json/${
-                        entity.id
-                      }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
+                    window.location.href = `api/export/${entityType}/json/${
+                      entity.id
+                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
                   },
                 });
               }

--- a/optimize/client/src/components/Home/SourcesList.js
+++ b/optimize/client/src/components/Home/SourcesList.js
@@ -121,6 +121,7 @@ export default withErrorHandling(
             bulkActions={
               !readOnly && [
                 <BulkDeleter
+                  key="sourcesListBulkDeleter"
                   type="remove"
                   deleteEntities={async (selectedSources) =>
                     await removeSources(collection, selectedSources)

--- a/optimize/client/src/components/Home/UserList.js
+++ b/optimize/client/src/components/Home/UserList.js
@@ -88,6 +88,7 @@ export default withErrorHandling(
             bulkActions={
               !readOnly && [
                 <BulkDeleter
+                  key="userListBulkDeleter"
                   type="remove"
                   deleteEntities={async (selectedUsers) =>
                     await removeUsers(collection, selectedUsers)

--- a/optimize/client/src/modules/components/BPMNDiagram/BPMNDiagram.tsx
+++ b/optimize/client/src/modules/components/BPMNDiagram/BPMNDiagram.tsx
@@ -173,7 +173,6 @@ export class BPMNDiagram extends Component<BPMNDiagramProps, BPMNDiagramState> {
       canvas: {
         deferUpdate: false,
       },
-      keyboard: {bindTo: document},
       bpmnRenderer: getDiagramColors(theme),
       additionalModules,
     });

--- a/optimize/client/src/modules/translation/translation.test.tsx
+++ b/optimize/client/src/modules/translation/translation.test.tsx
@@ -31,7 +31,8 @@ beforeEach(async () => {
       entity: {
         create: 'Create a new {label}',
       },
-      htmlString: 'This is an html <b>string</b> linking to <a href="testUrl" >{linkText}</a><br/>',
+      htmlString:
+        'This is an html <b class="bold">string</b> linking to <a href="testUrl" >{linkText}</a><br/>',
     })
   );
 
@@ -66,6 +67,7 @@ it('should convert html string to JSX', async () => {
   const node = shallow(<div>{translationJSX}</div>);
 
   expect(node.find('b').text()).toBe('string');
+  expect(node.find('b').props().className).toBe('bold');
   expect(node.find('a').text()).toBe('foo');
   expect(node.find('a').prop('href')).toBe('testUrl');
   expect(node.find('br')).toExist();

--- a/optimize/client/src/modules/translation/translation.tsx
+++ b/optimize/client/src/modules/translation/translation.tsx
@@ -120,11 +120,18 @@ function parseToJSX(translationString: string): JSX.Element[] {
   return JSXNodes;
 }
 
+const attributeMap: Record<string, string> = {
+  class: 'className',
+  for: 'htmlFor',
+};
+
 function getAllAttributes(el: Element): Record<string, string> {
   return el.getAttributeNames().reduce((obj, name) => {
+    const reactAttr = attributeMap[name] || name;
+
     return {
       ...obj,
-      [name]: el.getAttribute(name) ?? '',
+      [reactAttr]: el.getAttribute(name) ?? '',
     };
   }, {});
 }


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
I noticed that there are a lot of console warning in Optimize. I address three causes of those warnings in this PR.

1. Missing react key warning in the console caused by the BulkDeleter rendering
2. BindTo property is deprecated since bpmnjs can figure this out automatically now
3. when parsing html from translation file, we do not convert html to react attributes causing a warning in the console( e.g. class to className)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
