### PR TITLE
refactor: skip core application on demand workflow run if branch does not exist

### DIFF
--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -32,6 +32,7 @@ jobs:
           echo "Branch '${{ github.event.inputs.branch }}' is valid."
 
   core-e2e-component-tests:
+    needs: validate-branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
The `core-e2e-component-tests` job now depends on the `validate-branch` job using the needs keyword.
This ensures that the core-e2e-component-tests job is skipped if the branch validation fails.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
