### PR TITLE
fix: support incident error hash codes in or filters

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilter.java
@@ -17,104 +17,136 @@ package io.camunda.client.api.statistics.filter;
 
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.filter.ProcessInstanceFilterBase;
 import io.camunda.client.api.search.filter.ProcessInstanceVariableFilterRequest;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.statistics.request.StatisticsRequest.StatisticsRequestFilter;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public interface ProcessDefinitionStatisticsFilter extends StatisticsRequestFilter {
+public interface ProcessDefinitionStatisticsFilter extends ProcessDefinitionStatisticsFilterBase {
 
   /** Filter by processInstanceKey */
+  @Override
   ProcessDefinitionStatisticsFilter processInstanceKey(final Long processInstanceKey);
 
   /** Filter by processInstanceKey using {@link BasicLongProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter processInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by parentProcessInstanceKey */
+  @Override
   ProcessDefinitionStatisticsFilter parentProcessInstanceKey(final Long parentProcessInstanceKey);
 
   /** Filter by parentProcessInstanceKey using {@link BasicLongProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter parentProcessInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by parentElementInstanceKey */
+  @Override
   ProcessDefinitionStatisticsFilter parentElementInstanceKey(final Long parentElementInstanceKey);
 
   /** Filter by parentElementInstanceKey using {@link BasicLongProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter parentElementInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by startDate */
+  @Override
   ProcessDefinitionStatisticsFilter startDate(final OffsetDateTime startDate);
 
   /** Filter by startDate using {@link DateTimeProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter startDate(final Consumer<DateTimeProperty> fn);
 
   /** Filter by endDate */
+  @Override
   ProcessDefinitionStatisticsFilter endDate(final OffsetDateTime endDate);
 
   /** Filter by endDate using {@link DateTimeProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter endDate(final Consumer<DateTimeProperty> fn);
 
   /** Filter by state */
+  @Override
   ProcessDefinitionStatisticsFilter state(final ProcessInstanceState state);
 
   /** Filter by state using {@link ProcessInstanceStateProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter state(final Consumer<ProcessInstanceStateProperty> fn);
 
   /** Filter by hasIncident */
+  @Override
   ProcessDefinitionStatisticsFilter hasIncident(final Boolean hasIncident);
 
   /** Filter by tenantId */
+  @Override
   ProcessDefinitionStatisticsFilter tenantId(final String tenantId);
 
   /** Filter by tenantId using {@link StringProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter tenantId(final Consumer<StringProperty> fn);
 
   /** Filter by variables */
+  @Override
   ProcessDefinitionStatisticsFilter variables(
       final List<ProcessInstanceVariableFilterRequest> variableValueFilters);
 
   /** Filter by variables map */
+  @Override
   ProcessDefinitionStatisticsFilter variables(final Map<String, Object> variableValueFilters);
 
   /** Filter by batchOperationId */
+  @Override
   ProcessDefinitionStatisticsFilter batchOperationId(final String batchOperationId);
 
   /** Filter by batchOperationId using {@link StringProperty} */
+  @Override
   ProcessDefinitionStatisticsFilter batchOperationId(final Consumer<StringProperty> fn);
 
   /** Filter by error message */
+  @Override
   ProcessDefinitionStatisticsFilter errorMessage(final String errorMessage);
 
   /** Filter by error message using {@link StringProperty} consumer */
+  @Override
   ProcessDefinitionStatisticsFilter errorMessage(final Consumer<StringProperty> fn);
 
   /** Filter by hasRetriesLeft */
+  @Override
   ProcessDefinitionStatisticsFilter hasRetriesLeft(final Boolean hasRetriesLeft);
 
   /** Filter by elementId */
+  @Override
   ProcessDefinitionStatisticsFilter elementId(final String elementId);
 
   /** Filter by elementId using {@link StringProperty} */
+  @Override
   ProcessDefinitionStatisticsFilter elementId(final Consumer<StringProperty> fn);
 
   /** Filter by elementInstanceState */
+  @Override
   ProcessDefinitionStatisticsFilter elementInstanceState(final ElementInstanceState state);
 
   /** Filter by elementInstanceState using {@link ElementInstanceStateProperty} */
+  @Override
   ProcessDefinitionStatisticsFilter elementInstanceState(
       final Consumer<ElementInstanceStateProperty> fn);
 
   /** Filter by hasElementInstanceIncident */
+  @Override
   ProcessDefinitionStatisticsFilter hasElementInstanceIncident(
       final Boolean hasElementInstanceIncident);
 
   /** Filter by incidentErrorHashCode */
+  @Override
   ProcessDefinitionStatisticsFilter incidentErrorHashCode(final Integer incidentErrorHashCode);
+
+  /** Filter by or conjunction using {@link ProcessInstanceFilterBase} consumer */
+  ProcessDefinitionStatisticsFilter orFilters(
+      List<Consumer<ProcessDefinitionStatisticsFilterBase>> filters);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/filter/ProcessDefinitionStatisticsFilterBase.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.filter;
+
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.client.api.search.filter.ProcessInstanceVariableFilterRequest;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
+import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.statistics.request.StatisticsRequest.StatisticsRequestFilter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public interface ProcessDefinitionStatisticsFilterBase extends StatisticsRequestFilter {
+
+  /** Filter by processInstanceKey */
+  ProcessDefinitionStatisticsFilterBase processInstanceKey(final Long processInstanceKey);
+
+  /** Filter by processInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase processInstanceKey(final Consumer<BasicLongProperty> fn);
+
+  /** Filter by parentProcessInstanceKey */
+  ProcessDefinitionStatisticsFilterBase parentProcessInstanceKey(
+      final Long parentProcessInstanceKey);
+
+  /** Filter by parentProcessInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase parentProcessInstanceKey(
+      final Consumer<BasicLongProperty> fn);
+
+  /** Filter by parentElementInstanceKey */
+  ProcessDefinitionStatisticsFilterBase parentElementInstanceKey(
+      final Long parentElementInstanceKey);
+
+  /** Filter by parentElementInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase parentElementInstanceKey(
+      final Consumer<BasicLongProperty> fn);
+
+  /** Filter by startDate */
+  ProcessDefinitionStatisticsFilterBase startDate(final OffsetDateTime startDate);
+
+  /** Filter by startDate using {@link DateTimeProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase startDate(final Consumer<DateTimeProperty> fn);
+
+  /** Filter by endDate */
+  ProcessDefinitionStatisticsFilterBase endDate(final OffsetDateTime endDate);
+
+  /** Filter by endDate using {@link DateTimeProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase endDate(final Consumer<DateTimeProperty> fn);
+
+  /** Filter by state */
+  ProcessDefinitionStatisticsFilterBase state(final ProcessInstanceState state);
+
+  /** Filter by state using {@link ProcessInstanceStateProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase state(final Consumer<ProcessInstanceStateProperty> fn);
+
+  /** Filter by hasIncident */
+  ProcessDefinitionStatisticsFilterBase hasIncident(final Boolean hasIncident);
+
+  /** Filter by tenantId */
+  ProcessDefinitionStatisticsFilterBase tenantId(final String tenantId);
+
+  /** Filter by tenantId using {@link StringProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase tenantId(final Consumer<StringProperty> fn);
+
+  /** Filter by variables */
+  ProcessDefinitionStatisticsFilterBase variables(
+      final List<ProcessInstanceVariableFilterRequest> variableValueFilters);
+
+  /** Filter by variables map */
+  ProcessDefinitionStatisticsFilterBase variables(final Map<String, Object> variableValueFilters);
+
+  /** Filter by batchOperationId */
+  ProcessDefinitionStatisticsFilterBase batchOperationId(final String batchOperationId);
+
+  /** Filter by batchOperationId using {@link StringProperty} */
+  ProcessDefinitionStatisticsFilterBase batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by error message */
+  ProcessDefinitionStatisticsFilterBase errorMessage(final String errorMessage);
+
+  /** Filter by error message using {@link StringProperty} consumer */
+  ProcessDefinitionStatisticsFilterBase errorMessage(final Consumer<StringProperty> fn);
+
+  /** Filter by hasRetriesLeft */
+  ProcessDefinitionStatisticsFilterBase hasRetriesLeft(final Boolean hasRetriesLeft);
+
+  /** Filter by elementId */
+  ProcessDefinitionStatisticsFilterBase elementId(final String elementId);
+
+  /** Filter by elementId using {@link StringProperty} */
+  ProcessDefinitionStatisticsFilterBase elementId(final Consumer<StringProperty> fn);
+
+  /** Filter by elementInstanceState */
+  ProcessDefinitionStatisticsFilterBase elementInstanceState(final ElementInstanceState state);
+
+  /** Filter by elementInstanceState using {@link ElementInstanceStateProperty} */
+  ProcessDefinitionStatisticsFilterBase elementInstanceState(
+      final Consumer<ElementInstanceStateProperty> fn);
+
+  /** Filter by hasElementInstanceIncident */
+  ProcessDefinitionStatisticsFilterBase hasElementInstanceIncident(
+      final Boolean hasElementInstanceIncident);
+
+  /** Filter by incidentErrorHashCode */
+  ProcessDefinitionStatisticsFilterBase incidentErrorHashCode(final Integer incidentErrorHashCode);
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
+import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilterBase;
 import io.camunda.client.impl.RequestMapper;
 import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
@@ -31,6 +32,8 @@ import io.camunda.client.impl.search.filter.builder.ElementInstanceStateProperty
 import io.camunda.client.impl.search.filter.builder.ProcessInstanceStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.ProcessDefinitionStatisticsFilterMapper;
+import io.camunda.client.protocol.rest.BaseProcessInstanceFilterFields;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -38,13 +41,13 @@ import java.util.function.Consumer;
 
 public class ProcessDefinitionStatisticsFilterImpl
     extends TypedSearchRequestPropertyProvider<
-        io.camunda.client.protocol.rest.BaseProcessInstanceFilter>
+        io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter>
     implements ProcessDefinitionStatisticsFilter {
 
-  private final io.camunda.client.protocol.rest.BaseProcessInstanceFilter filter;
+  private final io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter filter;
 
   public ProcessDefinitionStatisticsFilterImpl() {
-    filter = new io.camunda.client.protocol.rest.BaseProcessInstanceFilter();
+    filter = new io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter();
   }
 
   @Override
@@ -254,6 +257,22 @@ public class ProcessDefinitionStatisticsFilterImpl
     return this;
   }
 
+  @Override
+  public ProcessDefinitionStatisticsFilter orFilters(
+      final List<Consumer<ProcessDefinitionStatisticsFilterBase>> fns) {
+    for (final Consumer<ProcessDefinitionStatisticsFilterBase> fn : fns) {
+      final ProcessDefinitionStatisticsFilterImpl orFilter =
+          new ProcessDefinitionStatisticsFilterImpl();
+      fn.accept(orFilter);
+      final io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter protocolFilter =
+          orFilter.getSearchRequestProperty();
+      final BaseProcessInstanceFilterFields protocolFilterFields =
+          ProcessDefinitionStatisticsFilterMapper.from(protocolFilter);
+      filter.add$OrItem(protocolFilterFields);
+    }
+    return this;
+  }
+
   static void variableValueNullCheck(final Object value) {
     if (value == null) {
       throw new IllegalArgumentException("Variable value cannot be null");
@@ -261,7 +280,8 @@ public class ProcessDefinitionStatisticsFilterImpl
   }
 
   @Override
-  protected io.camunda.client.protocol.rest.BaseProcessInstanceFilter getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter
+      getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/request/ProcessDefinitionElementStatisticsRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/request/ProcessDefinitionElementStatisticsRequestImpl.java
@@ -26,7 +26,6 @@ import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.statistics.filter.ProcessDefinitionStatisticsFilterImpl;
 import io.camunda.client.impl.statistics.response.StatisticsResponseMapper;
-import io.camunda.client.protocol.rest.BaseProcessInstanceFilter;
 import io.camunda.client.protocol.rest.ProcessDefinitionElementStatisticsQuery;
 import io.camunda.client.protocol.rest.ProcessDefinitionElementStatisticsQueryResult;
 import java.time.Duration;
@@ -77,7 +76,8 @@ public class ProcessDefinitionElementStatisticsRequestImpl
   @Override
   public ProcessDefinitionElementStatisticsRequest filter(
       final ProcessDefinitionStatisticsFilter value) {
-    final BaseProcessInstanceFilter filter = provideSearchRequestProperty(value);
+    final io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter filter =
+        provideSearchRequestProperty(value);
     request.setFilter(filter);
     return this;
   }
@@ -87,7 +87,8 @@ public class ProcessDefinitionElementStatisticsRequestImpl
       final Consumer<ProcessDefinitionStatisticsFilter> fn) {
     final ProcessDefinitionStatisticsFilter value = new ProcessDefinitionStatisticsFilterImpl();
     fn.accept(value);
-    final BaseProcessInstanceFilter filter = provideSearchRequestProperty(value);
+    final io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter filter =
+        provideSearchRequestProperty(value);
     request.setFilter(filter);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/ProcessDefinitionStatisticsFilterMapper.java
@@ -15,30 +15,23 @@
  */
 package io.camunda.client.impl.util;
 
-import io.camunda.client.protocol.rest.ProcessInstanceFilter;
-import io.camunda.client.protocol.rest.ProcessInstanceFilterFields;
+import io.camunda.client.protocol.rest.BaseProcessInstanceFilterFields;
+import io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter;
 
-/**
- * Utility class for mapping {@link ProcessInstanceFilter} to {@link ProcessInstanceFilterFields}.
- */
-public final class ProcessInstanceFilterMapper {
+public final class ProcessDefinitionStatisticsFilterMapper {
 
-  private ProcessInstanceFilterMapper() {
+  private ProcessDefinitionStatisticsFilterMapper() {
     // Prevent instantiation
   }
 
-  public static ProcessInstanceFilterFields from(final ProcessInstanceFilter filter) {
+  public static BaseProcessInstanceFilterFields from(
+      final ProcessDefinitionStatisticsFilter filter) {
     if (filter == null) {
       return null;
     }
 
-    final ProcessInstanceFilterFields target = new ProcessInstanceFilterFields();
+    final BaseProcessInstanceFilterFields target = new BaseProcessInstanceFilterFields();
 
-    target.setProcessDefinitionId(filter.getProcessDefinitionId());
-    target.setProcessDefinitionName(filter.getProcessDefinitionName());
-    target.setProcessDefinitionVersion(filter.getProcessDefinitionVersion());
-    target.setProcessDefinitionVersionTag(filter.getProcessDefinitionVersionTag());
-    target.setProcessDefinitionKey(filter.getProcessDefinitionKey());
     target.setStartDate(filter.getStartDate());
     target.setEndDate(filter.getEndDate());
     target.setState(filter.getState());

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -99,7 +99,6 @@
   <select id="flowNodeStatistics"
     parameterType="io.camunda.search.filter.ProcessDefinitionStatisticsFilter"
     resultMap="io.camunda.db.rdbms.sql.Commons.flowNodeStatisticsResultMap">
-    <bind name="filter" value="_parameter" />
     SELECT
       res.FLOW_NODE_ID,
       SUM(CASE WHEN res.COUNT_ACTIVE > 0 THEN 1 ELSE 0 END)    AS COUNT_ACTIVE,
@@ -128,133 +127,148 @@
     FROM ${prefix}PROCESS_DEFINITION pd
       JOIN ${prefix}PROCESS_INSTANCE pi ON (pd.PROCESS_DEFINITION_KEY = pi.PROCESS_DEFINITION_KEY)
       JOIN ${prefix}FLOW_NODE_INSTANCE fni ON (pi.PROCESS_INSTANCE_KEY = fni.PROCESS_INSTANCE_KEY)
-
-    WHERE pd.PROCESS_DEFINITION_KEY = #{filter.processDefinitionKey}
-    <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.statisticsSearchFilter"/>
+    <where>
+      pd.PROCESS_DEFINITION_KEY = #{processDefinitionKey}
+      <trim prefix="AND" prefixOverrides="AND">
+        <bind name="filter" value="_parameter" />
+        <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.statisticsSearchFilter"/>
+        <if test="orFilters != null and !orFilters.isEmpty()">
+          AND (
+          <foreach collection="orFilters" item="filter" separator=" OR ">
+            <trim prefix="(" suffix=")">
+              <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.statisticsSearchFilter"/>
+            </trim>
+          </foreach>
+          )
+        </if>
+      </trim>
+    </where>
     GROUP BY pi.PROCESS_INSTANCE_KEY, fni.FLOW_NODE_ID
   </sql>
 
   <sql id="statisticsSearchFilter">
-    <!-- basic filters -->
-    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.processInstanceKeyOperations" item="operation">
-        AND pi.PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.parentProcessInstanceKeyOperations != null and !filter.parentProcessInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.parentProcessInstanceKeyOperations" item="operation">
-        AND pi.PARENT_PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.parentFlowNodeInstanceKeyOperations != null and !filter.parentFlowNodeInstanceKeyOperations.isEmpty()">
-      <foreach collection="filter.parentFlowNodeInstanceKeyOperations" item="operation">
-        AND pi.PARENT_ELEMENT_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
-      <foreach collection="filter.stateOperations" item="operation">
-        AND pi.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
-      <foreach collection="filter.tenantIdOperations" item="operation">
-        AND pi.TENANT_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.hasIncident != null">
-      <if test="filter.hasIncident == true">
-        AND pi.NUM_INCIDENTS > 0
+    <trim prefixOverrides="AND">
+      <!-- basic filters -->
+      <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.processInstanceKeyOperations" item="operation">
+          AND pi.PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-      <if test="filter.hasIncident == false">
-        AND pi.NUM_INCIDENTS = 0
+      <if test="filter.parentProcessInstanceKeyOperations != null and !filter.parentProcessInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.parentProcessInstanceKeyOperations" item="operation">
+          AND pi.PARENT_PROCESS_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-    </if>
-    <if test="filter.hasRetriesLeft != null">
-      AND EXISTS (
-      SELECT 1
-      FROM ${prefix}JOB j
-      WHERE j.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-      AND j.STATE IN ('FAILED', 'ERROR_THROWN')
-      <if test="filter.hasRetriesLeft == true">
-        AND j.RETRIES > 0
+      <if test="filter.parentFlowNodeInstanceKeyOperations != null and !filter.parentFlowNodeInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.parentFlowNodeInstanceKeyOperations" item="operation">
+          AND pi.PARENT_ELEMENT_INSTANCE_KEY <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-      <if test="filter.hasRetriesLeft == false">
-         AND j.RETRIES = 0
+      <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+        <foreach collection="filter.stateOperations" item="operation">
+          AND pi.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-      )
-    </if>
-
-    <!-- date filters -->
-    <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">
-      <foreach collection="filter.startDateOperations" item="operation">
-        AND pi.START_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.endDateOperations != null and !filter.endDateOperations.isEmpty()">
-      <foreach collection="filter.endDateOperations" item="operation">
-        AND pi.END_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-
-    <!-- Flow node instance filters -->
-    <if test="filter.flowNodeIdOperations != null and !filter.flowNodeIdOperations.isEmpty()">
-      <foreach collection="filter.flowNodeIdOperations" item="operation">
-        AND fni.FLOW_NODE_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.flowNodeInstanceStateOperations != null and !filter.flowNodeInstanceStateOperations.isEmpty()">
-      <foreach collection="filter.flowNodeInstanceStateOperations" item="operation">
-        AND fni.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-    <if test="filter.hasFlowNodeInstanceIncident != null">
-      <if test="filter.hasFlowNodeInstanceIncident == true">
-        AND fni.INCIDENT_KEY IS NOT NULL
+      <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+        <foreach collection="filter.tenantIdOperations" item="operation">
+          AND pi.TENANT_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
       </if>
-      <if test="filter.hasFlowNodeInstanceIncident == false">
-        AND fni.INCIDENT_KEY IS NULL
+      <if test="filter.hasIncident != null">
+        <if test="filter.hasIncident == true">
+          AND pi.NUM_INCIDENTS > 0
+        </if>
+        <if test="filter.hasIncident == false">
+          AND pi.NUM_INCIDENTS = 0
+        </if>
       </if>
-    </if>
-
-    <!-- Variable filters -->
-    <if test="filter.variableFilters != null and !filter.variableFilters.isEmpty()">
-      <foreach collection="filter.variableFilters" item="variableFilter"
-        open="AND (" separator=" OR " close=")">
-        EXISTS (
+      <if test="filter.hasRetriesLeft != null">
+        AND EXISTS (
         SELECT 1
-        FROM ${prefix}VARIABLE v
-        WHERE v.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND v.VAR_NAME = #{variableFilter.name}
-        <if
-          test="variableFilter.valueOperations != null and !variableFilter.valueOperations.isEmpty()">
-          <foreach collection="variableFilter.valueOperations" item="operation">
-            AND
-            <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
-          </foreach>
+        FROM ${prefix}JOB j
+        WHERE j.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+        AND j.STATE IN ('FAILED', 'ERROR_THROWN')
+        <if test="filter.hasRetriesLeft == true">
+          AND j.RETRIES > 0
+        </if>
+        <if test="filter.hasRetriesLeft == false">
+           AND j.RETRIES = 0
         </if>
         )
-      </foreach>
-    </if>
+      </if>
 
-    <!-- Error message filters -->
-    <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
-      <foreach collection="filter.errorMessageOperations" item="operation">
-        AND EXISTS (
-        SELECT 1
-        FROM INCIDENT i
-        WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      <!-- date filters -->
+      <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">
+        <foreach collection="filter.startDateOperations" item="operation">
+          AND pi.START_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.endDateOperations != null and !filter.endDateOperations.isEmpty()">
+        <foreach collection="filter.endDateOperations" item="operation">
+          AND pi.END_DATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <!-- Flow node instance filters -->
+      <if test="filter.flowNodeIdOperations != null and !filter.flowNodeIdOperations.isEmpty()">
+        <foreach collection="filter.flowNodeIdOperations" item="operation">
+          AND fni.FLOW_NODE_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.flowNodeInstanceStateOperations != null and !filter.flowNodeInstanceStateOperations.isEmpty()">
+        <foreach collection="filter.flowNodeInstanceStateOperations" item="operation">
+          AND fni.STATE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.hasFlowNodeInstanceIncident != null">
+        <if test="filter.hasFlowNodeInstanceIncident == true">
+          AND fni.INCIDENT_KEY IS NOT NULL
+        </if>
+        <if test="filter.hasFlowNodeInstanceIncident == false">
+          AND fni.INCIDENT_KEY IS NULL
+        </if>
+      </if>
+
+      <!-- Variable filters -->
+      <if test="filter.variableFilters != null and !filter.variableFilters.isEmpty()">
+        <foreach collection="filter.variableFilters" item="variableFilter"
+          open="AND (" separator=" OR " close=")">
+          EXISTS (
+          SELECT 1
+          FROM ${prefix}VARIABLE v
+          WHERE v.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND v.VAR_NAME = #{variableFilter.name}
+          <if
+            test="variableFilter.valueOperations != null and !variableFilter.valueOperations.isEmpty()">
+            <foreach collection="variableFilter.valueOperations" item="operation">
+              AND
+              <include refid="io.camunda.db.rdbms.sql.Commons.variableOperationCondition"/>
+            </foreach>
+          </if>
+          )
+        </foreach>
+      </if>
+
+      <!-- Error message filters -->
+      <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
+        <foreach collection="filter.errorMessageOperations" item="operation">
+          AND EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          )
+        </foreach>
+      </if>
+      <if test="filter.incidentErrorHashCodes != null and !filter.incidentErrorHashCodes.isEmpty()">
+          AND EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND i.ERROR_MESSAGE_HASH IN <foreach collection="filter.incidentErrorHashCodes" item="value" open="(" separator=", " close=")">#{value}</foreach>
         )
-      </foreach>
-    </if>
-    <if test="filter.incidentErrorHashCodes != null and !filter.incidentErrorHashCodes.isEmpty()">
-        AND EXISTS (
-        SELECT 1
-        FROM INCIDENT i
-        WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-        AND i.ERROR_MESSAGE_HASH IN <foreach collection="filter.incidentErrorHashCodes" item="value" open="(" separator=", " close=")">#{value}</foreach>
-      )
-    </if>
+      </if>
+    </trim>
   </sql>
 
   <insert

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -16,6 +16,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,8 @@ import org.junit.jupiter.api.Test;
 @MultiDbTest
 public class ProcessDefinitionStatisticsTest {
 
+  public static final String INCIDENT_ERROR_MESSAGE_V1 =
+      "Expected result of the expression 'retriesA' to be 'NUMBER', but was 'STRING'.";
   public static final int INCIDENT_ERROR_HASH_CODE_V2 = 17551445;
   private static CamundaClient camundaClient;
 
@@ -78,6 +82,130 @@ public class ProcessDefinitionStatisticsTest {
 
     // then
     assertThat(actual).hasSize(0);
+  }
+
+  @Test
+  void shouldGetStatisticsAndFilterByProcessInstanceKeyOrFilters() {
+    // given
+    final var processDefinitionKey = deployCompleteBPMN();
+    final var pi1 = createInstance(processDefinitionKey);
+    final var pi2 = createInstance(processDefinitionKey);
+    final var pi3 = createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(
+        4, f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED));
+
+    // when
+    final var actual =
+        camundaClient
+            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+            .filter(
+                f ->
+                    f.orFilters(
+                        List.of(
+                            f1 -> f1.processInstanceKey(pi1.getProcessInstanceKey()),
+                            f2 -> f2.processInstanceKey(pi2.getProcessInstanceKey()),
+                            f3 -> f3.processInstanceKey(pi3.getProcessInstanceKey()))))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual).hasSize(2);
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 3L),
+            new ProcessElementStatisticsImpl("EndEvent", 0L, 0L, 0L, 3L));
+  }
+
+  @Test
+  void shouldGetStatisticsAndFilterByElementIdOrFilters() {
+    // given
+    final var processDefinitionKey = deployIncidentBPMN();
+    final var pi1 = createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(2, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
+
+    // when
+    final var actual =
+        camundaClient
+            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+            .filter(
+                f ->
+                    f.orFilters(
+                        List.of(
+                            f1 -> f1.elementId(b -> b.like("*Event")),
+                            f2 ->
+                                f2.processInstanceKey(pi1.getProcessInstanceKey())
+                                    .hasElementInstanceIncident(true))))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual).hasSize(2);
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),
+            new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L));
+  }
+
+  @Test
+  void shouldGetStatisticsAndFilterByVariablesOrFilters() {
+    // given
+    final var processDefinitionKey = deployIncidentBPMN();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(2, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
+
+    // when
+    final var actual =
+        camundaClient
+            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+            .filter(
+                f ->
+                    f.orFilters(
+                        List.of(
+                            f1 -> f1.elementId(b -> b.like("*Event")),
+                            f2 -> f2.hasElementInstanceIncident(false))))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual).hasSize(1);
+    assertThat(actual)
+        .containsExactlyInAnyOrder(new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L));
+  }
+
+  @Test
+  void shouldGetStatisticsAndFilterByErrorMessageOrFilters() {
+    // given
+    final var processDefinitionKey =
+        TestHelper.deployResource(camundaClient, "process/incident_process_v1.bpmn")
+            .getProcesses()
+            .getFirst()
+            .getProcessDefinitionKey();
+    createInstance(processDefinitionKey);
+    createInstance(processDefinitionKey);
+    waitForProcessInstances(2, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
+
+    // when
+    final var actual =
+        camundaClient
+            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+            .filter(
+                f ->
+                    f.orFilters(
+                        List.of(
+                            f1 -> f1.elementId(b -> b.neq("start")),
+                            f2 -> f2.errorMessage(INCIDENT_ERROR_MESSAGE_V1))))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual).hasSize(2);
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 2L),
+            new ProcessElementStatisticsImpl("taskAIncident", 0L, 0L, 2L, 0L));
   }
 
   @Test
