### PR TITLE
feat: add processInstanceKey to chunk record #31235

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,7 +28,7 @@
       </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
-          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="" withSubpackages="true" static="false" />
           <package name="" withSubpackages="true" static="true" />
           <emptyLine />
           <package name="" withSubpackages="true" static="false" />

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
@@ -25,7 +25,9 @@ public interface BatchOperationItems {
   interface BatchOperationItem {
     Long getBatchOperationKey();
 
-    Long getKey();
+    Long getItemKey();
+
+    Long getProcessInstanceKey();
 
     BatchOperationItemState getStatus();
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
@@ -43,14 +43,14 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
   public static class BatchOperationItemImpl implements BatchOperationItem {
 
     private final Long batchOperationKey;
-
     private final Long itemKey;
-
+    private final Long processInstanceKey;
     private final BatchOperationItemState status;
 
     public BatchOperationItemImpl(final BatchOperationItemResponse item) {
       batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
       itemKey = ParseUtil.parseLongOrNull(item.getItemKey());
+      processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
       status = EnumUtil.convert(item.getState(), BatchOperationItemState.class);
     }
 
@@ -60,8 +60,13 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     }
 
     @Override
-    public Long getKey() {
+    public Long getItemKey() {
       return itemKey;
+    }
+
+    @Override
+    public Long getProcessInstanceKey() {
+      return processInstanceKey;
     }
 
     @Override

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -498,6 +498,7 @@
         />
       </column>
       <column name="ITEM_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="STATE" type="VARCHAR(20)" defaultValue="ACTIVE"/>
     </createTable>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -9,12 +9,12 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Set;
 
 public interface BatchOperationMapper {
 
@@ -45,7 +45,7 @@ public interface BatchOperationMapper {
 
   record BatchOperationUpdateCountsDto(long batchOperationKey, long itemKey) {}
 
-  record BatchOperationItemsDto(Long batchOperationKey, Set<Long> items) {}
+  record BatchOperationItemsDto(Long batchOperationKey, List<BatchOperationItemDbModel> items) {}
 
   record BatchOperationItemDto(
       Long batchOperationKey, Long itemKey, BatchOperationEntity.BatchOperationItemState state) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.search.entities.BatchOperationEntity;
+
+public record BatchOperationItemDbModel(
+    long itemKey, long processInstanceKey, BatchOperationEntity.BatchOperationItemState state) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateCountsDt
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateDto;
 import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateTotalCountDto;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
@@ -22,7 +23,7 @@ import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
-import java.util.Set;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,8 @@ public class BatchOperationWriter {
     executionQueue.flush();
   }
 
-  public void updateBatchAndInsertItems(final long batchOperationKey, final Set<Long> items) {
+  public void updateBatchAndInsertItems(
+      final long batchOperationKey, final List<BatchOperationItemDbModel> items) {
     if (items != null && !items.isEmpty()) {
       executionQueue.executeInQueue(
           new QueueItem(

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -25,6 +25,7 @@
     <constructor>
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemState"/>
     </constructor>
@@ -51,10 +52,10 @@
 
   <insert id="insertItems"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto">
-    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY)
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY)
     VALUES
-    <foreach collection="items" item="itemKey" separator=",">
-      (#{batchOperationKey}, #{itemKey})
+    <foreach collection="items" item="item" separator=",">
+      (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey})
     </foreach>
   </insert>
 
@@ -116,7 +117,7 @@
   <select id="getItems"
     parameterType="java.lang.Long"
     resultMap="BatchOperationItemResultMap">
-    SELECT BATCH_OPERATION_KEY, ITEM_KEY, STATE
+    SELECT BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE
     FROM ${prefix}BATCH_OPERATION_ITEM
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
   </select>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
@@ -138,7 +138,7 @@ public class BatchOperationCancelProcessInstanceTest {
     // and
     final var itemsObj =
         camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
-    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getKey).toList();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
 
     assertThat(itemsObj.items()).hasSize(3);
     assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationModifyProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationModifyProcessInstanceTest.java
@@ -234,7 +234,7 @@ public class BatchOperationModifyProcessInstanceTest {
     final var filteredItems =
         itemsObj.items().stream().filter(i -> i.getStatus() == state).toList();
     assertThat(filteredItems).hasSize(failedItemKeys.size());
-    assertThat(filteredItems.stream().map(BatchOperationItem::getKey))
+    assertThat(filteredItems.stream().map(BatchOperationItem::getItemKey))
         .hasSize(failedItemKeys.size());
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
@@ -127,7 +127,7 @@ public class BatchOperationResolveIncidentTest {
     // and
     final var itemsObj =
         camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
-    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getKey).toList();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
 
     assertThat(itemsObj.items()).hasSize(3);
     assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -13,6 +13,8 @@ import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -54,12 +56,12 @@ public final class BatchOperationFixtures {
 
   public static List<Long> createAndSaveRandomBatchOperationItems(
       final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final int count) {
-    final Set<Long> items =
+    final Set<Long> itemKeys =
         IntStream.range(0, count)
             .mapToObj(i -> CommonFixtures.nextKey())
             .collect(Collectors.toSet());
-    insertBatchOperationsItems(rdbmsWriter, batchOperationKey, items);
-    return items.stream().toList();
+    insertBatchOperationsItems(rdbmsWriter, batchOperationKey, itemKeys);
+    return itemKeys.stream().toList();
   }
 
   public static BatchOperationDbModel createAndSaveBatchOperation(
@@ -79,7 +81,16 @@ public final class BatchOperationFixtures {
 
   public static void insertBatchOperationsItems(
       final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final Set<Long> items) {
-    rdbmsWriter.getBatchOperationWriter().updateBatchAndInsertItems(batchOperationKey, items);
+    rdbmsWriter
+        .getBatchOperationWriter()
+        .updateBatchAndInsertItems(
+            batchOperationKey,
+            items.stream()
+                .map(
+                    itemKey ->
+                        new BatchOperationItemDbModel(
+                            itemKey, itemKey, BatchOperationItemState.ACTIVE))
+                .toList());
     rdbmsWriter.flush();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationExecutionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
@@ -457,7 +458,20 @@ public class RecordFixtures {
             ImmutableBatchOperationChunkRecordValue.builder()
                 .from((ImmutableBatchOperationChunkRecordValue) recordValueRecord.getValue())
                 .withBatchOperationKey(batchOperationKey)
-                .withItemKeys(List.of(1L, 2L, 3L))
+                .withItems(
+                    List.of(
+                        ImmutableBatchOperationItemValue.builder()
+                            .withItemKey(1L)
+                            .withProcessInstanceKey(1L)
+                            .build(),
+                        ImmutableBatchOperationItemValue.builder()
+                            .withItemKey(2L)
+                            .withProcessInstanceKey(2L)
+                            .build(),
+                        ImmutableBatchOperationItemValue.builder()
+                            .withItemKey(3L)
+                            .withProcessInstanceKey(3L)
+                            .build()))
                 .build())
         .build();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -22,7 +22,10 @@ public record BatchOperationEntity(
     Integer operationsCompletedCount) {
 
   public record BatchOperationItemEntity(
-      Long batchOperationKey, Long itemKey, BatchOperationItemState state) {}
+      Long batchOperationKey,
+      Long itemKey,
+      Long processInstanceKey,
+      BatchOperationItemState state) {}
 
   public enum BatchOperationState {
     CREATED,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -9,15 +9,12 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import com.google.common.collect.Lists;
 import io.camunda.search.clients.SearchClientsProxy;
-import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPageBuilders;
 import io.camunda.search.query.SearchQueryBuilders;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -27,15 +24,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class provides methods to fetch entity keys for batch operations. It uses the search client
+ * This class provides methods to fetch entities for batch operations. It uses the search client
  * proxy to access the secondary database.
  */
-public class BatchOperationItemKeyProvider {
+public class BatchOperationItemProvider {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationItemKeyProvider.class);
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationItemProvider.class);
 
   /**
-   * The size of a page when fetching entity keys. This is the maximum number of keys that can be
+   * The size of a page when fetching entities. This is the maximum number of items that can be
    * fetched in a single query and is limited by ElasticSearch.
    */
   private static final int PAGE_SIZE = 10000;
@@ -48,62 +45,65 @@ public class BatchOperationItemKeyProvider {
 
   private final SearchClientsProxy searchClientsProxy;
 
-  public BatchOperationItemKeyProvider(final SearchClientsProxy searchClientsProxy) {
+  public BatchOperationItemProvider(final SearchClientsProxy searchClientsProxy) {
     this.searchClientsProxy = searchClientsProxy;
   }
 
   /**
-   * Fetches the process instance keys based on the provided filter. The keys are fetched
+   * Fetches the process instance items based on the provided filter. The items are fetched
    * sequentially in pages. Depending on the overall size of the result this can cause multiple
    * queries to the secondary database.
    *
    * @param filter the filter to use
    * @param shouldAbort if the process should be aborted
-   * @return a set of all found process instance keys
+   * @return a set of all found process instance items
    */
-  public Set<Long> fetchProcessInstanceKeys(
+  public Set<Item> fetchProcessInstanceItems(
       final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
-    return fetchEntityKeys(new ProcessInstanceKeyPageFetcher(), filter, shouldAbort);
+    return fetchEntityItems(new ProcessInstancePageFetcher(), filter, shouldAbort);
   }
 
   /**
-   * Fetches the incident keys based on the provided incident filter. The keys are fetched
+   * Fetches the incident items based on the provided incident filter. The items are fetched
    * sequentially in pages. Depending on the overall size of the result this can cause multiple
    * queries to the secondary database.
    *
    * @param filter the filter to use
    * @param shouldAbort if the process should be aborted
-   * @return a set of all found process instance keys
+   * @return a set of all found process instance items
    */
-  public Set<Long> fetchIncidentKeys(
+  public Set<Item> fetchIncidentItems(
       final IncidentFilter filter, final Supplier<Boolean> shouldAbort) {
-    return fetchEntityKeys(new IncidentKeyPageFetcher(), filter, shouldAbort);
+    return fetchEntityItems(new IncidentPageFetcher(), filter, shouldAbort);
   }
 
   /**
-   * Fetches the incident keys based on the provided process instance filter. This will return
-   * <b>ALL</b> incidents of the matching processInstances. The keys are fetched sequentially in
+   * Fetches the incident items based on the provided process instance filter. This will return
+   * <b>ALL</b> incidents of the matching processInstances. The items are fetched sequentially in
    * pages. Depending on the overall size of the result this can cause multiple queries to the
    * secondary database.
    *
    * @param filter the filter to use
    * @param shouldAbort if the process should be aborted
-   * @return a set of all found process instance keys
+   * @return a set of all found incident items
    */
-  public Set<Long> fetchIncidentKeys(
+  public Set<Item> fetchIncidentItems(
       final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
     // first fetch all matching processInstances
-    final var processInstanceKeys = fetchProcessInstanceKeys(filter, shouldAbort);
+    final var processInstanceKeys =
+        fetchProcessInstanceItems(filter, shouldAbort).stream()
+            .map(Item::processInstanceKey)
+            .toList();
 
     // then fetch all incidents of the matching processInstances
-    return getIncidentKeysOfProcessInstanceKeys(new ArrayList<>(processInstanceKeys), shouldAbort);
+    return getIncidentItemsOfProcessInstanceKeys(new ArrayList<>(processInstanceKeys), shouldAbort);
   }
 
-  private <F extends FilterBase> Set<Long> fetchEntityKeys(
-      final ItemKeyPageFetcher<F> itemKeyPageFetcher,
+  private <F extends FilterBase> Set<Item> fetchEntityItems(
+      final ItemPageFetcher<F> itemPageFetcher,
       final F filter,
       final Supplier<Boolean> shouldAbort) {
-    final var itemKeys = new LinkedHashSet<Long>();
+    final var items = new LinkedHashSet<Item>();
 
     Object[] searchValues = null;
     while (true) {
@@ -113,21 +113,21 @@ public class BatchOperationItemKeyProvider {
         return Set.of();
       }
 
-      final var result = itemKeyPageFetcher.fetchKeys(filter, searchValues);
-      itemKeys.addAll(result.keys);
+      final var result = itemPageFetcher.fetchItems(filter, searchValues);
+      items.addAll(result.items);
       searchValues = result.lastSortValues();
 
-      if (itemKeys.size() >= result.total() || result.keys.isEmpty()) {
+      if (items.size() >= result.total() || result.items.isEmpty()) {
         break;
       }
     }
 
-    return itemKeys;
+    return items;
   }
 
-  private Set<Long> getIncidentKeysOfProcessInstanceKeys(
+  private Set<Item> getIncidentItemsOfProcessInstanceKeys(
       final List<Long> processInstanceKeys, final Supplier<Boolean> shouldAbort) {
-    final Set<Long> incidentKeys = new HashSet<>();
+    final Set<Item> incidents = new LinkedHashSet<>();
 
     final List<List<Long>> processInstanceKeysBatches =
         Lists.partition(processInstanceKeys, IN_CLAUSE_SIZE);
@@ -138,44 +138,45 @@ public class BatchOperationItemKeyProvider {
       }
       final var filter =
           new IncidentFilter.Builder().processInstanceKeys(processInstanceKeysBatch).build();
-      incidentKeys.addAll(fetchIncidentKeys(filter, shouldAbort));
+      incidents.addAll(fetchIncidentItems(filter, shouldAbort));
     }
 
-    return incidentKeys;
+    return incidents;
   }
 
-  /**
-   * Internal abstraction to hold the result of a page of entity keys.
-   *
-   * @param keys the fetched keys
-   * @param lastSortValues the last sortValues for pagination
-   * @param total the total amount of found keys
-   */
-  private record ItemKeyPage(List<Long> keys, Object[] lastSortValues, long total) {}
+  public record Item(long itemKey, long processInstanceKey) {}
 
   /**
-   * Internal abstraction interface to get a single page of entity keys of a specific type. This is
+   * Internal abstraction to hold the result of a page of entity items.
+   *
+   * @param items the fetched items
+   * @param lastSortValues the last sortValues for pagination
+   * @param total the total amount of found items
+   */
+  private record ItemPage(List<Item> items, Object[] lastSortValues, long total) {}
+
+  /**
+   * Internal abstraction interface to get a single page of entity items of a specific type. This is
    * needed because the actual query to the secondary database is different for specific entity
    * types.
    *
    * @param <F> the filter type
    */
-  private interface ItemKeyPageFetcher<F extends FilterBase> {
+  private interface ItemPageFetcher<F extends FilterBase> {
 
     /**
-     * Fetches a page of entity keys based on the provided filter and search values.
+     * Fetches a page of entity items based on the provided filter and search values.
      *
      * @param filter the filter to apply
      * @param sortValues the current sortValues
-     * @return the fetched keys and pagination information
+     * @return the fetched items and pagination information
      */
-    ItemKeyPage fetchKeys(F filter, Object[] sortValues);
+    ItemPage fetchItems(F filter, Object[] sortValues);
   }
 
-  private final class ProcessInstanceKeyPageFetcher
-      implements ItemKeyPageFetcher<ProcessInstanceFilter> {
+  private final class ProcessInstancePageFetcher implements ItemPageFetcher<ProcessInstanceFilter> {
     @Override
-    public ItemKeyPage fetchKeys(final ProcessInstanceFilter filter, final Object[] sortValues) {
+    public ItemPage fetchItems(final ProcessInstanceFilter filter, final Object[] sortValues) {
       final var page =
           SearchQueryPageBuilders.page().size(PAGE_SIZE).searchAfter(sortValues).build();
       final var query =
@@ -185,24 +186,26 @@ public class BatchOperationItemKeyProvider {
               .resultConfig(c -> c.onlyKey(true))
               .build();
       final var result = searchClientsProxy.searchProcessInstances(query);
-      return new ItemKeyPage(
+      return new ItemPage(
           result.items().stream()
-              .map(ProcessInstanceEntity::processInstanceKey)
+              .map(pi -> new Item(pi.processInstanceKey(), pi.processInstanceKey()))
               .collect(Collectors.toList()),
           result.lastSortValues(),
           result.total());
     }
   }
 
-  private final class IncidentKeyPageFetcher implements ItemKeyPageFetcher<IncidentFilter> {
+  private final class IncidentPageFetcher implements ItemPageFetcher<IncidentFilter> {
     @Override
-    public ItemKeyPage fetchKeys(final IncidentFilter filter, final Object[] sortValues) {
+    public ItemPage fetchItems(final IncidentFilter filter, final Object[] sortValues) {
       final var page =
           SearchQueryPageBuilders.page().size(PAGE_SIZE).searchAfter(sortValues).build();
       final var query = SearchQueryBuilders.incidentSearchQuery().filter(filter).page(page).build();
       final var result = searchClientsProxy.searchIncidents(query);
-      return new ItemKeyPage(
-          result.items().stream().map(IncidentEntity::incidentKey).collect(Collectors.toList()),
+      return new ItemPage(
+          result.items().stream()
+              .map(pi -> new Item(pi.incidentKey(), pi.processInstanceKey()))
+              .collect(Collectors.toList()),
           result.lastSortValues(),
           result.total());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -92,7 +92,7 @@ public final class BatchOperationSetupProcessors {
         .withListener(
             new BatchOperationExecutionScheduler(
                 scheduledTaskStateFactory,
-                new BatchOperationItemKeyProvider(searchClientsProxy),
+                new BatchOperationItemProvider(searchClientsProxy),
                 Duration.ofMillis(1000)));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+import java.util.stream.Collectors;
 
 public class BatchOperationChunkCreatedApplier
     implements TypedEventApplier<BatchOperationChunkIntent, BatchOperationChunkRecord> {
@@ -23,6 +25,10 @@ public class BatchOperationChunkCreatedApplier
 
   @Override
   public void applyState(final long chunkKey, final BatchOperationChunkRecord value) {
-    batchOperationState.appendItemKeys(value.getBatchOperationKey(), value.getItemKeys());
+    batchOperationState.appendItemKeys(
+        value.getBatchOperationKey(),
+        value.getItems().stream()
+            .map(BatchOperationItemValue::getItemKey)
+            .collect(Collectors.toSet()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -7,12 +7,17 @@
  */
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+import java.util.Collection;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +44,16 @@ public class BatchOperationChunkExportHandler
   public void export(final Record<BatchOperationChunkRecordValue> record) {
     final var value = record.getValue();
     batchOperationWriter.updateBatchAndInsertItems(
-        value.getBatchOperationKey(), value.getItemKeys());
+        value.getBatchOperationKey(), mapItems(value.getItems()));
+  }
+
+  private List<BatchOperationItemDbModel> mapItems(
+      final Collection<BatchOperationItemValue> items) {
+    return items.stream().map(this::mapItem).toList();
+  }
+
+  private BatchOperationItemDbModel mapItem(final BatchOperationItemValue value) {
+    return new BatchOperationItemDbModel(
+        value.getItemKey(), value.getProcessInstanceKey(), BatchOperationItemState.ACTIVE);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8423,6 +8423,9 @@ components:
         itemKey:
           description: Key of the item, e.g. a process instance key.
           type: string
+        processInstanceKey:
+          description: the process instance key of the processed item.
+          type: string
         state:
           description: State of the item.
           type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -374,6 +374,7 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationItemResponse()
         .batchOperationKey(entity.batchOperationKey().toString())
         .itemKey(entity.itemKey().toString())
+        .processInstanceKey(entity.processInstanceKey().toString())
         .state(BatchOperationItemResponse.StateEnum.fromValue(entity.state().name()));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -155,7 +155,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
     final var batchOperationItem =
         new BatchOperationEntity.BatchOperationItemEntity(
-            batchOperationKey, 1L, BatchOperationItemState.COMPLETED);
+            batchOperationKey, 11L, 12L, BatchOperationItemState.COMPLETED);
     when(batchOperationServices.getItemsByKey(batchOperationKey))
         .thenReturn(List.of(batchOperationItem));
 
@@ -172,7 +172,8 @@ class BatchOperationControllerTest extends RestControllerTest {
             {"items":[
                 {
                    "batchOperationKey":"1",
-                   "itemKey":"1",
+                   "itemKey":"11",
+                   "processInstanceKey":"12",
                    "state":"COMPLETED"}
                 ]}
           """);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -9,25 +9,25 @@ package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
-import java.util.Set;
+import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public final class BatchOperationChunkRecord extends UnifiedRecordValue
     implements BatchOperationChunkRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
-  public static final String PROP_ITEM_KEY_LIST = "itemKeys";
+  public static final String PROP_ITEMS_LIST = "items";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
-  private final ArrayProperty<LongValue> itemKeysProp =
-      new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
+  private final ArrayProperty<BatchOperationItem> itemsProp =
+      new ArrayProperty<>(PROP_ITEMS_LIST, BatchOperationItem::new);
 
   public BatchOperationChunkRecord() {
     super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
+    declareProperty(batchOperationKeyProp).declareProperty(itemsProp);
   }
 
   @Override
@@ -42,18 +42,18 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Set<Long> getItemKeys() {
-    return itemKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
+  public List<BatchOperationItemValue> getItems() {
+    return itemsProp.stream().collect(Collectors.toList());
   }
 
-  public BatchOperationChunkRecord setItemKeys(final Set<Long> keys) {
-    itemKeysProp.reset();
-    keys.forEach(key -> itemKeysProp.add().setValue(key));
+  public BatchOperationChunkRecord setItems(final Collection<BatchOperationItemValue> items) {
+    itemsProp.reset();
+    items.forEach(item -> itemsProp.add().wrap(item));
     return this;
   }
 
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
-    setItemKeys(record.getItemKeys());
+    setItems(record.getItems());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
+
+public final class BatchOperationItem extends ObjectValue implements BatchOperationItemValue {
+
+  private final LongProperty itemKeyProperty = new LongProperty("itemKey", -1);
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty("processInstanceKey", -1);
+
+  public BatchOperationItem() {
+    super(2);
+    declareProperty(itemKeyProperty).declareProperty(processInstanceKeyProperty);
+  }
+
+  public BatchOperationItem(final long itemKey, final long processInstanceKey) {
+    this();
+    setItemKey(itemKey);
+    setProcessInstanceKey(processInstanceKey);
+  }
+
+  @Override
+  public long getItemKey() {
+    return itemKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setItemKey(final long itemKey) {
+    itemKeyProperty.setValue(itemKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  public BatchOperationItem wrap(final BatchOperationItemValue value) {
+    setItemKey(value.getItemKey());
+    setProcessInstanceKey(value.getProcessInstanceKey());
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.Set;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -25,7 +25,15 @@ import org.immutables.value.Value;
 public interface BatchOperationChunkRecordValue extends BatchOperationRelated, RecordValue {
 
   /**
-   * @return subset of item keys for the batch operation
+   * @return subset of items for the batch operation
    */
-  Set<Long> getItemKeys();
+  List<BatchOperationItemValue> getItems();
+
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableBatchOperationItemValue.Builder.class)
+  interface BatchOperationItemValue {
+    long getItemKey();
+
+    long getProcessInstanceKey();
+  }
 }


### PR DESCRIPTION
## Description

Adds the processInstanceKey to BatchOperationChunkRecord and relevant API objects to correlate the itemKey with the processInstanceKey.

## Related issues

closes #31235 
