### PR TITLE
[Backport stable/8.6] ci: extend FOSSA integration

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,147 @@
+version: 3
+
+project:
+  id: camunda/camunda@single-app
+  labels:
+  - camunda8
+  - identity
+  - operate
+  - tasklist
+  - zeebe
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/camunda
+
+paths:
+  exclude:
+  - c8run
+  - qa/core-application-e2e-test-suite
+  - tasklist/qa/backup-restore-tests
+
+maven:
+  scope-exclude:
+  - import
+  - provided
+  - system
+  - test
+
+targets:
+  exclude:
+  # qa
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa-acceptance-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa-util
+  # testing
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-process-test-spring
+  # operate
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-backup-restore-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-data-generator
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-it-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-performance-test
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-parent
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-110
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-120
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-130
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-800
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-810
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-820
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-830
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-840
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-850
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-query-performance-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-util
+  # tasklist
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-backup-restore-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-parent
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-810
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-820
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-830
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-840
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-850
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-test-coverage
+  # zeebe
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-integration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-update-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-util
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-protocol-test-util
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-test-util

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
     - main
+    - stable/*
+    tags:
+    - '*'
 
 jobs:
   analyze:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,0 +1,80 @@
+---
+name: Check Licenses
+
+# owner: @camunda/monorepo-devops-team
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  analyze:
+    name: Analyze dependencies
+    permissions: {}
+    runs-on: ubuntu-latest
+    strategy:
+      # The matrix is necessary to run separate analyses
+      matrix:
+        project:
+        - name: c8run
+          path: ./c8run
+        - name: single-app
+          path: ./
+          maven-config: |
+            -Dquickly=true
+            -DskipQaBuild=true
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    # Import FOSSA_API_KEY secret from Vault
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
+    - uses: ./.github/actions/setup-build
+      if: matrix.project.name == 'single-app'
+      with:
+        vault-address: ${{ secrets.VAULT_ADDR }}
+        vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+    - uses: actions/setup-go@v5
+      if: matrix.project.name == 'c8run'
+      with:
+        go-version: '>=1.23.1'
+        cache: false  # disabling since not working anyways without a cache-dependency-path specified
+    - name: Update Maven configs
+      if: matrix.project.maven-config != ''
+      env:
+        MAVEN_CONFIG: ${{ matrix.project.maven-config }}
+      run: |
+        echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
+    - name: Setup fossa-cli
+      uses: camunda/infra-global-github-actions/fossa/setup@a2d602acc0b46ad8da2bbc1c34edbdb5af74345a
+    - name: Adjust pom.xml files for FOSSA
+      if: matrix.project.name == 'single-app'
+      run: |
+        # The bom/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
+        yq -i \
+          '.project.modules.module += "./.."' \
+          parent/pom.xml
+        yq -i \
+          '.project.modules.module += "./../parent"' \
+          bom/pom.xml
+        # Remove bom and parent from the list of modules of ./pom.xml
+        yq -i \
+          'del(.project.modules.module[] | select(. == "bom" or . == "parent"))' \
+          pom.xml
+    - name: Analyze project
+      uses: camunda/infra-global-github-actions/fossa/analyze@a2d602acc0b46ad8da2bbc1c34edbdb5af74345a
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        branch: ${{ github.ref_name }}
+        path: ${{ matrix.project.path }}
+        revision-id: ${{ github.sha }}

--- a/c8run/.fossa.yml
+++ b/c8run/.fossa.yml
@@ -1,0 +1,13 @@
+version: 3
+
+project:
+  id: camunda/camunda@c8run
+  labels:
+  - camunda8
+  - c8run
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/camunda
+
+paths:
+  exclude:
+  - e2e_tests


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/751 and backport PR of https://github.com/camunda/camunda/pull/31236.

This PR:
- extends the FOSSA integration to include stable branches and tags in addition to the `main` branch
- updates the workflow to perform analysis for the single-app and c8run separately

Test workflow run: https://github.com/camunda/camunda/actions/runs/14596986782/job/40945327468?pr=31239

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

