### PR TITLE
[Backport stable/8.7] fix: (8.6) bean post processor produced warn logs

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
@@ -19,11 +19,15 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.bean.ClassInfo;
 import io.camunda.zeebe.spring.client.configuration.AnnotationProcessorConfiguration;
 import java.util.ArrayList;
+<<<<<<< HEAD
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+=======
+import java.util.List;
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -38,17 +42,28 @@ import org.springframework.core.Ordered;
 public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Ordered {
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeAnnotationProcessorRegistry.class);
 
+<<<<<<< HEAD
   private final Set<AbstractZeebeAnnotationProcessor> processors = new HashSet<>();
   private final Map<String, Object> beans = new HashMap<>();
+=======
+  private final List<AbstractZeebeAnnotationProcessor> processors = new ArrayList<>();
+  private final List<ClassInfo> beans = new ArrayList<>();
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
 
   @Override
   public Object postProcessAfterInitialization(final Object bean, final String beanName)
       throws BeansException {
     if (bean instanceof final AbstractZeebeAnnotationProcessor processor) {
+<<<<<<< HEAD
       LOG.debug("Found processor: {}", beanName);
       processors.add(processor);
     } else {
       beans.put(beanName, bean);
+=======
+      processors.add(processor);
+    } else {
+      beans.add(ClassInfo.builder().bean(bean).beanName(beanName).build());
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
     }
     return bean;
   }
@@ -69,6 +84,7 @@ public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Orde
 
   private void processBeans() {
     beans.forEach(
+<<<<<<< HEAD
         (beanName, bean) -> {
           final ClassInfo classInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
           for (final AbstractZeebeAnnotationProcessor zeebePostProcessor : processors) {
@@ -78,6 +94,12 @@ public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Orde
                   beanName,
                   zeebePostProcessor.getBeanName());
               zeebePostProcessor.configureFor(classInfo);
+=======
+        bean -> {
+          for (final AbstractZeebeAnnotationProcessor zeebePostProcessor : processors) {
+            if (zeebePostProcessor.isApplicableFor(bean)) {
+              zeebePostProcessor.configureFor(bean);
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
             }
           }
         });

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -37,6 +37,10 @@ public class ExecutorServiceConfiguration {
   @Bean
   public ZeebeClientExecutorService zeebeClientThreadPool(
       @Autowired(required = false) final MeterRegistry meterRegistry,
+<<<<<<< HEAD
+=======
+      final ZeebeClientConfigurationProperties configurationProperties,
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
       final CamundaClientProperties camundaClientProperties) {
     final ScheduledExecutorService threadPool =
         Executors.newScheduledThreadPool(

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -50,6 +50,10 @@ public class ZeebeClientAllAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public ZeebeClientExecutorService zeebeClientExecutorService(
+<<<<<<< HEAD
+=======
+      final ZeebeClientConfigurationProperties configurationProperties,
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
       final CamundaClientProperties camundaClientProperties) {
     return ZeebeClientExecutorService.createDefault(
         ofNullable(camundaClientProperties.getZeebe().getExecutionThreads())
@@ -100,7 +104,14 @@ public class ZeebeClientAllAutoConfiguration {
   @Bean("propertyBasedZeebeWorkerValueCustomizer")
   @ConditionalOnMissingBean(name = "propertyBasedZeebeWorkerValueCustomizer")
   public ZeebeWorkerValueCustomizer propertyBasedZeebeWorkerValueCustomizer(
+<<<<<<< HEAD
       final CamundaClientProperties camundaClientProperties) {
     return new PropertyBasedZeebeWorkerValueCustomizer(camundaClientProperties);
+=======
+      final ZeebeClientConfigurationProperties configurationProperties,
+      final CamundaClientProperties camundaClientProperties) {
+    return new PropertyBasedZeebeWorkerValueCustomizer(
+        configurationProperties, camundaClientProperties);
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -40,9 +40,14 @@ public class AnnotationProcessorConfigurationTest {
   void shouldRun() {
     final List<AbstractZeebeAnnotationProcessor> processors = registry.getProcessors();
     assertThat(processors).hasSize(2);
+<<<<<<< HEAD
     assertThat(processors)
         .anySatisfy(p -> assertThat(p).isInstanceOf(ZeebeWorkerAnnotationProcessor.class));
     assertThat(processors)
         .anySatisfy(p -> assertThat(p).isInstanceOf(ZeebeDeploymentAnnotationProcessor.class));
+=======
+    assertThat(processors.get(0)).isInstanceOf(ZeebeDeploymentAnnotationProcessor.class);
+    assertThat(processors.get(1)).isInstanceOf(ZeebeWorkerAnnotationProcessor.class);
+>>>>>>> 7c613cf4 (fix: bean post processor produced warn logs)
   }
 }


### PR DESCRIPTION
# Description
Backport of #28547 to `stable/8.7`.

relates to 