### PR TITLE
test: Add coverage for incident resolution on `"creating"` task listeners

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
@@ -52,6 +52,15 @@ public class TaskListenerIncidentsTest {
   }
 
   @Test
+  public void shouldCreateJobNoRetriesIncidentForCreatingListenerAndContinueAfterResolution() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.creating,
+        UnaryOperator.identity(),
+        ignored -> {},
+        UserTaskIntent.CREATED);
+  }
+
+  @Test
   public void
       shouldCreateJobNoRetriesIncidentForAssigningListenerAndContinueAfterResolutionOnTaskAssignAfterCreation() {
     verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
@@ -219,6 +228,17 @@ public class TaskListenerIncidentsTest {
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETE_TASK_LISTENER),
             tuple(ValueType.USER_TASK, terminalActionIntent));
     return processInstanceKey;
+  }
+
+  @Test
+  public void shouldRetryUserTaskCreateCommandAfterExtractValueErrorIncidentResolution() {
+    testUserTaskCommandRetryAfterExtractValueError(
+        ZeebeTaskListenerEventType.creating,
+        "creating_listener_var_name",
+        "expression_creating_listener_2",
+        ignored -> {},
+        UserTaskIntent.CREATED,
+        userTask -> Assertions.assertThat(userTask).hasAction(""));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds tests to verify that incidents raised on `"creating"` task listener jobs can be successfully resolved.

No implementation changes were required, as the existing logic for retrying failed listener commands already handles this scenario. This PR adds only the necessary test coverage to confirm that behavior works as expected.

Test coverage includes:
- Resolving `TASK_LISTENER_NO_RETRIES` incidents by updating retries and continuing with the remaining listeners.  
- Resolving `EXTRACT_VALUE_ERROR` incidents by providing missing variables and retrying all listeners of the failed type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29123
