### PR TITLE
refactor: remove dependencies to modificationsByFlowNode

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -219,7 +219,6 @@ describe('VariablePanel', () => {
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
@@ -252,12 +251,14 @@ describe('VariablePanel', () => {
     ).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
-    expect(
-      screen.queryByRole('button', {name: /add variable/i}),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    });
 
     expect(
       screen.getByText('The Flow Node has no Variables'),
@@ -434,7 +435,7 @@ describe('VariablePanel', () => {
     expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
 
     act(() => {
-      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
+      cancelAllTokens('Activity_0qtp1k6', 2, 2, {});
     });
 
     await waitFor(() => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.test.tsx
@@ -9,13 +9,13 @@
 import {act, render, screen} from 'modules/testing-library';
 import {ModificationIcons} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {useEffect} from 'react';
-import {open} from 'modules/mocks/diagrams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {cancelAllTokens} from 'modules/utils/modifications';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {open} from 'modules/mocks/diagrams';
 
 type Props = {
   children?: React.ReactNode;
@@ -61,7 +61,9 @@ describe('<ModificationIcons />', () => {
       ],
     });
 
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
+    );
   });
 
   it('should show correct icons for modifications planning to be added', () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/ModificationIcons/v2/index.tsx
@@ -8,7 +8,6 @@
 
 import React from 'react';
 import {observer} from 'mobx-react';
-import {modificationsStore} from 'modules/stores/modifications';
 import {Container, AddIcon, CancelIcon, WarningIcon} from '../styled';
 import {FlowNodeInstance} from 'modules/stores/flowNodeInstance';
 import {Stack} from '@carbon/react';
@@ -27,7 +26,7 @@ const ModificationIcons: React.FC<Props> = observer(({flowNodeInstance}) => {
   const instanceKeyHierarchy = flowNodeInstance.treePath.split('/');
 
   const hasCancelModification =
-    modificationsStore.modificationsByFlowNode[flowNodeInstance.flowNodeId]
+    modificationsByFlowNode[flowNodeInstance.flowNodeId]
       ?.areAllTokensCanceled ||
     instanceKeyHierarchy.some((instanceKey) =>
       hasPendingCancelOrMoveModification(

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -6,17 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {screen, waitForElementToBeRemoved} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {mockProcessWithEventBasedGateway} from 'modules/mocks/mockProcessWithEventBasedGateway';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
 import {renderPopover} from './mocks';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
 import {incidentFlowNodeMetaData} from 'modules/mocks/metadata';
 import {open} from 'modules/mocks/diagrams';
@@ -93,7 +87,6 @@ describe('Modification Dropdown', () => {
       items: statisticsData,
     });
 
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('diagramForModifications.bpmn'),
     );
@@ -106,12 +99,6 @@ describe('Modification Dropdown', () => {
 
   it('should not render dropdown when no flow node is selected', async () => {
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     expect(
       screen.queryByText(/Flow Node Modifications/),
@@ -140,10 +127,10 @@ describe('Modification Dropdown', () => {
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
     expect(
-      screen.getByTitle(/Add single flow node instance/),
+      await screen.findByTitle(/Add single flow node instance/),
     ).toHaveTextContent(/Add/);
     expect(
-      screen.getByTitle(
+      await screen.findByTitle(
         /Cancel all running flow node instances in this flow node/,
       ),
     ).toHaveTextContent(/Cancel/);
@@ -156,12 +143,6 @@ describe('Modification Dropdown', () => {
 
   it('should not render dropdown when moving token', async () => {
     const {user} = renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
@@ -183,12 +164,6 @@ describe('Modification Dropdown', () => {
   it('should only render add option for completed flow nodes', async () => {
     renderPopover();
 
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
-
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
         flowNodeId: 'service-task-3',
@@ -198,19 +173,13 @@ describe('Modification Dropdown', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Add/)).toBeInTheDocument();
+    expect(await screen.findByText(/Add/)).toBeInTheDocument();
     expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
   });
 
   it('should only render move and cancel options for boundary events', async () => {
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
@@ -229,12 +198,6 @@ describe('Modification Dropdown', () => {
   it('should render unsupported flow node type for non modifiable flow nodes', async () => {
     renderPopover();
 
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
-
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
         flowNodeId: 'boundary-event',
@@ -244,7 +207,9 @@ describe('Modification Dropdown', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Unsupported flow node type/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Unsupported flow node type/),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Cancel/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Move/)).not.toBeInTheDocument();
@@ -291,18 +256,11 @@ describe('Modification Dropdown', () => {
       ],
     });
 
-    mockFetchProcessXML().withSuccess(mockProcessWithEventBasedGateway);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithEventBasedGateway,
     );
 
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
@@ -313,7 +271,7 @@ describe('Modification Dropdown', () => {
     expect(
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+    expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
     expect(screen.getByText(/Move/)).toBeInTheDocument();
     expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
 
@@ -363,7 +321,6 @@ describe('Modification Dropdown', () => {
   });
 
   it('should not support move operation for sub processes', async () => {
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('diagramForModifications.bpmn'),
     );
@@ -401,12 +358,6 @@ describe('Modification Dropdown', () => {
 
     renderPopover();
 
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
-
     mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
 
     act(() => {
@@ -421,18 +372,12 @@ describe('Modification Dropdown', () => {
       screen.getByTestId('dropdown-spinner'),
     );
     expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Move instance/)).toBeInTheDocument();
+    expect(await screen.findByText(/Move instance/)).toBeInTheDocument();
     expect(screen.getByText(/Cancel instance/)).toBeInTheDocument();
   });
 
   it('should support cancel instance when flow node has 1 running instance', async () => {
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     // select a flow node that has 1 running instance
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mocks.tsx
@@ -10,7 +10,6 @@ import {render} from 'modules/testing-library';
 import {PROCESS_INSTANCE_ID} from 'modules/mocks/metadata';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {createInstance} from 'modules/testUtils';
 import {createRef, useEffect} from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
@@ -68,7 +67,6 @@ const renderPopover = (
 
 const initializeStores = () => {
   flowNodeSelectionStore.init();
-  processInstanceDetailsDiagramStore.init();
   processInstanceDetailsStore.setProcessInstance(
     createInstance({
       id: PROCESS_INSTANCE_ID,
@@ -82,7 +80,6 @@ const resetStores = () => {
   flowNodeSelectionStore.reset();
   processInstanceDetailsStore.reset();
   modificationsStore.reset();
-  processInstanceDetailsDiagramStore.reset();
   flowNodeMetaDataStore.reset();
 };
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -6,13 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {screen, waitFor} from '@testing-library/react';
+import {screen} from '@testing-library/react';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
 import {open} from 'modules/mocks/diagrams';
 import {renderPopover} from './mocks';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
 import {act} from 'react';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
@@ -47,7 +45,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
   };
 
   beforeEach(() => {
-    mockFetchProcessXML().withSuccess(open('multipleInstanceSubProcess.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('multipleInstanceSubProcess.bpmn'),
     );
@@ -89,12 +86,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
 
     renderPopover();
 
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
-
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
         flowNodeId: 'TaskB',
@@ -114,12 +105,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
     async () => {
       renderPopover();
 
-      await waitFor(() =>
-        expect(
-          processInstanceDetailsDiagramStore.state.diagramModel,
-        ).not.toBeNull(),
-      );
-
       act(() => {
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
@@ -129,7 +114,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
       expect(
         await screen.findByText(/Flow Node Modifications/),
       ).toBeInTheDocument();
-      expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+      expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
       expect(screen.getByText(/Move/)).toBeInTheDocument();
       expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
     },
@@ -166,12 +151,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
 
       renderPopover();
 
-      await waitFor(() =>
-        expect(
-          processInstanceDetailsDiagramStore.state.diagramModel,
-        ).not.toBeNull(),
-      );
-
       act(() => {
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
@@ -181,7 +160,7 @@ describe('Modification Dropdown - Multi Scopes', () => {
       expect(
         await screen.findByText(/Flow Node Modifications/),
       ).toBeInTheDocument();
-      expect(screen.getByText(/Cancel/)).toBeInTheDocument();
+      expect(await screen.findByText(/Cancel/)).toBeInTheDocument();
       expect(screen.getByText(/Move/)).toBeInTheDocument();
       expect(screen.queryByText(/Add/)).not.toBeInTheDocument();
     },
@@ -192,18 +171,13 @@ describe('Modification Dropdown - Multi Scopes', () => {
     async () => {
       renderPopover();
 
-      await waitFor(() =>
-        expect(
-          processInstanceDetailsDiagramStore.state.diagramModel,
-        ).not.toBeNull(),
-      );
+      act(() => cancelAllTokens('TaskB', 0, 0, {}));
 
-      act(() => {
-        cancelAllTokens('TaskB', 0, 0, {});
+      act(() =>
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
-        });
-      });
+        }),
+      );
 
       expect(
         await screen.findByText(/Flow Node Modifications/),
@@ -222,18 +196,13 @@ describe('Modification Dropdown - Multi Scopes', () => {
     async () => {
       renderPopover();
 
-      await waitFor(() =>
-        expect(
-          processInstanceDetailsDiagramStore.state.diagramModel,
-        ).not.toBeNull(),
-      );
+      act(() => cancelAllTokens('TaskB', 0, 0, {}));
 
-      act(() => {
-        cancelAllTokens('TaskB', 0, 0, {});
+      act(() =>
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
-        });
-      });
+        }),
+      );
 
       expect(
         await screen.findByText(/Flow Node Modifications/),

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
@@ -6,12 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {act, screen, waitFor} from 'modules/testing-library';
+import {act, screen} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {modificationsStore} from 'modules/stores/modifications';
 import {renderPopover} from './mocks';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {open} from 'modules/mocks/diagrams';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -72,7 +70,6 @@ describe('selectedRunningInstanceCount', () => {
       ],
     });
 
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('diagramForModifications.bpmn'),
     );
@@ -86,12 +83,6 @@ describe('selectedRunningInstanceCount', () => {
     modificationsStore.enableModificationMode();
 
     renderPopover();
-
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
-    );
 
     act(() => {
       flowNodeSelectionStore.selectFlowNode({
@@ -113,10 +104,8 @@ describe('selectedRunningInstanceCount', () => {
 
     renderPopover();
 
-    await waitFor(() =>
-      expect(
-        processInstanceDetailsDiagramStore.state.diagramModel,
-      ).not.toBeNull(),
+    mockFetchProcessDefinitionXml().withSuccess(
+      open('diagramForModifications.bpmn'),
     );
 
     act(() => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.tsx
@@ -46,7 +46,10 @@ import {
   useTotalRunningInstancesForFlowNode,
   useTotalRunningInstancesVisibleForFlowNode,
 } from 'modules/queries/flownodeInstancesStatistics/useTotalRunningInstancesForFlowNode';
-import {finishMovingToken} from 'modules/utils/modifications';
+import {
+  finishMovingToken,
+  hasPendingCancelOrMoveModification,
+} from 'modules/utils/modifications';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {init} from 'modules/utils/flowNodeMetadata';
@@ -337,8 +340,10 @@ const TopPanel: React.FC = observer(() => {
                       state={payload.flowNodeState}
                       count={payload.count}
                       container={overlay.container}
-                      isFaded={modificationsStore.hasPendingCancelOrMoveModification(
+                      isFaded={hasPendingCancelOrMoveModification(
                         overlay.flowNodeId,
+                        undefined,
+                        modificationsByFlowNode,
                       )}
                       title={
                         payload.flowNodeState === 'completed'

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -14,9 +14,11 @@ import {
 } from './modifications';
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {TOKEN_OPERATIONS} from 'modules/constants';
+import {hasPendingCancelOrMoveModification} from 'modules/utils/modifications';
 
 const useHasPendingCancelOrMoveModification = () => {
   const willAllFlowNodesBeCanceled = useWillAllFlowNodesBeCanceled();
+  const modificationsByFlowNode = useModificationsByFlowNode();
   const currentSelection = flowNodeSelectionStore.state.selection;
 
   if (currentSelection === null) {
@@ -29,17 +31,16 @@ const useHasPendingCancelOrMoveModification = () => {
     return willAllFlowNodesBeCanceled;
   }
 
-  if (
-    modificationsStore.modificationsByFlowNode[flowNodeId]?.areAllTokensCanceled
-  ) {
+  if (modificationsByFlowNode[flowNodeId]?.areAllTokensCanceled) {
     return true;
   }
 
   return (
     flowNodeInstanceId !== undefined &&
-    modificationsStore.hasPendingCancelOrMoveModification(
+    hasPendingCancelOrMoveModification(
       flowNodeId,
       flowNodeInstanceId,
+      modificationsByFlowNode,
     )
   );
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes dependencies to `modificationsStore.modificationsByFlowNode`, which has dependencies to `processInstanceDetailsDiagramStore.businessObjects`. 

`modificationsStore.modificationsByFlowNode` should now only be used in v1 components (or in other dependent store methods which are used only in v1 components).

This should be the last dependency to `processInstanceDetailsDiagramStore` from `modificationsStore`. `modificationsStore.modificationsByFlowNode` can be removed entirely once https://github.com/camunda/camunda/issues/30785 is merged and all v1 components are removed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
