### PR TITLE
Only run Snyk job for Zeebe on main and stable branches

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -156,7 +156,7 @@ outputs:
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
-    description: Output whether the change is occurring on a stable branch or not
+    description: Output whether the change is occurring on a stable/X.Y branch or not
     value: >-
       ${{
         github.event_name == 'push' &&

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -155,6 +155,13 @@ outputs:
         github.event_name == 'schedule' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
+  stable-branch-changes:
+    description: Output whether the change is occurring on a stable branch or not
+    value: >-
+      ${{
+        github.event_name == 'push' &&
+        steps.filter-stable-branch.outputs.stable-branch == 'true'
+      }}
 
 runs:
   using: composite
@@ -271,3 +278,12 @@ runs:
           - optimize/client/**
           - optimize/c4/**
           - optimize/backend/src/main/resources/localization/**
+
+  - id: filter-stable-branch
+    shell: bash
+    run: |
+      if [[ '${{ github.ref_name }}' =~ ^stable\/[0-9]+\.[0-9]+$ ]]; then
+        echo "stable-branch=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "stable-branch=false" >> "$GITHUB_OUTPUT"
+      fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       optimize-backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
       protobuf-changes: ${{ steps.filter.outputs.protobuf-changes }}
       openapi-changes: ${{ steps.filter.outputs.openapi-changes }}
+      stable-branch-changes: ${{ steps.filter.outputs.stable-branch-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -814,6 +815,8 @@ jobs:
     needs: [detect-changes]
     uses: ./.github/workflows/zeebe-ci.yml
     secrets: inherit
+    with:
+      stable-branch: ${{ needs.detect-changes.outputs.stable-branch-changes == 'true' }}
 
   build-operate-backend:
     if: needs.detect-changes.outputs.operate-backend-changes == 'true'

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -1,8 +1,18 @@
 name: Zeebe CI
 
 on:
-  workflow_dispatch: { }
-  workflow_call: { }
+  workflow_dispatch:
+    inputs:
+      stable-branch:
+        description: "Set to true if the change is running on a stable branch"
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      stable-branch:
+        description: "Set to true if the change is running on a stable branch"
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -446,7 +456,7 @@ jobs:
     if: |
       github.repository == 'camunda/camunda' &&
       github.event_name == 'push' &&
-      (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
+      ( inputs.stable-branch || github.ref_name == 'main')
     concurrency:
       group: deploy-snyk-projects
       cancel-in-progress: false


### PR DESCRIPTION
## Description

This PR fixes that Snyk is executed on any branch prefixed with `stable/`, since this prefix is reused for feature branches as well, not just actual stable branches.

Otherwise we run it also for things like `stable/8.7-my-cool-bug-fix`, which is pointless.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
