### PR TITLE
31055 add dedicated call hierarchy endpoint to v2 api

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -61,6 +61,7 @@
       <column name="ELEMENT_ID" type="VARCHAR(255)"/>
       <column name="VERSION" type="SMALLINT" />
       <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="TREE_PATH" type="VARCHAR(4000)" />
       <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -26,6 +26,7 @@ public record ProcessInstanceDbModel(
     String elementId,
     int version,
     int partitionId,
+    String treePath,
     OffsetDateTime historyCleanupDate)
     implements DbModel<ProcessInstanceDbModel> {
 
@@ -69,6 +70,7 @@ public record ProcessInstanceDbModel(
     private int numIncidents = 0;
     private int version;
     private int partitionId;
+    private String treePath;
     private OffsetDateTime historyCleanupDate;
 
     // Public constructor to initialize the builder
@@ -146,6 +148,11 @@ public record ProcessInstanceDbModel(
       return this;
     }
 
+    public ProcessInstanceDbModelBuilder treePath(final String treePath) {
+      this.treePath = treePath;
+      return this;
+    }
+
     public ProcessInstanceDbModelBuilder historyCleanupDate(final OffsetDateTime value) {
       historyCleanupDate = value;
       return this;
@@ -167,6 +174,7 @@ public record ProcessInstanceDbModel(
           elementId,
           version,
           partitionId,
+          treePath,
           historyCleanupDate);
     }
   }

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -26,6 +26,7 @@
            pi.PARENT_ELEMENT_INSTANCE_KEY,
            pi.ELEMENT_ID,
            pi.VERSION AS PROCESS_DEFINITION_VERSION,
+           pi.TREE_PATH,
            pd.NAME        AS PROCESS_DEFINITION_NAME,
            pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
@@ -62,6 +63,7 @@
     pi.PARENT_ELEMENT_INSTANCE_KEY,
     pi.ELEMENT_ID,
     pi.VERSION PROCESS_DEFINITION_VERSION,
+    pi.TREE_PATH,
     pd.NAME AS PROCESS_DEFINITION_NAME,
     pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
@@ -261,6 +263,7 @@
       <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"/>
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TREE_PATH" javaType="java.lang.String"/>
     </constructor>
 
   </resultMap>
@@ -294,9 +297,9 @@
     parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel"
     flushCache="true">
     INSERT INTO ${prefix}PROCESS_INSTANCE (PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, STATE, START_DATE, END_DATE, TENANT_ID, PARENT_PROCESS_INSTANCE_KEY, PARENT_ELEMENT_INSTANCE_KEY,
-                                           NUM_INCIDENTS, VERSION, PARTITION_ID, HISTORY_CLEANUP_DATE)
+                                           NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH, HISTORY_CLEANUP_DATE)
     VALUES (#{processInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state}, #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId}, #{parentProcessInstanceKey},
-            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
+            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath}, #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
   <update
@@ -314,6 +317,7 @@
         PARENT_ELEMENT_INSTANCE_KEY = #{parentElementInstanceKey},
         NUM_INCIDENTS               = #{numIncidents},
         VERSION                     = #{version},
+        TREE_PATH                   = #{treePath},
         HISTORY_CLEANUP_DATE        = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -30,7 +30,8 @@ public class ProcessInstanceEntityTransformer
         source.getEndDate(),
         toState(source.getState()),
         source.isIncident(),
