### PR TITLE
[Backport stable/8.6] CI: always deploy even if commitlint is skipped

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -133,7 +133,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.protobuf-change == 'true'
+        (steps.filter-common.outputs.protobuf-change == 'true' && github.event_name != 'schedule')
       }}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
     steps:
       - name: Determine fetch depth for checkout
         id: depth
-        run: echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+        run: |
+          echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -600,9 +601,9 @@ jobs:
       checks: read
     needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
-      - commitlint
       - build-operate-backend
       - build-platform-frontend
+      - commitlint
       - detect-changes
       - docker-checks
       - identity-frontend-tests
@@ -687,7 +688,7 @@ jobs:
 
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ docker-checks, check-results ]
+    needs: [ check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-maven-snapshot
       cancel-in-progress: false
@@ -692,7 +692,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-camunda-docker-snapshot
       cancel-in-progress: false


### PR DESCRIPTION
# Description
Backport of #31225 to `stable/8.6`.

relates to #30745 #30745