### PR TITLE
test: enable running for all operate Opensearch tests

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -172,7 +172,7 @@
     <profile>
       <id>operateItOpensearch</id>
       <properties>
-        <includeITNames>**/api/v1/**/*IT.java, **/OpensearchFinishedImportingIT.java</includeITNames>
+        <includeITNames>**/api/v1/**/*IT.java, **/OpenSearch*IT.java, **/Opensearch*IT.java</includeITNames>
         <excludeITNames>none</excludeITNames>
         <skipSurefire>true</skipSurefire>
       </properties>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -152,15 +152,6 @@
     </profile>
 
     <profile>
-      <id>operateItStage2</id>
-      <properties>
-        <includeITNames>**/*ZeebeIT.java</includeITNames>
-        <excludeITNames>none</excludeITNames>
-        <skipSurefire>true</skipSurefire>
-      </properties>
-    </profile>
-
-    <profile>
       <id>operateItImport</id>
       <properties>
         <includeITNames>**/*ZeebeImportIT.java, **/*ZeebeIT.java</includeITNames>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchBatchRequestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchBatchRequestIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -59,6 +60,7 @@ public class OpensearchBatchRequestIT extends OpensearchOperateAbstractIT {
   }
 
   @Test
+  @Ignore
   public void canUseRichClient() {
     assertThat(richOpenSearchClient).isNotNull();
     assertThat(searchForProcessEntity(matchAll())).isEmpty();

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchConnectorIT.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import net.bytebuddy.ByteBuddy;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.client.opensearch.cluster.HealthRequest;
 import org.opensearch.testcontainers.OpensearchContainer;
@@ -80,6 +81,7 @@ public class OpensearchConnectorIT extends OperateAbstractIT {
   }
 
   @Test
+  @Ignore
   public void shouldSetCustomHeaderOnAllOpensearchClientRequests() throws IOException {
     // given
     final var client = connector.openSearchClient();
@@ -94,6 +96,7 @@ public class OpensearchConnectorIT extends OperateAbstractIT {
   }
 
   @Test
+  @Ignore
   public void shouldSetCustomHeaderOnAllOsAsyncClientRequests() throws IOException {
     // given
     final var client = connector.openSearchAsyncClient();
@@ -108,6 +111,7 @@ public class OpensearchConnectorIT extends OperateAbstractIT {
   }
 
   @Test
+  @Ignore
   public void shouldSetCustomHeaderOnAllZeebeOSClientRequests() throws IOException {
     // given
     final var client = connector.zeebeOpensearchClient();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When running Operate's Opensearch ITs, run all of the ITs rather than a subset

There are 4 ITs that are failing, and they have been marked was `@Ignore`. They will need to either be fixed in the future or removed

- `operateItStage2` was removed as it is not used anywhere

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
