### PR TITLE
test: RaftCorruptedDataTest append less entries to avoid timeouts

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -86,7 +86,7 @@ public class RaftCorruptedDataTest {
     final var node1 = MemberId.from(servers[1].name());
     final var node2 = MemberId.from(servers[2].name());
 
-    raftRule.appendEntries(2000);
+    raftRule.appendEntries(200);
     raftRule.appendEntries(1);
     Awaitility.await("commitIndex is > 0 on all nodes")
         .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
@@ -114,7 +114,7 @@ public class RaftCorruptedDataTest {
     // wait for the two corrupted nodes to form quorum
     Awaitility.await("corrupted nodes form a quorum")
         .until(() -> server0.isLeader() || server1.isLeader());
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 100; i++) {
       //      raftRule.appendEntry();
       Awaitility.await("entry is committed")
           .untilAsserted(() -> assertThatNoException().isThrownBy(() -> raftRule.appendEntry()));


### PR DESCRIPTION
## Description
`RaftCorruptedDataTest` is flaky because sometimes it times out before being able to append ~ 3000 entries in the raft log (with the restarts of some nodes etc).
By reducing the number of entries to 100 + 200 it should happen less often

See this [workflow run](https://github.com/camunda/camunda/actions/runs/14598947976/attempts/1)

## Related issues

relates #30790
