### PR TITLE
fix: log failed operation IDs when bulk fails for nested document error

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -864,9 +864,11 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
       try {
         final BulkResponse bulkResponse = bulk(bulkRequest);
         if (bulkResponse.errors()) {
+          final Set<String> failedOperationIds = getFailedOperationIds(bulkResponse);
           throw new OptimizeRuntimeException(
               String.format(
-                  "There were failures while performing bulk on %s.%n%s Message: %s",
+                  "There were %s failures while performing bulk on %s.%n%s Message: %s",
+                  failedOperationIds.size(),
                   itemName,
                   getHintForErrorMsg(bulkResponse),
                   bulkResponse.items().stream()
@@ -921,27 +923,12 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
           return;
         }
         if (containsNestedDocumentLimitErrorMessage(bulkResponse)) {
-          final Map<String, List<String>> failedNestedDocLimitItemIdsByIndexName =
-              bulkResponse.items().stream()
-                  .filter(b -> b.error() != null && b.error().reason() != null && b.id() != null)
-                  .filter(
-                      responseItem ->
-                          responseItem.error().reason().contains(NESTED_DOC_LIMIT_MESSAGE))
-                  .collect(
-                      Collectors.groupingBy(
-                          BulkResponseItem::index,
-                          Collectors.mapping(BulkResponseItem::id, Collectors.toList())));
-
-          final Set<String> failedOperationIds =
-              failedNestedDocLimitItemIdsByIndexName.values().stream()
-                  .flatMap(Collection::stream)
-                  .collect(Collectors.toSet());
+          final Set<String> failedOperationIds = getFailedOperationIds(bulkResponse);
           LOG.warn(
               "There were failures while performing bulk on {} due to the nested document limit being reached."
                   + " Removing {} failed items and retrying",
               itemName,
               failedOperationIds.size());
-          LOG.debug("Failed operation IDs by Index: {}", failedNestedDocLimitItemIdsByIndexName);
           final List<BulkOperation> bulkOperations = new ArrayList<>(bulkRequest.operations());
           bulkOperations.removeIf(
               request -> {
@@ -971,8 +958,27 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
         throw new OptimizeRuntimeException(reason, e);
       }
     } else {
-      LOG.debug("Bulkrequest on {} not executed because it contains no actions.", itemName);
+      LOG.debug("Bulk request on {} not executed because it contains no actions.", itemName);
     }
+  }
+
+  private static Set<String> getFailedOperationIds(final BulkResponse bulkResponse) {
+    final Map<String, List<String>> failedNestedDocLimitItemIdsByIndexName =
+        bulkResponse.items().stream()
+            .filter(b -> b.error() != null && b.error().reason() != null && b.id() != null)
+            .filter(
+                responseItem -> responseItem.error().reason().contains(NESTED_DOC_LIMIT_MESSAGE))
+            .collect(
+                Collectors.groupingBy(
+                    BulkResponseItem::index,
+                    Collectors.mapping(BulkResponseItem::id, Collectors.toList())));
+
+    final Set<String> failedOperationIds =
+        failedNestedDocLimitItemIdsByIndexName.values().stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+    LOG.debug("Failed operation IDs by Index: {}", failedNestedDocLimitItemIdsByIndexName);
+    return failedOperationIds;
   }
 
   public DeleteByQueryResponse submitDeleteTask(final DeleteByQueryRequest request)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Previously, we only logged the failed operation IDs when retrying was enabled, but not when rety-handling is disabled. This PR adds similar logging for both scenarios

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
