### PR TITLE
refactor: store mapping group membership decoupled from mapping state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -206,17 +206,15 @@ public final class AuthorizationCheckBehavior {
   private boolean isUserAuthorizedForTenant(
       final AuthorizationRequest request, final PersistedUser user) {
     final var tenantId = request.tenantId;
-    if (membershipState.hasRelation(
-        EntityType.USER, user.getUsername(), RelationType.TENANT, tenantId)) {
+    final var username = user.getUsername();
+    if (membershipState.hasRelation(EntityType.USER, username, RelationType.TENANT, tenantId)) {
       return true;
     }
-    for (final var groupId :
-        membershipState.getMemberships(EntityType.USER, user.getUsername(), RelationType.GROUP)) {
-      if (membershipState.hasRelation(EntityType.GROUP, groupId, RelationType.TENANT, tenantId)) {
-        return true;
-      }
-    }
-    return false;
+    return membershipState.getMemberships(EntityType.USER, username, RelationType.GROUP).stream()
+        .anyMatch(
+            groupId ->
+                membershipState.hasRelation(
+                    EntityType.GROUP, groupId, RelationType.TENANT, tenantId));
   }
 
   private boolean isMappingAuthorizedForTenant(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -144,10 +144,13 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
 
   private boolean isEntityAssigned(final GroupRecord record) {
     return switch (record.getEntityType()) {
-      case USER ->
+      case USER, MAPPING ->
           membershipState.hasRelation(
-              EntityType.USER, record.getEntityId(), RelationType.GROUP, record.getGroupId());
-      default -> groupState.getEntityType(record.getGroupId(), record.getEntityId()).isPresent();
+              record.getEntityType(),
+              record.getEntityId(),
+              RelationType.GROUP,
+              record.getGroupId());
+      default -> false;
     };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -117,10 +117,10 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
     final var isAssigned =
         switch (record.getEntityType()) {
-          case USER ->
+          case USER, MAPPING ->
               membershipState.hasRelation(
-                  EntityType.USER, record.getEntityId(), RelationType.GROUP, groupId);
-          default -> groupState.getEntityType(groupId, record.getEntityId()).isPresent();
+                  record.getEntityType(), record.getEntityId(), RelationType.GROUP, groupId);
+          default -> false;
         };
 
     if (isAssigned) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -154,14 +154,15 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
               .setEntityKey(mappingKey)
               .setEntityType(EntityType.MAPPING));
     }
