### PR TITLE
feat: Support incident resolution for canceling user task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -164,7 +164,9 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   }
 
   private boolean isUserTaskRelatedIncident(final ElementInstance elementInstance) {
-    return elementInstance.getState() == ProcessInstanceIntent.ELEMENT_ACTIVATED
+    final var state = elementInstance.getState();
+    return (state == ProcessInstanceIntent.ELEMENT_ACTIVATED
+        || state == ProcessInstanceIntent.ELEMENT_TERMINATING)
         && elementInstance.getValue().getBpmnElementType() == BpmnElementType.USER_TASK
         && elementInstance.getUserTaskKey() > 0;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -201,7 +201,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             intent -> {
               final var userTaskRecord = new UserTaskRecord();
               userTaskRecord.wrap(intermediateState.getRecord());
-              return new IncidentRecordWrapper<UserTaskRecord>(userTaskKey, intent, userTaskRecord);
+              return new IncidentRecordWrapper<>(userTaskKey, intent, userTaskRecord);
             });
   }
 
@@ -213,8 +213,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             intent -> {
               final var record = new ProcessInstanceRecord();
               record.wrap(elementInstance.getValue());
-              return new IncidentRecordWrapper<ProcessInstanceRecord>(
-                  elementInstance.getKey(), intent, record);
+              return new IncidentRecordWrapper<>(elementInstance.getKey(), intent, record);
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -163,12 +164,22 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     }
   }
 
-  private boolean isUserTaskRelatedIncident(final ElementInstance elementInstance) {
-    final var state = elementInstance.getState();
-    return (state == ProcessInstanceIntent.ELEMENT_ACTIVATED
-        || state == ProcessInstanceIntent.ELEMENT_TERMINATING)
-        && elementInstance.getValue().getBpmnElementType() == BpmnElementType.USER_TASK
-        && elementInstance.getUserTaskKey() > 0;
+  private boolean isUserTaskListenerRelatedIncident(
+      final IncidentRecord incidentRecord, final ElementInstance elementInstance) {
+
+    final boolean isExpressionFailure =
+        incidentRecord.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR;
+
+    final boolean isCamundaUserTask =
+        elementInstance.getValue().getBpmnElementType() == BpmnElementType.USER_TASK
+            && elementInstance.getUserTaskKey() > 0;
+
+    final var currentState = elementInstance.getState();
+    final boolean isInRelevantState =
+        currentState == ProcessInstanceIntent.ELEMENT_ACTIVATED
+            || currentState == ProcessInstanceIntent.ELEMENT_TERMINATING;
+
+    return isExpressionFailure && isCamundaUserTask && isInRelevantState;
   }
 
   private Either<String, TypedRecord<? extends UnifiedRecordValue>> getFailedCommand(
@@ -182,7 +193,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
               elementInstanceKey));
     }
 
-    return isUserTaskRelatedIncident(elementInstance)
+    return isUserTaskListenerRelatedIncident(incidentRecord, elementInstance)
         ? createUserTaskCommand(elementInstance)
         : createProcessInstanceCommand(elementInstance);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
@@ -128,6 +128,15 @@ public class TaskListenerIncidentsTest {
         UserTaskIntent.COMPLETED);
   }
 
+  @Test
+  public void shouldCreateJobNoRetriesIncidentForCancelingListenerAndContinueAfterResolution() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.canceling,
+        UnaryOperator.identity(),
+        pik -> ENGINE.processInstance().withInstanceKey(pik).expectTerminating().cancel(),
+        UserTaskIntent.CANCELED);
+  }
+
   private long verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
       final ZeebeTaskListenerEventType eventType,
       final UnaryOperator<UserTaskBuilder> userTaskBuilder,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
@@ -419,5 +420,78 @@ public class TaskListenerIncidentsTest {
         processInstanceKey,
         UserTaskIntent.ASSIGNED,
         userTask -> Assertions.assertThat(userTask).hasAssignee(assignee).hasAction(""));
+  }
+
+  @Test
+  public void shouldRetryCancelingListenerJobAfterExtractValueErrorDuringUserTaskInterruption() {
+
+    // given
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .userTask(
+                    "user_task",
+                    t ->
+                        t.zeebeUserTask()
+                            .zeebeTaskListener(l -> l.canceling().type(listenerType))
+                            .zeebeTaskListener(
+                                l -> l.canceling().typeExpression("canceling_listener_var_name"))
+                            .zeebeTaskListener(l -> l.canceling().type(listenerType + "_3")))
+                .boundaryEvent(
+                    "msg_boundary_event",
+                    e -> e.message(m -> m.name("my_message").zeebeCorrelationKey("=\"my_key-1\"")))
+                .endEvent("boundary_end")
+                .moveToActivity("user_task")
+                .endEvent("main_end")
+                .done());
+
+    // when: interrupt the user task via message boundary event to trigger canceling transition
+    ENGINE.message().withName("my_message").withCorrelationKey("my_key-1").publish();
+
+    // complete the first task listener job
+    ENGINE.job().ofInstance(processInstanceKey).withType(listenerType).complete();
+
+    // then: expect incident due to missing variable in canceling listener expression
+    final var incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+                Expected result of the expression '%s' to be 'STRING', but was 'NULL'. \
+                The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name '%s'"""
+                .formatted("canceling_listener_var_name", "canceling_listener_var_name"));
+
+    // when: fix the missing variable and resolve the incident
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("canceling_listener_var_name", listenerType + "_2"))
+        .update();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentRecord.getKey()).resolve();
+
+    // complete the retried task listener job and remaining task listeners
+    helper.completeRecreatedJobWithType(processInstanceKey, listenerType);
+    helper.completeJobs(processInstanceKey, listenerType + "_2", listenerType + "_3");
+
+    // then
+    helper.assertTaskListenerJobsCompletionSequence(
+        processInstanceKey,
+        helper.mapToJobListenerEventType(ZeebeTaskListenerEventType.canceling),
+        listenerType,
+        listenerType, // re-created task listener job
+        listenerType + "_2",
+        listenerType + "_3");
+
+    helper.assertUserTaskRecordWithIntent(
+        processInstanceKey,
+        UserTaskIntent.CANCELED,
+        userTask -> assertThat(userTask.getAction()).isEmpty());
   }
 }


### PR DESCRIPTION
## Description

This PR implements support for resolving incidents raised for "canceling" task listeners.
- Listener job fails with no retries left.
- Listener job fails due to expression evaluation (`EXTRACT_VALUE_ERROR`).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28576 
