### PR TITLE
31061 implement call hierarchy logic for rdbms

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -61,6 +61,7 @@
       <column name="ELEMENT_ID" type="VARCHAR(255)"/>
       <column name="VERSION" type="SMALLINT" />
       <column name="PARTITION_ID" type="NUMBER"/>
+      <column name="TREE_PATH" type="VARCHAR(4000)" />
       <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -26,6 +26,7 @@ public record ProcessInstanceDbModel(
     String elementId,
     int version,
     int partitionId,
+    String treePath,
     OffsetDateTime historyCleanupDate)
     implements DbModel<ProcessInstanceDbModel> {
 
@@ -69,6 +70,7 @@ public record ProcessInstanceDbModel(
     private int numIncidents = 0;
     private int version;
     private int partitionId;
+    private String treePath;
     private OffsetDateTime historyCleanupDate;
 
     // Public constructor to initialize the builder
@@ -146,6 +148,11 @@ public record ProcessInstanceDbModel(
       return this;
     }
 
+    public ProcessInstanceDbModelBuilder treePath(final String treePath) {
+      this.treePath = treePath;
+      return this;
+    }
+
     public ProcessInstanceDbModelBuilder historyCleanupDate(final OffsetDateTime value) {
       historyCleanupDate = value;
       return this;
@@ -167,6 +174,7 @@ public record ProcessInstanceDbModel(
           elementId,
           version,
           partitionId,
+          treePath,
           historyCleanupDate);
     }
   }

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -62,6 +62,7 @@
     pi.PARENT_ELEMENT_INSTANCE_KEY,
     pi.ELEMENT_ID,
     pi.VERSION PROCESS_DEFINITION_VERSION,
+    pi.TREE_PATH,
     pd.NAME AS PROCESS_DEFINITION_NAME,
     pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM ${prefix}PROCESS_INSTANCE pi
@@ -261,6 +262,7 @@
       <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"/>
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="TREE_PATH" javaType="java.lang.String"/>
     </constructor>
 
   </resultMap>
@@ -294,9 +296,9 @@
     parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel"
     flushCache="true">
     INSERT INTO ${prefix}PROCESS_INSTANCE (PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, STATE, START_DATE, END_DATE, TENANT_ID, PARENT_PROCESS_INSTANCE_KEY, PARENT_ELEMENT_INSTANCE_KEY,
-                                           NUM_INCIDENTS, VERSION, PARTITION_ID, HISTORY_CLEANUP_DATE)
+                                           NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH, HISTORY_CLEANUP_DATE)
     VALUES (#{processInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state}, #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId}, #{parentProcessInstanceKey},
-            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
+            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath}, #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
   <update
@@ -314,6 +316,7 @@
         PARENT_ELEMENT_INSTANCE_KEY = #{parentElementInstanceKey},
         NUM_INCIDENTS               = #{numIncidents},
         VERSION                     = #{version},
+        TREE_PATH                   = #{treePath},
         HISTORY_CLEANUP_DATE        = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -30,7 +30,8 @@ public class ProcessInstanceEntityTransformer
         source.getEndDate(),
         toState(source.getState()),
         source.isIncident(),
