### PR TITLE
refactor: rename batch operation type PROCESS_CANCELLATION to CANCEL_…

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationType.java
@@ -16,7 +16,7 @@
 package io.camunda.client.api.search.enums;
 
 public enum BatchOperationType {
-  PROCESS_CANCELLATION,
+  CANCEL_PROCESS_INSTANCE,
   RESOLVE_INCIDENT,
   MIGRATE_PROCESS_INSTANCE,
   UNKNOWN_ENUM_VALUE;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -100,7 +100,7 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
 
   private String getUrl() {
     switch (type) {
-      case PROCESS_CANCELLATION:
+      case CANCEL_PROCESS_INSTANCE:
         return "/process-instances/batch-operations/cancellation";
       case RESOLVE_INCIDENT:
         return "/process-instances/batch-operations/incident-resolution";
@@ -126,7 +126,7 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
       return new CreateBatchOperationCommandImpl<>(
           httpClient,
           jsonMapper,
-          BatchOperationTypeEnum.PROCESS_CANCELLATION,
+          BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
     }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -13,10 +13,10 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationExecu
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifecycleCanceledRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifecyclePausedRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationLifecycleResumeRecord;
-import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationProcessCancelledRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationResolveIncidentRecord;
-import static io.camunda.it.rdbms.exporter.RecordFixtures.getFailedBatchOperationProcessCancelledRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getCanceledProcessRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getFailedBatchOperationResolveIncidentRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getRejectedCancelProcessRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
@@ -175,19 +175,19 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   @Test
-  public void shouldMonitorProcessInstanceCancellationBatchOperation() {
+  public void shouldMonitorCancelProcessInstanceBatchOperation() {
     // given
     final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;
-    final var processCancelledRecord =
-        getBatchOperationProcessCancelledRecord(processInstanceKey, batchOperationKey, 3L);
+    final var canceledProcessRecord =
+        getCanceledProcessRecord(processInstanceKey, batchOperationKey, 3L);
 
     // when
     exporter.export(batchOperationCreatedRecord);
     exporter.export(batchOperationChunkRecord);
-    exporter.export(processCancelledRecord);
+    exporter.export(canceledProcessRecord);
 
     // then
     final var batchOperation =
@@ -200,19 +200,19 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   @Test
-  public void shouldMonitorFailedProcessInstanceCancellationBatchOperation() {
+  public void shouldMonitorFailedCancelProcessInstanceBatchOperation() {
     // given
     final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;
-    final var processFailedCancelledRecord =
-        getFailedBatchOperationProcessCancelledRecord(processInstanceKey, batchOperationKey, 3L);
+    final var rejectedCancelProcessRecord =
+        getRejectedCancelProcessRecord(processInstanceKey, batchOperationKey, 3L);
 
     // when
     exporter.export(batchOperationCreatedRecord);
     exporter.export(batchOperationChunkRecord);
-    exporter.export(processFailedCancelledRecord);
+    exporter.export(rejectedCancelProcessRecord);
 
     // then
     final var batchOperation =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -520,7 +520,7 @@ public class RecordFixtures {
         .build();
   }
 
-  protected static ImmutableRecord<RecordValue> getBatchOperationProcessCancelledRecord(
+  protected static ImmutableRecord<RecordValue> getCanceledProcessRecord(
       final Long processInstanceKey, final Long batchOperationKey, final Long position) {
     final Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.PROCESS_INSTANCE);
@@ -542,7 +542,7 @@ public class RecordFixtures {
         .build();
   }
 
-  protected static ImmutableRecord<RecordValue> getFailedBatchOperationProcessCancelledRecord(
+  protected static ImmutableRecord<RecordValue> getRejectedCancelProcessRecord(
       final Long processInstanceKey, final Long batchOperationKey, final Long position) {
     final Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.PROCESS_INSTANCE);

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -168,7 +168,7 @@ public final class ProcessInstanceServices
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(rootInstanceFilter)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     return sendBrokerRequest(brokerRequest);
   }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -151,7 +151,7 @@ public final class ProcessInstanceServiceTest {
     final long batchOperationKey = 123L;
     final var record = new BatchOperationCreationRecord();
     record.setBatchOperationKey(batchOperationKey);
-    record.setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    record.setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     final var captor = ArgumentCaptor.forClass(BrokerCreateBatchOperationRequest.class);
     when(authentication.claims()).thenReturn(emptyMap());
@@ -163,7 +163,8 @@ public final class ProcessInstanceServiceTest {
 
     // then
     assertThat(result.getBatchOperationKey()).isEqualTo(batchOperationKey);
-    assertThat(result.getBatchOperationType()).isEqualTo(BatchOperationType.PROCESS_CANCELLATION);
+    assertThat(result.getBatchOperationType())
+        .isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     // and our filter got enriched
     final var filterBuffer = captor.getValue().getRequestWriter().getEntityFilterBuffer();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -165,7 +165,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
         () -> !batchOperationState.exists(batchOperation.getKey());
 
     return switch (batchOperation.getBatchOperationType()) {
-      case PROCESS_CANCELLATION, MIGRATE_PROCESS_INSTANCE ->
+      case CANCEL_PROCESS_INSTANCE, MIGRATE_PROCESS_INSTANCE ->
           entityKeyProvider.fetchProcessInstanceKeys(
               batchOperation.getEntityFilter(ProcessInstanceFilter.class), abortCondition);
       case RESOLVE_INCIDENT ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -39,7 +39,7 @@ public final class BatchOperationSetupProcessors {
       final int partitionId) {
     final var batchExecutionHandlers =
         Map.of(
-            BatchOperationType.PROCESS_CANCELLATION,
+            BatchOperationType.CANCEL_PROCESS_INSTANCE,
             new CancelProcessInstanceBatchOperationExecutor(writers.command()),
             BatchOperationType.RESOLVE_INCIDENT,
             new ResolveIncidentBatchOperationExecutor(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -44,7 +44,7 @@ abstract class AbstractBatchOperationTest {
   public final EngineRule engine =
       EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
 
-  protected long createNewProcessInstanceCancellationBatchOperation(final Set<Long> itemKeys) {
+  protected long createNewCancelProcessInstanceBatchOperation(final Set<Long> itemKeys) {
     final var result =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
@@ -60,14 +60,14 @@ abstract class AbstractBatchOperationTest {
 
     return engine
         .batchOperation()
-        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+        .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
         .withFilter(filterBuffer)
         .create()
         .getValue()
         .getBatchOperationKey();
   }
 
-  protected long createNewFailedProcessInstanceCancellationBatchOperation() {
+  protected long createNewFailedCancelProcessInstanceBatchOperation() {
     Mockito.when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
         .thenThrow(new RuntimeException("You are playing with fire!"));
 
@@ -77,7 +77,7 @@ abstract class AbstractBatchOperationTest {
 
     return engine
         .batchOperation()
-        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+        .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
         .withFilter(filterBuffer)
         .waitForStarted()
         .create()
@@ -156,10 +156,6 @@ abstract class AbstractBatchOperationTest {
         .create()
         .getValue()
         .getBatchOperationKey();
-  }
-
-  protected void cancelBatchOperation(final Long batchOperationKey) {
-    engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).cancel();
   }
 
   protected static UnsafeBuffer convertToBuffer(final Object object) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static io.camunda.zeebe.engine.processing.batchoperation.BatchOperationExecutionScheduler.CHUNK_SIZE_IN_RECORD;
+import static io.camunda.zeebe.protocol.record.value.BatchOperationType.CANCEL_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.MIGRATE_PROCESS_INSTANCE;
-import static io.camunda.zeebe.protocol.record.value.BatchOperationType.PROCESS_CANCELLATION;
 import static io.camunda.zeebe.protocol.record.value.BatchOperationType.RESOLVE_INCIDENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -62,7 +62,7 @@ public class BatchOperationExecutionSchedulerTest {
   public void setUp() {
     setUpBasicSchedulerBehaviour();
 
-    when(batchOperation.getBatchOperationType()).thenReturn(PROCESS_CANCELLATION);
+    when(batchOperation.getBatchOperationType()).thenReturn(CANCEL_PROCESS_INSTANCE);
     lenient()
         .when(batchOperation.getEntityFilter(eq(ProcessInstanceFilter.class)))
         .thenReturn(mock(ProcessInstanceFilter.class));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
@@ -45,7 +45,7 @@ public final class CreateBatchOperationMultiPartitionTest {
     final long batchOperationKey =
         engine
             .batchOperation()
-            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .withFilter(new UnsafeBuffer("{\"processInstanceKeys\": [1, 2, 3]}".getBytes()))
             .create()
             .getValue()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -33,7 +33,7 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
     final var batchOperationKey =
         engine
             .batchOperation()
-            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .withFilter(new UnsafeBuffer())
             .expectRejection()
             .create()
@@ -57,7 +57,7 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
     final var batchOperationKey =
         engine
             .batchOperation()
-            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .withFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{}")))
             .expectRejection()
             .create()
@@ -99,7 +99,7 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
     final long batchOperationKey =
         engine
             .batchOperation()
-            .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+            .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .withFilter(filterBuffer)
             .create()
             .getValue()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
@@ -19,11 +19,10 @@ import org.junit.Test;
 public final class ExecuteBatchOperationTest extends AbstractBatchOperationTest {
 
   @Test
-  public void shouldExecuteBatchOperationForProcessInstanceCancellation() {
+  public void shouldExecuteBatchOperationForCancelProcessInstance() {
     // given
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // then we have executed and completed event
     assertThat(
@@ -42,7 +41,7 @@ public final class ExecuteBatchOperationTest extends AbstractBatchOperationTest 
         .extracting(Record::getIntent)
         .containsSequence(BatchOperationExecutionIntent.EXECUTE);
 
-    // and we have several process cancellation commands
+    // and we have several cancel process commands
     processInstanceKeys.forEach(
         key -> {
           assertThat(RecordingExporter.processInstanceRecords().withProcessInstanceKey(key))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/LifecycleBatchOperationTest.java
@@ -23,8 +23,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   public void shouldCancelBatchOperation() {
     // given
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // when we cancel the batch operation
     engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).cancel();
@@ -50,8 +49,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   public void shouldPauseBatchOperationInScheduler() {
     // given
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // when we pause the batch operation
     engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).pause();
@@ -77,8 +75,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   public void shouldPauseBatchOperationInExecutor() {
     // given
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // when we pause the batch operation
     engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).pause();
@@ -140,7 +137,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   @Test
   public void shouldRejectPauseBatchOperationIfInvalidState() {
     // given a failed batch operation
-    final var batchOperationKey = createNewFailedProcessInstanceCancellationBatchOperation();
+    final var batchOperationKey = createNewFailedCancelProcessInstanceBatchOperation();
 
     // when we pause the batch operation which does not exist
     engine
@@ -171,8 +168,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   public void shouldResumeBatchOperation() {
     // given
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // and we pause the batch operation
     engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).pause();
@@ -230,8 +226,7 @@ public final class LifecycleBatchOperationTest extends AbstractBatchOperationTes
   public void shouldRejectResumeBatchOperationIfInvalidState() {
     // given a batch operation wich is not paused
     final var processInstanceKeys = Set.of(1L, 2L, 3L);
-    final var batchOperationKey =
-        createNewProcessInstanceCancellationBatchOperation(processInstanceKeys);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
 
     // when we resume the batch operation which is not paused
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -242,7 +242,7 @@ public class CommandDistributionIdempotencyTest {
                 () ->
                     ENGINE
                         .batchOperation()
-                        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+                        .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
                         .withFilter(
                             new UnsafeBuffer(
                                 MsgPackConverter.convertToMsgPack(
@@ -730,7 +730,7 @@ public class CommandDistributionIdempotencyTest {
   private static Record<BatchOperationCreationRecordValue> createBatchOperation() {
     return ENGINE
         .batchOperation()
-        .newCreation(BatchOperationType.PROCESS_CANCELLATION)
+        .newCreation(BatchOperationType.CANCEL_PROCESS_INSTANCE)
         .withFilter(
             new UnsafeBuffer(
                 MsgPackConverter.convertToMsgPack(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -46,7 +46,7 @@ public class BatchOperationStateTest {
   void shouldCreateBatchOperation() throws JsonProcessingException {
     // given
     final var batchOperationKey = 1L;
-    final var type = BatchOperationType.PROCESS_CANCELLATION;
+    final var type = BatchOperationType.CANCEL_PROCESS_INSTANCE;
     final var filter =
         new ProcessInstanceFilter.Builder()
             .processDefinitionIds("process")
@@ -122,7 +122,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
 
     // then
@@ -139,7 +139,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
 
     // when
@@ -163,7 +163,7 @@ public class BatchOperationStateTest {
     final var roleRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, roleRecord);
 
     // when
@@ -199,7 +199,7 @@ public class BatchOperationStateTest {
     final var createRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
     state.create(batchOperationKey, createRecord);
 
@@ -225,7 +225,7 @@ public class BatchOperationStateTest {
     final var createRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
     state.create(batchOperationKey, createRecord);
 
@@ -251,7 +251,7 @@ public class BatchOperationStateTest {
     final var createRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
     state.create(batchOperationKey, createRecord);
 
@@ -274,7 +274,7 @@ public class BatchOperationStateTest {
     final var createRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
     state.create(batchOperationKey, createRecord);
 
@@ -347,7 +347,7 @@ public class BatchOperationStateTest {
         batchOperationKey,
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build())));
     state.appendItemKeys(
         batchOperationKey, LongStream.range(0, numKeys).boxed().collect(Collectors.toSet()));
@@ -362,7 +362,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
 
     // when
@@ -379,7 +379,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
 
     // when
@@ -397,7 +397,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     // when
     state.create(batchOperationKey, batchRecord);
@@ -415,7 +415,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     state.create(batchOperationKey, batchRecord);
 
@@ -435,7 +435,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
 
     // when
@@ -454,7 +454,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
     state.pause(batchOperationKey);
 
@@ -474,7 +474,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
     state.start(batchOperationKey);
     state.pause(batchOperationKey);
@@ -495,7 +495,7 @@ public class BatchOperationStateTest {
     final var batchRecord =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
-            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
     state.create(batchOperationKey, batchRecord);
     state.fail(batchOperationKey);
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8102,9 +8102,9 @@ components:
       description: The type of the batch operation.
       type: string
       enum:
-      - PROCESS_CANCELLATION
-      - RESOLVE_INCIDENT
-      - MIGRATE_PROCESS_INSTANCE
+        - CANCEL_PROCESS_INSTANCE
+        - RESOLVE_INCIDENT
+        - MIGRATE_PROCESS_INSTANCE
     BatchOperationCreatedResult:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -61,7 +61,7 @@ class BatchOperationControllerTest extends RestControllerTest {
           {
               "batchOperationKey":"1",
               "state":"COMPLETED",
-              "batchOperationType":"PROCESS_CANCELLATION",
+              "batchOperationType":"CANCEL_PROCESS_INSTANCE",
               "startDate":"2025-03-18T10:57:44.000+01:00",
               "endDate":"2025-03-18T10:57:45.000+01:00",
               "operationsTotalCount":10,
@@ -96,7 +96,7 @@ class BatchOperationControllerTest extends RestControllerTest {
           {
             "batchOperationKey":"1",
             "state":"COMPLETED",
-            "batchOperationType":"PROCESS_CANCELLATION",
+            "batchOperationType":"CANCEL_PROCESS_INSTANCE",
             "startDate":"2025-03-18T10:57:44.000+01:00",
             "endDate":"2025-03-18T10:57:45.000+01:00",
             "operationsTotalCount":10,
@@ -182,7 +182,7 @@ class BatchOperationControllerTest extends RestControllerTest {
     return new BatchOperationEntity(
         batchOperationKey,
         BatchOperationState.COMPLETED,
-        "PROCESS_CANCELLATION",
+        "CANCEL_PROCESS_INSTANCE",
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
         OffsetDateTime.parse("2025-03-18T10:57:45+01:00"),
         10,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1309,7 +1309,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     // given
     final var record = new BatchOperationCreationRecord();
     record.setBatchOperationKey(123L);
-    record.setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    record.setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
 
     when(processInstanceServices.cancelProcessInstanceBatchOperationWithResult(
             any(ProcessInstanceFilter.class)))
@@ -1336,7 +1336,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"batchOperationKey":"123","batchOperationType":"PROCESS_CANCELLATION"}
+          {"batchOperationKey":"123","batchOperationType":"CANCEL_PROCESS_INSTANCE"}
         """);
 
     verify(processInstanceServices)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.protocol.record.value;
 
 public enum BatchOperationType {
-  PROCESS_CANCELLATION,
+  CANCEL_PROCESS_INSTANCE,
   MIGRATE_PROCESS_INSTANCE,
   RESOLVE_INCIDENT
 }


### PR DESCRIPTION
Rename batch operation type PROCESS_CANCELLATION to CANCEL_PROCESS_INSTANCE.
This is needed for the batch operation camunda exporter epic, in order to NOT map between the old and new types. 

## Related issues

closes #31232 
