### PR TITLE
fix: [Backport 8.7] use correct ports when printing status for --docker flag

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,8 +1,8 @@
 -------------------------------------------
 Access each component at the following urls:
 
-Operate:                     http://localhost:{{.ServerPort}}/operate
-Tasklist:                    http://localhost:{{.ServerPort}}/tasklist
+Operate:                     http://localhost:{{.OperatePort}}/operate
+Tasklist:                    http://localhost:{{.TasklistPort}}/tasklist
 Zeebe Cluster Endpoint:      http://localhost:26500
 Inbound Connectors Endpoint: http://localhost:8085
 

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -35,7 +35,7 @@ func QueryCamunda(c8 opener, name string, settings types.C8RunSettings) error {
 			fmt.Println("Failed to open browser")
 			return nil
 		}
-		if err := printStatus(settings.Port); err != nil {
+		if err := PrintStatus(settings); err != nil {
 			fmt.Println("Failed to print status:", err)
 			return err
 		}
@@ -58,7 +58,15 @@ func isRunning(name, url string, retries int, delay time.Duration) bool {
 	return false
 }
 
-func printStatus(port int) error {
+func PrintStatus(settings types.C8RunSettings) error {
+        var operatePort, tasklistPort int
+        if settings.Docker {
+                operatePort = 8081
+                tasklistPort = 8082
+        } else {
+                operatePort = 8080
+                tasklistPort = 8080
+        }
 	endpoints, _ := os.ReadFile("endpoints.txt")
 	t, err := template.New("endpoints").Parse(string(endpoints))
 	if err != nil {
@@ -66,9 +74,11 @@ func printStatus(port int) error {
 	}
 
 	data := struct {
-		ServerPort int
+		OperatePort int
+                TasklistPort int
 	}{
-		ServerPort: port,
+		OperatePort: operatePort,
+                TasklistPort: tasklistPort,
 	}
 
 	err = t.Execute(os.Stdout, data)

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -130,7 +130,10 @@ func handleDockerCommand(settings types.C8RunSettings, baseCommand string, compo
 	switch baseCommand {
 	case "start":
 		err = runDockerCommand(composeExtractedFolder, "up", "-d")
-		health.PrintStatus(settings)
+		if err != nil {
+			return err
+		}
+		err = health.PrintStatus(settings)
 	case "stop":
 		err = runDockerCommand(composeExtractedFolder, "down")
 	default:

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -130,6 +130,7 @@ func handleDockerCommand(settings types.C8RunSettings, baseCommand string, compo
 	switch baseCommand {
 	case "start":
 		err = runDockerCommand(composeExtractedFolder, "up", "-d")
+		health.PrintStatus(settings)
 	case "stop":
 		err = runDockerCommand(composeExtractedFolder, "down")
 	default:


### PR DESCRIPTION
## Description

Prints the status correctly when making use of the `--docker` flag.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/30779
