### PR TITLE
[Backport stable/8.7] fix: Optimise heap used during file uploads to GCP

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
@@ -42,6 +42,8 @@ public class GcpDocumentStore implements DocumentStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcpDocumentStore.class);
 
+  private static final int UPLOAD_BUFFER_SIZE_BYTES = 256 * 1024;
+
   private static final String CONTENT_HASH_METADATA_KEY = "contentHash";
   private static final String METADATA_PROCESS_DEFINITION_ID = "camunda.processDefinitionId";
   private static final String METADATA_PROCESS_INSTANCE_KEY = "camunda.processInstanceKey";
@@ -160,7 +162,8 @@ public class GcpDocumentStore implements DocumentStore {
       hash =
           InputStreamHashCalculator.streamAndCalculateHash(
               request.contentInputStream(),
-              stream -> storage.createFrom(blobInfoBuilder.build(), stream));
+              stream ->
+                  storage.createFrom(blobInfoBuilder.build(), stream, UPLOAD_BUFFER_SIZE_BYTES));
 
       applyMetadata(blobInfoBuilder, request.metadata(), fileName, hash);
       storage.update(blobInfoBuilder.build());

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
@@ -10,6 +10,7 @@ package io.camunda.document.store.gcp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -54,6 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class GcpDocumentStoreTest {
 
+  private static final int EXPECTED_BUFFER_SIZE = 256 * 1024;
   private static final String BUCKET_NAME = "camunda-saas-dev-test-document-storage";
   @Mock private Storage storage;
   private final ObjectMapper mapper = new ObjectMapper();
@@ -114,7 +116,7 @@ public class GcpDocumentStoreTest {
                 Map.of("key", "value")));
 
     when(storage.get(BUCKET_NAME, "documentId")).thenReturn(null);
-    when(storage.createFrom(BlobInfo.newBuilder(BUCKET_NAME, "documentId").build(), inputStream))
+    when(storage.createFrom(any(), (InputStream) any(), eq(EXPECTED_BUFFER_SIZE)))
         .thenThrow(new RuntimeException("Failed to create document"));
 
     // when
@@ -126,12 +128,14 @@ public class GcpDocumentStoreTest {
     assertThat(documentReferenceResponse).isInstanceOf(Left.class);
     assertThat(((Left<DocumentError, DocumentReference>) documentReferenceResponse).value())
         .isInstanceOf(UnknownDocumentError.class);
+    verify(storage).get(BUCKET_NAME, "documentId");
+    verify(storage).createFrom(any(), (InputStream) any(), eq(EXPECTED_BUFFER_SIZE));
   }
 
   @Test
-  void createDocumentShouldSucceed() {
+  void createDocumentShouldSucceed() throws IOException {
     // given
-    final var inputStream = new ByteArrayInputStream("content".getBytes());
+    final var inputStream = new ByteArrayInputStream("Some custom content".getBytes());
     final var documentCreationRequest =
         new DocumentCreationRequest(
             "documentId",
@@ -148,16 +152,49 @@ public class GcpDocumentStoreTest {
     final Blob mockBlob = mock(Blob.class);
 
     when(storage.get(BUCKET_NAME, "documentId")).thenReturn(null).thenReturn(mockBlob);
+    when(storage.createFrom(any(), (InputStream) any(), eq(EXPECTED_BUFFER_SIZE)))
+        .then(
+            invocation -> {
+              try (final var stream = invocation.getArgument(1, InputStream.class)) {
+                stream.transferTo(OutputStream.nullOutputStream());
+              }
+              return null;
+            });
 
     // when
     final var documentReferenceResponse =
         gcpDocumentStore.createDocument(documentCreationRequest).join();
 
     // then
+    final var creationBlobCaptor = ArgumentCaptor.forClass(BlobInfo.class);
+    final var updateBlobCaptor = ArgumentCaptor.forClass(BlobInfo.class);
+
     assertThat(documentReferenceResponse).isNotNull();
     assertThat(documentReferenceResponse).isInstanceOf(Right.class);
     assertThat(((Right<DocumentError, DocumentReference>) documentReferenceResponse).value())
         .isNotNull();
+    verify(storage).get(BUCKET_NAME, "documentId");
+    verify(storage)
+        .createFrom(
+            creationBlobCaptor.capture(), (DigestInputStream) any(), eq(EXPECTED_BUFFER_SIZE));
+    verify(storage).update(updateBlobCaptor.capture());
+    verifyNoMoreInteractions(storage);
+
+    final var creationBlobMetadata = creationBlobCaptor.getValue().getMetadata();
+    assertThat(creationBlobMetadata).hasSize(2);
+    assertThat(creationBlobMetadata)
+        .containsAllEntriesOf(
+            Map.of(
+                "key", "\"value\"",
+                "contentHash", ""));
+
+    final var updateBlobMetadata = updateBlobCaptor.getValue().getMetadata();
+    assertThat(updateBlobMetadata).hasSize(2);
+    assertThat(updateBlobMetadata)
+        .containsAllEntriesOf(
+            Map.of(
+                "key", "\"value\"",
+                "contentHash", "dbd17af5357df5e6c4cad5e382c9b1b7a1f9da31ceef9747995147ef1f12e852"));
   }
 
   @Test
@@ -511,7 +548,7 @@ public class GcpDocumentStoreTest {
                     "Map",
                     Map.of("key1", "val1", "key2", "val2"))));
     when(storage.get(BUCKET_NAME, documentId)).thenReturn(null);
-    when(storage.createFrom(any(), (InputStream) any()))
+    when(storage.createFrom(any(), (InputStream) any(), eq(EXPECTED_BUFFER_SIZE)))
         .then(
             invocation -> {
               try (final var stream = invocation.getArgument(1, InputStream.class)) {
@@ -538,7 +575,9 @@ public class GcpDocumentStoreTest {
                 .metadata()
                 .processInstanceKey())
         .isEqualTo(123L);
-    verify(storage).createFrom(creationBlobCaptor.capture(), (DigestInputStream) any());
+    verify(storage)
+        .createFrom(
+            creationBlobCaptor.capture(), (DigestInputStream) any(), eq(EXPECTED_BUFFER_SIZE));
     verify(storage).update(updateBlobCaptor.capture());
     verifyNoMoreInteractions(storage);
 


### PR DESCRIPTION
# Description
Backport of #31016 to `stable/8.7`.

relates to #30930