### PR TITLE
Agentic AI support: add fromAi FEEL wrapper function

### DIFF
--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
@@ -72,6 +72,12 @@ public class FeelFromAiFunctionTest {
             EvaluationResult::getNumber,
             10),
         new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description, type, schema & options",
+            "fromAi(toolCall.a, \"The a parameter.\", \"integer\", { multipleOf: 1 }, { optional: true })",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
             "Only value (named params)",
             "fromAi(value: toolCall.a)",
             ResultType.NUMBER,
@@ -96,8 +102,14 @@ public class FeelFromAiFunctionTest {
             EvaluationResult::getNumber,
             10),
         new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
-            "Value, description, type & schema (named params, mixed order)",
-            "fromAi(schema: { multipleOf: 1 }, description: \"The a parameter.\", value: toolCall.a, type: \"integer\")",
+            "Value, description, type, schema & options (named params)",
+            "fromAi(value: toolCall.a, description: \"The a parameter.\", type: \"integer\", schema: { multipleOf: 1 }, options: { optional: true })",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description, type, schema & options (named params, mixed order)",
+            "fromAi(schema: { multipleOf: 1 }, description: \"The a parameter.\", options: { optional: true }, value: toolCall.a, type: \"integer\")",
             ResultType.NUMBER,
             EvaluationResult::getNumber,
             10));
@@ -123,8 +135,8 @@ public class FeelFromAiFunctionTest {
     return Stream.of(
         arguments("fromAi()", 0),
         arguments(
-            "fromAi(toolCall.a, \"The a parameter.\", \"integer\", { multipleOf: 1 }, \"testme\")",
-            5));
+            "fromAi(toolCall.a, \"The a parameter.\", \"integer\", { multipleOf: 1 }, { optional: true }, \"testme\")",
+            6));
   }
 
   @Test

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
@@ -140,16 +140,10 @@ public class FeelFromAiFunctionTest {
   }
 
   @Test
