### PR TITLE
[Backport stable/optimize-8.6] fix: update broken link for optimize dashboard to outlier analysis

### DIFF
--- a/optimize/backend/src/main/resources/instant_preview_dashboards/template1.json
+++ b/optimize/backend/src/main/resources/instant_preview_dashboards/template1.json
@@ -1584,7 +1584,7 @@
                       "rel": "noopener norefereer",
                       "type": "link",
                       "version": 1,
-                      "url": "https://docs.camunda.io/optimize/components/userguide/process-analysis/outlier-analysis/",
+                      "url": "https://docs.camunda.io/docs/next/components/optimize/userguide/process-analysis/task-analysis/",
                       "direction": "ltr",
                       "target": "_blank"
                     }


### PR DESCRIPTION
# Description
Backport of #31273 to `stable/optimize-8.6`.

relates to 