### PR TITLE
CI: always deploy even if commitlint is skipped

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -145,7 +145,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (steps.filter-common.outputs.protobuf-change == 'true' &&  github.event_name != 'schedule')
+        (steps.filter-common.outputs.protobuf-change == 'true' && github.event_name != 'schedule')
       }}
   openapi-changes:
     description: Output whether any C8 OpenAPI code has changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
     steps:
       - name: Determine fetch depth for checkout
         id: depth
-        run: echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+        run: |
+          echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -1055,9 +1056,9 @@ jobs:
       checks: read
     needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
-      - commitlint
       - build-operate-backend
       - build-platform-frontend
+      - commitlint
       - detect-changes
       - docker-checks
       - elasticsearch-integration-tests
@@ -1132,7 +1133,7 @@ jobs:
 
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ docker-checks, check-results ]
+    needs: [ check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,7 +1093,7 @@ jobs:
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 25
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-maven-snapshot
       cancel-in-progress: false
@@ -1137,7 +1137,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-camunda-docker-snapshot
       cancel-in-progress: false


### PR DESCRIPTION
## Description

As [reported on Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1744879650217859) the Maven and Docker SNAPSHOT artifacts of 8.8 didn't get pushed since #30745 was merged.

This is due to GHA [skipping the execution of dependent jobs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) if an earlier job was `skipped`: this is the case for `commitlint` job on `main` as we only want to lint on PRs, thus the problem didn't get caught on the PR.

Options:

1. always run `commitlint` job 👎🏼
    * not desired since `main` has multiple 10000 commits and there is no value in running commitlint, we only want to catch PRs introducing new commits
2. always run `commitlint` job but skip all steps inside if not a PR 👎🏼
    * this fakes it so that all jobs appear green and none gets skipped, but requires boilerplate in each step to skip it
    * could break again if new jobs in the future are also skipped under some conditions
3. keep `commitlint` job behavior but adjust `deploy-*` jobs to ignore previous skipped jobs 👍🏼
    * makes condition on `deploy-*` jobs more verbose but also more clear
    * future-proof if new jobs get introduced that are skipped sometimes

GHA still executes jobs marked as `if: always()` which we use for the `check-results` job. This PR extends this usage also to the jobs coming after `check-results`, namely the `deploy-*` jobs and combines it with a condition that `check-results` needs to be successful.

This PR also has a dedicated commit to fix formatting problems.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - yes, but needs backporting of #30745 first

## Related issues

None