-        source.getTenantId());
+        source.getTenantId(),
+        source.getTreePath());
   }
 
   private ProcessInstanceState toState(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -24,7 +24,8 @@ public record ProcessInstanceEntity(
     OffsetDateTime endDate,
     ProcessInstanceState state,
     Boolean hasIncident,
-    String tenantId) {
+    String tenantId,
+    String treePath) {
 
   public enum ProcessInstanceState {
     ACTIVE,

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -104,9 +104,7 @@ public final class ProcessInstanceServices
     }
 
     final List<Long> orderedKeys =
-        TreePathParser.extractProcessInstanceKeys(rootInstance.treePath()).stream()
-            .map(Long::valueOf)
-            .toList();
+        TreePathParser.extractProcessInstanceKeys(rootInstance.treePath()).stream().toList();
 
     if (orderedKeys.size() == 1
         && orderedKeys.getFirst().equals(rootInstance.processInstanceKey())) {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -22,6 +22,7 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.service.util.TreePathParser;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
@@ -46,8 +47,10 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public final class ProcessInstanceServices
     extends SearchQueryService<
@@ -90,6 +93,37 @@ public final class ProcessInstanceServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .processInstanceFlowNodeStatistics(processInstanceKey);
+  }
+
+  public List<ProcessInstanceEntity> callHierarchy(final long processInstanceKey) {
+    final var rootInstance = getByKey(processInstanceKey);
+
+    final var treePath = rootInstance.treePath();
+    if (treePath == null || treePath.isBlank()) {
+      return List.of();
+    }
+
+    final List<Long> orderedKeys =
+        TreePathParser.extractProcessInstanceKeys(rootInstance.treePath()).stream()
+            .map(Long::valueOf)
+            .toList();
+
+    if (orderedKeys.size() == 1
+        && orderedKeys.getFirst().equals(rootInstance.processInstanceKey())) {
+      return List.of();
+    }
+
+    final var resultsByKey =
+        processInstanceSearchClient
+            .searchProcessInstances(
+                processInstanceSearchQuery(
+                    q -> q.filter(f -> f.processInstanceKeyOperations(Operation.in(orderedKeys)))))
+            .items()
+            .stream()
+            .collect(
+                Collectors.toMap(ProcessInstanceEntity::processInstanceKey, Function.identity()));
+
+    return orderedKeys.stream().map(resultsByKey::get).filter(Objects::nonNull).toList();
   }
 
   public ProcessInstanceEntity getByKey(final Long processInstanceKey) {

--- a/service/src/main/java/io/camunda/service/util/TreePathParser.java
+++ b/service/src/main/java/io/camunda/service/util/TreePathParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Temporary workaround for parsing treePath strings within the service module.
+ *
+ * <p>The real implementation should eventually live in a shared module within Camunda 8, which
+ * provides centralized access to TreePath logic for all modules that need it (e.g., service,
+ * webapp, exporter, importer).
+ *
+ * <p>This class should be removed once a proper <a
+ * href="https://github.com/camunda/camunda/issues/31218">shared utility or domain module</a> is
+ * established.
+ */
+public final class TreePathParser {
+
+  private TreePathParser() {}
+
+  public static List<String> extractProcessInstanceKeys(final String treePath) {
+    final List<String> processInstanceIds = new ArrayList<>();
+    final Pattern piPattern = Pattern.compile("PI_(\\d*)$");
+    Arrays.stream(treePath.split("/"))
+        .map(piPattern::matcher)
+        .filter(Matcher::matches)
+        .forEach(matcher -> processInstanceIds.add(matcher.group(1)));
+
+    return processInstanceIds;
+  }
+}

--- a/service/src/main/java/io/camunda/service/util/TreePathParser.java
+++ b/service/src/main/java/io/camunda/service/util/TreePathParser.java
@@ -13,17 +13,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Temporary workaround for parsing treePath strings within the service module.
- *
- * <p>The real implementation should eventually live in a shared module within Camunda 8, which
- * provides centralized access to TreePath logic for all modules that need it (e.g., service,
- * webapp, exporter, importer).
- *
- * <p>This class should be removed once a proper <a
- * href="https://github.com/camunda/camunda/issues/31218">shared utility or domain module</a> is
- * established.
- */
 public final class TreePathParser {
 
   private static final String PROCESS_INSTANCE_PATTERN = "PI_(\\d*)$";

--- a/service/src/main/java/io/camunda/service/util/TreePathParser.java
+++ b/service/src/main/java/io/camunda/service/util/TreePathParser.java
@@ -26,15 +26,17 @@ import java.util.regex.Pattern;
  */
 public final class TreePathParser {
 
+  private static final String PROCESS_INSTANCE_PATTERN = "PI_(\\d*)$";
+
   private TreePathParser() {}
 
-  public static List<String> extractProcessInstanceKeys(final String treePath) {
-    final List<String> processInstanceIds = new ArrayList<>();
-    final Pattern piPattern = Pattern.compile("PI_(\\d*)$");
+  public static List<Long> extractProcessInstanceKeys(final String treePath) {
+    final List<Long> processInstanceIds = new ArrayList<>();
+    final Pattern piPattern = Pattern.compile(PROCESS_INSTANCE_PATTERN);
     Arrays.stream(treePath.split("/"))
         .map(piPattern::matcher)
         .filter(Matcher::matches)
-        .forEach(matcher -> processInstanceIds.add(matcher.group(1)));
+        .forEach(matcher -> processInstanceIds.add(Long.valueOf(matcher.group(1))));
 
     return processInstanceIds;
   }

--- a/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
+++ b/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
@@ -20,10 +20,10 @@ class TreePathParserTest {
     final String treePath = "PI_1/FN_1/FNI_1/PI_2/FN_3/FNI_3";
 
     // when
-    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+    final List<Long> result = TreePathParser.extractProcessInstanceKeys(treePath);
 
     // then
-    assertThat(result).containsExactly("1", "2"); // Extracts all process instance keys in order
+    assertThat(result).containsExactly(1L, 2L); // Extracts all process instance keys in order
   }
 
   @Test
@@ -32,7 +32,7 @@ class TreePathParserTest {
     final String treePath = "FN_1/FNI_1/FN_3/FNI_3";
 
     // when
-    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+    final List<Long> result = TreePathParser.extractProcessInstanceKeys(treePath);
 
     // then
     assertThat(result).isEmpty(); // No PI_x patterns present
@@ -44,10 +44,10 @@ class TreePathParserTest {
     final String treePath = "PI_123";
 
     // when
-    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+    final List<Long> result = TreePathParser.extractProcessInstanceKeys(treePath);
 
     // then
-    assertThat(result).containsExactly("123"); // Only one process instance key
+    assertThat(result).containsExactly(123L); // Only one process instance key
   }
 
   @Test
@@ -56,7 +56,7 @@ class TreePathParserTest {
     final String treePath = "";
 
     // when
-    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+    final List<Long> result = TreePathParser.extractProcessInstanceKeys(treePath);
 
     // then
     assertThat(result).isEmpty(); // No valid content in a tree path

--- a/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
+++ b/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TreePathParserTest {
+
+  @Test
+  void shouldExtractProcessInstanceKeysFromValidTreePath() {
+    // given
+    final String treePath = "PI_1/FN_1/FNI_1/PI_2/FN_3/FNI_3";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).containsExactly("1", "2"); // Extracts all process instance keys in order
+  }
+
+  @Test
+  void shouldReturnEmptyListForTreePathWithoutProcessInstances() {
+    // given
+    final String treePath = "FN_1/FNI_1/FN_3/FNI_3";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).isEmpty(); // No PI_x patterns present
+  }
+
+  @Test
+  void shouldHandleTreePathWithSingleProcessInstance() {
+    // given
+    final String treePath = "PI_123";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).containsExactly("123"); // Only one process instance key
+  }
+
+  @Test
+  void shouldReturnEmptyListForEmptyTreePath() {
+    // given
+    final String treePath = "";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).isEmpty(); // No valid content in a tree path
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -61,6 +66,18 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>${version.caffeine}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${version.jetbrains-annotations}</version>
     </dependency>
 
     <!-- testing -->

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -80,6 +80,11 @@
       <version>${version.jetbrains-annotations}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/CachedProcessEntity.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/CachedProcessEntity.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import java.util.List;
+
+public record CachedProcessEntity(String name, String versionTag, List<String> callElementIds) {}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
@@ -11,6 +11,7 @@ import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import java.util.Map;
 import java.util.Optional;
 
 public class ExporterEntityCache<K, T> {
@@ -37,6 +38,10 @@ public class ExporterEntityCache<K, T> {
 
   public Optional<T> get(final K entityKey) {
     return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  public Map<K, T> getAll(final Iterable<K> keys) {
+    return cache.getAll(keys);
   }
 
   public void put(final K entityKey, final T entity) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
@@ -10,17 +10,21 @@ package io.camunda.exporter.rdbms.cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Optional;
 
 public class ExporterEntityCache<K, T> {
 
-  private static final int DEFAULT_MAX_CACHE_SIZE = 10000;
   private final LoadingCache<K, T> cache;
 
-  public ExporterEntityCache(final CacheLoader<K, T> loader) {
+  public ExporterEntityCache(
+      final long maxCacheSize,
+      final CacheLoader<K, T> loader,
+      final CaffeineCacheStatsCounter statsCounter) {
     cache =
         Caffeine.newBuilder()
-            .maximumSize(DEFAULT_MAX_CACHE_SIZE)
+            .maximumSize(maxCacheSize)
+            .recordStats(() -> statsCounter)
             .build(
                 k -> {
                   try {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.Optional;
+
+public class ExporterEntityCache<K, T> {
+
+  private static final int DEFAULT_MAX_CACHE_SIZE = 10000;
+  private final LoadingCache<K, T> cache;
+
+  public ExporterEntityCache(final CacheLoader<K, T> loader) {
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(DEFAULT_MAX_CACHE_SIZE)
+            .build(
+                k -> {
+                  try {
+                    return loader.load(k);
+                  } catch (final Exception e) {
+                    throw new CacheLoaderFailedException(e);
+                  }
+                });
+  }
+
+  public Optional<T> get(final K entityKey) {
+    return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  public void put(final K entityKey, final T entity) {
+    cache.put(entityKey, entity);
+  }
+
+  public void remove(final K entityKey) {
+    cache.invalidate(entityKey);
+  }
+
+  public void clear() {
+    cache.invalidateAll();
+  }
+
+  static class CacheLoaderFailedException extends RuntimeException {
+    public CacheLoaderFailedException(final Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
+import io.camunda.exporter.rdbms.utils.ProcessCacheUtil;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RdbmsProcessCacheLoader implements CacheLoader<Long, CachedProcessEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RdbmsProcessCacheLoader.class);
+  private final ProcessDefinitionReader reader;
+
+  public RdbmsProcessCacheLoader(final ProcessDefinitionReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public CachedProcessEntity load(final @NotNull Long key) throws Exception {
+    final var response = reader.findOne(key);
+    if (response.isPresent()) {
+      final var processDefinitionEntity = response.get();
+      return new CachedProcessEntity(
+          processDefinitionEntity.name(),
+          processDefinitionEntity.versionTag(),
+          ProcessCacheUtil.extractCallActivityIdsFromDiagram(processDefinitionEntity));
+    }
+    LOG.debug("Process '{}' not found in RDBMS", key);
+    return null;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -31,9 +31,8 @@ import org.slf4j.LoggerFactory;
 public class ProcessInstanceExportHandler
     implements RdbmsExportHandler<ProcessInstanceRecordValue> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceExportHandler.class);
-
   public static final long NO_PARENT_EXISTS_KEY = -1L;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceExportHandler.class);
 
   private final ProcessInstanceWriter processInstanceWriter;
   private final HistoryCleanupService historyCleanupService;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -114,6 +114,9 @@ public class ProcessInstanceExportHandler
       return new TreePath().startTreePath(processInstanceKey);
     }
 
+    final var callActivities =
+        ProcessCacheUtil.getCallActivityIds(processCache, processDefinitionPath);
+
     final TreePath treePath = new TreePath();
     for (int i = 0; i < elementInstancePath.size(); i++) {
       final List<Long> keysWithinOnePI = elementInstancePath.get(i);
@@ -122,11 +125,9 @@ public class ProcessInstanceExportHandler
         // we reached the leaf of the tree path, when we reached current processInstanceKey
         break;
       }
-      final var callActivity =
-          ProcessCacheUtil.getCallActivityId(
-              processCache, processDefinitionPath.get(i), callingElementPath.get(i));
-      if (callActivity.isPresent()) {
-        treePath.appendFlowNode(callActivity.get());
+      final var callActivity = callActivities.get(i);
+      if (callActivity != null && !callActivity.isEmpty()) {
+        treePath.appendFlowNode(callActivity.get(callingElementPath.get(i)));
       } else {
         final var index = callingElementPath.get(i);
         LOGGER.warn(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
@@ -17,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 public class ProcessCacheUtil {
 
@@ -34,20 +33,15 @@ public class ProcessCacheUtil {
     return callActivities.stream().map(BaseElement::getId).sorted().toList();
   }
 
-  public static Optional<String> getCallActivityId(
+  public static List<List<String>> getCallActivityIds(
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final Long processDefinitionKey,
-      final Integer callActivityIndex) {
+      final List<Long> processDefinitionKeys) {
+    if (processDefinitionKeys == null) {
+      return List.of();
+    }
 
-    if (processDefinitionKey == null) {
-      return Optional.empty();
-    }
-    final var cachedProcess = processCache.get(processDefinitionKey);
-    if (cachedProcess.isEmpty()
-        || cachedProcess.get().callElementIds() == null
-        || callActivityIndex == null) {
-      return Optional.empty();
-    }
-    return Optional.of(cachedProcess.get().callElementIds().get(callActivityIndex));
+    return processCache.getAll(processDefinitionKeys).values().stream()
+        .map(CachedProcessEntity::callElementIds)
+        .toList();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.utils;
+
+import io.camunda.exporter.rdbms.cache.CachedProcessEntity;
+import io.camunda.exporter.rdbms.cache.ExporterEntityCache;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.util.modelreader.ProcessModelReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class ProcessCacheUtil {
+
+  public static List<String> extractCallActivityIdsFromDiagram(
+      final ProcessDefinitionEntity entity) {
+    final String bpmnXml = entity.bpmnXml();
+    return ProcessModelReader.of(
+            bpmnXml.getBytes(StandardCharsets.UTF_8), entity.processDefinitionId())
+        .map(reader -> sortedCallActivityIds(reader.extractCallActivities()))
+        .orElseGet(ArrayList::new);
+  }
+
+  public static List<String> sortedCallActivityIds(final Collection<CallActivity> callActivities) {
+    return callActivities.stream().map(BaseElement::getId).sorted().toList();
+  }
+
+  public static Optional<String> getCallActivityId(
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final Long processDefinitionKey,
+      final Integer callActivityIndex) {
+
+    if (processDefinitionKey == null) {
+      return Optional.empty();
+    }
+    final var cachedProcess = processCache.get(processDefinitionKey);
+    if (cachedProcess.isEmpty()
+        || cachedProcess.get().callElementIds() == null
+        || callActivityIndex == null) {
+      return Optional.empty();
+    }
+    return Optional.of(cachedProcess.get().callElementIds().get(callActivityIndex));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/TreePath.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/TreePath.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.utils;
+
+/**
+ * Class represents call tree path to store sequence of calls in case of call activities.
+ *
+ * <p>PI = Process instance, FN = Flow node, FNI = Flow node instance.
+ *
+ * <p>If we have a process with call activity, then tree path for child process instance will be
+ * build as
+ * PI_<parent_process_instance_id>/FN_<call_activity_id>/FNI_<parent_flow_node_instance_id_of_call_activity_type>/PI_<child_process_instance_id>,
+ * for the incident in child instance we will have tree path as
+ * PI_<parent_process_instance_id>/FN_<call_activity_id>/FNI_<parent_flow_node_instance_id_of_call_activity_type>/PI_<child_process_instance_id>/FN_<flow_node_id>/FNI<flow_node_instance_id_where_incident_happenned>.
+ */
+public class TreePath {
+
+  private StringBuffer treePath;
+
+  public TreePath() {
+    treePath = new StringBuffer();
+  }
+
+  public TreePath startTreePath(final String processInstanceId) {
+    treePath = new StringBuffer(String.format("%s_%s", TreePathEntryType.PI, processInstanceId));
+    return this;
+  }
+
+  public TreePath startTreePath(final long processInstanceKey) {
+    return startTreePath(String.valueOf(processInstanceKey));
+  }
+
+  public void appendFlowNode(final String newEntry) {
+    if (newEntry != null) {
+      treePath.append(String.format("/%s_%s", TreePathEntryType.FN, newEntry));
+    }
+  }
+
+  public void appendFlowNodeInstance(final String newEntry) {
+    if (newEntry != null) {
+      treePath.append(String.format("/%s_%s", TreePathEntryType.FNI, newEntry));
+    }
+  }
+
+  public void appendProcessInstance(final String newEntry) {
+    if (newEntry != null) {
+      if (treePath == null || treePath.isEmpty()) {
+        startTreePath(newEntry);
+      } else {
+        treePath.append(String.format("/%s_%s", TreePathEntryType.PI, newEntry));
+      }
+    }
+  }
+
+  public void appendProcessInstance(final long newEntry) {
+    appendProcessInstance(String.valueOf(newEntry));
+  }
+
+  public boolean isEmpty() {
+    return treePath == null || treePath.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return treePath.toString();
+  }
+
+  public enum TreePathEntryType {
+    /** Process instance. */
+    PI,
+    /** Flow node instance. */
+    FNI,
+    /** Flow node. */
+    FN
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5445,7 +5445,7 @@ components:
           description: The key of the process definition.
         processDefinitionName:
           type: string
-          description: The name of the process definition (fallbacks to process definition ID if not available).
+          description: The name of the process definition (fall backs to the process definition ID if not available).
     ProcessDefinitionElementStatisticsQuery:
       description: Process definition element statistics request.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1799,6 +1799,44 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /process-instances/{processInstanceKey}/call-hierarchy:
+    get:
+      tags:
+        - Process instance
+      operationId: getProcessInstanceCallHierarchy
+      summary: Get call hierarchy for process instance
+      description: |
+        Returns the call hierarchy for a given process instance, showing its ancestry up to the root instance.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The key of the process instance to fetch the hierarchy for.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The call hierarchy is successfully returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProcessInstanceCallHierarchyEntry"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The process instance is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /element-instances/search:
     post:
@@ -5392,6 +5430,22 @@ components:
         - ACTIVE
         - COMPLETED
         - TERMINATED
+    ProcessInstanceCallHierarchyEntry:
+      type: object
+      required:
+        - processInstanceKey
+        - processDefinitionKey
+        - processDefinitionName
+      properties:
+        processInstanceKey:
+          type: string
+          description: The key of the process instance.
+        processDefinitionKey:
+          type: string
+          description: The key of the process definition.
+        processDefinitionName:
+          type: string
+          description: The name of the process definition (fallbacks to process definition ID if not available).
     ProcessDefinitionElementStatisticsQuery:
       description: Process definition element statistics request.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -73,6 +73,7 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionElementStatistics
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessElementStatisticsResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCallHierarchyEntry;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceElementStatisticsQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResult;
@@ -761,6 +762,24 @@ public final class SearchQueryResponseMapper {
       return ProcessInstanceStateEnum.TERMINATED;
     }
     return ProcessInstanceStateEnum.fromValue(value.name());
+  }
+
+  public static List<ProcessInstanceCallHierarchyEntry> toProcessInstanceCallHierarchyEntries(
+      final List<ProcessInstanceEntity> processInstanceEntities) {
+    return processInstanceEntities.stream()
+        .map(SearchQueryResponseMapper::toProcessInstanceCallHierarchyEntry)
+        .toList();
+  }
+
+  public static ProcessInstanceCallHierarchyEntry toProcessInstanceCallHierarchyEntry(
+      final ProcessInstanceEntity processInstanceEntity) {
+    return new ProcessInstanceCallHierarchyEntry()
+        .processInstanceKey(KeyUtil.keyToString(processInstanceEntity.processInstanceKey()))
+        .processDefinitionKey(KeyUtil.keyToString(processInstanceEntity.processDefinitionKey()))
+        .processDefinitionName(
+            processInstanceEntity.processDefinitionName().isBlank()
+                ? processInstanceEntity.processDefinitionId()
+                : processInstanceEntity.processDefinitionName());
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -109,6 +109,22 @@ public class ProcessInstanceController {
     }
   }
 
+  @CamundaGetMapping(path = "/{processInstanceKey}/call-hierarchy")
+  public ResponseEntity<Object> getCallHierarchy(
+      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+    try {
+      return ResponseEntity.ok()
+          .body(
+              SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntries(
+                  processInstanceServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .callHierarchy(processInstanceKey)));
+
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
   @CamundaGetMapping(path = "/{processInstanceKey}/statistics/element-instances")
   public ResponseEntity<Object> elementStatistics(
       @PathVariable("processInstanceKey") final Long processInstanceKey) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements the process instance call hierarchy feature for the V2 API by addressing both the API layer for the ES/OS and RDBMS backends.

### 🔍 What’s included:
- Implements [issue #31055](https://github.com/camunda/camunda/issues/31055): Adds a dedicated REST API endpoint to retrieve the call hierarchy for a given process instance (using ES/OS data store).
- Implements [issue #31061](https://github.com/camunda/camunda/issues/31061): Adds logic in the RDBMS exporter to generate and persist the treePath, enabling the call hierarchy data to be stored and queried.

The call hierarchy is essential for supporting features in Operate such as breadcrumb navigation and root instance cancellation. This functionality is intentionally separated from the main /process-instances/{key} endpoint to avoid performance degradation during standard queries.

---

### Note on Code Duplication

To integrate this feature with the RDBMS backend in a self-contained and milestone-friendly manner, I mirrored logic previously written for ES/OS. The following classes and methods were adapted and copied into the RDBMS module:
- CachedProcessEntity
- ExporterEntityCache interface
- ProcessCacheUtil
- createTreePath(...) from ProcessInstanceExporterHandler

While not ideal, this duplication was accepted for pragmatic reasons. A follow-up task is planned ([#31218](https://github.com/camunda/camunda/issues/31218)) to extract this shared logic into a reusable module (camunda-domain-common) to ensure long-term maintainability.

### Circular Dependency Handling

Originally, these changes were split across two separate PRs (#31219 and #31291). However, due to mutual dependencies between the API contract and the exporter logic, they have now been merged into this single PR to enable a clean review and integration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31055, #31061
