### PR TITLE
fix: Tasklist backups do not complete if the request times out

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/BackupProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/BackupProperties.java
@@ -11,12 +11,23 @@ public class BackupProperties {
 
   private String repositoryName;
 
+  private int snapshotTimeout = 0;
+
   public String getRepositoryName() {
     return repositoryName;
   }
 
-  public BackupProperties setRepositoryName(String repositoryName) {
+  public BackupProperties setRepositoryName(final String repositoryName) {
     this.repositoryName = repositoryName;
+    return this;
+  }
+
+  public int getSnapshotTimeout() {
+    return snapshotTimeout;
+  }
+
+  public BackupProperties setSnapshotTimeout(final int snapshotTimeout) {
+    this.snapshotTimeout = snapshotTimeout;
     return this;
   }
 }

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -555,6 +555,11 @@
       <artifactId>annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/Metadata.java
@@ -85,7 +85,7 @@ public class Metadata {
         .replace("{count}", partCount + "");
   }
 
-  public boolean isInitialized() {
+  public boolean checkIsInitialized() {
     return partCount != null && partNo != null && version != null;
   }
 
@@ -149,7 +149,7 @@ public class Metadata {
 
   public static Metadata extractFromMetadataOrName(
       final Metadata fromMetadata, final String snapshotName) {
-    if (fromMetadata != null && fromMetadata.isInitialized()) {
+    if (fromMetadata != null && fromMetadata.checkIsInitialized()) {
       return fromMetadata;
     } else {
       return Metadata.extractMetadataFromSnapshotName(snapshotName);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/response/SnapshotState.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/response/SnapshotState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.es.backup.os.response;
+
+public enum SnapshotState {
+  FAILED("FAILED"),
+  PARTIAL("PARTIAL"),
+  STARTED("STARTED"),
+  SUCCESS("SUCCESS");
+  private final String state;
+
+  SnapshotState(final String state) {
+    this.state = state;
+  }
+
+  @Override
+  public String toString() {
+    return state;
+  }
+}

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
@@ -8,20 +8,31 @@
 package io.camunda.tasklist.webapp.es.backup.es;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.es.backup.Metadata;
+import io.camunda.tasklist.webapp.es.backup.es.BackupManagerElasticSearch.CreateSnapshotListener;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -32,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
@@ -42,8 +54,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 class BackupManagerElasticsearchTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final long backupId = 2L;
   final Metadata metadata =
-      new Metadata().setBackupId(2L).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+      new Metadata().setBackupId(backupId).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+
+  private final String repositoryName = "test-repo";
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private RestHighLevelClient searchClient;
@@ -61,7 +77,7 @@ class BackupManagerElasticsearchTest {
   public void setUp() {
     when(objectMapper.convertValue(any(), eq(Metadata.class)))
         .thenAnswer(invocation -> MAPPER.convertValue(invocation.getArgument(0), Metadata.class));
-    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn("test-repo");
+    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
   }
 
   @ParameterizedTest
@@ -125,5 +141,78 @@ class BackupManagerElasticsearchTest {
     // then
     verify(searchClient.snapshot())
         .get(argThat(r -> Arrays.asList(r.snapshots()).contains("camunda_tasklist_2025*")), any());
+  }
+
+  @Test
+  public void shouldWaitForSnapshotWithTimeout() throws IOException {
+    // given
+    final int timeout = 1;
+    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
+
+    when(tasklistProperties.getBackup().getSnapshotTimeout()).thenReturn(timeout);
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state()).thenReturn(snapshotState);
+    when(snapshotInfo.snapshotId().getName()).thenReturn(metadata.buildSnapshotName());
+    final GetSnapshotsResponse mockResponse =
+        new GetSnapshotsResponse(List.of(snapshotInfo), null, null, 1, 0);
+    when(searchClient.snapshot().get(any(), any())).thenReturn(mockResponse);
+
+    // when
+    final boolean finished =
+        backupManager.isSnapshotFinishedWithinTimeout(snapshotInfo.snapshotId().getName());
+
+    // then
+    assertFalse(finished);
+    verify(searchClient.snapshot(), atLeast(5)).get(any(), any());
+  }
+
+  @Test
+  public void shouldWaitForSnapshotTillCompleted() throws IOException {
+    // given
+    final int timeout = 0;
+    when(tasklistProperties.getBackup().getSnapshotTimeout()).thenReturn(timeout);
+    final var snapshotInfos = new ArrayList<SnapshotInfo>();
+
+    final Metadata metadata =
+        new Metadata().setBackupId(backupId).setPartCount(1).setPartNo(1).setVersion("8.3.0");
+
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state())
+        .thenReturn(SnapshotState.IN_PROGRESS)
+        .thenReturn(SnapshotState.IN_PROGRESS)
+        .thenReturn(SnapshotState.SUCCESS);
+
+    when(snapshotInfo.snapshotId().getName()).thenReturn(metadata.buildSnapshotName());
+    when(snapshotInfo.userMetadata())
+        .thenReturn(MAPPER.convertValue(metadata, new TypeReference<>() {}));
+    snapshotInfos.add(snapshotInfo);
+
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    when(snapshotResponse.getSnapshots()).thenReturn(snapshotInfos);
+    when(searchClient.snapshot().get(any(), any())).thenReturn(snapshotResponse);
+    final var captor = ArgumentCaptor.forClass(CreateSnapshotListener.class);
+    when(searchClient.snapshot().createAsync(any(), any(), any())).thenReturn(null);
+
+    // when
+    backupManager.executeSnapshotting(
+        new CreateSnapshotRequest()
+            .repository(repositoryName)
+            .snapshot(metadata.buildSnapshotName())
+            .userMetadata(MAPPER.convertValue(metadata, new TypeReference<>() {})));
+
+    verify(searchClient.snapshot(), times(1)).createAsync(any(), any(), captor.capture());
+    captor.getValue().onFailure(new SocketTimeoutException());
+
+    // then
+    // gets called one time for every mocked "IN_PROGRESS" snapshotInfo.state() call plus one for
+    // success
+    verify(searchClient.snapshot(), times(3)).get(any(), any());
+    Awaitility.await("backup is completed")
+        .atMost(15, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              final var response = backupManager.getBackupState(backupId);
+              assertThat(response.getState()).isEqualTo(BackupStateDto.COMPLETED);
+            });
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
@@ -11,16 +11,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.es.backup.Metadata;
+import io.camunda.tasklist.webapp.es.backup.os.GetCustomSnapshotResponse.Builder;
+import io.camunda.tasklist.webapp.es.backup.os.response.SnapshotState;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,21 +39,30 @@ import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class BackupManagerOpenSearchTest {
 
   @Mock OpenSearchTransport openSearchTransport;
+  private final long backupId = 2L;
+  final Metadata metadata =
+      new Metadata().setBackupId(backupId).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+  private final String repositoryName = "test-repo";
 
-  @Mock(strictness = Strictness.LENIENT)
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private OpenSearchAsyncClient openSearchAsyncClient;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -59,7 +75,7 @@ class BackupManagerOpenSearchTest {
 
   @BeforeEach
   public void setUp() {
-    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn("test-repo");
+    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
     when(openSearchClient._transport()).thenReturn(openSearchTransport);
     when(openSearchAsyncClient._transport()).thenReturn(openSearchTransport);
   }
@@ -81,6 +97,7 @@ class BackupManagerOpenSearchTest {
   @ValueSource(strings = {"SUCCESS", "IN_PROGRESS", "PARTIAL", "FAILED"})
   void shouldReturnPartialDataWhenVerboseIsFalse(final String state) throws IOException {
     // given
+
     final var metadata =
         new Metadata().setBackupId(2L).setPartCount(3).setPartNo(1).setVersion("8.6.1");
     final var snapshots = new ArrayList<SnapshotInfo>(metadata.getPartCount());
@@ -99,6 +116,7 @@ class BackupManagerOpenSearchTest {
 
     final var snapshotResponse = GetCustomSnapshotResponse.of(b -> b.snapshots(snapshots));
     when(openSearchTransport.performRequest(any(), any(), any())).thenReturn(snapshotResponse);
+    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
 
     // when
     final var backupResponse = backupManagerOpenSearch.getBackups(false, null);
@@ -144,5 +162,95 @@ class BackupManagerOpenSearchTest {
             argThat((GetSnapshotRequest r) -> r.snapshot().contains("camunda_tasklist_2025*")),
             any(),
             any());
+  }
+
+  @Test
+  public void shouldWaitForSnapshotWithTimeout() throws IOException {
+    // given
+    final int timeout = 1;
+    final SnapshotState snapshotState = SnapshotState.STARTED;
+
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state()).thenReturn(snapshotState.name());
+    when(snapshotInfo.snapshot()).thenReturn(metadata.buildSnapshotName());
+    when(tasklistProperties.getBackup().getSnapshotTimeout()).thenReturn(timeout);
+    final GetCustomSnapshotResponse response =
+        new GetCustomSnapshotResponse.Builder().snapshots(snapshotInfo).build();
+    when(openSearchClient._transport().performRequest(any(), any(), any())).thenReturn(response);
+
+    // when
+    final boolean finished =
+        backupManagerOpenSearch.isSnapshotFinishedWithinTimeout(snapshotInfo.snapshot());
+
+    // then
+    assertFalse(finished);
+    verify(openSearchClient._transport(), atLeast(5)).performRequest(any(), any(), any());
+  }
+
+  @Test
+  public void shouldWaitForSnapshotTillCompleted() throws IOException {
+    // given
+    final int timeout = 0;
+    when(tasklistProperties.getBackup().getSnapshotTimeout()).thenReturn(timeout);
+    final int numberOfSnapshots = 3;
+    final var snapshotInfos = new ArrayList<SnapshotInfo>();
+
+    final List<Metadata> metadata = new ArrayList<>();
+    for (int i = 0; i < numberOfSnapshots; i++) {
+      metadata.add(
+          new Metadata()
+              .setBackupId(backupId)
+              .setPartCount(numberOfSnapshots)
+              .setPartNo(i)
+              .setVersion("8.3.0"));
+    }
+
+    for (int i = 0; i < numberOfSnapshots; i++) {
+      final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+      when(snapshotInfo.state())
+          .thenReturn(SnapshotState.STARTED.name())
+          .thenReturn(SnapshotState.STARTED.name())
+          .thenReturn(SnapshotState.SUCCESS.name());
+      when(snapshotInfo.snapshot()).thenReturn(metadata.get(i).buildSnapshotName());
+      snapshotInfos.add(snapshotInfo);
+    }
+
+    final CompletableFuture<CreateSnapshotResponse> failedResponse =
+        CompletableFuture.failedFuture(new SocketTimeoutException("Request timed out."));
+    when(openSearchAsyncClient.snapshot().create(any(CreateSnapshotRequest.class)))
+        .thenReturn(failedResponse);
+    when(openSearchClient._transport().performRequest(any(), any(), any()))
+        .thenReturn(new Builder().snapshots(snapshotInfos).build());
+
+    // when
+    for (int i = 0; i < numberOfSnapshots; i++) {
+      final Metadata snapshotMetadata = metadata.get(i);
+      final String snapshotName = snapshotMetadata.buildSnapshotName();
+      backupManagerOpenSearch.executeSnapshotting(
+          CreateSnapshotRequest.of(
+              csr ->
+                  csr.repository(repositoryName)
+                      .snapshot(snapshotName)
+                      .indices(List.of("index-1", "index-2"))
+                      .ignoreUnavailable(false)
+                      .includeGlobalState(true)
+                      .metadata(
+                          Map.of(
+                              "backupId", JsonData.of(snapshotMetadata.getBackupId()),
+                              "version", JsonData.of(snapshotMetadata.getVersion()),
+                              "partNo", JsonData.of(snapshotMetadata.getPartNo()),
+                              "partCount", JsonData.of(snapshotMetadata.getPartCount())))
+                      .featureStates("none")
+                      .waitForCompletion(true)));
+    }
+
+    // then
+    // 4 times numberOfSnapshots because there are 3 mocked states plus one time for findSnapshots
+    // being called in the
+    // exceptionally branch before entering the isSnapshotFinishedWithinTimeout loop to get the name
+    verify(openSearchClient._transport(), times(numberOfSnapshots * 4))
+        .performRequest(any(), any(), any());
+    final var response = backupManagerOpenSearch.getBackupState(backupId);
+    assertThat(response.getState()).isEqualTo(BackupStateDto.COMPLETED);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Taking snapshots can fail due to connection timeouts in the elasticsearch client while the snapshot is still being (successfully) processed by elasticsearch. This PR fixes this problem for both elasticsearch and opensearch.

- introduce timeout when waiting for backup snapshot to finish
- add configuration parameter camunda.tasklist.backup.snapshotTimeout to set the timeout (default no timeout).
-added error handler that checks snapshot status after connection timeout until a configurable snapshotTimeout is reached
-added unit tests to verify functionality

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/29755
