### PR TITLE
fix: Update core application test suite workflow files

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   nightly-tests:
     strategy:
+      fail-fast: false
       matrix:
         branch: [stable/8.6, stable/8.7, main] # Run all three branches in parallel
     runs-on: ubuntu-latest

--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -7,19 +7,30 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Select the branch to test"
+        description: "Enter the branch to test"
         required: true
         default: "main"
-        type: choice
-        options:
-          - main
-          - stable/8.6
-          - stable/8.7
 
 permissions:
   contents: read
 
 jobs:
+  validate-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Branches
+        id: fetch-branches
+        run: |
+          echo "Fetching branches..."
+          branches=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/branches | jq -r '.[].name')
+          echo "Available branches: $branches"
+          if [[ ! " $branches " =~ " ${{ github.event.inputs.branch }} " ]]; then
+            echo "Error: Branch '${{ github.event.inputs.branch }}' does not exist."
+            exit 1
+          fi
+          echo "Branch '${{ github.event.inputs.branch }}' is valid."
+
   core-e2e-component-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description  
During the last nightly run, I noticed that if one version fails, the remaining versions in the matrix are skipped. To address this, I added `fail-fast: false` to ensure all matrix versions run, even if one fails.  
Additionally, I updated the on-demand workflow to accept plain text input instead of a predefined list of stable and main branches. This allows us to use the on-demand workflow for testing unmerged changes as well.

📗 successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/14611730604) 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30874 