-        source.getTenantId());
+        source.getTenantId(),
+        source.getTreePath());
   }
 
   private ProcessInstanceState toState(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -24,7 +24,8 @@ public record ProcessInstanceEntity(
     OffsetDateTime endDate,
     ProcessInstanceState state,
     Boolean hasIncident,
-    String tenantId) {
+    String tenantId,
+    String treePath) {
 
   public enum ProcessInstanceState {
     ACTIVE,

--- a/service/src/main/java/io/camunda/service/util/TreePathParser.java
+++ b/service/src/main/java/io/camunda/service/util/TreePathParser.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class TreePathParser {
+
+  private TreePathParser() {}
+
+  public static List<String> extractProcessInstanceKeys(final String treePath) {
+    final List<String> processInstanceIds = new ArrayList<>();
+    final Pattern piPattern = Pattern.compile("PI_(\\d*)$");
+    Arrays.stream(treePath.split("/"))
+        .map(piPattern::matcher)
+        .filter(Matcher::matches)
+        .forEach(matcher -> processInstanceIds.add(matcher.group(1)));
+
+    return processInstanceIds;
+  }
+}

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -175,6 +175,70 @@ public final class ProcessInstanceServiceTest {
         .containsExactly(Operation.eq(ProcessInstanceState.ACTIVE.name()));
   }
 
+  @Test
+  public void shouldReturnOrderedProcessHierarchy() {
+    // given
+    final var childProcess = mock(ProcessInstanceEntity.class);
+    when(childProcess.processInstanceKey()).thenReturn(789L);
+    when(childProcess.treePath()).thenReturn("PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654");
+    when(childProcess.processDefinitionId()).thenReturn("child_process_id");
+    authorizeProcessReadInstance(true, "child_process_id");
+
+    final var parentProcess = mock(ProcessInstanceEntity.class);
+    when(parentProcess.processInstanceKey()).thenReturn(123L);
+    when(parentProcess.processDefinitionId()).thenReturn("parent_process_id");
+    authorizeProcessReadInstance(true, "parent_process_id");
+
+    when(client.searchProcessInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(childProcess, parentProcess), null, null));
+
+    // when
+    final var result = services.callHierarchy(childProcess.processInstanceKey());
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).processInstanceKey()).isEqualTo(123L); // Parent comes first
+    assertThat(result.get(1).processInstanceKey()).isEqualTo(789L); // Child comes next
+  }
+
+  @Test
+  public void shouldReturnEmptyListForBlankTreePath() {
+    // given
+    final var rootInstance = mock(ProcessInstanceEntity.class);
+    when(rootInstance.processInstanceKey()).thenReturn(123L);
+    when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
+    authorizeProcessReadInstance(true, "root_process_id");
+    when(rootInstance.treePath()).thenReturn(null); // No treePath
+
+    when(client.searchProcessInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
+
+    // when
+    final var result = services.callHierarchy(123L);
+
+    // then
+    assertThat(result).isEmpty(); // No hierarchy should return an empty list
+  }
+
+  @Test
+  public void shouldReturnEmptyListForRootTreePath() {
+    // given
+    final var rootInstance = mock(ProcessInstanceEntity.class);
+    when(rootInstance.processInstanceKey()).thenReturn(123L);
+    when(rootInstance.processDefinitionId()).thenReturn("root_process_id");
+    authorizeProcessReadInstance(true, "root_process_id");
+    when(rootInstance.treePath()).thenReturn("PI_123"); // Root treePath
+
+    when(client.searchProcessInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
+
+    // when
+    final var result = services.callHierarchy(123L);
+
+    // then
+    assertThat(result).isEmpty(); // No hierarchy should return an empty list
+  }
+
   private void authorizeProcessReadInstance(final boolean authorize, final String processId) {
     when(securityContextProvider.isAuthorized(
             processId,

--- a/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
+++ b/service/src/test/java/io/camunda/service/util/TreePathParserTest.java
@@ -1,0 +1,57 @@
+package io.camunda.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TreePathParserTest {
+
+  @Test
+  void shouldExtractProcessInstanceKeysFromValidTreePath() {
+    // given
+    final String treePath = "PI_1/FN_1/FNI_1/PI_2/FN_3/FNI_3";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).containsExactly("1", "2"); // Extracts all process instance keys in order
+  }
+
+  @Test
+  void shouldReturnEmptyListForTreePathWithoutProcessInstances() {
+    // given
+    final String treePath = "FN_1/FNI_1/FN_3/FNI_3";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).isEmpty(); // No PI_x patterns present
+  }
+
+  @Test
+  void shouldHandleTreePathWithSingleProcessInstance() {
+    // given
+    final String treePath = "PI_123";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).containsExactly("123"); // Only one process instance key
+  }
+
+  @Test
+  void shouldReturnEmptyListForEmptyTreePath() {
+    // given
+    final String treePath = "";
+
+    // when
+    final List<String> result = TreePathParser.extractProcessInstanceKeys(treePath);
+
+    // then
+    assertThat(result).isEmpty(); // No valid content in a tree path
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/CachedProcessEntity.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/CachedProcessEntity.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import java.util.List;
+
+public record CachedProcessEntity(String name, String versionTag, List<String> callElementIds) {}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/ExporterEntityCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.Optional;
+
+public class ExporterEntityCache<K, T> {
+
+  private static final int DEFAULT_MAX_CACHE_SIZE = 10000;
+  private final LoadingCache<K, T> cache;
+
+  public ExporterEntityCache(final CacheLoader<K, T> loader) {
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(DEFAULT_MAX_CACHE_SIZE)
+            .build(
+                k -> {
+                  try {
+                    return loader.load(k);
+                  } catch (final Exception e) {
+                    throw new CacheLoaderFailedException(e);
+                  }
+                });
+  }
+
+  public Optional<T> get(final K entityKey) {
+    return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  public void put(final K entityKey, final T entity) {
+    cache.put(entityKey, entity);
+  }
+
+  public void remove(final K entityKey) {
+    cache.invalidate(entityKey);
+  }
+
+  public void clear() {
+    cache.invalidateAll();
+  }
+
+  static class CacheLoaderFailedException extends RuntimeException {
+    public CacheLoaderFailedException(final Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsProcessCacheLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
+import io.camunda.exporter.rdbms.utils.ProcessCacheUtil;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RdbmsProcessCacheLoader implements CacheLoader<Long, CachedProcessEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RdbmsProcessCacheLoader.class);
+  private final ProcessDefinitionReader reader;
+
+  public RdbmsProcessCacheLoader(final ProcessDefinitionReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public CachedProcessEntity load(final @NotNull Long key) throws Exception {
+    final var response = reader.findOne(key);
+    if (response.isPresent()) {
+      final var processDefinitionEntity = response.get();
+      return new CachedProcessEntity(
+          processDefinitionEntity.name(),
+          processDefinitionEntity.versionTag(),
+          ProcessCacheUtil.extractCallActivityIdsFromDiagram(processDefinitionEntity));
+    }
+    LOG.debug("Process '{}' not found in RDBMS", key);
+    return null;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -12,6 +12,10 @@ import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDb
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.exporter.rdbms.cache.CachedProcessEntity;
+import io.camunda.exporter.rdbms.cache.ExporterEntityCache;
+import io.camunda.exporter.rdbms.utils.ProcessCacheUtil;
+import io.camunda.exporter.rdbms.utils.TreePath;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,18 +24,26 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.util.DateUtil;
 import java.time.OffsetDateTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceExportHandler
     implements RdbmsExportHandler<ProcessInstanceRecordValue> {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceExportHandler.class);
+
   private final ProcessInstanceWriter processInstanceWriter;
   private final HistoryCleanupService historyCleanupService;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
 
   public ProcessInstanceExportHandler(
       final ProcessInstanceWriter processInstanceWriter,
-      final HistoryCleanupService historyCleanupService) {
+      final HistoryCleanupService historyCleanupService,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
     this.processInstanceWriter = processInstanceWriter;
     this.historyCleanupService = historyCleanupService;
+    this.processCache = processCache;
   }
 
   @Override
@@ -75,6 +87,46 @@ public class ProcessInstanceExportHandler
         .parentElementInstanceKey(value.getParentElementInstanceKey())
         .version(value.getVersion())
         .partitionId(record.getPartitionId())
+        .treePath(createTreePath(record).toString())
         .build();
+  }
+
+  public TreePath createTreePath(final Record<ProcessInstanceRecordValue> record) {
+    final var value = record.getValue();
+    final var elementInstancePath = value.getElementInstancePath();
+    final var processDefinitionPath = value.getProcessDefinitionPath();
+    final var callingElementPath = value.getCallingElementPath();
+    final Long processInstanceKey = value.getProcessInstanceKey();
+    if (elementInstancePath == null || elementInstancePath.isEmpty()) {
+      return new TreePath().startTreePath(processInstanceKey);
+    }
+
+    final TreePath treePath = new TreePath();
+    for (int i = 0; i < elementInstancePath.size(); i++) {
+      final List<Long> keysWithinOnePI = elementInstancePath.get(i);
+      treePath.appendProcessInstance(keysWithinOnePI.getFirst());
+      if (keysWithinOnePI.getFirst().equals(processInstanceKey)) {
+        // we reached the leaf of the tree path, when we reached current processInstanceKey
+        break;
+      }
+      final var callActivity =
+          ProcessCacheUtil.getCallActivityId(
+              processCache, processDefinitionPath.get(i), callingElementPath.get(i));
+      if (callActivity.isPresent()) {
+        treePath.appendFlowNode(callActivity.get());
+      } else {
+        final var index = callingElementPath.get(i);
+        LOGGER.warn(
+            "Expected to find process in cache. TreePath won't contain proper callActivityId, will use the lexicographic index instead {}. [processInstanceKey: {}, processDefinitionKey: {}, incidentKey: {}]",
+            processInstanceKey,
+            processDefinitionPath.get(i),
+            record.getKey(),
+            index);
+
+        treePath.appendFlowNode(String.valueOf(callingElementPath.get(i)));
+      }
+      treePath.appendFlowNodeInstance(String.valueOf(keysWithinOnePI.getLast()));
+    }
+    return treePath;
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ProcessCacheUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.utils;
+
+import io.camunda.exporter.rdbms.cache.CachedProcessEntity;
+import io.camunda.exporter.rdbms.cache.ExporterEntityCache;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.util.modelreader.ProcessModelReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class ProcessCacheUtil {
+
+  public static List<String> extractCallActivityIdsFromDiagram(
+      final ProcessDefinitionEntity entity) {
+    final String bpmnXml = entity.bpmnXml();
+    return ProcessModelReader.of(
+            bpmnXml.getBytes(StandardCharsets.UTF_8), entity.processDefinitionId())
+        .map(reader -> sortedCallActivityIds(reader.extractCallActivities()))
+        .orElseGet(ArrayList::new);
+  }
+
+  public static List<String> sortedCallActivityIds(final Collection<CallActivity> callActivities) {
+    return callActivities.stream().map(BaseElement::getId).sorted().toList();
+  }
+
+  public static Optional<String> getCallActivityId(
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final Long processDefinitionKey,
+      final Integer callActivityIndex) {
+
+    if (processDefinitionKey == null) {
+      return Optional.empty();
+    }
+    final var cachedProcess = processCache.get(processDefinitionKey);
+    if (cachedProcess.isEmpty()
+        || cachedProcess.get().callElementIds() == null
+        || callActivityIndex == null) {
+      return Optional.empty();
+    }
+    return Optional.of(cachedProcess.get().callElementIds().get(callActivityIndex));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/TreePath.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/TreePath.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.utils;
+
+/**
+ * Class represents call tree path to store sequence of calls in case of call activities.
+ *
+ * <p>PI = Process instance, FN = Flow node, FNI = Flow node instance.
+ *
+ * <p>If we have a process with call activity, then tree path for child process instance will be
+ * build as
+ * PI_<parent_process_instance_id>/FN_<call_activity_id>/FNI_<parent_flow_node_instance_id_of_call_activity_type>/PI_<child_process_instance_id>,
+ * for the incident in child instance we will have tree path as
+ * PI_<parent_process_instance_id>/FN_<call_activity_id>/FNI_<parent_flow_node_instance_id_of_call_activity_type>/PI_<child_process_instance_id>/FN_<flow_node_id>/FNI<flow_node_instance_id_where_incident_happenned>.
+ */
+public class TreePath {
+
+  private StringBuffer treePath;
+
+  public TreePath() {
+    treePath = new StringBuffer();
+  }
+
+  public TreePath startTreePath(final String processInstanceId) {
+    treePath = new StringBuffer(String.format("%s_%s", TreePathEntryType.PI, processInstanceId));
+    return this;
+  }
+
+  public TreePath startTreePath(final long processInstanceKey) {
+    return startTreePath(String.valueOf(processInstanceKey));
+  }
+
+  public void appendFlowNode(final String newEntry) {
+    if (newEntry != null) {
+      treePath.append(String.format("/%s_%s", TreePathEntryType.FN, newEntry));
+    }
+  }
+
+  public void appendFlowNodeInstance(final String newEntry) {
+    if (newEntry != null) {
+      treePath.append(String.format("/%s_%s", TreePathEntryType.FNI, newEntry));
+    }
+  }
+
+  public void appendProcessInstance(final String newEntry) {
+    if (newEntry != null) {
+      if (treePath == null || treePath.isEmpty()) {
+        startTreePath(newEntry);
+      } else {
+        treePath.append(String.format("/%s_%s", TreePathEntryType.PI, newEntry));
+      }
+    }
+  }
+
+  public void appendProcessInstance(final long newEntry) {
+    appendProcessInstance(String.valueOf(newEntry));
+  }
+
+  public boolean isEmpty() {
+    return treePath == null || treePath.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return treePath.toString();
+  }
+
+  public enum TreePathEntryType {
+    /** Process instance. */
+    PI,
+    /** Flow node instance. */
+    FNI,
+    /** Flow node. */
+    FN
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1727,6 +1727,44 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /process-instances/{processInstanceKey}/call-hierarchy:
+    get:
+      tags:
+        - Process instance
+      operationId: getProcessInstanceCallHierarchy
+      summary: Get call hierarchy for process instance
+      description: |
+        Returns the call hierarchy for a given process instance, showing its ancestry up to the root instance.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The key of the process instance to fetch the hierarchy for.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The call hierarchy is successfully returned.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProcessInstanceCallHierarchyEntry"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The process instance is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /element-instances/search:
     post:
@@ -5113,6 +5151,22 @@ components:
         - ACTIVE
         - COMPLETED
         - TERMINATED
+    ProcessInstanceCallHierarchyEntry:
+      type: object
+      required:
+        - processInstanceKey
+        - processDefinitionKey
+        - processDefinitionName
+      properties:
+        processInstanceKey:
+          type: string
+          description: The key of the process instance.
+        processDefinitionKey:
+          type: string
+          description: The key of the process definition.
+        processDefinitionName:
+          type: string
+          description: The name of the process definition (fallbacks to process definition ID if not available).
     ProcessDefinitionElementStatisticsQuery:
       description: Process definition element statistics request.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -74,6 +74,8 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessElementStatisticsResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceElementStatisticsQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessFlowNodeStatisticsResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCallHierarchyEntry;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateEnum;
@@ -757,6 +759,24 @@ public final class SearchQueryResponseMapper {
       return ProcessInstanceStateEnum.TERMINATED;
     }
     return ProcessInstanceStateEnum.fromValue(value.name());
+  }
+
+  public static List<ProcessInstanceCallHierarchyEntry> toProcessInstanceCallHierarchyEntries(
+      final List<ProcessInstanceEntity> processInstanceEntities) {
+    return processInstanceEntities.stream()
+        .map(SearchQueryResponseMapper::toProcessInstanceCallHierarchyEntry)
+        .toList();
+  }
+
+  public static ProcessInstanceCallHierarchyEntry toProcessInstanceCallHierarchyEntry(
+      final ProcessInstanceEntity processInstanceEntity) {
+    return new ProcessInstanceCallHierarchyEntry()
+        .processInstanceKey(KeyUtil.keyToString(processInstanceEntity.processInstanceKey()))
+        .processDefinitionKey(KeyUtil.keyToString(processInstanceEntity.processDefinitionKey()))
+        .processDefinitionName(
+            processInstanceEntity.processDefinitionName().isBlank()
+                ? processInstanceEntity.processDefinitionId()
+                : processInstanceEntity.processDefinitionName());
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -104,6 +104,21 @@ public class ProcessInstanceController {
       return mapErrorToResponse(e);
     }
   }
+  @CamundaGetMapping(path = "/{processInstanceKey}/call-hierarchy")
+  public ResponseEntity<Object> getCallHierarchy(
+      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+    try {
+      return ResponseEntity.ok()
+          .body(
+              SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntries(
+                  processInstanceServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .callHierarchy(processInstanceKey)));
+
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
 
   @CamundaGetMapping(path = "/{processInstanceKey}/statistics/element-instances")
   public ResponseEntity<Object> elementStatistics(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -49,6 +49,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   private static final String PROCESS_INSTANCES_BY_KEY_URL =
       "/v2/process-instances/{processInstanceKey}";
 
+  private static final String PROCESS_INSTANCE_CALL_HIERARCHY_BY_KEY_URL =
+      "/v2/process-instances/{processInstanceKey}/call-hierarchy";
+
   private static final ProcessInstanceEntity PROCESS_INSTANCE_ENTITY =
       new ProcessInstanceEntity(
           123L,
@@ -63,7 +66,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           null,
           ProcessInstanceState.ACTIVE,
           false,
-          "tenant");
+          "tenant",
+          "PI_123");
 
   private static final String PROCESS_INSTANCE_ENTITY_JSON =
       """
@@ -111,6 +115,17 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               }
           }
           """;
+
+  private static final String EXPECTED_CALL_HIERARCHY =
+      """
+        [
+          {
+             "processInstanceKey": "123",
+             "processDefinitionKey": "789",
+             "processDefinitionName": "Demo Process"
+          }
+        ]
+      """;
 
   private static final SearchQueryResult<ProcessInstanceEntity> SEARCH_QUERY_RESULT =
       new Builder<ProcessInstanceEntity>()
@@ -628,5 +643,28 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
     verify(processInstanceServices)
         .search(new ProcessInstanceQuery.Builder().filter(expectedFilter.build()).build());
+  }
+
+  @Test
+  public void shouldReturnCallHierarchyForGivenKey() {
+    // given
+    final var processInstanceKey = 123L;
+
+    when(processInstanceServices.callHierarchy(processInstanceKey))
+        .thenReturn(List.of(PROCESS_INSTANCE_ENTITY));
+
+    // when / then
+    webClient
+        .get()
+        .uri(PROCESS_INSTANCE_CALL_HIERARCHY_BY_KEY_URL, processInstanceKey)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(EXPECTED_CALL_HIERARCHY);
+
+    // Verify that the service was called with the valid key
+    verify(processInstanceServices).callHierarchy(processInstanceKey);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR implements [issue #31061](https://github.com/camunda/camunda/issues/31061), adding support for generating and persisting the process instance call hierarchy (treePath) in the RDBMS exporter backend.

### 🔁 Note on Code Duplication
This implementation mirrors the Elasticsearch/OpenSearch version of the call hierarchy logic, adapted for the RDBMS backend. In order to get this working end-to-end, several key classes and methods were manually copied into the RDBMS-specific module.

These include:
- CachedProcessEntity.java
- ExporterEntityCache.java (interface)
- ProcessCacheUtil.java
- createTreePath(...) logic from ProcessInstanceExporterHandler

While this duplication is not ideal, it was the most pragmatic way to complete the feature in a self-contained way within the current milestone timeline.

As discussed in [issue #31218](https://github.com/camunda/camunda/issues/31218), we plan to consolidate this logic into a shared module (e.g., camunda-domain-common) that can be reused across exporters and other consumers. This refactoring will eliminate duplication and improve long-term maintainability.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31061
