### PR TITLE
Pass initial assignee to subsequent `creating` listener

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2Applier.java
@@ -31,7 +31,7 @@ public class UserTaskCreatingV2Applier
   public void applyState(final long key, final UserTaskRecord value) {
     final var valueWithoutAssignee = value.copy().unsetAssignee();
     userTaskState.create(valueWithoutAssignee);
-    userTaskState.storeIntermediateState(valueWithoutAssignee, LifecycleState.CREATING);
+    userTaskState.storeIntermediateState(value, LifecycleState.CREATING);
     userTaskState.storeInitialAssignee(key, value.getAssignee());
 
     final long elementInstanceKey = value.getElementInstanceKey();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -281,10 +281,10 @@ public class TaskListenerBlockedTransitionTest {
         .containsExactly(
             // assignee should be present in the CREATING
             tuple(UserTaskIntent.CREATING, assignee, action, List.of()),
-            // creating first task listener completion, assignee should NOT be present
-            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, StringUtils.EMPTY, action, List.of()),
-            // creating second task listener completion, assignee should NOT be present
-            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, StringUtils.EMPTY, action, List.of()),
+            // creating first task listener completion
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action, List.of()),
+            // creating second task listener completion
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action, List.of()),
             // assignee should NOT be present in the CREATED
             tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action, List.of()),
             // assignee should be present in the ASSIGNING

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingV2ApplierTest.java
@@ -73,10 +73,10 @@ public class UserTaskCreatingV2ApplierTest {
     userTaskCreatingV2Applier.applyState(userTaskKey, userTaskRecord);
 
     // then
-    // ensure the intermediate state is present without an assignee
+    // ensure the intermediate state is present and has an assignee
     assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord().getAssignee())
-        .describedAs("Expect that intermediate state to be present")
-        .isEmpty();
+        .describedAs("Expect that intermediate state is present with the assignee")
+        .isEqualTo(initialAssignee);
 
     // ensure the intermediate assignee is stored
     assertThat(userTaskState.findInitialAssignee(userTaskKey))


### PR DESCRIPTION
## Description
We should make `initial assignee` available for subsequent `creating` task listeners:

- we should create a new user task without an `assignee`
- we should pass the intermediate user task with `assignee` to listeners so they can choose to correct it if needed:
  - listener can differentiate based on whether or not there is an assignee
  - we'll reject correcting if user task has an initial assignee
 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
relates to #29122
