### PR TITLE
Add ClusterChangeOperation that awaits for distribution and relocation

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -36,7 +36,6 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPartitionScaleUpRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.GetScaleUpProgress;
-import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -56,9 +55,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -566,9 +565,7 @@ public final class PartitionManagerImpl
         new GetScaleUpProgress(desiredPartitionCount),
         (key, response) -> {
           final Set<Integer> currentlyRedistributedPartitions =
-              response.getRedistributedPartitions().stream()
-                  .map(IntegerValue::getValue)
-                  .collect(Collectors.toSet());
+              new TreeSet<>(response.getRedistributedPartitions());
           if (currentlyRedistributedPartitions.equals(redistributedPartitions)) {
             result.complete(null);
           } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -579,13 +579,15 @@ public final class PartitionManagerImpl
                   new TimeoutException(
                       "Timeout reached while waiting for redistribution completion"));
             } else {
-              final var sleep = concurrencyControl.createFuture();
-              concurrencyControl.schedule(SCALE_UP_INTERVAL, () -> sleep.complete(null));
-              sleep.andThen(
-                  () ->
-                      awaitRedistributionCompletion(
-                          desiredPartitionCount, redistributedPartitions, newTimeout),
-                  concurrencyControl);
+              if (!result.isCancelled()) {
+                final var sleep = concurrencyControl.createFuture();
+                concurrencyControl.schedule(SCALE_UP_INTERVAL, () -> sleep.complete(null));
+                sleep.andThen(
+                    () ->
+                        awaitRedistributionCompletion(
+                            desiredPartitionCount, redistributedPartitions, newTimeout),
+                    concurrencyControl);
+              }
             }
           }
         },

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -79,10 +79,9 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
           }
         },
         error -> {
-          if (error instanceof final BrokerRejectionException rejection) {
-            if (rejection.getRejection().type() == RejectionType.INVALID_ARGUMENT) {
-              LOGGER.debug("Await redistribution request is invalid", rejection);
-            }
+          if (error instanceof final BrokerRejectionException rejection
+              && rejection.getRejection().type() == RejectionType.INVALID_ARGUMENT) {
+            LOGGER.debug("Await redistribution request is invalid", rejection);
             result.complete(null);
           } else {
             result.completeExceptionally(error);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerPartitionScaleUpRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.GetScaleUpProgress;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
+import java.util.Set;
+import java.util.TreeSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BrokerClientPartitionScalingExecutor implements PartitionScalingChangeExecutor {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BrokerClientPartitionScalingExecutor.class);
+  private final BrokerClient brokerClient;
+  private final ConcurrencyControl concurrencyControl;
+
+  public BrokerClientPartitionScalingExecutor(
+      final BrokerClient brokerClient, final ConcurrencyControl concurrencyControl) {
+    this.brokerClient = brokerClient;
+    this.concurrencyControl = concurrencyControl;
+  }
+
+  @Override
+  public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
+    final var result = concurrencyControl.<Void>createFuture();
+
+    brokerClient.sendRequestWithRetry(
+        new BrokerPartitionScaleUpRequest(desiredPartitionCount),
+        (key, response) -> {
+          result.complete(null);
+        },
+        error -> {
+          if (error instanceof final BrokerRejectionException rejection
+              && rejection.getRejection().type() == RejectionType.ALREADY_EXISTS) {
+            LOGGER.debug("Scale up request already succeeded before", rejection);
+            result.complete(null);
+          } else {
+            result.completeExceptionally(error);
+          }
+        });
+
+    return result;
+  }
+
+  @Override
+  public ActorFuture<Void> awaitRedistributionCompletion(
+      final int desiredPartitionCount,
+      final Set<Integer> redistributedPartitions,
+      final Duration timeout) {
+    final var result = concurrencyControl.<Void>createFuture();
+
+    brokerClient.sendRequestWithRetry(
+        new GetScaleUpProgress(desiredPartitionCount),
+        (key, response) -> {
+          final Set<Integer> currentlyRedistributedPartitions =
+              new TreeSet<>(response.getRedistributedPartitions());
+          if (currentlyRedistributedPartitions.equals(redistributedPartitions)) {
+            result.complete(null);
+          } else {
+            final var missingPartitions = new TreeSet<>(redistributedPartitions);
+            missingPartitions.removeAll(redistributedPartitions);
+            result.completeExceptionally(
+                new RuntimeException(
+                    "Redistribution not completed yet: waiting for these partitions: %s"
+                        .formatted(missingPartitions)));
+          }
+        },
+        error -> {
+          if (error instanceof final BrokerRejectionException rejection) {
+            if (rejection.getRejection().type() == RejectionType.INVALID_ARGUMENT) {
+              LOGGER.debug("Await redistribution request is invalid", rejection);
+            }
+            result.complete(null);
+          } else {
+            result.completeExceptionally(error);
+          }
+        });
+
+    return result;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -71,7 +71,7 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
             result.complete(null);
           } else {
             final var missingPartitions = new TreeSet<>(redistributedPartitions);
-            missingPartitions.removeAll(redistributedPartitions);
+            missingPartitions.removeAll(currentlyRedistributedPartitions);
             result.completeExceptionally(
                 new RuntimeException(
                     "Redistribution not completed yet: waiting for these partitions: %s"

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.GetScaleUpProgress;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BrokerClientPartitionScalingExecutorTest {
+
+  TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
+  BrokerClientPartitionScalingExecutor executor;
+  @Mock BrokerClient brokerClient;
+
+  @BeforeEach
+  void setup() {
+    executor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
+  }
+
+  @Test
+  public void shouldFailFutureWhenInvalidDesiredPartitionCount() {
+    final var scaleRecord = new ScaleRecord().setDesiredPartitionCount(2);
+    final var future = awaitRedistributionWith(scaleRecord);
+
+    Awaitility.await("Until future completes exceptionally")
+        .untilAsserted(
+            () -> {
+              assertThat(future).isCompletedExceptionally();
+            });
+  }
+
+  @Test
+  public void shouldFailFutureResponseWhenNotAllPartitionsAreReady() {
+    final var scaleRecord =
+        new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitionsProperty(Set.of(4));
+    final var future = awaitRedistributionWith(scaleRecord);
+
+    // then
+    Awaitility.await("Until future completes exceptionally")
+        .untilAsserted(
+            () -> {
+              assertThat(future).isCompletedExceptionally();
+            });
+  }
+
+  @Test
+  public void shouldCompleteResponseWhenAllPartitionsAreReady() {
+    final var scaleRecord =
+        new ScaleRecord()
+            .setDesiredPartitionCount(5)
+            .setRedistributedPartitionsProperty(Set.of(4, 5));
+    final var future = awaitRedistributionWith(scaleRecord);
+    // then
+
+    Awaitility.await("Until future completes")
+        .untilAsserted(
+            () -> {
+              assertThat(future).isCompleted();
+            });
+  }
+
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> awaitRedistributionWith(final ScaleRecord scaleRecord) {
+    // given
+    doNothing().when(brokerClient).sendRequestWithRetry(any(), any(), any());
+    final var responseConsumerCaptor = ArgumentCaptor.forClass(BrokerResponseConsumer.class);
+    final var requestCaptor = ArgumentCaptor.forClass(BrokerRequest.class);
+
+    // when
+    final var future =
+        executor
+            .awaitRedistributionCompletion(5, Set.of(4, 5), Duration.ofSeconds(5))
+            .toCompletableFuture();
+    verify(brokerClient)
+        .sendRequestWithRetry(requestCaptor.capture(), responseConsumerCaptor.capture(), any());
+    final var request = requestCaptor.getValue();
+    assertThat(request).isInstanceOf(GetScaleUpProgress.class);
+    final var getScaleUpProgress = (GetScaleUpProgress) request;
+    assertThat(request.getPartitionId()).isEqualTo(1);
+    assertThat(getScaleUpProgress.getRequestWriter())
+        .satisfies(
+            writer -> {
+              final var requestRecord = (ScaleRecord) writer;
+              assertThat(requestRecord.getDesiredPartitionCount()).isEqualTo(5);
+            });
+
+    responseConsumerCaptor.getValue().accept(1L, scaleRecord);
+    return future;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -14,13 +14,16 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
+import io.camunda.zeebe.broker.client.api.BrokerResponseException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.GetScaleUpProgress;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,9 +46,7 @@ public class BrokerClientPartitionScalingExecutorTest {
   @Test
   public void shouldFailFutureWhenInvalidDesiredPartitionCount() {
     final var scaleRecord = new ScaleRecord().setDesiredPartitionCount(2);
-    final var future = awaitRedistributionWith(scaleRecord);
-
-    assertThat(future)
+    assertThat(awaitRedistributionWith(Either.right(scaleRecord)))
         .completesExceptionallyWithin(Duration.ZERO)
         .withThrowableThat()
         .withMessageContaining(
@@ -56,10 +57,9 @@ public class BrokerClientPartitionScalingExecutorTest {
   public void shouldFailFutureResponseWhenNotAllPartitionsAreReady() {
     final var scaleRecord =
         new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitionsProperty(Set.of(4));
-    final var future = awaitRedistributionWith(scaleRecord);
 
     // then
-    assertThat(future)
+    assertThat(awaitRedistributionWith(Either.right(scaleRecord)))
         .completesExceptionallyWithin(Duration.ZERO)
         .withThrowableThat()
         .withMessageContaining(
@@ -74,15 +74,25 @@ public class BrokerClientPartitionScalingExecutorTest {
             .setRedistributedPartitionsProperty(Set.of(4, 5));
 
     // then
-    assertThat(awaitRedistributionWith(scaleRecord)).isCompleted();
+    assertThat(awaitRedistributionWith(Either.right(scaleRecord))).isCompleted();
+  }
+
+  @Test
+  public void shoulFailFutureWhenBrokerReturnsError() {
+    assertThat(awaitRedistributionWith(Either.left(new BrokerResponseException("expected"))))
+        .completesExceptionallyWithin(Duration.ZERO)
+        .withThrowableThat()
+        .withCause(new BrokerResponseException("expected"));
   }
 
   @SuppressWarnings("unchecked")
-  private CompletableFuture<Void> awaitRedistributionWith(final ScaleRecord scaleRecord) {
+  private CompletableFuture<Void> awaitRedistributionWith(
+      final Either<Throwable, ScaleRecord> scaleRecord) {
     // given
     doNothing().when(brokerClient).sendRequestWithRetry(any(), any(), any());
     final var responseConsumerCaptor = ArgumentCaptor.forClass(BrokerResponseConsumer.class);
     final var requestCaptor = ArgumentCaptor.forClass(BrokerRequest.class);
+    final var throwableCaptor = ArgumentCaptor.forClass(Consumer.class);
 
     // when
     final var future =
@@ -90,7 +100,8 @@ public class BrokerClientPartitionScalingExecutorTest {
             .awaitRedistributionCompletion(5, Set.of(4, 5), Duration.ofSeconds(5))
             .toCompletableFuture();
     verify(brokerClient)
-        .sendRequestWithRetry(requestCaptor.capture(), responseConsumerCaptor.capture(), any());
+        .sendRequestWithRetry(
+            requestCaptor.capture(), responseConsumerCaptor.capture(), throwableCaptor.capture());
     final var request = requestCaptor.getValue();
     assertThat(request).isInstanceOf(GetScaleUpProgress.class);
     final var getScaleUpProgress = (GetScaleUpProgress) request;
@@ -102,7 +113,9 @@ public class BrokerClientPartitionScalingExecutorTest {
               assertThat(requestRecord.getDesiredPartitionCount()).isEqualTo(5);
             });
 
-    responseConsumerCaptor.getValue().accept(1L, scaleRecord);
+    scaleRecord.ifRightOrLeft(
+        record -> responseConsumerCaptor.getValue().accept(1L, record),
+        ex -> throwableCaptor.getValue().accept(ex));
     return future;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.Co
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map.Entry;
@@ -45,10 +44,10 @@ public class ScaleUpRequestTransformer implements ConfigurationChangeRequest {
                     desiredPartitionCount)));
       }
       final var operations =
-          // TODO how many operations must be sent?
-          // For which members ID?
-          clusterConfiguration.members().entrySet().stream()
-              .filter(e -> e.getValue().hasPartition(Protocol.START_PARTITION_ID))
+          // Generate the operations for the "coordinator" node, which is the node with the lowest
+          // id.
+          // See ClusterConfigurationCoordinatorSupplier
+          clusterConfiguration.members().entrySet().stream().min(Entry.comparingByKey()).stream()
               .map(Entry::getKey)
               .flatMap(
                   id ->

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+public class ScaleUpRequestTransformer implements ConfigurationChangeRequest {
+
+  private final int desiredPartitionCount;
+  private final SortedSet<Integer> bootstrappedPartitions;
+
+  public ScaleUpRequestTransformer(
+      final int desiredPartitionCount, final SortedSet<Integer> bootstrappedPartitions) {
+    this.desiredPartitionCount = desiredPartitionCount;
+    this.bootstrappedPartitions = bootstrappedPartitions;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    if (desiredPartitionCount > clusterConfiguration.partitionCount()) {
+      if (clusterConfiguration.partitionCount() + bootstrappedPartitions.size()
+          != desiredPartitionCount) {
+        return Either.left(
+            new InvalidRequest(
+                String.format(
+                    "Cannot start scale up: clusterConfiguration.partitionCount(%d) + bootstrappedPartitions(%d) != desiredPartitionCount(%d)",
+                    clusterConfiguration.partitionCount(),
+                    bootstrappedPartitions.size(),
+                    desiredPartitionCount)));
+      }
+      final var operations =
+          // TODO how many operations must be sent?
+          // For which members ID?
+          clusterConfiguration.members().entrySet().stream()
+              .filter(e -> e.getValue().hasPartition(Protocol.START_PARTITION_ID))
+              .map(Entry::getKey)
+              .flatMap(
+                  id ->
+                      Stream.of(
+                          new StartPartitionScaleUp(id, desiredPartitionCount),
+                          new AwaitRedistributionCompletion(
+                              id, desiredPartitionCount, bootstrappedPartitions),
+                          new AwaitRelocationCompletion(
+                              id, desiredPartitionCount, bootstrappedPartitions)))
+              .map(ClusterConfigurationChangeOperation.class::cast)
+              .toList();
+      return Either.right(operations);
+    } else {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Cannot start scale up: desiredPartitionCount(%d) <= clusterConfiguration.partitionCount (%d)",
+                  desiredPartitionCount, clusterConfiguration.partitionCount())));
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleUpRequestTransformer.java
@@ -32,40 +32,43 @@ public class ScaleUpRequestTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
-    if (desiredPartitionCount > clusterConfiguration.partitionCount()) {
-      if (clusterConfiguration.partitionCount() + bootstrappedPartitions.size()
-          != desiredPartitionCount) {
-        return Either.left(
-            new InvalidRequest(
-                String.format(
-                    "Cannot start scale up: clusterConfiguration.partitionCount(%d) + bootstrappedPartitions(%d) != desiredPartitionCount(%d)",
-                    clusterConfiguration.partitionCount(),
-                    bootstrappedPartitions.size(),
-                    desiredPartitionCount)));
-      }
-      final var operations =
-          // Generate the operations for the "coordinator" node, which is the node with the lowest
-          // id.
-          // See ClusterConfigurationCoordinatorSupplier
-          clusterConfiguration.members().entrySet().stream().min(Entry.comparingByKey()).stream()
-              .map(Entry::getKey)
-              .flatMap(
-                  id ->
-                      Stream.of(
-                          new StartPartitionScaleUp(id, desiredPartitionCount),
-                          new AwaitRedistributionCompletion(
-                              id, desiredPartitionCount, bootstrappedPartitions),
-                          new AwaitRelocationCompletion(
-                              id, desiredPartitionCount, bootstrappedPartitions)))
-              .map(ClusterConfigurationChangeOperation.class::cast)
-              .toList();
-      return Either.right(operations);
-    } else {
+    if (desiredPartitionCount <= clusterConfiguration.partitionCount()) {
       return Either.left(
           new InvalidRequest(
               String.format(
-                  "Cannot start scale up: desiredPartitionCount(%d) <= clusterConfiguration.partitionCount (%d)",
+                  "Cannot scale up when desiredPartitionCount %d is less than the current partition count %d",
                   desiredPartitionCount, clusterConfiguration.partitionCount())));
     }
+    if (clusterConfiguration.partitionCount() + bootstrappedPartitions.size()
+        != desiredPartitionCount) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Cannot start scale up: clusterConfiguration.partitionCount(%d) + bootstrappedPartitions(%d) != desiredPartitionCount(%d)",
+                  clusterConfiguration.partitionCount(),
+                  bootstrappedPartitions.size(),
+                  desiredPartitionCount)));
+    }
+    final var operations =
+        // Generate the operations for the "coordinator" node, which is the node with the lowest
+        // id.
+        // See ClusterConfigurationCoordinatorSupplier
+        clusterConfiguration.members().entrySet().stream().min(Entry.comparingByKey()).stream()
+            .map(Entry::getKey)
+            .flatMap(
+                id ->
+                    Stream.of(
+                        new StartPartitionScaleUp(id, desiredPartitionCount),
+                        new AwaitRedistributionCompletion(
+                            id, desiredPartitionCount, bootstrappedPartitions),
+                        new AwaitRelocationCompletion(
+                            id, desiredPartitionCount, bootstrappedPartitions)))
+            .map(ClusterConfigurationChangeOperation.class::cast)
+            .toList();
+    if (operations.isEmpty()) {
+      return Either.left(
+          new InvalidRequest("Cannot scale up: no members registered in the configuration."));
+    }
+    return Either.right(operations);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -36,7 +36,7 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
   public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
       final ClusterConfiguration currentClusterConfiguration) {
 
-    if (operation.redistributedPartitions().isEmpty()) {
+    if (operation.partitionsToRedistribute().isEmpty()) {
       return Either.left(
           new IllegalArgumentException("Cannot activate partitions: empty list provided"));
     }
@@ -60,7 +60,7 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
     final var result = new CompletableActorFuture<UnaryOperator<ClusterConfiguration>>();
     executor
         .awaitRedistributionCompletion(
-            operation.desiredPartitionCount(), operation.redistributedPartitions(), null)
+            operation.desiredPartitionCount(), operation.partitionsToRedistribute(), null)
         .onComplete(
             (ignored, error) -> {
               if (error != null) {
@@ -89,7 +89,7 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
   private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {
     return switch (requestHandling) {
       case final ActivePartitions activePartitions ->
-          activePartitions.activatePartitions(operation.redistributedPartitions());
+          activePartitions.activatePartitions(operation.partitionsToRedistribute());
       case final AllPartitions ignored ->
           throw new IllegalStateException("Cannot be AllPartitions");
     };

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -49,7 +49,7 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
         instanceof AllPartitions) {
       return Either.left(
           new IllegalStateException(
-              "Cannot include partitions in request handling when all partitions are active."));
+              "All partitions are active, cannot include partitions in request handling."));
     }
     return Either.right(UnaryOperator.identity());
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+public class AwaitRedistributionCompletionApplier implements ClusterOperationApplier {
+
+  private final PartitionScalingChangeExecutor executor;
+  private final AwaitRedistributionCompletion operation;
+
+  public AwaitRedistributionCompletionApplier(
+      final PartitionScalingChangeExecutor executor,
+      final AwaitRedistributionCompletion operation) {
+    this.executor = Objects.requireNonNull(executor);
+    this.operation = Objects.requireNonNull(operation);
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+
+    if (operation.redistributedPartitions().isEmpty()) {
+      return Either.left(
+          new IllegalArgumentException("Cannot activate partitions: empty list provided"));
+    }
+    if (currentClusterConfiguration.routingState().isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              "Routing state is not initialized yet, cannot include partitions in request handling."));
+    }
+
+    if (currentClusterConfiguration.routingState().get().requestHandling()
+        instanceof AllPartitions) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot include partitions in request handling when all partitions are active."));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<ClusterConfiguration>>();
+    executor
+        .awaitRedistributionCompletion(
+            operation.desiredPartitionCount(), operation.redistributedPartitions(), null)
+        .onComplete(
+            (ignored, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(this::updateRequestHandling);
+              }
+            });
+    return result;
+  }
+
+  private ClusterConfiguration updateRequestHandling(final ClusterConfiguration config) {
+    return config
+        .routingState()
+        .map(
+            routingState ->
+                switch (routingState.requestHandling()) {
+                  case final ActivePartitions activePartitions -> {
+                    final var requestHandling =
+                        activePartitions.activatePartitions(operation.redistributedPartitions());
+                    yield new ClusterConfiguration(
+                        config.version(),
+                        config.members(),
+                        config.lastChange(),
+                        config.pendingChanges(),
+                        Optional.of(routingState.updateRequestHandling(requestHandling)));
+                  }
+
+                  case final AllPartitions ignored ->
+                      throw new IllegalStateException("Cannot be AllPartitions");
+                })
+        .orElseThrow(() -> new IllegalStateException("Missing routingState"));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -110,7 +110,7 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
                     partitionScalingChangeExecutor, awaitRedistributionCompletion);
             case final AwaitRelocationCompletion ignored ->
                 // TODO IMPLEMENT
-                throw new RuntimeException("Not implemented");
+                throw new UnsupportedOperationException("Not implemented yet");
           };
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.StartPartitionScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
 
 public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppliers {
 
@@ -97,10 +98,20 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               partitionChangeExecutor);
       case final DeleteHistoryOperation deleteHistoryOperation ->
           new DeleteHistoryApplier(deleteHistoryOperation.memberId(), clusterChangeExecutor);
-      case StartPartitionScaleUpOperation(
-              final var ignoredMemberId,
-              final var desiredPartitionCount) ->
-          new StartPartitionScaleUpApplier(partitionScalingChangeExecutor, desiredPartitionCount);
+      case final ScaleUpOperation scaleUpOperation ->
+          switch (scaleUpOperation) {
+            case StartPartitionScaleUp(
+                    final var ignoredMemberId,
+                    final var desiredPartitionCount) ->
+                new StartPartitionScaleUpApplier(
+                    partitionScalingChangeExecutor, desiredPartitionCount);
+            case final AwaitRedistributionCompletion awaitRedistributionCompletion ->
+                new AwaitRedistributionCompletionApplier(
+                    partitionScalingChangeExecutor, awaitRedistributionCompletion);
+            case final AwaitRelocationCompletion ignored ->
+                // TODO IMPLEMENT
+                throw new RuntimeException("Not implemented");
+          };
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
@@ -71,7 +71,7 @@ public interface ConfigurationChangeCoordinator {
      * applied in the given order in the list.
      *
      * @param clusterConfiguration the current cluster configuration
-     * @return an Either with the list of operations to apply or an exception if the request is not
+     * @return Either with the list of operations to apply or an exception if the request is not
      *     valid.
      */
     Either<Exception, List<ClusterConfigurationChangeOperation>> operations(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.Set;
 
 /**
  * An executor that supports partition scaling and monitoring progress of redistribution and
@@ -23,9 +25,20 @@ public interface PartitionScalingChangeExecutor {
    */
   ActorFuture<Void> initiateScaleUp(int desiredPartitionCount);
 
+  ActorFuture<Void> awaitRedistributionCompletion(
+      int desiredPartitionCount, Set<Integer> redistributedPartitions, Duration timeout);
+
   final class NoopPartitionScalingChangeExecutor implements PartitionScalingChangeExecutor {
     @Override
     public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public ActorFuture<Void> awaitRedistributionCompletion(
+        final int desiredPartitionCount,
+        final Set<Integer> redistributedPartitions,
+        final Duration timeout) {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -139,9 +139,9 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
                 .collect(Collectors.toSet());
         yield new ActivePartitions(currentPartitionCount, Set.of(), newPartitions);
       }
-      default ->
+      case final ActivePartitions activePartitions ->
           throw new IllegalStateException(
-              "Unexpected request handling state: %s".formatted(requestHandling));
+              "Unexpected request handling state: %s".formatted(activePartitions));
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -50,7 +50,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.StartPartitionScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
@@ -429,12 +429,22 @@ public class ProtoBufSerializer
           builder.setPartitionBootstrap(encodePartitionBootstrapOperation(bootstrapOperation));
       case final DeleteHistoryOperation deleteHistoryOperation ->
           builder.setDeleteHistory(Topology.DeleteHistoryOperation.newBuilder().build());
-      case StartPartitionScaleUpOperation(
-              final var ignoredMemberId,
-              final var desiredPartitionCount) ->
+      case StartPartitionScaleUp(final var ignoredMemberId, final var desiredPartitionCount) ->
           builder.setInitiateScaleUpPartitions(
               Topology.StartPartitionScaleUpOperation.newBuilder()
                   .setDesiredPartitionCount(desiredPartitionCount)
+                  .build());
+      case final AwaitRedistributionCompletion awaitRedistribution ->
+          builder.setAwaitRedistributionCompletion(
+              Topology.AwaitRedistributionCompletion.newBuilder()
+                  .setDesiredPartitionCount(awaitRedistribution.desiredPartitionCount())
+                  .addAllRedistributedPartitions(awaitRedistribution.redistributedPartitions())
+                  .build());
+      case final AwaitRelocationCompletion msg ->
+          builder.setAwaitRelocationCompletion(
+              Topology.AwaitRelocationCompletion.newBuilder()
+                  .setDesiredPartitionCount(msg.desiredPartitionCount())
+                  .addAllRelocatedPartitions(msg.relocatedPartitions())
                   .build());
     }
     return builder.build();
@@ -584,39 +594,39 @@ public class ProtoBufSerializer
 
   private ClusterConfigurationChangeOperation decodeOperation(
       final Topology.TopologyChangeOperation topologyChangeOperation) {
+    final var memberId = MemberId.from(topologyChangeOperation.getMemberId());
     if (topologyChangeOperation.hasPartitionJoin()) {
       return new PartitionJoinOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           topologyChangeOperation.getPartitionJoin().getPartitionId(),
           topologyChangeOperation.getPartitionJoin().getPriority());
     } else if (topologyChangeOperation.hasPartitionLeave()) {
       return new PartitionLeaveOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           topologyChangeOperation.getPartitionLeave().getPartitionId(),
           topologyChangeOperation.getPartitionLeave().getMinimumAllowedReplicas());
     } else if (topologyChangeOperation.hasMemberJoin()) {
-      return new MemberJoinOperation(MemberId.from(topologyChangeOperation.getMemberId()));
+      return new MemberJoinOperation(memberId);
     } else if (topologyChangeOperation.hasMemberLeave()) {
-      return new MemberLeaveOperation(MemberId.from(topologyChangeOperation.getMemberId()));
+      return new MemberLeaveOperation(memberId);
     } else if (topologyChangeOperation.hasPartitionReconfigurePriority()) {
       return new PartitionReconfigurePriorityOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           topologyChangeOperation.getPartitionReconfigurePriority().getPartitionId(),
           topologyChangeOperation.getPartitionReconfigurePriority().getPriority());
     } else if (topologyChangeOperation.hasPartitionForceReconfigure()) {
       return new PartitionForceReconfigureOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           topologyChangeOperation.getPartitionForceReconfigure().getPartitionId(),
           topologyChangeOperation.getPartitionForceReconfigure().getMembersList().stream()
               .map(MemberId::from)
               .toList());
     } else if (topologyChangeOperation.hasMemberRemove()) {
       return new MemberRemoveOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
-          MemberId.from(topologyChangeOperation.getMemberRemove().getMemberToRemove()));
+          memberId, MemberId.from(topologyChangeOperation.getMemberRemove().getMemberToRemove()));
     } else if (topologyChangeOperation.hasPartitionDisableExporter()) {
       return new PartitionDisableExporterOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           topologyChangeOperation.getPartitionDisableExporter().getPartitionId(),
           topologyChangeOperation.getPartitionDisableExporter().getExporterId());
     } else if (topologyChangeOperation.hasPartitionEnableExporter()) {
@@ -626,7 +636,7 @@ public class ProtoBufSerializer
               ? Optional.of(enableExporterOperation.getInitializeFrom())
               : Optional.empty();
       return new PartitionEnableExporterOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           enableExporterOperation.getPartitionId(),
           enableExporterOperation.getExporterId(),
           initializeFrom);
@@ -637,16 +647,28 @@ public class ProtoBufSerializer
               ? Optional.of(decodePartitionConfig(bootstrapOperation.getConfig()))
               : Optional.empty();
       return new PartitionBootstrapOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+          memberId,
           bootstrapOperation.getPartitionId(),
           bootstrapOperation.getPriority(),
           partitionConfig);
     } else if (topologyChangeOperation.hasInitiateScaleUpPartitions()) {
-      return new StartPartitionScaleUpOperation(
-          MemberId.from(topologyChangeOperation.getMemberId()),
+      return new StartPartitionScaleUp(
+          memberId,
           topologyChangeOperation.getInitiateScaleUpPartitions().getDesiredPartitionCount());
     } else if (topologyChangeOperation.hasDeleteHistory()) {
-      return new DeleteHistoryOperation(MemberId.from(topologyChangeOperation.getMemberId()));
+      return new DeleteHistoryOperation(memberId);
+    } else if (topologyChangeOperation.hasAwaitRedistributionCompletion()) {
+      final var redistribution = topologyChangeOperation.getAwaitRedistributionCompletion();
+      return new AwaitRedistributionCompletion(
+          memberId,
+          redistribution.getDesiredPartitionCount(),
+          new HashSet<>(redistribution.getRedistributedPartitionsList()));
+    } else if (topologyChangeOperation.hasAwaitRelocationCompletion()) {
+      final var redistribution = topologyChangeOperation.getAwaitRelocationCompletion();
+      return new AwaitRedistributionCompletion(
+          memberId,
+          redistribution.getDesiredPartitionCount(),
+          new HashSet<>(redistribution.getRelocatedPartitionsList()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -439,13 +439,13 @@ public class ProtoBufSerializer
           builder.setAwaitRedistributionCompletion(
               Topology.AwaitRedistributionCompletion.newBuilder()
                   .setDesiredPartitionCount(msg.desiredPartitionCount())
-                  .addAllPartitionToRedistribute(msg.redistributedPartitions())
+                  .addAllPartitionsToRedistribute(msg.partitionsToRedistribute())
                   .build());
       case final AwaitRelocationCompletion msg ->
           builder.setAwaitRelocationCompletion(
               Topology.AwaitRelocationCompletion.newBuilder()
                   .setDesiredPartitionCount(msg.desiredPartitionCount())
-                  .addAllPartitionsToRelocate(msg.relocatedPartitions())
+                  .addAllPartitionsToRelocate(msg.partitionsToRelocate())
                   .build());
     }
     return builder.build();
@@ -663,7 +663,7 @@ public class ProtoBufSerializer
       return new AwaitRedistributionCompletion(
           memberId,
           redistribution.getDesiredPartitionCount(),
-          new TreeSet<>(redistribution.getPartitionToRedistributeList()));
+          new TreeSet<>(redistribution.getPartitionsToRedistributeList()));
     } else if (topologyChangeOperation.hasAwaitRelocationCompletion()) {
       final var relocation = topologyChangeOperation.getAwaitRelocationCompletion();
       return new AwaitRelocationCompletion(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -439,13 +439,13 @@ public class ProtoBufSerializer
           builder.setAwaitRedistributionCompletion(
               Topology.AwaitRedistributionCompletion.newBuilder()
                   .setDesiredPartitionCount(msg.desiredPartitionCount())
-                  .addAllRedistributedPartitions(msg.redistributedPartitions())
+                  .addAllPartitionToRedistribute(msg.redistributedPartitions())
                   .build());
       case final AwaitRelocationCompletion msg ->
           builder.setAwaitRelocationCompletion(
               Topology.AwaitRelocationCompletion.newBuilder()
                   .setDesiredPartitionCount(msg.desiredPartitionCount())
-                  .addAllRelocatedPartitions(msg.relocatedPartitions())
+                  .addAllPartitionsToRelocate(msg.relocatedPartitions())
                   .build());
     }
     return builder.build();
@@ -663,13 +663,13 @@ public class ProtoBufSerializer
       return new AwaitRedistributionCompletion(
           memberId,
           redistribution.getDesiredPartitionCount(),
-          new TreeSet<>(redistribution.getRedistributedPartitionsList()));
+          new TreeSet<>(redistribution.getPartitionToRedistributeList()));
     } else if (topologyChangeOperation.hasAwaitRelocationCompletion()) {
       final var relocation = topologyChangeOperation.getAwaitRelocationCompletion();
       return new AwaitRelocationCompletion(
           memberId,
           relocation.getDesiredPartitionCount(),
-          new TreeSet<>(relocation.getRelocatedPartitionsList()));
+          new TreeSet<>(relocation.getPartitionsToRelocateList()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -66,6 +66,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 public class ProtoBufSerializer
@@ -434,11 +435,11 @@ public class ProtoBufSerializer
               Topology.StartPartitionScaleUpOperation.newBuilder()
                   .setDesiredPartitionCount(desiredPartitionCount)
                   .build());
-      case final AwaitRedistributionCompletion awaitRedistribution ->
+      case final AwaitRedistributionCompletion msg ->
           builder.setAwaitRedistributionCompletion(
               Topology.AwaitRedistributionCompletion.newBuilder()
-                  .setDesiredPartitionCount(awaitRedistribution.desiredPartitionCount())
-                  .addAllRedistributedPartitions(awaitRedistribution.redistributedPartitions())
+                  .setDesiredPartitionCount(msg.desiredPartitionCount())
+                  .addAllRedistributedPartitions(msg.redistributedPartitions())
                   .build());
       case final AwaitRelocationCompletion msg ->
           builder.setAwaitRelocationCompletion(
@@ -662,13 +663,13 @@ public class ProtoBufSerializer
       return new AwaitRedistributionCompletion(
           memberId,
           redistribution.getDesiredPartitionCount(),
-          new HashSet<>(redistribution.getRedistributedPartitionsList()));
+          new TreeSet<>(redistribution.getRedistributedPartitionsList()));
     } else if (topologyChangeOperation.hasAwaitRelocationCompletion()) {
-      final var redistribution = topologyChangeOperation.getAwaitRelocationCompletion();
-      return new AwaitRedistributionCompletion(
+      final var relocation = topologyChangeOperation.getAwaitRelocationCompletion();
+      return new AwaitRelocationCompletion(
           memberId,
-          redistribution.getDesiredPartitionCount(),
-          new HashSet<>(redistribution.getRelocatedPartitionsList()));
+          relocation.getDesiredPartitionCount(),
+          new TreeSet<>(relocation.getRelocatedPartitionsList()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -65,20 +65,19 @@ public sealed interface ClusterConfigurationChangeOperation {
     /**
      * @param memberId the id of the member that initiated the scale up
      * @param desiredPartitionCount the desired partition count after scaling up
-     * @param redistributedPartitions the partitions to add to {@link RoutingState.RequestHandling}
+     * @param partitionsToRedistribute the partitions to add to {@link RoutingState.RequestHandling}
      */
     record AwaitRedistributionCompletion(
-        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> redistributedPartitions)
+        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRedistribute)
         implements ScaleUpOperation {}
 
     /**
      * @param memberId the id of the member that initiated the scale up
      * @param desiredPartitionCount the desired partition count after scaling up
-     * @param relocatedPartitions the partitions to add to {@link RoutingState.MessageCorrelation}
+     * @param partitionsToRelocate the partitions to add to {@link RoutingState.MessageCorrelation}
      */
-    // TODO NOT IMPLEMENTED YET
     record AwaitRelocationCompletion(
-        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> relocatedPartitions)
+        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> partitionsToRelocate)
         implements ScaleUpOperation {}
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
+import java.util.SortedSet;
 
 /**
  * An operation that changes the configuration. The operation could be a member join or leave a
@@ -68,7 +68,7 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param redistributedPartitions the partitions to add to {@link RoutingState.RequestHandling}
      */
     record AwaitRedistributionCompletion(
-        MemberId memberId, int desiredPartitionCount, Set<Integer> redistributedPartitions)
+        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> redistributedPartitions)
         implements ScaleUpOperation {}
 
     /**
@@ -78,7 +78,7 @@ public sealed interface ClusterConfigurationChangeOperation {
      */
     // TODO NOT IMPLEMENTED YET
     record AwaitRelocationCompletion(
-        MemberId memberId, int desiredPartitionCount, Set<Integer> relocatedPartitions)
+        MemberId memberId, int desiredPartitionCount, SortedSet<Integer> relocatedPartitions)
         implements ScaleUpOperation {}
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -33,6 +33,10 @@ public record RoutingState(
     }
   }
 