@@ -656,6 +784,22 @@ public class ProcessDefinitionStatisticsTest {
             .getProcessDefinitionKey();
     createInstance(processDefinitionKey);
     waitForProcessInstances(1, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
+    Awaitility.await("should receive data from ES")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newIncidentSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processDefinitionKey(processDefinitionKey)
+                                        .state(IncidentState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
 
     // when
     final var actual =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionFlowNodeStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessDefinitionFlowNodeStatisticsAggregationTransformer.java
@@ -10,31 +10,23 @@ package io.camunda.search.clients.transformers.aggregation;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_ACTIVE;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_CANCELED;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_COMPLETED;
-import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_FLOW_NODES;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_INCIDENTS;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODE_ID;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TERMS_SIZE;
-import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TO_CHILDREN_FN;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TO_PARENT_PI;
-import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.children;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.parent;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
-import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
-import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITIES_JOIN_RELATION;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_ID;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_STATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
-import static java.util.Optional.ofNullable;
 
 import io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation;
 import io.camunda.search.clients.aggregator.SearchAggregator;
-import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ProcessDefinitionFlowNodeStatisticsAggregationTransformer
@@ -88,31 +80,6 @@ public class ProcessDefinitionFlowNodeStatisticsAggregationTransformer
             .aggregations(groupFlowNodesAgg)
             .build();
 
-    final var filter = value.filter();
-    final var queries = new ArrayList<SearchQuery>();
-    ofNullable(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(filter.hasFlowNodeInstanceIncident())
-        .ifPresent(incident -> queries.add((term(INCIDENT, incident))));
-
-    // aggregate filter flow nodes
-    final var filterFlowNodesAgg =
-        filter()
-            .name(AGGREGATION_FILTER_FLOW_NODES)
-            .query(queries.isEmpty() ? matchAll() : and(queries))
-            .aggregations(activeAgg, completedAgg, canceledAgg, incidentsAgg)
-            .build();
-
-    // aggregate children flow nodes
-    final var toFlowNodesAgg =
-        children()
-            .name(AGGREGATION_TO_CHILDREN_FN)
-            .type(ACTIVITIES_JOIN_RELATION)
-            .aggregations(filterFlowNodesAgg)
-            .build();
-
-    return List.of(toFlowNodesAgg);
+    return List.of(activeAgg, completedAgg, canceledAgg, incidentsAgg);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer.java
@@ -10,10 +10,8 @@ package io.camunda.search.clients.transformers.aggregation.result;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_ACTIVE;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_CANCELED;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_COMPLETED;
-import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_FLOW_NODES;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_FILTER_INCIDENTS;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODE_ID;
-import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TO_CHILDREN_FN;
 import static io.camunda.search.aggregation.ProcessDefinitionFlowNodeStatisticsAggregation.AGGREGATION_TO_PARENT_PI;
 
 import io.camunda.search.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResult;
@@ -50,18 +48,12 @@ public class ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer
   @Override
   public ProcessDefinitionFlowNodeStatisticsAggregationResult apply(
       final Map<String, AggregationResult> aggregations) {
-    final var children = aggregations.get(AGGREGATION_TO_CHILDREN_FN);
-    final var filter = children.aggregations().get(AGGREGATION_FILTER_FLOW_NODES);
 
     final var entitiesMap = new HashMap<String, Builder>();
-    processFilter(
-        filter.aggregations().get(AGGREGATION_FILTER_ACTIVE), entitiesMap, Builder::active);
-    processFilter(
-        filter.aggregations().get(AGGREGATION_FILTER_COMPLETED), entitiesMap, Builder::completed);
-    processFilter(
-        filter.aggregations().get(AGGREGATION_FILTER_CANCELED), entitiesMap, Builder::canceled);
-    processFilter(
-        filter.aggregations().get(AGGREGATION_FILTER_INCIDENTS), entitiesMap, Builder::incidents);
+    processFilter(aggregations.get(AGGREGATION_FILTER_ACTIVE), entitiesMap, Builder::active);
+    processFilter(aggregations.get(AGGREGATION_FILTER_COMPLETED), entitiesMap, Builder::completed);
+    processFilter(aggregations.get(AGGREGATION_FILTER_CANCELED), entitiesMap, Builder::canceled);
+    processFilter(aggregations.get(AGGREGATION_FILTER_INCIDENTS), entitiesMap, Builder::incidents);
 
     return new ProcessDefinitionFlowNodeStatisticsAggregationResult(
         entitiesMap.values().stream().map(Builder::build).toList());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -10,7 +10,9 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringMatchWithHasChildOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
@@ -31,6 +33,9 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PR
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_KEY;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.START_DATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.STATE;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VARIABLES_JOIN_RELATION;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_NAME;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_VALUE;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchMatchQuery.SearchMatchQueryOperator;
@@ -41,6 +46,7 @@ import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ProcessDefinitionStatisticsFilterTransformer
@@ -58,8 +64,49 @@ public class ProcessDefinitionStatisticsFilterTransformer
   public SearchQuery toSearchQuery(final ProcessDefinitionStatisticsFilter filter) {
 
     final var queries = new ArrayList<SearchQuery>();
-    queries.add(term(PROCESS_KEY, filter.processDefinitionKey()));
-    ofNullable(getIsProcessInstanceQuery()).ifPresent(queries::add);
+    queries.add(term(JOIN_RELATION, ACTIVITIES_JOIN_RELATION));
+    queries.add(
+        hasParentQuery(
+            PROCESS_INSTANCE_JOIN_RELATION, term(PROCESS_KEY, filter.processDefinitionKey())));
+    queries.addAll(toSearchQueryFields(filter));
+
+    if (filter.orFilters() != null && !filter.orFilters().isEmpty()) {
+      final var orQueries = new ArrayList<SearchQuery>();
+      filter.orFilters().stream().map(f -> and(toSearchQueryFields(f))).forEach(orQueries::add);
+      queries.add(or(orQueries));
+    }
+
+    return and(queries);
+  }
+
+  public ArrayList<SearchQuery> toSearchQueryFields(
+      final ProcessDefinitionStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    toProcessInstanceQueries(filter)
+        .ifPresent(
+            query -> queries.add(hasParentQuery(PROCESS_INSTANCE_JOIN_RELATION, and(query))));
+    toFlowNodeInstanceQueries(filter).ifPresent(queries::addAll);
+    return queries;
+  }
+
+  private Optional<ArrayList<SearchQuery>> toFlowNodeInstanceQueries(
+      final ProcessDefinitionStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    ofNullable(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()))
+        .ifPresent(queries::addAll);
+    ofNullable(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()))
+        .ifPresent(queries::addAll);
+    ofNullable(filter.hasFlowNodeInstanceIncident())
+        .ifPresent(value -> queries.add(term(INCIDENT, value)));
+
+    return ofNullable(queries.isEmpty() ? null : queries);
+  }
+
+  private Optional<ArrayList<SearchQuery>> toProcessInstanceQueries(
+      final ProcessDefinitionStatisticsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
     ofNullable(longOperations(KEY, filter.processInstanceKeyOperations()))
         .ifPresent(queries::addAll);
     ofNullable(
@@ -74,67 +121,25 @@ public class ProcessDefinitionStatisticsFilterTransformer
         .ifPresent(queries::addAll);
     ofNullable(dateTimeOperations(END_DATE, filter.endDateOperations())).ifPresent(queries::addAll);
     ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
-    ofNullable(getIncidentQuery(filter.hasIncident())).ifPresent(queries::add);
+    ofNullable(filter.hasIncident()).ifPresent(value -> queries.add(term(INCIDENT, value)));
     ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
-
-    if (filter.variableFilters() != null && !filter.variableFilters().isEmpty()) {
-      final var processVariableQuery = getProcessVariablesQuery(filter.variableFilters());
-      queries.add(processVariableQuery);
-    }
-
-    if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
-      ofNullable(
-              stringMatchWithHasChildOperations(
-                  ERROR_MSG,
-                  filter.errorMessageOperations(),
-                  ACTIVITIES_JOIN_RELATION,
-                  SearchMatchQueryOperator.AND))
-          .ifPresent(queries::addAll);
-    }
-
+    ofNullable(getProcessVariablesQuery(filter.variableFilters())).ifPresent(queries::add);
+    ofNullable(
+            stringMatchWithHasChildOperations(
+                ERROR_MSG,
+                filter.errorMessageOperations(),
+                ACTIVITIES_JOIN_RELATION,
+                SearchMatchQueryOperator.AND))
+        .ifPresent(queries::addAll);
     ofNullable(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()))
         .ifPresent(queries::addAll);
+    ofNullable(filter.hasRetriesLeft()).ifPresent(value -> queries.add(hasRetriesLeftQuery(value)));
 
-    ofNullable(getHasRetriesLeftQuery(filter.hasRetriesLeft())).ifPresent(queries::add);
-
-    if (filter.flowNodeIdOperations() != null && !filter.flowNodeIdOperations().isEmpty()) {
-      queries.add(getFlowNodeInstanceQuery(filter));
-    }
-
-    return and(queries);
+    return ofNullable(queries.isEmpty() ? null : queries);
   }
 
-  private static SearchQuery getFlowNodeInstanceQuery(
-      final ProcessDefinitionStatisticsFilter filter) {
-    final var flowNodeInstanceQueries = new ArrayList<SearchQuery>();
-
-    ofNullable(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()))
-        .ifPresent(flowNodeInstanceQueries::addAll);
-    ofNullable(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()))
-        .ifPresent(flowNodeInstanceQueries::addAll);
-    ofNullable(filter.hasFlowNodeInstanceIncident())
-        .ifPresent(incident -> flowNodeInstanceQueries.add((term(INCIDENT, incident))));
-
-    return hasChildQuery(ACTIVITIES_JOIN_RELATION, and(flowNodeInstanceQueries));
-  }
-
-  private SearchQuery getHasRetriesLeftQuery(final Boolean hasRetriesLeft) {
-    if (hasRetriesLeft != null) {
-      return hasChildQuery(
-          ACTIVITIES_JOIN_RELATION, term(JOB_FAILED_WITH_RETRIES_LEFT, hasRetriesLeft));
-    }
-    return null;
-  }
-
-  private SearchQuery getIsProcessInstanceQuery() {
-    return term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION);
-  }
-
-  private SearchQuery getIncidentQuery(final Boolean hasIncident) {
-    if (hasIncident != null) {
-      return term(INCIDENT, hasIncident);
-    }
-    return null;
+  private static SearchQuery hasRetriesLeftQuery(final Boolean value) {
+    return hasChildQuery(ACTIVITIES_JOIN_RELATION, term(JOB_FAILED_WITH_RETRIES_LEFT, value));
   }
 
   private SearchQuery getProcessVariablesQuery(final List<VariableValueFilter> variableFilters) {
@@ -144,8 +149,8 @@ public class ProcessDefinitionStatisticsFilterTransformer
           (VariableValueFilterTransformer) transformer;
       final var queries =
           variableFilters.stream()
-              .map(v -> variableTransformer.toSearchQuery(v, "varName", "varValue"))
-              .map((q) -> hasChildQuery("variable", q))
+              .map(v -> variableTransformer.toSearchQuery(v, VAR_NAME, VAR_VALUE))
+              .map((q) -> hasChildQuery(VARIABLES_JOIN_RELATION, q))
               .collect(Collectors.toList());
       return and(queries);
     }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionFlowNodeStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessDefinitionFlowNodeStatisticsAggregation.java
@@ -13,9 +13,7 @@ public record ProcessDefinitionFlowNodeStatisticsAggregation(
     ProcessDefinitionStatisticsFilter filter) implements AggregationBase {
 
   public static final int AGGREGATION_TERMS_SIZE = 10000;
-  public static final String AGGREGATION_TO_CHILDREN_FN = "to-flow-nodes";
   public static final String AGGREGATION_TO_PARENT_PI = "parents-process-instances";
-  public static final String AGGREGATION_FILTER_FLOW_NODES = "filter-flow-nodes";
   public static final String AGGREGATION_GROUP_FLOW_NODE_ID = "terms-flow-nodes";
   public static final String AGGREGATION_FILTER_ACTIVE = "active";
   public static final String AGGREGATION_FILTER_COMPLETED = "completed";

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
@@ -91,6 +91,11 @@ public record ProcessDefinitionStatisticsFilter(
       return this;
     }
 
+    public Builder replaceOrFilters(final List<ProcessDefinitionStatisticsFilter> orFilters) {
+      this.orFilters = orFilters;
+      return this;
+    }
+
     @SafeVarargs
     public final Builder processInstanceKeyOperations(
         final Operation<Long> operation, final Operation<Long>... operations) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionStatisticsFilter.java
@@ -9,10 +9,10 @@ package io.camunda.search.filter;
 
 import static io.camunda.util.CollectionUtil.*;
 
-import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -34,7 +34,8 @@ public record ProcessDefinitionStatisticsFilter(
     List<Operation<String>> flowNodeIdOperations,
     Boolean hasFlowNodeInstanceIncident,
     List<Operation<String>> flowNodeInstanceStateOperations,
-    List<Integer> incidentErrorHashCodes)
+    List<Integer> incidentErrorHashCodes,
+    List<ProcessDefinitionStatisticsFilter> orFilters)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -70,6 +71,7 @@ public record ProcessDefinitionStatisticsFilter(
     private Boolean hasFlowNodeInstanceIncident;
     private List<Operation<String>> flowNodeInstanceStateOperations;
     private List<Integer> incidentErrorHashCodes;
+    private List<ProcessDefinitionStatisticsFilter> orFilters;
 
     public Builder(final long processDefinitionKey) {
       this.processDefinitionKey = processDefinitionKey;
@@ -269,6 +271,14 @@ public record ProcessDefinitionStatisticsFilter(
       return this;
     }
 
+    public Builder addOrOperation(final ProcessDefinitionStatisticsFilter orOperation) {
+      if (orFilters == null) {
+        orFilters = new ArrayList<>();
+      }
+      orFilters.add(orOperation);
+      return this;
+    }
+
     @Override
     public ProcessDefinitionStatisticsFilter build() {
       return new ProcessDefinitionStatisticsFilter(
@@ -288,7 +298,8 @@ public record ProcessDefinitionStatisticsFilter(
           Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
           hasFlowNodeInstanceIncident,
           Objects.requireNonNullElse(flowNodeInstanceStateOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()));
+          Objects.requireNonNullElse(incidentErrorHashCodes, Collections.emptyList()),
+          orFilters);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4898,7 +4898,7 @@ components:
           title: Exact match
           description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedDateTimeFilter"
-    BaseProcessInstanceFilter:
+    BaseProcessInstanceFilterFields:
       description: Base process instance search filter.
       type: object
       properties:
@@ -4964,11 +4964,52 @@ components:
           description: The incident error hash code, associated with this process.
           type: integer
           format: int32
+    ProcessDefinitionStatisticsFilter:
+      description: Process definition statistics search filter.
+      allOf:
+        - $ref: "#/components/schemas/BaseProcessInstanceFilterFields"
+        - type: object
+          properties:
+            $or:
+              description: |
+                Defines a list of alternative filter groups combined using OR logic. Each object in the array is evaluated independently, and the filter matches if any one of them is satisfied.
+
+                Top-level fields and the `$or` clause are combined using AND logic — meaning: (top-level filters) AND (any of the `$or` filters) must match.
+                <br>
+                <em>Example:</em>
+
+                ```json
+                {
+                  "state": "ACTIVE",
+                  "tenantId": 123,
+                  "$or": [
+                    { "processInstanceId": "process_v1" },
+                    { "processInstanceId": "process_v2", "hasIncident": true }
+                  ]
+                }
+                ```
+                This matches process instances that:
+
+                <ul style="padding-left: 20px; margin-left: 20px;">
+                  <li style="list-style-type: disc;">are in <em>ACTIVE</em> state</li>
+                  <li style="list-style-type: disc;">have tenant ID equal to <em>123</em></li>
+                  <li style="list-style-type: disc;">and match either:
+                    <ul style="padding-left: 20px; margin-left: 20px;">
+                      <li style="list-style-type: circle;"><code>processInstanceId</code> is <em>process_v1</em>, or</li>
+                      <li style="list-style-type: circle;"><code>processInstanceId</code> is <em>process_v2</em> and <code>hasIncident</code> is <em>true</em></li>
+                    </ul>
+                  </li>
+                </ul>
+                <br>
+                <p>Note: Using complex <code>$or</code> conditions may impact performance, use with caution in high-volume environments.
+              type: array
+              items:
+                $ref: "#/components/schemas/BaseProcessInstanceFilterFields"
     ProcessInstanceFilterFields:
       description: Process instance search filter.
       type: object
       allOf:
-        - $ref: "#/components/schemas/BaseProcessInstanceFilter"
+        - $ref: "#/components/schemas/BaseProcessInstanceFilterFields"
       properties:
         processDefinitionId:
           description: The process definition ID.
@@ -5118,9 +5159,9 @@ components:
       type: object
       properties:
         filter:
-          description: The process instance search filters.
+          description: The process definition statistics search filters.
           allOf:
-            - $ref: "#/components/schemas/BaseProcessInstanceFilter"
+            - $ref: "#/components/schemas/ProcessDefinitionStatisticsFilter"
     ProcessDefinitionElementStatisticsQueryResult:
       description: Process definition element statistics query response.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -138,7 +138,8 @@ public final class SearchQueryRequestMapper {
       return Either.right(
           new ProcessDefinitionStatisticsFilter.Builder(processDefinitionKey).build());
     }
-    final var filter = toBaseProcessInstanceFilter(processDefinitionKey, request.getFilter());
+    final var filter =
+        toProcessDefinitionStatisticsFilter(processDefinitionKey, request.getFilter());
 
     if (filter.isLeft()) {
       final var problem = RequestValidator.createProblemDetail(filter.getLeft());
@@ -149,9 +150,39 @@ public final class SearchQueryRequestMapper {
     return Either.right(filter.get());
   }
 
-  private static Either<List<String>, ProcessDefinitionStatisticsFilter>
-      toBaseProcessInstanceFilter(
-          final long processDefinitionKey, final BaseProcessInstanceFilter filter) {
+  public static Either<List<String>, ProcessDefinitionStatisticsFilter>
+      toProcessDefinitionStatisticsFilter(
+          final long processDefinitionKey,
+          final io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionStatisticsFilter filter) {
+    final List<String> validationErrors = new ArrayList<>();
+
+    final Either<List<String>, ProcessDefinitionStatisticsFilter.Builder> builder =
+        toBaseProcessInstanceFilterFields(processDefinitionKey, filter);
+    if (builder.isLeft()) {
+      validationErrors.addAll(builder.getLeft());
+    }
+
+    if (filter != null) {
+      if (filter.get$Or() != null && !filter.get$Or().isEmpty()) {
+        for (final BaseProcessInstanceFilterFields or : filter.get$Or()) {
+          final var orBuilder = toBaseProcessInstanceFilterFields(processDefinitionKey, or);
+          if (orBuilder.isLeft()) {
+            validationErrors.addAll(orBuilder.getLeft());
+          } else {
+            builder.get().addOrOperation(orBuilder.get().build());
+          }
+        }
+      }
+    }
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.get().build())
+        : Either.left(validationErrors);
+  }
+
+  private static Either<List<String>, ProcessDefinitionStatisticsFilter.Builder>
+      toBaseProcessInstanceFilterFields(
+          final long processDefinitionKey, final BaseProcessInstanceFilterFields filter) {
     final var builder = FilterBuilders.processDefinitionStatisticsFilter(processDefinitionKey);
     final List<String> validationErrors = new ArrayList<>();
     if (filter != null) {
@@ -203,9 +234,7 @@ public final class SearchQueryRequestMapper {
         }
       }
     }
-    return validationErrors.isEmpty()
-        ? Either.right(builder.build())
-        : Either.left(validationErrors);
+    return validationErrors.isEmpty() ? Either.right(builder) : Either.left(validationErrors);
   }
 
   public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(


### PR DESCRIPTION
## Description

Add support for `incidentErrorHashCode` with `$or` filters in PI search & PD statistics.

## Related issues

closes https://github.com/camunda/camunda/issues/31180
