### PR TITLE
Add E2E coverage for Identity Groups page and operations

### DIFF
--- a/identity/client/e2e/pages/GroupsPage.ts
+++ b/identity/client/e2e/pages/GroupsPage.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { Page, Locator } from "@playwright/test";
+
+export class GroupsPage {
+  readonly groupsList: Locator;
+  readonly createGroupButton: Locator;
+  readonly editGroupButton: (rowName?: string) => Locator;
+  readonly deleteGroupButton: (rowName?: string) => Locator;
+  readonly createGroupModal: Locator;
+  readonly closeCreateGroupModal: Locator;
+  readonly createGroupIdField: Locator;
+  readonly createNameField: Locator;
+  readonly createDescriptionField: Locator;
+  readonly createGroupModalCancelButton: Locator;
+  readonly createGroupModalCreateButton: Locator;
+  readonly editGroupModal: Locator;
+  readonly closeEditGroupModal: Locator;
+  readonly editNameField: Locator;
+  readonly editDescriptionField: Locator;
+  readonly editGroupModalCancelButton: Locator;
+  readonly editGroupModalUpdateButton: Locator;
+  readonly deleteGroupModal: Locator;
+  readonly closeDeleteGroupModal: Locator;
+  readonly deleteGroupModalCancelButton: Locator;
+  readonly deleteGroupModalDeleteButton: Locator;
+
+  constructor(page: Page) {
+    // List page
+    this.groupsList = page.getByRole("table");
+    this.createGroupButton = page.getByRole("button", {
+      name: /create group/i,
+    });
+    this.editGroupButton = (rowName) =>
+      this.groupsList
+        .getByRole("row", { name: rowName })
+        .getByLabel(/edit group/i);
+    this.deleteGroupButton = (rowName) =>
+      this.groupsList.getByRole("row", { name: rowName }).getByLabel("Delete");
+
+    // Create group modal
+    this.createGroupModal = page.getByRole("dialog", {
+      name: "Create group",
+    });
+    this.closeCreateGroupModal = this.createGroupModal.getByRole("button", {
+      name: "Close",
+    });
+    this.createGroupIdField = this.createGroupModal.getByRole("textbox", {
+      name: /group id/i,
+    });
+    this.createNameField = this.createGroupModal.getByRole("textbox", {
+      name: /group name/i,
+    });
+    this.createDescriptionField = this.createGroupModal.getByRole("textbox", {
+      name: "Description",
+    });
+    this.createGroupModalCancelButton = this.createGroupModal.getByRole(
+      "button",
+      {
+        name: "Cancel",
+      },
+    );
+    this.createGroupModalCreateButton = this.createGroupModal.getByRole(
+      "button",
+      {
+        name: /create group/i,
+      },
+    );
+
+    // Edit group modal
+    this.editGroupModal = page.getByRole("dialog", { name: /edit group/i });
+    this.closeEditGroupModal = this.editGroupModal.getByRole("button", {
+      name: "Close",
+    });
+    this.editNameField = this.editGroupModal.getByRole("textbox", {
+      name: "Name",
+      exact: true,
+    });
+    this.editDescriptionField = this.editGroupModal.getByRole("textbox", {
+      name: "Description",
+    });
+    this.editGroupModalCancelButton = this.editGroupModal.getByRole("button", {
+      name: "Cancel",
+    });
+    this.editGroupModalUpdateButton = this.editGroupModal.getByRole("button", {
+      name: /update group/i,
+    });
+
+    // Delete group modal
+    this.deleteGroupModal = page.getByRole("dialog", { name: /delete group/i });
+    this.closeDeleteGroupModal = this.deleteGroupModal.getByRole("button", {
+      name: "Close",
+    });
+    this.deleteGroupModalCancelButton = this.deleteGroupModal.getByRole(
+      "button",
+      {
+        name: "Cancel",
+      },
+    );
+    this.deleteGroupModalDeleteButton = this.deleteGroupModal.getByRole(
+      "button",
+      {
+        name: /delete group/i,
+      },
+    );
+  }
+}

--- a/identity/client/e2e/pages/GroupsPage.ts
+++ b/identity/client/e2e/pages/GroupsPage.ts
@@ -7,8 +7,11 @@
  */
 
 import { Page, Locator } from "@playwright/test";
