### PR TITLE
ci: extend FOSSA integration

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,16 +1,21 @@
 version: 3
 
 project:
-  id: camunda/camunda
+  id: camunda/camunda@single-app
   labels:
-  - camunda
+  - camunda8
+  - identity
+  - operate
+  - tasklist
+  - zeebe
   policy: Camunda8 Distribution
   url: https://github.com/camunda/camunda
 
 paths:
   exclude:
   - .github/optimize/scripts/healthStatusReport
-  - c8run/e2e_tests
+  - c8run
+  - optimize
   - qa/core-application-e2e-test-suite
   - tasklist/qa/backup-restore-tests
 

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -14,17 +14,20 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     strategy:
-      # The matrix is needed to run separate analyses for the Single-App and Optimize
+      # The matrix is necessary to run separate analyses
       matrix:
         project:
+        - name: c8run
+          path: ./c8run
+        - name: optimize
+          path: ./optimize
+          maven-config: |
+            -DskipQaBuild=true
         - name: single-app
           path: ./
           maven-config: |
+            -Dquickly=true
             -DskipQaBuild=true
-        # TODO: to be uncommented when Optimize is fully seperated
-        # Dedicated configs already exist, see optimize/.fossa.yml
-        # - name: optimize
-        #   path: ./optimize
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
@@ -40,11 +43,13 @@ jobs:
         secrets: |
           secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
     - uses: ./.github/actions/setup-build
+      if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
       with:
         vault-address: ${{ secrets.VAULT_ADDR }}
         vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
     - uses: actions/setup-go@v5
+      if: matrix.project.name == 'c8run'
       with:
         go-version: '>=1.23.1'
         cache: false  # disabling since not working anyways without a cache-dependency-path specified
@@ -57,7 +62,7 @@ jobs:
     - name: Setup fossa-cli
       uses: camunda/infra-global-github-actions/fossa/setup@a2d602acc0b46ad8da2bbc1c34edbdb5af74345a
     - name: Adjust pom.xml files for FOSSA
-      if: matrix.project.name == 'single-app'
+      if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
       run: |
         # The bom/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
         yq -i \
@@ -70,6 +75,11 @@ jobs:
         yq -i \
           'del(.project.modules.module[] | select(. == "bom" or . == "parent"))' \
           pom.xml
+        # Remove optimize/qa module as a bug in FOSSA prevents scope filtering
+        # TODO remove this workaround once FOSSA is fixed
+        yq -i \
+          'del(.project.modules.module[] | select(. == "qa"))' \
+          optimize/pom.xml
     - name: Analyze project
       uses: camunda/infra-global-github-actions/fossa/analyze@a2d602acc0b46ad8da2bbc1c34edbdb5af74345a
       with:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
     - main
+    - stable/*
+    tags:
+    - '*'
 
 jobs:
   analyze:

--- a/c8run/.fossa.yml
+++ b/c8run/.fossa.yml
@@ -1,0 +1,13 @@
+version: 3
+
+project:
+  id: camunda/camunda@c8run
+  labels:
+  - camunda8
+  - c8run
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/camunda
+
+paths:
+  exclude:
+  - e2e_tests

--- a/optimize/.fossa.yml
+++ b/optimize/.fossa.yml
@@ -1,8 +1,9 @@
 version: 3
 
 project:
-  id: camunda/optimize
+  id: camunda/camunda@optimize
   labels:
+  - camunda8
   - optimize
   policy: Camunda8 Distribution
   url: https://github.com/camunda/connectors


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/751.

This PR:
- extends the FOSSA integration to include stable branches and tags in addition to the `main` branch
- updates the workflow to perform analysis for the single-app, optimize and C8run separately

Subsequent backport PRs for stable/8.6, stable/8.7, stable/optimize-8.6 and stable/optimize-8.7 have been created.

Test workflow run: https://github.com/camunda/camunda/actions/runs/14596700686/job/40944347511?pr=31236

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
