### PR TITLE
ci: add issue templates for CI and release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/devops-ci.md
+++ b/.github/ISSUE_TEMPLATE/devops-ci.md
@@ -1,0 +1,27 @@
+---
+
+name: CI ticket
+about: For issues about bugs, features or tasks related to Monorepo CI.
+title: 'CI: '
+labels: ['area/build', 'component/build-pipeline']
+assignees: ''
+
+---
+
+## Description
+
+<!-- Describe the bug, feature or task regarding the Monorepo CI that this ticket should be about. -->
+<!-- For bugs describe a) where it happened with links, b) what the impact is, c) how to reproduce it, if known. -->
+
+## Goal
+
+<!-- For features and tasks, describe how the end result should look like and what steps are needed to get there, if known. -->
+
+## Hints
+
+<!-- Any additional context, links or information you have about this ticket. Also specify if any backporting should be done, see the guidelines:
+https://github.com/camunda/camunda/wiki/CI-&-Automation#backporting-guidelines
+-->
+<!--
+"The CI changes related to this ticket should be backported to all applicable `stable/*` branches."
+-->

--- a/.github/ISSUE_TEMPLATE/devops-release.md
+++ b/.github/ISSUE_TEMPLATE/devops-release.md
@@ -1,0 +1,24 @@
+---
+
+name: Release process ticket
+about: For issues about bugs, features or tasks related to Monorepo Release process.
+title: 'Release: '
+labels: ['component/release']
+assignees: ''
+
+---
+
+## Description
+
+<!-- Describe the bug, feature or task regarding the Monorepo Release process that this ticket should be about. -->
+<!-- For bugs describe a) where it happened, b) what the impact is, c) how to reproduce it, if known. -->
+
+## Goal
+
+<!-- For features and tasks, describe how the end result should look like and what steps are needed to get there, if known. -->
+
+## Hints
+
+<!-- Any additional context, links or information you have about this ticket. Also specify if any backporting should be done, see the guidelines:
+https://github.com/camunda/camunda/wiki/Release-Process#backporting-guidelines
+-->

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -108,3 +108,12 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/79
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/feel-js
+      - id: add-to-devops
+        name: Add to Monorepo DevOps Team project
+        uses: actions/add-to-project@v1.0.2
+        if: ${{ steps.has-project.outputs.result == 'false' }}
+        with:
+          project-url: https://github.com/orgs/camunda/projects/115
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+          # any of the following labels:
+          labeled: component/build-pipeline, component/release, area/build


### PR DESCRIPTION
## Description

Address e.g. [this Slack request](https://camunda.slack.com/archives/C071KP5BTHB/p1744898113866489) to help engineers that want to file issues regarding the Monorepo CI and/or Monorepo Release process in this repo, and add them automatically to the project board.

Rationale: I went for dedicated issue templates instead of adding new component labels to the existing bug/task/feature configurations as those have many redundant fields compared to our use case.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