+import { Paths } from "../utils/paths";
+import { relativizePath } from "../utils/relativizePaths";
 
 export class GroupsPage {
+  private page: Page;
   readonly groupsList: Locator;
   readonly createGroupButton: Locator;
   readonly editGroupButton: (rowName?: string) => Locator;
@@ -32,6 +35,7 @@ export class GroupsPage {
   readonly deleteGroupModalDeleteButton: Locator;
 
   constructor(page: Page) {
+    this.page = page;
     // List page
     this.groupsList = page.getByRole("table");
     this.createGroupButton = page.getByRole("button", {
@@ -109,5 +113,9 @@ export class GroupsPage {
         name: /delete group/i,
       },
     );
+  }
+
+  async navigateToGroups() {
+    await this.page.goto(relativizePath(Paths.groups()));
   }
 }

--- a/identity/client/e2e/pages/UsersPage.ts
+++ b/identity/client/e2e/pages/UsersPage.ts
@@ -7,8 +7,11 @@
  */
 
 import { Page, Locator } from "@playwright/test";
+import { Paths } from "../utils/paths";
+import { relativizePath } from "../utils/relativizePaths";
 
 export class UsersPage {
+  private page: Page;
   readonly usersList: Locator;
   readonly createUserButton: Locator;
   readonly editUserButton: (rowName?: string) => Locator;
@@ -36,6 +39,7 @@ export class UsersPage {
   readonly deleteUserModalDeleteButton: Locator;
 
   constructor(page: Page) {
+    this.page = page;
     // List page
     this.usersList = page.getByRole("table");
     this.createUserButton = page.getByRole("button", {
@@ -130,5 +134,9 @@ export class UsersPage {
         name: /delete user/i,
       },
     );
+  }
+
+  async navigateToUsers() {
+    await this.page.goto(relativizePath(Paths.users()));
   }
 }

--- a/identity/client/e2e/tests/groups.spec.ts
+++ b/identity/client/e2e/tests/groups.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { expect } from "@playwright/test";
+import { test } from "../text-fixtures";
+import { Paths } from "../utils/paths";
+import { relativizePath } from "../utils/relativizePaths";
+import { LOGIN_CREDENTIALS } from "../utils/constants";
+import { waitForItemInList } from "../utils/waitForItemInList";
+
+const NEW_GROUP = {
+  groupId: "testgroupid",
+  name: "Test Group",
+  description: "test description",
+};
+
+const EDITED_GROUP = {
+  name: "Edited Group",
+  description: "edited description",
+};
+
+test.beforeEach(async ({ page, loginPage, groupsPage }) => {
+  await loginPage.navigateToLogin();
+  await loginPage.login(LOGIN_CREDENTIALS);
+  await expect(page).toHaveURL(relativizePath(Paths.users()));
+  await groupsPage.navigateToGroups();
+  await expect(page).toHaveURL(relativizePath(Paths.groups()));
+});
+
+test.describe.serial("groups CRUD", () => {
+  test.only("creates a group", async ({ page, groupsPage }) => {
+    await expect(
+      groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
+    ).not.toBeVisible();
+
+    await groupsPage.createGroupButton.click();
+    await expect(groupsPage.createGroupModal).toBeVisible();
+    await groupsPage.createGroupIdField.fill(NEW_GROUP.groupId);
+    await groupsPage.createNameField.fill(NEW_GROUP.name);
+    await groupsPage.createDescriptionField.fill(NEW_GROUP.description);
+    await groupsPage.createGroupModalCreateButton.click();
+    await expect(groupsPage.createGroupModal).not.toBeVisible();
+
+    const item = groupsPage.groupsList.getByRole("cell", {
+      name: NEW_GROUP.name,
+    });
+
+    await waitForItemInList(page, item);
+  });
+
+  test("edits a group", async ({ page, groupsPage }) => {
+    await expect(
+      groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
+    ).toBeVisible();
+
+    await groupsPage.editGroupButton(NEW_GROUP.name).click();
+    await expect(groupsPage.editGroupModal).toBeVisible();
+    await groupsPage.editNameField.fill(EDITED_GROUP.name);
+    await groupsPage.editDescriptionField.fill(EDITED_GROUP.description);
+    await groupsPage.editGroupModalUpdateButton.click();
+    await expect(groupsPage.editGroupModal).not.toBeVisible();
+
+    const item = groupsPage.groupsList.getByRole("cell", {
+      name: EDITED_GROUP.name,
+    });
+
+    await waitForItemInList(page, item);
+  });
+
+  test("deletes a group", async ({ page, groupsPage }) => {
+    await expect(
+      groupsPage.groupsList.getByRole("cell", { name: EDITED_GROUP.name }),
+    ).toBeVisible();
+
+    await groupsPage.deleteGroupButton(EDITED_GROUP.name).click();
+    await expect(groupsPage.deleteGroupModal).toBeVisible();
+    await groupsPage.deleteGroupModalDeleteButton.click();
+    await expect(groupsPage.deleteGroupModal).not.toBeVisible();
+
+    const item = groupsPage.groupsList.getByRole("cell", {
+      name: EDITED_GROUP.name,
+    });
+
+    await waitForItemInList(page, item, false);
+  });
+});

--- a/identity/client/e2e/tests/groups.spec.ts
+++ b/identity/client/e2e/tests/groups.spec.ts
@@ -13,6 +13,8 @@ import { relativizePath } from "../utils/relativizePaths";
 import { LOGIN_CREDENTIALS } from "../utils/constants";
 import { waitForItemInList } from "../utils/waitForItemInList";
 
+import { IS_GROUPS_BASE_PAGE_INTEGRATED } from "../../src/feature-flags";
+
 const NEW_GROUP = {
   groupId: "testgroupid",
   name: "Test Group",
@@ -32,60 +34,63 @@ test.beforeEach(async ({ page, loginPage, groupsPage }) => {
   await expect(page).toHaveURL(relativizePath(Paths.groups()));
 });
 
-test.describe.serial("groups CRUD", () => {
-  test.only("creates a group", async ({ page, groupsPage }) => {
-    await expect(
-      groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
-    ).not.toBeVisible();
+test.describe[IS_GROUPS_BASE_PAGE_INTEGRATED ? "serial" : "skip"](
+  "groups CRUD",
+  () => {
+    test("creates a group", async ({ page, groupsPage }) => {
+      await expect(
+        groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
+      ).not.toBeVisible();
 
-    await groupsPage.createGroupButton.click();
-    await expect(groupsPage.createGroupModal).toBeVisible();
-    await groupsPage.createGroupIdField.fill(NEW_GROUP.groupId);
-    await groupsPage.createNameField.fill(NEW_GROUP.name);
-    await groupsPage.createDescriptionField.fill(NEW_GROUP.description);
-    await groupsPage.createGroupModalCreateButton.click();
-    await expect(groupsPage.createGroupModal).not.toBeVisible();
+      await groupsPage.createGroupButton.click();
+      await expect(groupsPage.createGroupModal).toBeVisible();
+      await groupsPage.createGroupIdField.fill(NEW_GROUP.groupId);
+      await groupsPage.createNameField.fill(NEW_GROUP.name);
+      await groupsPage.createDescriptionField.fill(NEW_GROUP.description);
+      await groupsPage.createGroupModalCreateButton.click();
+      await expect(groupsPage.createGroupModal).not.toBeVisible();
 
-    const item = groupsPage.groupsList.getByRole("cell", {
-      name: NEW_GROUP.name,
+      const item = groupsPage.groupsList.getByRole("cell", {
+        name: NEW_GROUP.name,
+      });
+
+      await waitForItemInList(page, item);
     });
 
-    await waitForItemInList(page, item);
-  });
+    test("edits a group", async ({ page, groupsPage }) => {
+      await expect(
+        groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
+      ).toBeVisible();
 
-  test("edits a group", async ({ page, groupsPage }) => {
-    await expect(
-      groupsPage.groupsList.getByRole("cell", { name: NEW_GROUP.name }),
-    ).toBeVisible();
+      await groupsPage.editGroupButton(NEW_GROUP.name).click();
+      await expect(groupsPage.editGroupModal).toBeVisible();
+      await groupsPage.editNameField.fill(EDITED_GROUP.name);
+      await groupsPage.editDescriptionField.fill(EDITED_GROUP.description);
+      await groupsPage.editGroupModalUpdateButton.click();
+      await expect(groupsPage.editGroupModal).not.toBeVisible();
 
-    await groupsPage.editGroupButton(NEW_GROUP.name).click();
-    await expect(groupsPage.editGroupModal).toBeVisible();
-    await groupsPage.editNameField.fill(EDITED_GROUP.name);
-    await groupsPage.editDescriptionField.fill(EDITED_GROUP.description);
-    await groupsPage.editGroupModalUpdateButton.click();
-    await expect(groupsPage.editGroupModal).not.toBeVisible();
+      const item = groupsPage.groupsList.getByRole("cell", {
+        name: EDITED_GROUP.name,
+      });
 
-    const item = groupsPage.groupsList.getByRole("cell", {
-      name: EDITED_GROUP.name,
+      await waitForItemInList(page, item);
     });
 
-    await waitForItemInList(page, item);
-  });
+    test("deletes a group", async ({ page, groupsPage }) => {
+      await expect(
+        groupsPage.groupsList.getByRole("cell", { name: EDITED_GROUP.name }),
+      ).toBeVisible();
 
-  test("deletes a group", async ({ page, groupsPage }) => {
-    await expect(
-      groupsPage.groupsList.getByRole("cell", { name: EDITED_GROUP.name }),
-    ).toBeVisible();
+      await groupsPage.deleteGroupButton(EDITED_GROUP.name).click();
+      await expect(groupsPage.deleteGroupModal).toBeVisible();
+      await groupsPage.deleteGroupModalDeleteButton.click();
+      await expect(groupsPage.deleteGroupModal).not.toBeVisible();
 
-    await groupsPage.deleteGroupButton(EDITED_GROUP.name).click();
-    await expect(groupsPage.deleteGroupModal).toBeVisible();
-    await groupsPage.deleteGroupModalDeleteButton.click();
-    await expect(groupsPage.deleteGroupModal).not.toBeVisible();
+      const item = groupsPage.groupsList.getByRole("cell", {
+        name: EDITED_GROUP.name,
+      });
 
-    const item = groupsPage.groupsList.getByRole("cell", {
-      name: EDITED_GROUP.name,
+      await waitForItemInList(page, item, false);
     });
-
-    await waitForItemInList(page, item, false);
-  });
-});
+  },
+);

--- a/identity/client/e2e/tests/users.spec.ts
+++ b/identity/client/e2e/tests/users.spec.ts
@@ -87,22 +87,6 @@ test.describe.serial("users CRUD", () => {
     await usersPage.deleteUserModalDeleteButton.click();
     await expect(usersPage.deleteUserModal).not.toBeVisible();
 
-    await expect
-      .poll(
-        async () => {
-          await page.reload();
-          await page.waitForTimeout(1000); // this timeout is needed to give time for the table to load when the page loads, regular assertions do not have the same effect
-          const isVisible = await usersPage.usersList
-            .getByRole("cell", { name: EDITED_USER.email })
-            .isVisible();
-          return isVisible;
-        },
-        {
-          timeout: 10000,
-        },
-      )
-      .toBeFalsy();
-
     const item = usersPage.usersList.getByRole("cell", {
       name: EDITED_USER.email,
     });

--- a/identity/client/e2e/text-fixtures.ts
+++ b/identity/client/e2e/text-fixtures.ts
@@ -24,5 +24,5 @@ export const test = base.extend<Fixtures>({
   header: createFixture(Header),
   loginPage: createFixture(LoginPage),
   usersPage: createFixture(UsersPage),
-  groupsPage: createFixture(UsersPage),
+  groupsPage: createFixture(GroupsPage),
 });

--- a/identity/client/e2e/text-fixtures.ts
+++ b/identity/client/e2e/text-fixtures.ts
@@ -10,16 +10,19 @@ import { test as base } from "@playwright/test";
 import { Header } from "./pages/Header";
 import { LoginPage } from "./pages/LoginPage";
 import { UsersPage } from "./pages/UsersPage";
+import { GroupsPage } from "./pages/GroupsPage";
 import { createFixture } from "./utils/createFixture";
 
 type Fixtures = {
   header: Header;
   loginPage: LoginPage;
   usersPage: UsersPage;
+  groupsPage: GroupsPage;
 };
 
 export const test = base.extend<Fixtures>({
   header: createFixture(Header),
   loginPage: createFixture(LoginPage),
   usersPage: createFixture(UsersPage),
+  groupsPage: createFixture(UsersPage),
 });

--- a/identity/client/e2e/utils/waitForItemInList.ts
+++ b/identity/client/e2e/utils/waitForItemInList.ts
@@ -18,6 +18,7 @@ export const waitForItemInList = async (
     async () => {
       await page.reload();
       await page.getByRole("table").waitFor();
+      await page.getByRole("cell").first().waitFor();
       const isVisible = await item.isVisible();
 
       return isVisible;

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -18,3 +18,6 @@ export const IS_GROUP_MAPPINGS_SUPPORTED = false;
 // Roles details page - Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
 export const IS_ROLES_USERS_SUPPORTED = false;
 export const IS_ROLES_MAPPINGS_SUPPORTED = false;
+
+// Groups base page (and e2e tests) - Remove when Groups page is integrated https://github.com/camunda/camunda/issues/29718
+export const IS_GROUPS_BASE_PAGE_INTEGRATED = false;


### PR DESCRIPTION
## Description

Add E2E coverage for Identity Groups page and operations.
More details on parent issue - #30952 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30952 