-    for (final var groupKey : mapping.getGroupKeysList()) {
+    for (final var groupKey :
+        membershipState.getMemberships(
+            EntityType.MAPPING, mapping.getMappingId(), RelationType.GROUP)) {
       stateWriter.appendFollowUpEvent(
-          groupKey,
+          Long.parseLong(groupKey),
           GroupIntent.ENTITY_REMOVED,
           new GroupRecord()
-              .setGroupKey(groupKey)
-              // TODO: revisit with https://github.com/camunda/camunda/issues/30092
-              .setEntityId(String.valueOf(mappingKey))
+              .setGroupKey(Long.parseLong(groupKey))
+              .setEntityId(mapping.getMappingId())
               .setEntityType(EntityType.MAPPING));
     }
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -9,23 +9,15 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
-
-  private final MutableGroupState groupState;
-  private final MutableMappingState mappingState;
   private final MutableMembershipState membershipState;
 
   public GroupEntityAddedApplier(final MutableProcessingState processingState) {
-    groupState = processingState.getGroupState();
-    mappingState = processingState.getMappingState();
     membershipState = processingState.getMembershipState();
   }
 
@@ -36,12 +28,8 @@ public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, G
     final var groupId = value.getGroupId();
 
     switch (entityType) {
-      case USER ->
-          membershipState.insertRelation(EntityType.USER, entityId, RelationType.GROUP, groupId);
-      case MAPPING -> {
-        groupState.addEntity(value);
-        mappingState.addGroup(entityId, Long.parseLong(value.getGroupId()));
-      }
+      case USER, MAPPING ->
+          membershipState.insertRelation(entityType, entityId, RelationType.GROUP, groupId);
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
@@ -9,23 +9,16 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationType;
-import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableMembershipState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
 
-  private final MutableGroupState groupState;
-  private final MutableMappingState mappingState;
   private final MutableMembershipState membershipState;
 
   public GroupEntityRemovedApplier(final MutableProcessingState processingState) {
-    groupState = processingState.getGroupState();
-    mappingState = processingState.getMappingState();
     membershipState = processingState.getMembershipState();
   }
 
@@ -36,12 +29,8 @@ public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent,
     final var groupId = value.getGroupId();
 
     switch (entityType) {
-      case USER ->
-          membershipState.deleteRelation(EntityType.USER, entityId, RelationType.GROUP, groupId);
-      case MAPPING -> {
-        groupState.removeEntity(groupId, entityId);
-        mappingState.removeGroup(entityId, Long.parseLong(value.getGroupId()));
-      }
+      case USER, MAPPING ->
+          membershipState.deleteRelation(entityType, entityId, RelationType.GROUP, groupId);
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
-import java.util.List;
 import java.util.Optional;
 
 public class DbMappingState implements MutableMappingState {
@@ -112,32 +111,6 @@ public class DbMappingState implements MutableMappingState {
                       "Expected to update mapping with id '%s', but a mapping with this id does not exist.",
                       mappingRecord.getMappingId()));
             });
-  }
-
-  @Override
-  public void addGroup(final String mappingId, final long groupKey) {
-    this.mappingId.wrapString(mappingId);
-    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      persistedMapping.addGroupKey(groupKey);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
-  public void removeGroup(final String mappingId, final long groupKey) {
-    this.mappingId.wrapString(mappingId);
-    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      final List<Long> groupKeys = persistedMapping.getGroupKeysList();
-      groupKeys.remove(groupKey);
-      persistedMapping.setGroupKeysList(groupKeys);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -9,14 +9,9 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
-import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class PersistedMapping extends UnpackedObject implements DbValue {
 
@@ -25,16 +20,13 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
-  private final ArrayProperty<LongValue> groupKeysProp =
-      new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedMapping() {
-    super(6);
+    super(5);
     declareProperty(mappingKeyProp)
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
-        .declareProperty(groupKeysProp)
         .declareProperty(mappingIdProp);
   }
 
@@ -86,23 +78,6 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
 
   public PersistedMapping setMappingId(final String mappingId) {
     mappingIdProp.setValue(mappingId);
-    return this;
-  }
-
-  public List<Long> getGroupKeysList() {
-    return StreamSupport.stream(groupKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
-        .collect(Collectors.toList());
-  }
-
-  public PersistedMapping setGroupKeysList(final List<Long> groupKeys) {
-    groupKeysProp.reset();
-    groupKeys.forEach(groupKey -> groupKeysProp.add().setValue(groupKey));
-    return this;
-  }
-
-  public PersistedMapping addGroupKey(final long groupKey) {
-    groupKeysProp.add().setValue(groupKey);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -10,18 +10,10 @@ package io.camunda.zeebe.engine.state.group;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
-import io.camunda.zeebe.db.impl.DbCompositeKey;
-import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbString;
-import io.camunda.zeebe.engine.state.authorization.EntityTypeValue;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public class DbGroupState implements MutableGroupState {
@@ -30,13 +22,6 @@ public class DbGroupState implements MutableGroupState {
   private final PersistedGroup persistedGroup = new PersistedGroup();
   private final ColumnFamily<DbString, PersistedGroup> groupColumnFamily;
 
-  private final DbForeignKey<DbString> fkGroupId;
-  private final DbString entityId;
-  private final DbCompositeKey<DbForeignKey<DbString>, DbString> fkGroupIdAndEntityId;
-  private final EntityTypeValue entityTypeValue = new EntityTypeValue();
-  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbString>, DbString>, EntityTypeValue>
-      entityTypeByGroupColumnFamily;
-
   public DbGroupState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
 
@@ -44,16 +29,6 @@ public class DbGroupState implements MutableGroupState {
     groupColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.GROUPS, transactionContext, groupId, new PersistedGroup());
-
-    fkGroupId = new DbForeignKey<>(groupId, ZbColumnFamilies.GROUPS);
-    entityId = new DbString();
-    fkGroupIdAndEntityId = new DbCompositeKey<>(fkGroupId, entityId);
-    entityTypeByGroupColumnFamily =
-        zeebeDb.createColumnFamily(
-            ZbColumnFamilies.ENTITY_BY_GROUP,
-            transactionContext,
-            fkGroupIdAndEntityId,
-            entityTypeValue);
   }
 
   @Override
@@ -74,31 +49,8 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public void addEntity(final GroupRecord group) {
-    groupId.wrapString(group.getGroupId());
-    entityId.wrapString(String.valueOf(group.getEntityId()));
-    entityTypeValue.setEntityType(group.getEntityType());
-    entityTypeByGroupColumnFamily.insert(fkGroupIdAndEntityId, entityTypeValue);
-  }
-
-  @Override
-  public void removeEntity(final String groupId, final String entityId) {
-    this.groupId.wrapString(groupId);
-    this.entityId.wrapString(entityId);
-    entityTypeByGroupColumnFamily.deleteExisting(fkGroupIdAndEntityId);
-  }
-
-  @Override
   public void delete(final String groupId) {
     this.groupId.wrapString(groupId);
-
-    // remove entries from ENTITY_BY_GROUP cf
-    entityTypeByGroupColumnFamily.whileEqualPrefix(
-        fkGroupId,
-        (compositeKey, value) -> {
-          entityTypeByGroupColumnFamily.deleteExisting(compositeKey);
-        });
-
     groupColumnFamily.deleteExisting(this.groupId);
   }
 
@@ -114,27 +66,5 @@ public class DbGroupState implements MutableGroupState {
     this.groupId.wrapString(groupId);
     final var persistedGroup = groupColumnFamily.get(this.groupId);
     return Optional.ofNullable(persistedGroup);
-  }
-
-  @Override
-  public Optional<EntityType> getEntityType(final String groupId, final String entityId) {
-    this.groupId.wrapString(groupId);
-    this.entityId.wrapString(entityId);
-    final var entityType = entityTypeByGroupColumnFamily.get(fkGroupIdAndEntityId);
-    return Optional.ofNullable(entityType).map(EntityTypeValue::getEntityType);
-  }
-
-  @Override
-  public Map<EntityType, List<String>> getEntitiesByType(final String groupId) {
-    this.groupId.wrapString(groupId);
-    final Map<EntityType, List<String>> entitiesMap = new HashMap<>();
-    entityTypeByGroupColumnFamily.whileEqualPrefix(
-        fkGroupId,
-        (compositeKey, value) -> {
-          final var entityType = value.getEntityType();
-          final var entityId = compositeKey.second().toString();
-          entitiesMap.computeIfAbsent(entityType, k -> new ArrayList<>()).add(entityId);
-        });
-    return entitiesMap;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -8,9 +8,6 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.group.PersistedGroup;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface GroupState {
@@ -20,8 +17,4 @@ public interface GroupState {
   Optional<PersistedGroup> get(long groupKey);
 
   Optional<PersistedGroup> get(String groupId);
-
-  Optional<EntityType> getEntityType(String groupId, String entityId);
-
-  Map<EntityType, List<String>> getEntitiesByType(String groupId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -16,9 +16,5 @@ public interface MutableGroupState extends GroupState {
 
   void update(final GroupRecord group);
 
-  void addEntity(final GroupRecord group);
-
-  void removeEntity(final String groupId, final String entityId);
-
   void delete(final String groupId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,9 +16,5 @@ public interface MutableMappingState extends MappingState {
 
   void update(MappingRecord mappingRecord);
 
-  void addGroup(final String mappingId, final long groupKey);
-
-  void removeGroup(final String mappingId, final long groupKey);
-
   void delete(final String id);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -160,7 +160,7 @@ public class MappingAppliersTest {
     // create group
     final var groupId = "1";
     final var groupKey = Long.parseLong(groupId);
-    mappingState.addGroup(mappingId, groupKey);
+    membershipState.insertRelation(EntityType.MAPPING, mappingId, RelationType.GROUP, groupId);
     final var group =
         new GroupRecord()
             .setGroupKey(groupKey)
@@ -169,7 +169,6 @@ public class MappingAppliersTest {
             .setEntityId(String.valueOf(mappingKey))
             .setEntityType(EntityType.MAPPING);
     groupState.create(group);
-    groupState.addEntity(group);
     // create authorization
     authorizationState.create(
         5L,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -13,10 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,83 +107,12 @@ public class GroupStateTest {
   }
 
   @Test
-  void shouldAddEntity() {
-    // given
-    final var groupId = Strings.newRandomValidIdentityId();
-    final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
-    groupState.create(groupRecord);
-
-    // when
-    final var username = Strings.newRandomValidIdentityId();
-    final var userEntityType = EntityType.USER;
-    groupRecord.setEntityId(username).setEntityType(userEntityType);
-    groupState.addEntity(groupRecord);
-
-    // then
-    final var entityType = groupState.getEntityType(groupId, username);
-    assertThat(entityType.isPresent()).isTrue();
-    assertThat(entityType.get()).isEqualTo(userEntityType);
-  }
-
-  @Test
-  void shouldReturnEntitiesByType() {
-    // given
-    final var groupId = Strings.newRandomValidIdentityId();
-    final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
-    groupState.create(groupRecord);
-    final var username = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(username).setEntityType(EntityType.USER);
-    groupState.addEntity(groupRecord);
-    final var mappingId = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(mappingId).setEntityType(EntityType.MAPPING);
-    groupState.addEntity(groupRecord);
-
-    // when
-    final var entities = groupState.getEntitiesByType(groupId);
-
-    // then
-    assertThat(entities)
-        .containsEntry(EntityType.USER, List.of(username))
-        .containsEntry(EntityType.MAPPING, List.of(mappingId));
-  }
-
-  @Test
-  void shouldRemoveEntity() {
-    // given
-    final var groupId = Strings.newRandomValidIdentityId();
-    final var groupName = "group";
-    final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
-    groupState.create(groupRecord);
-    final var username = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(username).setEntityType(EntityType.USER);
-    groupState.addEntity(groupRecord);
-    final var mappingId = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(mappingId).setEntityType(EntityType.MAPPING);
-    groupState.addEntity(groupRecord);
-
-    // when
-    groupState.removeEntity(groupId, username);
-
-    // then
-    final var entityType = groupState.getEntitiesByType(groupId);
-    assertThat(entityType).containsOnly(Map.entry(EntityType.MAPPING, List.of(mappingId)));
-  }
-
-  @Test
   void shouldDeleteGroup() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
     final var groupName = "group";
     final var groupRecord = new GroupRecord().setGroupId(groupId).setName(groupName);
     groupState.create(groupRecord);
-    final var username = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(username).setEntityType(EntityType.USER);
-    groupState.addEntity(groupRecord);
-    final var mappingId = Strings.newRandomValidIdentityId();
-    groupRecord.setEntityId(mappingId).setEntityType(EntityType.MAPPING);
-    groupState.addEntity(groupRecord);
 
     // when
     groupState.delete(groupId);
@@ -194,8 +120,5 @@ public class GroupStateTest {
     // then
     final var group = groupState.get(groupId);
     assertThat(group).isEmpty();
-
-    final var entitiesByGroup = groupState.getEntitiesByType(groupId);
-    assertThat(entitiesByGroup).isEmpty();
   }
 }


### PR DESCRIPTION
We now track mapping group membership in the generalized membership state instead of the PersistedMapping and GroupState.

depends on https://github.com/camunda/camunda/pull/31183
closes https://github.com/camunda/camunda/issues/30456