-  void createsWarningWhenFirstParameterIsNull() {
-    final var evaluationResult = evaluateExpression("fromAi(toolCall.c)", CONTEXT_VALUES::get);
-
-    assertThat(evaluationResult.isFailure()).isFalse();
-    assertThat(evaluationResult.getWarnings())
-        .extracting(EvaluationWarning::getType, EvaluationWarning::getMessage)
-        .contains(
-            tuple(
-                "FUNCTION_INVOCATION_FAILURE",
-                "Failed to invoke function 'fromAi': fromAi function expected at least one parameter (value), but received null"));
+  void returnsNullWhenInputValueIsNull() {
+    final var evaluationResult =
+        evaluateSuccessfulExpression("fromAi(toolCall.c)", CONTEXT_VALUES::get);
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.NULL);
   }
 
   private EvaluationResult evaluateSuccessfulExpression(

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelFromAiFunctionTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.el;
+
+import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.camunda.zeebe.el.util.TestFeelEngineClock;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class FeelFromAiFunctionTest {
+
+  private static final Map<String, DirectBuffer> CONTEXT_VALUES =
+      Map.of("toolCall", asMsgPack(Map.of("a", 10, "b", "twenty")));
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(new TestFeelEngineClock());
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("valueTestCases")
+  <T> void returnsInjectedValue(final FromAiExpressionTestCase<T> testCase) {
+    final var evaluationResult =
+        evaluateSuccessfulExpression(testCase.expression(), CONTEXT_VALUES::get);
+    assertThat(evaluationResult.getType()).isEqualTo(testCase.expectedResultType);
+    assertThat(testCase.resultExtractor.apply(evaluationResult)).isEqualTo(testCase.expectedResult);
+  }
+
+  static Stream<FromAiExpressionTestCase<?>> valueTestCases() {
+    return Stream.of(
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Only value (number)",
+            "fromAi(toolCall.a)",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Only value (string)",
+            "fromAi(toolCall.b)",
+            ResultType.STRING,
+            EvaluationResult::getString,
+            "twenty"),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value & description",
+            "fromAi(toolCall.a, \"The a parameter.\")",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description & type",
+            "fromAi(toolCall.a, \"The a parameter.\", \"integer\")",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description, type & schema",
+            "fromAi(toolCall.a, \"The a parameter.\", \"integer\", { multipleOf: 1 })",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Only value (named params)",
+            "fromAi(value: toolCall.a)",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value & description (named params)",
+            "fromAi(value: toolCall.a, description: \"The a parameter.\")",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description & type (named params)",
+            "fromAi(value: toolCall.a, description: \"The a parameter.\", type: \"integer\")",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description, type & schema (named params)",
+            "fromAi(value: toolCall.a, description: \"The a parameter.\", type: \"integer\", schema: { multipleOf: 1 })",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10),
+        new FeelFromAiFunctionTest.FromAiExpressionTestCase<>(
+            "Value, description, type & schema (named params, mixed order)",
+            "fromAi(schema: { multipleOf: 1 }, description: \"The a parameter.\", value: toolCall.a, type: \"integer\")",
+            ResultType.NUMBER,
+            EvaluationResult::getNumber,
+            10));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidParameterLists")
+  void createsWarningWhenParameterListDoesNotMatch(
+      final String expression, final int parameterCount) {
+    final var evaluationResult = evaluateSuccessfulExpression(expression, CONTEXT_VALUES::get);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertThat(evaluationResult.getWarnings())
+        .extracting(EvaluationWarning::getType, EvaluationWarning::getMessage)
+        .containsExactly(
+            tuple(
+                "NO_FUNCTION_FOUND",
+                "No function found with name 'fromAi' and %d parameters"
+                    .formatted(parameterCount)));
+  }
+
+  public static Stream<Arguments> invalidParameterLists() {
+    return Stream.of(
+        arguments("fromAi()", 0),
+        arguments(
+            "fromAi(toolCall.a, \"The a parameter.\", \"integer\", { multipleOf: 1 }, \"testme\")",
+            5));
+  }
+
+  @Test
+  void createsWarningWhenFirstParameterIsNull() {
+    final var evaluationResult = evaluateExpression("fromAi(toolCall.c)", CONTEXT_VALUES::get);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertThat(evaluationResult.getWarnings())
+        .extracting(EvaluationWarning::getType, EvaluationWarning::getMessage)
+        .contains(
+            tuple(
+                "FUNCTION_INVOCATION_FAILURE",
+                "Failed to invoke function 'fromAi': fromAi function expected at least one parameter (value), but received null"));
+  }
+
+  private EvaluationResult evaluateSuccessfulExpression(
+      final String expression, final EvaluationContext context) {
+    final var evaluationResult = evaluateExpression(expression, context);
+
+    assertThat(evaluationResult.isFailure())
+        .describedAs(evaluationResult.getFailureMessage())
+        .isFalse();
+
+    return evaluationResult;
+  }
+
+  private EvaluationResult evaluateExpression(
+      final String expression, final EvaluationContext context) {
+    final var parseExpression = expressionLanguage.parseExpression("=" + expression);
+    return expressionLanguage.evaluateExpression(parseExpression, context);
+  }
+
+  record FromAiExpressionTestCase<T>(
+      String description,
+      String expression,
+      ResultType expectedResultType,
+      Function<EvaluationResult, T> resultExtractor,
+      T expectedResult) {
+
+    @Override
+    public String toString() {
+      return "%s: %s".formatted(description, expression);
+    }
+  }
+}

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelFunctionProvider.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelFunctionProvider.java
@@ -27,7 +27,7 @@ public class FeelFunctionProvider extends JavaFunctionProvider {
           "cycle",
           List.of(CycleFunction.INSTANCE, CycleInfiniteFunction.INSTANCE),
           "fromAi",
-          FromAiFunctions.INSTANCES);
+          FromAiFunction.INSTANCES);
 
   @Override
   public Optional<JavaFunction> resolveFunction(final String functionName) {

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelFunctionProvider.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelFunctionProvider.java
@@ -23,7 +23,11 @@ import org.camunda.feel.syntaxtree.ValYearMonthDuration;
 
 public class FeelFunctionProvider extends JavaFunctionProvider {
   private static final Map<String, List<JavaFunction>> FUNCTIONS =
-      Map.of("cycle", List.of(CycleFunction.INSTANCE, CycleInfiniteFunction.INSTANCE));
+      Map.of(
+          "cycle",
+          List.of(CycleFunction.INSTANCE, CycleInfiniteFunction.INSTANCE),
+          "fromAi",
+          FromAiFunctions.INSTANCES);
 
   @Override
   public Optional<JavaFunction> resolveFunction(final String functionName) {

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.feel.impl;
 import java.util.List;
 import org.camunda.feel.context.JavaFunction;
 import org.camunda.feel.syntaxtree.Val;
-import org.camunda.feel.syntaxtree.ValError;
-import org.camunda.feel.syntaxtree.ValNull$;
 
 public class FromAiFunction extends JavaFunction {
   public static final List<JavaFunction> INSTANCES =
@@ -27,12 +25,6 @@ public class FromAiFunction extends JavaFunction {
   }
 
   private static Val invoke(final List<Val> args) {
-    final var firstArg = !args.isEmpty() ? args.getFirst() : null;
-    if (firstArg == null || firstArg instanceof ValNull$) {
-      return new ValError(
-          "fromAi function expected at least one parameter (value), but received null");
-    }
-
-    return firstArg;
+    return !args.isEmpty() ? args.getFirst() : null;
   }
 }

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
@@ -19,7 +19,8 @@ public class FromAiFunction extends JavaFunction {
           new FromAiFunction(List.of("value")),
           new FromAiFunction(List.of("value", "description")),
           new FromAiFunction(List.of("value", "description", "type")),
-          new FromAiFunction(List.of("value", "description", "type", "schema")));
+          new FromAiFunction(List.of("value", "description", "type", "schema")),
+          new FromAiFunction(List.of("value", "description", "type", "schema", "options")));
 
   public FromAiFunction(final List<String> params) {
     super(params, FromAiFunction::invoke);

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
@@ -14,15 +14,20 @@ import org.camunda.feel.syntaxtree.ValContext;
 import org.camunda.feel.syntaxtree.ValError;
 import org.camunda.feel.syntaxtree.ValString;
 
-public abstract class FromAiFunctions {
+public class FromAiFunction extends JavaFunction {
   public static final List<JavaFunction> INSTANCES =
       List.of(
-          new FromAiFunction2(),
-          new FromAiFunction3(),
-          new FromAiFunction4(),
-          new FromAiFunction5());
+          new FromAiFunction(List.of("context", "name")),
+          new FromAiFunction(List.of("context", "name", "description")),
+          new FromAiFunction(List.of("context", "name", "description", "type")),
+          new FromAiFunction(List.of("context", "name", "description", "type", "schema")));
 
-  private static final MessagePackValueMapper MAPPER = new MessagePackValueMapper();
+  private static final MessagePackValueMapper MESSAGE_PACK_VALUE_MAPPER =
+      new MessagePackValueMapper();
+
+  public FromAiFunction(final List<String> params) {
+    super(params, FromAiFunction::invoke);
+  }
 
   private static Val invoke(final List<Val> args) {
     if (args.size() < 2) {
@@ -52,30 +57,6 @@ public abstract class FromAiFunctions {
               .formatted(nameStr.value()));
     }
 
-    return MAPPER.toVal(variable.get(), null).get();
-  }
-
-  public static class FromAiFunction2 extends JavaFunction {
-    public FromAiFunction2() {
-      super(List.of("context", "name"), FromAiFunctions::invoke);
-    }
-  }
-
-  public static class FromAiFunction3 extends JavaFunction {
-    public FromAiFunction3() {
-      super(List.of("context", "name", "description"), FromAiFunctions::invoke);
-    }
-  }
-
-  public static class FromAiFunction4 extends JavaFunction {
-    public FromAiFunction4() {
-      super(List.of("context", "name", "description", "type"), FromAiFunctions::invoke);
-    }
-  }
-
-  public static class FromAiFunction5 extends JavaFunction {
-    public FromAiFunction5() {
-      super(List.of("context", "name", "description", "type", "schema"), FromAiFunctions::invoke);
-    }
+    return MESSAGE_PACK_VALUE_MAPPER.toVal(variable.get(), null).get();
   }
 }

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.camunda.feel.context.JavaFunction;
 import org.camunda.feel.syntaxtree.Val;
 import org.camunda.feel.syntaxtree.ValError;
+import org.camunda.feel.syntaxtree.ValNull$;
 
 public class FromAiFunction extends JavaFunction {
   public static final List<JavaFunction> INSTANCES =
@@ -25,11 +26,12 @@ public class FromAiFunction extends JavaFunction {
   }
 
   private static Val invoke(final List<Val> args) {
-    if (args.isEmpty()) {
+    final var firstArg = !args.isEmpty() ? args.getFirst() : null;
+    if (firstArg == null || firstArg instanceof ValNull$) {
       return new ValError(
-          "fromAi function expected at least one parameter (value), but found none");
+          "fromAi function expected at least one parameter (value), but received null");
     }
 
-    return args.getFirst();
+    return firstArg;
   }
 }

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunction.java
@@ -10,53 +10,26 @@ package io.camunda.zeebe.feel.impl;
 import java.util.List;
 import org.camunda.feel.context.JavaFunction;
 import org.camunda.feel.syntaxtree.Val;
-import org.camunda.feel.syntaxtree.ValContext;
 import org.camunda.feel.syntaxtree.ValError;
-import org.camunda.feel.syntaxtree.ValString;
 
 public class FromAiFunction extends JavaFunction {
   public static final List<JavaFunction> INSTANCES =
       List.of(
-          new FromAiFunction(List.of("context", "name")),
-          new FromAiFunction(List.of("context", "name", "description")),
-          new FromAiFunction(List.of("context", "name", "description", "type")),
-          new FromAiFunction(List.of("context", "name", "description", "type", "schema")));
-
-  private static final MessagePackValueMapper MESSAGE_PACK_VALUE_MAPPER =
-      new MessagePackValueMapper();
+          new FromAiFunction(List.of("value")),
+          new FromAiFunction(List.of("value", "description")),
+          new FromAiFunction(List.of("value", "description", "type")),
+          new FromAiFunction(List.of("value", "description", "type", "schema")));
 
   public FromAiFunction(final List<String> params) {
     super(params, FromAiFunction::invoke);
   }
 
   private static Val invoke(final List<Val> args) {
-    if (args.size() < 2) {
+    if (args.isEmpty()) {
       return new ValError(
-          "fromAi function expected at least two parameters, but found %s: '%s'"
-              .formatted(args.size(), args));
+          "fromAi function expected at least one parameter (value), but found none");
     }
 
-    final var context = args.getFirst();
-    if (!(context instanceof final ValContext contextCtx)) {
-      return new ValError(
-          "fromAi function expected first parameter (context) to be a context, but found '%s'"
-              .formatted(context.getClass().getName()));
-    }
-
-    final var name = args.get(1);
-    if (!(name instanceof final ValString nameStr)) {
-      return new ValError(
-          "fromAi function expected second parameter (name) to be a string, but found '%s'"
-              .formatted(name.getClass().getName()));
-    }
-
-    final var variable = contextCtx.context().variableProvider().getVariable(nameStr.value());
-    if (variable.isEmpty()) {
-      return new ValError(
-          "fromAi function expected context to contain property '%s', but it was not found"
-              .formatted(nameStr.value()));
-    }
-
-    return MESSAGE_PACK_VALUE_MAPPER.toVal(variable.get(), null).get();
+    return args.getFirst();
   }
 }

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunctions.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FromAiFunctions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.feel.impl;
+
+import java.util.List;
+import org.camunda.feel.context.JavaFunction;
+import org.camunda.feel.syntaxtree.Val;
+import org.camunda.feel.syntaxtree.ValContext;
+import org.camunda.feel.syntaxtree.ValError;
+import org.camunda.feel.syntaxtree.ValString;
+
+public abstract class FromAiFunctions {
+  public static final List<JavaFunction> INSTANCES =
+      List.of(
+          new FromAiFunction2(),
+          new FromAiFunction3(),
+          new FromAiFunction4(),
+          new FromAiFunction5());
+
+  private static final MessagePackValueMapper MAPPER = new MessagePackValueMapper();
+
+  private static Val invoke(final List<Val> args) {
+    if (args.size() < 2) {
+      return new ValError(
+          "fromAi function expected at least two parameters, but found %s: '%s'"
+              .formatted(args.size(), args));
+    }
+
+    final var context = args.getFirst();
+    if (!(context instanceof final ValContext contextCtx)) {
+      return new ValError(
+          "fromAi function expected first parameter (context) to be a context, but found '%s'"
+              .formatted(context.getClass().getName()));
+    }
+
+    final var name = args.get(1);
+    if (!(name instanceof final ValString nameStr)) {
+      return new ValError(
+          "fromAi function expected second parameter (name) to be a string, but found '%s'"
+              .formatted(name.getClass().getName()));
+    }
+
+    final var variable = contextCtx.context().variableProvider().getVariable(nameStr.value());
+    if (variable.isEmpty()) {
+      return new ValError(
+          "fromAi function expected context to contain property '%s', but it was not found"
+              .formatted(nameStr.value()));
+    }
+
+    return MAPPER.toVal(variable.get(), null).get();
+  }
+
+  public static class FromAiFunction2 extends JavaFunction {
+    public FromAiFunction2() {
+      super(List.of("context", "name"), FromAiFunctions::invoke);
+    }
+  }
+
+  public static class FromAiFunction3 extends JavaFunction {
+    public FromAiFunction3() {
+      super(List.of("context", "name", "description"), FromAiFunctions::invoke);
+    }
+  }
+
+  public static class FromAiFunction4 extends JavaFunction {
+    public FromAiFunction4() {
+      super(List.of("context", "name", "description", "type"), FromAiFunctions::invoke);
+    }
+  }
+
+  public static class FromAiFunction5 extends JavaFunction {
+    public FromAiFunction5() {
+      super(List.of("context", "name", "description", "type", "schema"), FromAiFunctions::invoke);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Implements a `fromAi` FEEL function supporting different parameter lists which always returns its first argument and ignores the remaining arguments. The arguments will be parsed and used as metadata in https://github.com/camunda/connectors/issues/4634. 

See #31258 for background and implementation details.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31258 