+  public RoutingState updateRequestHandling(final RequestHandling requestHandling) {
+    return new RoutingState(version + 1, requestHandling, messageCorrelation);
+  }
+
   public RoutingState merge(final RoutingState other) {
     if (equals(other)) {
       return this;
@@ -133,6 +137,19 @@ public record RoutingState(
         all.addAll(additionalActivePartitions);
         all.removeAll(inactivePartitions);
         return all;
+      }
+
+      public RequestHandling activatePartitions(final Set<Integer> partitions) {
+        final var updatedInactivePartitions = new HashSet<>(inactivePartitions());
+        updatedInactivePartitions.removeAll(partitions);
+        final var updatedAdditionalActivePartitions = new HashSet<>(additionalActivePartitions);
+        updatedAdditionalActivePartitions.addAll(partitions);
+        if (updatedInactivePartitions.isEmpty()) {
+          return new AllPartitions(basePartitionCount + updatedAdditionalActivePartitions.size());
+        } else {
+          return new ActivePartitions(
+              basePartitionCount, updatedAdditionalActivePartitions, updatedInactivePartitions);
+        }
       }
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -33,8 +34,8 @@ public record RoutingState(
     }
   }
 
-  public RoutingState updateRequestHandling(final RequestHandling requestHandling) {
-    return new RoutingState(version + 1, requestHandling, messageCorrelation);
+  public RoutingState withRequestHandling(final UnaryOperator<RequestHandling> update) {
+    return new RoutingState(version + 1, update.apply(requestHandling), messageCorrelation);
   }
 
   public RoutingState merge(final RoutingState other) {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -160,12 +160,12 @@ message StartPartitionScaleUpOperation {
 
 message AwaitRedistributionCompletion{
   int32 desiredPartitionCount = 1;
-  repeated int32 redistributedPartitions= 2;
+  repeated int32 partitionToRedistribute= 2;
 }
 
 message AwaitRelocationCompletion{
   int32 desiredPartitionCount = 1;
-  repeated int32 relocatedPartitions = 2;
+  repeated int32 partitionsToRelocate = 2;
 }
 
 message DeleteHistoryOperation {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -5,9 +5,7 @@ import "google/protobuf/timestamp.proto";
 
 option java_package = "io.camunda.zeebe.dynamic.config.protocol";
 
-message GossipState {
-  ClusterTopology clusterTopology = 1;
-}
+message GossipState { ClusterTopology clusterTopology = 1; }
 
 message ClusterTopology {
   int64 version = 1;
@@ -18,7 +16,7 @@ message ClusterTopology {
 }
 
 message RoutingState {
-  int64  version = 1;
+  int64 version = 1;
   RequestHandling requestHandling = 2;
   MessageCorrelation messageCorrelation = 3;
 }
@@ -29,9 +27,7 @@ message RequestHandling {
     ActivePartitions activePartitions = 2;
   }
 
-  message AllPartitions {
-    sint32 partitionCount = 1;
-  }
+  message AllPartitions { sint32 partitionCount = 1; }
   message ActivePartitions {
     sint32 basePartitionCount = 1;
     repeated sint32 additionalActivePartitions = 2;
@@ -40,13 +36,9 @@ message RequestHandling {
 }
 
 message MessageCorrelation {
-  oneof correlation {
-    HashMod hashMod = 1;
-  }
+  oneof correlation { HashMod hashMod = 1; }
 
-  message HashMod {
-    sint32 partitionCount = 1;
-  }
+  message HashMod { sint32 partitionCount = 1; }
 }
 
 message MemberState {
@@ -62,13 +54,9 @@ message PartitionState {
   PartitionConfig config = 3;
 }
 
-message PartitionConfig {
-  ExportersConfig exporting = 1;
-}
+message PartitionConfig { ExportersConfig exporting = 1; }
 
-message ExportersConfig{
-  map<string, ExporterState> exporters = 1;
-}
+message ExportersConfig { map<string, ExporterState> exporters = 1; }
 
 message ExporterState {
   EnabledDisabledState state = 1;
@@ -107,8 +95,8 @@ message TopologyChangeOperation {
     PartitionBootstrapOperation partitionBootstrap = 11;
     StartPartitionScaleUpOperation initiateScaleUpPartitions = 12;
     DeleteHistoryOperation deleteHistory = 13;
-    AwaitRedistributionCompletion awaitRedistributionCompletion= 14;
-    AwaitRelocationCompletion awaitRelocationCompletion= 15;
+    AwaitRedistributionCompletion awaitRedistributionCompletion = 14;
+    AwaitRelocationCompletion awaitRelocationCompletion = 15;
   }
 }
 
@@ -154,31 +142,25 @@ message PartitionBootstrapOperation {
   optional PartitionConfig config = 3;
 }
 
-message StartPartitionScaleUpOperation {
-  int32 desiredPartitionCount = 2;
-}
+message StartPartitionScaleUpOperation { int32 desiredPartitionCount = 2; }
 
-message AwaitRedistributionCompletion{
+message AwaitRedistributionCompletion {
   int32 desiredPartitionCount = 1;
-  repeated int32 partitionToRedistribute= 2;
+  repeated int32 partitionsToRedistribute = 2;
 }
 
-message AwaitRelocationCompletion{
+message AwaitRelocationCompletion {
   int32 desiredPartitionCount = 1;
   repeated int32 partitionsToRelocate = 2;
 }
 
-message DeleteHistoryOperation {
-  int32 memberId = 1;
-}
+message DeleteHistoryOperation { int32 memberId = 1; }
 
 message MemberJoinOperation {}
 
 message MemberLeaveOperation {}
 
-message MemberRemoveOperation {
-  string memberToRemove = 1;
-}
+message MemberRemoveOperation { string memberToRemove = 1; }
 
 enum State {
   UNKNOWN = 0;
@@ -202,5 +184,3 @@ enum EnabledDisabledState {
   ENABLED = 1;
   DISABLED = 2;
 }
-
-

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -107,6 +107,8 @@ message TopologyChangeOperation {
     PartitionBootstrapOperation partitionBootstrap = 11;
     StartPartitionScaleUpOperation initiateScaleUpPartitions = 12;
     DeleteHistoryOperation deleteHistory = 13;
+    AwaitRedistributionCompletion awaitRedistributionCompletion= 14;
+    AwaitRelocationCompletion awaitRelocationCompletion= 15;
   }
 }
 
@@ -154,6 +156,16 @@ message PartitionBootstrapOperation {
 
 message StartPartitionScaleUpOperation {
   int32 desiredPartitionCount = 2;
+}
+
+message AwaitRedistributionCompletion{
+  int32 desiredPartitionCount = 1;
+  repeated int32 redistributedPartitions= 2;
+}
+
+message AwaitRelocationCompletion{
+  int32 desiredPartitionCount = 1;
+  repeated int32 relocatedPartitions = 2;
 }
 
 message DeleteHistoryOperation {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleUpTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleUpTransformerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+public class ScaleUpTransformerTest {
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private final int clusterSize = 5;
+  private final int replicationFactor = 3;
+
+  @Property
+  void shouldFailIfDesiredPartitionCountIsLessThanNewPartitions(
+      @ForAll @IntRange(min = 1, max = 100) final int currentPartitionCount,
+      @ForAll @IntRange(min = 1, max = 100) final int desiredPartitionCount,
+      @ForAll @IntRange(min = 1, max = 100) final int newPartitionCount) {
+    scaleUpWithValidation(currentPartitionCount, desiredPartitionCount, newPartitionCount, null);
+  }
+
+  @Property
+  void shouldGenerateOperationForAllPartition1Members(
+      @ForAll @IntRange(min = 1, max = 100) final int currentPartitionCount,
+      @ForAll @IntRange(min = 1, max = 100) final int newPartitionCount) {
+    final var desiredPartitionCount = currentPartitionCount + newPartitionCount;
+    scaleUpWithValidation(
+        currentPartitionCount,
+        desiredPartitionCount,
+        newPartitionCount,
+        operations -> {
+          assertThat(operations).hasSize(3); // 3 operation for each replica
+          final var lowestMemberId = MemberId.from("1");
+          final var newPartitions =
+              partitionsInRange(currentPartitionCount + 1, desiredPartitionCount + 1);
+          assertThat(operations)
+              .allSatisfy(
+                  operation -> {
+                    assertThat(operation.memberId()).isEqualTo(lowestMemberId);
+                  });
+          assertThat(operations)
+              .isEqualTo(
+                  List.of(
+                      new StartPartitionScaleUp(lowestMemberId, desiredPartitionCount),
+                      new AwaitRedistributionCompletion(
+                          lowestMemberId, desiredPartitionCount, newPartitions),
+                      new AwaitRelocationCompletion(
+                          lowestMemberId, desiredPartitionCount, newPartitions)));
+        });
+  }
+
+  public void scaleUpWithValidation(
+      final int currentPartitionCount,
+      final int desiredPartitionCount,
+      final int newPartitionCount,
+      final Consumer<List<ClusterConfigurationChangeOperation>> whenRight) {
+    final var distribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                IntStream.range(1, clusterSize)
+                    .mapToObj(id -> MemberId.from(Integer.toString(id)))
+                    .collect(Collectors.toSet()),
+                partitionsInRange(1, 1 + currentPartitionCount).stream()
+                    .map(i -> PartitionId.from("temp", i))
+                    .toList(),
+                replicationFactor);
+    final var config = ConfigurationUtil.getClusterConfigFrom(true, distribution, partitionConfig);
+    final var transformer =
+        new ScaleUpRequestTransformer(
+            desiredPartitionCount,
+            partitionsInRange(
+                currentPartitionCount + 1, newPartitionCount + currentPartitionCount + 1));
+    final var operations = transformer.operations(config);
+    if (desiredPartitionCount < currentPartitionCount) {
+      EitherAssert.assertThat(operations).isLeft();
+    } else if (desiredPartitionCount != currentPartitionCount + newPartitionCount) {
+      EitherAssert.assertThat(operations).isLeft();
+    } else {
+      EitherAssert.assertThat(operations).right();
+      if (whenRight != null) {
+        whenRight.accept(operations.get());
+      }
+    }
+  }
+
+  SortedSet<Integer> partitionsInRange(final int from, final int to) {
+    return new TreeSet<>(IntStream.range(from, to).boxed().toList());
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AbstractApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AbstractApplierTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+
+abstract class AbstractApplierTest {
+  protected ClusterConfiguration runApplier(
+      final ClusterOperationApplier applier, final ClusterConfiguration initialConfiguration) {
+    final var initializedConfiguration =
+        applier.init(initialConfiguration).get().apply(initialConfiguration);
+    final var updater = applier.apply().join();
+    return updater.apply(initializedConfiguration);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.*;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+public class AwaitRedistributionCompletionTest {
+
+  MemberId memberId = new MemberId("1");
+
+  ClusterConfiguration empty = ClusterConfiguration.init();
+  ClusterConfiguration validAllPartitionConfig =
+      new ClusterConfiguration(
+          1,
+          Map.of(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(RoutingState.initializeWithPartitionCount(3)));
+
+  ClusterConfiguration valid3OutOf6Partitions =
+      new ClusterConfiguration(
+          1,
+          Map.of(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(
+              new RoutingState(
+                  1, new ActivePartitions(3, Set.of(), Set.of(4, 5, 6)), new HashMod(3))));
+
+  PartitionScalingChangeExecutor executor = new NoopPartitionScalingChangeExecutor();
+
+  @Test
+  public void shouldFailWhenNoRoutingStateIsPresent() {
+    final var changeOperation = new AwaitRedistributionCompletion(memberId, 6, Set.of(2, 3));
+    final var applier = new AwaitRedistributionCompletionApplier(executor, changeOperation);
+    EitherAssert.assertThat(applier.init(empty)).isLeft();
+  }
+
+  @Test
+  public void shouldFailWhenListOfPartitionIsEmpty() {
+    final var changeOperation = new AwaitRedistributionCompletion(memberId, 6, Set.of());
+    final var applier = new AwaitRedistributionCompletionApplier(executor, changeOperation);
+    EitherAssert.assertThat(applier.init(validAllPartitionConfig))
+        .isLeft()
+        .satisfies(left -> assertThat(left.getLeft()).isInstanceOf(IllegalArgumentException.class));
+  }
+
+  @Test
+  public void shouldAddNewPartitionToRequestHandling()
+      throws ExecutionException, InterruptedException {
+    final var operation = new AwaitRedistributionCompletion(memberId, 6, Set.of(4, 5));
+    final var applier = new AwaitRedistributionCompletionApplier(executor, operation);
+    final var transformer =
+        EitherAssert.assertThat(applier.init(valid3OutOf6Partitions)).isRight().right();
+    final var initialized = transformer.actual().apply(valid3OutOf6Partitions);
+    final var modified = applier.apply().get().apply(initialized);
+
+    assertThat(modified.routingState())
+        .isNotEmpty()
+        .satisfies(
+            routingState ->
+                assertThat(routingState.get().requestHandling())
+                    .isEqualTo(new ActivePartitions(3, Set.of(4, 5), Set.of(6))));
+  }
+
+  @Test
+  public void shouldSetRequestHandlingAsAllPartition()
+      throws ExecutionException, InterruptedException {
+    final var operation = new AwaitRedistributionCompletion(memberId, 6, Set.of(4, 5, 6));
+    final var applier = new AwaitRedistributionCompletionApplier(executor, operation);
+    final var transformer =
+        EitherAssert.assertThat(applier.init(valid3OutOf6Partitions)).isRight().right();
+    final var initialized = transformer.actual().apply(valid3OutOf6Partitions);
+    final var modified = applier.apply().get().apply(initialized);
+
+    assertThat(modified.routingState())
+        .isNotEmpty()
+        .satisfies(
+            routingState ->
+                assertThat(routingState.get().requestHandling()).isEqualTo(new AllPartitions(6)));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.util.ReflectUtil;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Combinators;
@@ -101,6 +103,11 @@ public final class ClusterTopologyDomain extends DomainContextBase {
             ReflectUtil.implementationsOfSealedInterface(ClusterConfigurationChangeOperation.class)
                 .toList())
         .flatMap(Arbitraries::forType);
+  }
+
+  @Provide
+  Arbitrary<SortedSet<Integer>> sortedIntegerSets() {
+    return Arbitraries.integers().list().map(TreeSet::new);
   }
 
   @Provide

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionScaleUpRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionScaleUpRequest.java
@@ -22,6 +22,8 @@ public final class BrokerPartitionScaleUpRequest extends BrokerExecuteCommand<Sc
   public BrokerPartitionScaleUpRequest(final int desiredPartitionCount) {
     super(ValueType.SCALE, ScaleIntent.SCALE_UP);
     requestDto.setDesiredPartitionCount(desiredPartitionCount);
+
+    // set the target partition for this request
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/GetScaleUpProgress.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/GetScaleUpProgress.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class GetScaleUpProgress extends BrokerExecuteCommand<ScaleRecord> {
+
+  private final ScaleRecord requestDto = new ScaleRecord();
+
+  public GetScaleUpProgress(final int desiredPartitionCount) {
+    super(ValueType.SCALE, ScaleIntent.SCALE_UP);
+    requestDto.setDesiredPartitionCount(desiredPartitionCount);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ScaleRecord toResponseDto(final DirectBuffer buffer) {
+    final var responseDto = new ScaleRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -62,4 +62,8 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
   public boolean isEmpty() {
     return value.isEmpty();
   }
+
+  public int size() {
+    return value.size();
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
+import java.util.Collection;
 
 public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue {
   private final IntegerProperty desiredPartitionCountProp =
@@ -20,17 +21,17 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   // partitions that have been activated because of this scale up operation
   // activated = completed redistribution
   private final ArrayProperty<IntegerValue> redistributedPartitions =
-      new ArrayProperty<>("activePartitions", IntegerValue::new);
+      new ArrayProperty<>("redistributedPartitions", IntegerValue::new);
   // partitions that are ready to take part of processing completely:
   // ready = completed relocation
-  private final ArrayProperty<IntegerValue> readyPartitions =
-      new ArrayProperty<>("readyPartitions", IntegerValue::new);
+  private final ArrayProperty<IntegerValue> relocatedPartitions =
+      new ArrayProperty<>("relocatedPartitions", IntegerValue::new);
 
   public ScaleRecord() {
     super(3);
     declareProperty(desiredPartitionCountProp)
         .declareProperty(redistributedPartitions)
-        .declareProperty(readyPartitions);
+        .declareProperty(relocatedPartitions);
   }
 
   @Override
@@ -43,11 +44,29 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
     return this;
   }
 
-  public ArrayProperty<IntegerValue> getRedistributedPartitions() {
-    return redistributedPartitions;
+  @Override
+  public Collection<Integer> getRedistributedPartitions() {
+    return redistributedPartitions.stream().map(IntegerValue::getValue).toList();
   }
 
-  public ArrayProperty<IntegerValue> getReadyPartitions() {
-    return readyPartitions;
+  @Override
+  public Collection<Integer> getRelocatedPartitions() {
+    return relocatedPartitions.stream().map(IntegerValue::getValue).toList();
+  }
+
+  public ScaleRecord setRedistributedPartitionsProperty(final Collection<Integer> partitions) {
+    redistributedPartitions.reset();
+    for (final int partition : partitions) {
+      redistributedPartitions.add().setValue(partition);
+    }
+    return this;
+  }
+
+  public ScaleRecord setRelocatedPartitionsProperty(final Collection<Integer> partitions) {
+    relocatedPartitions.reset();
+    for (final int partition : partitions) {
+      relocatedPartitions.add().setValue(partition);
+    }
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.scaling;
 
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 
@@ -15,9 +17,20 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   private final IntegerProperty desiredPartitionCountProp =
       new IntegerProperty("desiredPartitionCount", -1);
 
+  // partitions that have been activated because of this scale up operation
+  // activated = completed redistribution
+  private final ArrayProperty<IntegerValue> redistributedPartitions =
+      new ArrayProperty<>("activePartitions", IntegerValue::new);
+  // partitions that are ready to take part of processing completely:
+  // ready = completed relocation
+  private final ArrayProperty<IntegerValue> readyPartitions =
+      new ArrayProperty<>("readyPartitions", IntegerValue::new);
+
   public ScaleRecord() {
-    super(1);
-    declareProperty(desiredPartitionCountProp);
+    super(3);
+    declareProperty(desiredPartitionCountProp)
+        .declareProperty(redistributedPartitions)
+        .declareProperty(readyPartitions);
   }
 
   @Override
@@ -28,5 +41,13 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   public ScaleRecord setDesiredPartitionCount(final int desiredPartitionCount) {
     desiredPartitionCountProp.setValue(desiredPartitionCount);
     return this;
+  }
+
+  public ArrayProperty<IntegerValue> getRedistributedPartitions() {
+    return redistributedPartitions;
+  }
+
+  public ArrayProperty<IntegerValue> getReadyPartitions() {
+    return readyPartitions;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2921,7 +2921,9 @@ final class JsonSerializableToJsonTest {
         (Supplier<ScaleRecord>) ScaleRecord::new,
         """
         {
-          "desiredPartitionCount": -1
+          "desiredPartitionCount": -1,
+          "redistributedPartitions": [],
+          "relocatedPartitions": []
         }
         """
       },
@@ -2930,7 +2932,25 @@ final class JsonSerializableToJsonTest {
         (Supplier<ScaleRecord>) () -> new ScaleRecord().setDesiredPartitionCount(5),
         """
         {
-         "desiredPartitionCount": 5
+         "desiredPartitionCount": 5,
+          "redistributedPartitions": [],
+          "relocatedPartitions": []
+        }
+        """
+      },
+      {
+        "ScaleRecord w/ redistributedPartitions & relocatedPartitions",
+        (Supplier<ScaleRecord>)
+            () ->
+                new ScaleRecord()
+                    .setDesiredPartitionCount(5)
+                    .setRelocatedPartitionsProperty(List.of(4, 5))
+                    .setRedistributedPartitionsProperty(List.of(4, 5)),
+        """
+        {
+         "desiredPartitionCount": 5,
+          "redistributedPartitions": [4,5],
+          "relocatedPartitions": [4,5]
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -17,10 +17,15 @@ package io.camunda.zeebe.protocol.record.value.scaling;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.Collection;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableScaleRecordValue.Builder.class)
 public interface ScaleRecordValue extends RecordValue {
   int getDesiredPartitionCount();
+
+  Collection<Integer> getRedistributedPartitions();
+
+  Collection<Integer> getRelocatedPartitions();
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/ClientRequest.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 public interface ClientRequest extends BufferWriter {
 
   /**
-   * @return the partition id to which the request should be send to
+   * @return the partition id to which the request should be sent to
    */
   int getPartitionId();
 


### PR DESCRIPTION
## Description
This PR adds two new `ClusterChangeOperation` needed for waiting that redistribution and relocation are terminated.
To keep the scope not too big only waiting for redistribution is implemented as follows:

- A new `ScaleUpTransformer` is added that when invoked will generate the ClusterChangeOperations needed to complete the scale up, which are now grouped under a common interface `ScaleUpOperation`.
  - StartPartitionScaleUp (renamed from `StartPartitionScaleUpOperation`)
  - AwaitRedistributionCompletion
  - AwaitRelocationCompletion 

- Two new protobuf messages have been added in `topology.proto` for the new operations.
- `AwaitRedistributionCompletionApplier` has been added which polls the `PartitionScalingExecutor` in order to wait for the redistribution to be completed. When it's done, it will update the RoutingState.RequestHandling section of the ClusterConfiguration in order to route new requests to the new partitions.

## Checklist
- [x] Improve the polling mechanism in `PartitionScalingExecutor`, consider to implement it in `BrokerClient`
- [x] Add tests for `PartitionScalingExecutor`
- [x] Verify the memberId to use when publish ScaleUpOperation:
   - The memberId is the lowest, i.e. the coordinator node 

## Related issues

closes #31010 
