### PR TITLE
[Backport stable/8.7] [stable/8.6] fix: removal of meter registry workaround

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
@@ -20,10 +20,6 @@ import io.camunda.zeebe.spring.client.actuator.MicrometerMetricsRecorder;
 import io.camunda.zeebe.spring.client.actuator.ZeebeClientHealthIndicator;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -41,25 +37,8 @@ import org.springframework.context.annotation.Lazy;
 public class ZeebeActuatorConfiguration {
   @Bean
   @ConditionalOnMissingBean
-  public MetricsRecorder micrometerMetricsRecorder(
-      final @Autowired @Lazy MeterRegistry meterRegistry) {
+  public MetricsRecorder micrometerMetricsRecorder(@Lazy final MeterRegistry meterRegistry) {
     return new MicrometerMetricsRecorder(meterRegistry);
-  }
-
-  /**
-   * Workaround to fix premature initialization of MeterRegistry that seems to happen here, see
-   * https://github.com/camunda-community-hub/spring-zeebe/issues/296
-   */
-  @Bean
-  InitializingBean forceMeterRegistryPostProcessor(
-      final @Autowired(required = false) @Qualifier("meterRegistryPostProcessor") BeanPostProcessor
-              meterRegistryPostProcessor,
-      final @Autowired(required = false) MeterRegistry registry) {
-    if (registry == null || meterRegistryPostProcessor == null) {
-      return () -> {};
-    } else {
-      return () -> meterRegistryPostProcessor.postProcessAfterInitialization(registry, "");
-    }
   }
 
   @Bean


### PR DESCRIPTION
# Description
Backport of #31168 to `stable/8.7`.

relates to camunda-community-hub/spring-zeebe#296 #30812