### PR TITLE
Suppress transient elastic errors to WARN level

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -37,7 +37,7 @@ public final class ReschedulingTask implements Runnable {
     this.executor = executor;
     this.logger = logger;
 
-    periodicLogger = new ReschedulingTaskLogger(logger);
+    periodicLogger = new ReschedulingTaskLogger(logger, true);
     idleStrategy = new ExponentialBackoff(maxDelayBetweenRunsMs, delayBetweenRunsMs, 1.2, 0);
     errorStrategy = new ExponentialBackoff(10_000, delayBetweenRunsMs, 1.2, 0);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
@@ -21,6 +21,10 @@ import org.slf4j.event.Level;
  * `ConnectException` it logs them on WARN level.
  */
 public class ReschedulingTaskLogger {
+  private static final Set<String> BACKGROUND_SUPPRESSED_ELASTIC_RESPONSE_EXCEPTION_TYPES =
+      Set.of(
+          "\"type\":\"no_shard_available_action_exception\"",
+          "\"type\":\"node_not_connected_exception\"");
   private static final Integer DEFAULT_SKIP_ENTRIES_COUNT = 10;
   private static final Set<Class<? extends Exception>> BACKGROUND_SUPPRESSED_EXCEPTIONS =
       Set.of(SocketTimeoutException.class, ConnectException.class, SocketException.class);
@@ -74,6 +78,9 @@ public class ReschedulingTaskLogger {
     return suppressErrorMessages
         || BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getClass())
         || (error.getCause() != null
-            && BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass()));
+            && BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass()))
+        || (error.getCause() != null
+            && BACKGROUND_SUPPRESSED_ELASTIC_RESPONSE_EXCEPTION_TYPES.stream()
+                .anyMatch(error.getCause().getMessage()::contains));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
@@ -29,9 +29,15 @@ public class ReschedulingTaskLogger {
   private Integer failureCount = 0;
   private String lastErrorMessage;
   private Object[] lastErrorMessageArgs;
+  private boolean suppressErrorMessages = false;
 
   public ReschedulingTaskLogger(final Logger logger) {
     this.logger = logger;
+  }
+
+  public ReschedulingTaskLogger(final Logger logger, final boolean suppressErrorMessages) {
+    this.logger = logger;
+    this.suppressErrorMessages = suppressErrorMessages;
   }
 
   public ReschedulingTaskLogger(final Integer skipEntriesCount, final Logger logger) {
@@ -53,7 +59,7 @@ public class ReschedulingTaskLogger {
     // every n-th time
     final Level logLevel;
     if (failureCount % skipEntriesCount == 1) {
-      if (shouldBeSupressed(error)) {
+      if (shouldBeSuppressed(error)) {
         logLevel = Level.WARN;
       } else {
         logLevel = Level.ERROR;
@@ -64,8 +70,9 @@ public class ReschedulingTaskLogger {
     logger.atLevel(logLevel).setCause(error).log(errorMessage, args);
   }
 
-  private boolean shouldBeSupressed(final Throwable error) {
-    return BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getClass())
+  private boolean shouldBeSuppressed(final Throwable error) {
+    return suppressErrorMessages
+        || BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getClass())
         || (error.getCause() != null
             && BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass()));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerIT.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.utils;
+
+import static org.awaitility.Awaitility.await;
+
+import co.elastic.clients.json.JsonData;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.tasks.util.ReschedulingTaskLogger;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class ReschedulingTaskLoggerIT {
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @Test
+  void shouldSuppressAllShardsFailedTransientError() {
+    // given
+    final var config = new ExporterConfiguration();
+    config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
+    final var client = new ElasticsearchConnector(config.getConnect()).createAsyncClient();
+
+    // this will result in newly created indices not being assigned to shards, so an all-shards
+    // failed error is thrown for a search request
+    client
+        .cluster()
+        .putSettings(r -> r.persistent("cluster.routing.allocation.enable", JsonData.of("none")));
+
+    client.indices().create(r -> r.index("test_index"));
+
+    await().until(() -> client.indices().exists(r -> r.index("test_index")).get().value());
+
+    // when
+    final var res = client.search(r -> r.index("test_index"), Object.class);
+
+    final var logger = Mockito.spy(LoggerFactory.getLogger(ReschedulingTaskLoggerIT.class));
+    final var reschedulingTaskLogger = new ReschedulingTaskLogger(logger, true);
+
+    final AtomicReference<Throwable> searchErr = new AtomicReference<>();
+    res.exceptionally(
+        ex -> {
+          searchErr.set(ex);
+          return null;
+        });
+
+    reschedulingTaskLogger.logError("", searchErr.get());
+
+    // then
+    Mockito.verify(logger).atLevel(Level.WARN);
+    Mockito.verify(logger, Mockito.times(0)).atLevel(Level.ERROR);
+  }
+}


### PR DESCRIPTION
## Description

There are transiest elastic errors which result in a large amount of error logs, these will naturally resolve themselves so it has been decided to suppress these messages to a WARN from ERROR.

This builds on the suppress warning base in https://github.com/camunda/camunda/pull/31049

## Related issues

closes #29953
