### PR TITLE
fix: flaky integration tests

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -57,6 +57,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -97,15 +98,13 @@ describe('VariablePanel', () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: statistics,
     });
-    mockFetchFlownodeInstancesStatistics().withSuccess({
-      items: statistics,
-    });
 
     mockFetchVariables().withSuccess([createVariable()]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
 
     init(statistics);
@@ -121,11 +120,6 @@ describe('VariablePanel', () => {
   afterEach(async () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
     await new Promise(process.nextTick);
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -1,0 +1,576 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {variablesStore} from 'modules/stores/variables';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {
+  createInstance,
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {singleInstanceMetadata} from 'modules/mocks/metadata';
+import {useEffect, act} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {init} from 'modules/utils/flowNodeMetadata';
+import {cancelAllTokens} from 'modules/utils/modifications';
+
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+}));
+
+jest.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: jest.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        variablesStore.reset();
+        flowNodeSelectionStore.reset();
+        flowNodeMetaDataStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('VariablePanel', () => {
+  beforeEach(() => {
+    const statistics = [
+      {
+        elementId: 'TEST_FLOW_NODE',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    init(statistics);
+    flowNodeSelectionStore.init();
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    variablesStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    modificationsStore.reset();
+    processInstanceDetailsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
+  it('should display correct state for a flow node that has only one running token on it', async () => {
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '2251799813695856',
+      instanceCount: 1,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    modificationsStore.enableModificationMode();
+
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+      });
+    });
+
+    await waitFor(() =>
+      expect(flowNodeMetaDataStore.state.metaData).toEqual({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: '2251799813695856',
+        instanceCount: 1,
+        instanceMetadata: {
+          ...singleInstanceMetadata.instanceMetadata!,
+          endDate: null,
+        },
+      }),
+    );
+
+    // initial state
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    act(() => {
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
+    });
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    // add a new token
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'Activity_0qtp1k6',
+            name: 'Flow Node with running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    // remove cancel modification
+    act(() => {
+      modificationsStore.removeFlowNodeModification({
+        operation: 'CANCEL_TOKEN',
+        flowNode: {
+          id: 'Activity_0qtp1k6',
+          name: 'Flow Node with running tokens',
+        },
+        affectedTokenCount: 1,
+        visibleAffectedTokenCount: 1,
+      });
+    });
+
+    expect(
+      screen.getByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '2251799813695856',
+      instanceCount: 1,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+        startDate: '2022-09-30T15:00:31.772+0000',
+      },
+    });
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    // select existing scope
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+        flowNodeInstanceId: '2251799813695856',
+      });
+    });
+
+    await waitFor(() =>
+      expect(flowNodeMetaDataStore.state.metaData).toEqual({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: '2251799813695856',
+        instanceCount: 1,
+        instanceMetadata: {
+          ...singleInstanceMetadata.instanceMetadata!,
+          endDate: null,
+        },
+      }),
+    );
+
+    expect(
+      screen.queryByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    // select new scope
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+        flowNodeInstanceId: 'some-new-scope-id',
+        isPlaceholder: true,
+      });
+    });
+
+    expect(
+      screen.queryByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should display correct state for a flow node that has no running or finished tokens on it', async () => {
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'flowNode-without-running-tokens',
+      });
+    });
+
+    // initial state
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('The Flow Node has no Variables'),
+    ).not.toBeInTheDocument();
+
+    // one 'add token' modification is created
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'flowNode-without-running-tokens',
+            name: 'Flow Node without running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {
+            'another-flownode-without-any-tokens': 'some-new-parent-scope-id',
+          },
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    mockFetchProcessDefinitionXml().withSuccess('');
+
+    // go to input mappings and back, see the correct state
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+
+    // second 'add token' modification is created
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'flowNode-without-running-tokens',
+            name: 'Flow Node without running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id-2',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    // select only one of the scopes
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'flowNode-without-running-tokens',
+        flowNodeInstanceId: 'some-new-scope-id-1',
+        isPlaceholder: true,
+      });
+    });
+
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    // select new parent scope
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'another-flownode-without-any-tokens',
+        flowNodeInstanceId: 'some-new-parent-scope-id',
+        isPlaceholder: true,
+      });
+    });
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should display correct state for a flow node that has only one finished token on it', async () => {
+    const statistics = [
+      {
+        elementId: 'StartEvent_1',
+        active: 1,
+        canceled: 0,
+        incidents: 0,
+        completed: 0,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: null,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: '2022-09-08T12:44:45.406+0000',
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+      });
+    });
+
+    await waitFor(() =>
+      expect(flowNodeMetaDataStore.state.metaData).toEqual({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: null,
+        instanceMetadata: {
+          ...singleInstanceMetadata.instanceMetadata!,
+          endDate: '2018-12-12 00:00:00',
+        },
+      }),
+    );
+
+    // initial state
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    // one 'add token' modification is created
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'Activity_0qtp1k6',
+            name: 'Flow Node with finished tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(
+      await screen.findByText(
+        'To view the Variables, select a single Flow Node Instance in the Instance History.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    // select only one of the scopes
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+        flowNodeInstanceId: 'some-new-scope-id',
+        isPlaceholder: true,
+      });
+    });
+
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -70,6 +70,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -134,11 +135,6 @@ describe('VariablePanel', () => {
   afterEach(async () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
     await new Promise(process.nextTick);
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
@@ -70,6 +70,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -134,11 +135,6 @@ describe('VariablePanel', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
   });
 
   it('should display error notification if add variable operation could not be created', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {variablesStore} from 'modules/stores/variables';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {
+  createInstance,
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {singleInstanceMetadata} from 'modules/mocks/metadata';
+import {useEffect, act} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {init} from 'modules/utils/flowNodeMetadata';
+
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+}));
+
+jest.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: jest.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        variablesStore.reset();
+        flowNodeSelectionStore.reset();
+        flowNodeMetaDataStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('VariablePanel', () => {
+  beforeEach(() => {
+    const statistics = [
+      {
+        elementId: 'TEST_FLOW_NODE',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    init(statistics);
+    flowNodeSelectionStore.init();
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    variablesStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    modificationsStore.reset();
+    processInstanceDetailsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
+  it.each([true, false])(
+    'should show multiple scope placeholder when multiple nodes are selected - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      mockFetchFlowNodeMetadata().withSuccess({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: null,
+        instanceCount: 2,
+        instanceMetadata: null,
+      });
+
+      render(<VariablePanel />, {wrapper: getWrapper()});
+
+      await waitFor(() => expect(variablesStore.state.status).toBe('fetched'));
+
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeInTheDocument();
+      mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+      act(() => {
+        flowNodeSelectionStore.setSelection({
+          flowNodeId: 'TEST_FLOW_NODE',
+        });
+      });
+
+      expect(
+        await screen.findByText(
+          'To view the Variables, select a single Flow Node Instance in the Instance History.',
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([true, false])(
+    'should show failed placeholder if server error occurs while fetching variables - modification mode: %p',
+    async (enableModificationMode) => {
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      render(<VariablePanel />, {wrapper: getWrapper()});
+
+      await waitFor(() => expect(variablesStore.state.status).toBe('fetched'));
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeInTheDocument();
+
+      mockFetchVariables().withServerError();
+
+      act(() => {
+        variablesStore.fetchVariables({
+          fetchType: 'initial',
+          instanceId: 'invalid_instance',
+          payload: {pageSize: 10, scopeId: '1'},
+        });
+      });
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each([true, false])(
+    'should show failed placeholder if network error occurs while fetching variables - modification mode: %p',
+    async (enableModificationMode) => {
+      const consoleErrorMock = jest
+        .spyOn(global.console, 'error')
+        .mockImplementation();
+
+      if (enableModificationMode) {
+        modificationsStore.enableModificationMode();
+      }
+
+      render(<VariablePanel />, {wrapper: getWrapper()});
+
+      await waitFor(() => expect(variablesStore.state.status).toBe('fetched'));
+      expect(
+        screen.getByRole('button', {name: /add variable/i}),
+      ).toBeInTheDocument();
+
+      mockFetchVariables().withNetworkError();
+
+      act(() => {
+        variablesStore.fetchVariables({
+          fetchType: 'initial',
+          instanceId: 'invalid_instance',
+          payload: {pageSize: 10, scopeId: '1'},
+        });
+      });
+
+      expect(
+        await screen.findByText('Variables could not be fetched'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+
+      consoleErrorMock.mockRestore();
+    },
+  );
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
@@ -56,6 +56,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -120,11 +121,6 @@ describe('VariablePanel', () => {
   afterEach(async () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
     await new Promise(process.nextTick);
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -1,0 +1,503 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {variablesStore} from 'modules/stores/variables';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {
+  createInstance,
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {singleInstanceMetadata} from 'modules/mocks/metadata';
+import {useEffect, act} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {GetProcessInstanceStatisticsResponseBody} from '@vzeta/camunda-api-zod-schemas/operate';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {init} from 'modules/utils/flowNodeMetadata';
+import {cancelAllTokens} from 'modules/utils/modifications';
+
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+}));
+
+jest.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: jest.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        variablesStore.reset();
+        flowNodeSelectionStore.reset();
+        flowNodeMetaDataStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('VariablePanel', () => {
+  beforeEach(() => {
+    const statistics = [
+      {
+        elementId: 'TEST_FLOW_NODE',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    init(statistics);
+    flowNodeSelectionStore.init();
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    variablesStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    modificationsStore.reset();
+    processInstanceDetailsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
+  it('should be readonly if root node is selected and applying modifications will cancel the whole process', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'TEST_FLOW_NODE',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+        {
+          elementId: 'Activity_0qtp1k6',
+          active: 0,
+          canceled: 0,
+          incidents: 1,
+          completed: 0,
+        },
+      ],
+    };
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: null,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    render(<VariablePanel />, {
+      wrapper: getWrapper([Paths.processInstance('processInstanceId123')]),
+    });
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
+
+    act(() => {
+      cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('edit-variable-value'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should display readonly state for existing node if cancel modification is applied on the flow node and one new token is added', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'TEST_FLOW_NODE',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+        {
+          elementId: 'Activity_0qtp1k6',
+          active: 0,
+          canceled: 0,
+          incidents: 1,
+          completed: 0,
+        },
+      ],
+    };
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '2251799813695856',
+      instanceCount: 1,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+
+    act(() => {
+      modificationsStore.enableModificationMode();
+    });
+
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+        flowNodeInstanceId: '2251799813695856',
+      });
+    });
+
+    await waitFor(() =>
+      expect(flowNodeMetaDataStore.state.metaData).toEqual({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: '2251799813695856',
+        instanceCount: 1,
+        instanceMetadata: {
+          ...singleInstanceMetadata.instanceMetadata!,
+          endDate: null,
+        },
+      }),
+    );
+
+    // initial state
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+
+    act(() => {
+      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
+    });
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    // add a new token
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'Activity_0qtp1k6',
+            name: 'Flow Node with running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'some-new-scope-id',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+  });
+
+  it('should display readonly state for existing node if it has finished state and one new token is added on the same flow node', async () => {
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '2251799813695856',
+      instanceCount: 1,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: '2022-04-10T15:01:31.794+0000',
+      },
+    });
+
+    modificationsStore.enableModificationMode();
+
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([]);
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+        flowNodeInstanceId: '2251799813695856',
+      });
+    });
+
+    await waitFor(() =>
+      expect(flowNodeMetaDataStore.state.metaData).toEqual({
+        ...singleInstanceMetadata,
+        flowNodeInstanceId: '2251799813695856',
+        instanceCount: 1,
+        instanceMetadata: {
+          ...singleInstanceMetadata.instanceMetadata!,
+          endDate: '2018-12-12 00:00:00',
+        },
+      }),
+    );
+
+    // initial state
+    expect(
+      await screen.findByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+
+    // add one new token
+    act(() => {
+      modificationsStore.addModification({
+        type: 'token',
+        payload: {
+          operation: 'ADD_TOKEN',
+          flowNode: {
+            id: 'Activity_0qtp1k6',
+            name: 'Flow Node with running tokens',
+          },
+          affectedTokenCount: 1,
+          visibleAffectedTokenCount: 1,
+          scopeId: 'new-scope',
+          parentScopeIds: {},
+        },
+      });
+    });
+
+    expect(
+      screen.getByText('The Flow Node has no Variables'),
+    ).toBeInTheDocument();
+  });
+
+  it('should be readonly if flow node has variables and running instances', async () => {
+    const mockData: GetProcessInstanceStatisticsResponseBody = {
+      items: [
+        {
+          elementId: 'TEST_FLOW_NODE',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+        {
+          elementId: 'Activity_0qtp1k6',
+          active: 2,
+          canceled: 0,
+          incidents: 0,
+          completed: 0,
+        },
+      ],
+    };
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+    mockFetchFlownodeInstancesStatistics().withSuccess(mockData);
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: null,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+
+    act(() => {
+      modificationsStore.enableModificationMode();
+    });
+
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
+
+    mockFetchVariables().withSuccess([
+      createVariable({name: 'some-other-variable'}),
+    ]);
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '9007199254742797',
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+      });
+    });
+
+    // initial state
+    expect(await screen.findByText('some-other-variable')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
+
+    act(() => {
+      cancelAllTokens('Activity_0qtp1k6', 0, 0, {});
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('some-other-variable')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /edit variable/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should be readonly if flow node has variables but no running instances', async () => {
+    modificationsStore.enableModificationMode();
+
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+    mockFetchVariables().withSuccess([
+      createVariable({name: 'some-other-variable'}),
+    ]);
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      flowNodeInstanceId: '9007199254742797',
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: '2022-09-15T12:44:45.406+0000',
+      },
+    });
+
+    act(() => {
+      flowNodeSelectionStore.selectFlowNode({
+        flowNodeId: 'Activity_0qtp1k6',
+      });
+    });
+
+    expect(await screen.findByText('some-other-variable')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /add variable/i}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /edit variable/i}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -58,6 +58,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -122,11 +123,6 @@ describe('VariablePanel', () => {
   afterEach(async () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
     await new Promise(process.nextTick);
   });
 
@@ -348,7 +344,7 @@ describe('VariablePanel', () => {
     ).not.toBeInTheDocument();
 
     // add one new token
-    act(() => {
+    await act(async () => {
       modificationsStore.addModification({
         type: 'token',
         payload: {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {VariablePanel} from '../index';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {variablesStore} from 'modules/stores/variables';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {
+  createInstance,
+  createVariable,
+  mockProcessWithInputOutputMappingsXML,
+} from 'modules/testUtils';
+import {modificationsStore} from 'modules/stores/modifications';
+import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
+import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
+import {singleInstanceMetadata} from 'modules/mocks/metadata';
+import {useEffect, act} from 'react';
+import {Paths} from 'modules/Routes';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
+import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {init} from 'modules/utils/flowNodeMetadata';
+
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+}));
+
+jest.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: jest.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = (
+  initialEntries: React.ComponentProps<
+    typeof MemoryRouter
+  >['initialEntries'] = [Paths.processInstance('1')],
+) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        variablesStore.reset();
+        flowNodeSelectionStore.reset();
+        flowNodeMetaDataStore.reset();
+        modificationsStore.reset();
+      };
+    }, []);
+
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={getMockQueryClient()}>
+          <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+              <Route path={Paths.processInstance()} element={children} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+  return Wrapper;
+};
+
+describe('VariablePanel spinner', () => {
+  beforeEach(() => {
+    const statistics = [
+      {
+        elementId: 'TEST_FLOW_NODE',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 1,
+      },
+      {
+        elementId: 'Activity_0qtp1k6',
+        active: 0,
+        canceled: 0,
+        incidents: 1,
+        completed: 0,
+      },
+    ];
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statistics,
+    });
+
+    mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+
+    init(statistics);
+    flowNodeSelectionStore.init();
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    variablesStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    modificationsStore.reset();
+    processInstanceDetailsStore.reset();
+  });
+
+  it('should display spinner for variables tab when switching between tabs', async () => {
+    const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+    mockFetchVariables().withDelay([createVariable({name: 'test2'})]);
+
+    act(() => {
+      flowNodeSelectionStore.setSelection({
+        flowNodeInstanceId: 'another_flow_node',
+        flowNodeId: 'TEST_FLOW_NODE',
+      });
+    });
+
+    expect(await screen.findByTestId('variables-spinner')).toBeInTheDocument();
+    await waitForElementToBeRemoved(screen.getByTestId('variables-spinner'));
+    expect(screen.getByText('test2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+
+    mockFetchVariables().withDelay([createVariable({name: 'test2'})]);
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    await waitForElementToBeRemoved(screen.getByTestId('variables-spinner'));
+  });
+
+  it('should display spinner on second variable fetch', async () => {
+    render(<VariablePanel />, {wrapper: getWrapper()});
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+
+    mockFetchVariables().withDelay([createVariable()]);
+
+    act(() => {
+      variablesStore.fetchVariables({
+        fetchType: 'initial',
+        instanceId: '1',
+        payload: {pageSize: 10, scopeId: '1'},
+      });
+    });
+
+    expect(screen.getByTestId('variables-spinner')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByTestId('variables-spinner'),
+    );
+  });
+
+  it('should not display spinner for variables tab when switching between tabs if scope does not exist', async () => {
+    modificationsStore.enableModificationMode();
+
+    const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+
+    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+
+    mockFetchProcessInstanceListeners().withSuccess(noListeners);
+    act(() => {
+      flowNodeSelectionStore.setSelection({
+        flowNodeId: 'non-existing',
+        isPlaceholder: true,
+      });
+    });
+
+    expect(screen.queryByText('testVariableName')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Input Mappings'}));
+    expect(screen.getByText('No Input Mappings defined')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', {name: 'Variables'}));
+    expect(screen.queryByTestId('variables-spinner')).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -60,6 +60,7 @@ const getWrapper = (
         flowNodeSelectionStore.reset();
         flowNodeMetaDataStore.reset();
         modificationsStore.reset();
+        processInstanceDetailsStore.reset();
       };
     }, []);
 
@@ -121,14 +122,10 @@ describe('VariablePanel spinner', () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-    variablesStore.reset();
-    flowNodeSelectionStore.reset();
-    flowNodeMetaDataStore.reset();
-    modificationsStore.reset();
-    processInstanceDetailsStore.reset();
+    await new Promise(process.nextTick);
   });
 
   it('should display spinner for variables tab when switching between tabs', async () => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -89,6 +89,9 @@ describe('Modification Dropdown', () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: statisticsData,
     });
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statisticsData,
+    });
 
     mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
@@ -98,15 +101,10 @@ describe('Modification Dropdown', () => {
   });
 
   afterEach(async () => {
-    flowNodeSelectionStore.reset();
-    modificationsStore.reset();
     await new Promise(process.nextTick);
   });
 
   it('should not render dropdown when no flow node is selected', async () => {
-    mockFetchFlownodeInstancesStatistics().withSuccess({
-      items: statisticsData,
-    });
     renderPopover();
 
     await waitFor(() =>

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/index.test.tsx
@@ -97,7 +97,16 @@ describe('Modification Dropdown', () => {
     modificationsStore.enableModificationMode();
   });
 
+  afterEach(async () => {
+    flowNodeSelectionStore.reset();
+    modificationsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
   it('should not render dropdown when no flow node is selected', async () => {
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: statisticsData,
+    });
     renderPopover();
 
     await waitFor(() =>

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mocks.tsx
@@ -15,7 +15,6 @@ import {createInstance} from 'modules/testUtils';
 import {createRef, useEffect} from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {ModificationDropdown} from '.';
-import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {modificationsStore} from 'modules/stores/modifications';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {Paths} from 'modules/Routes';
@@ -69,7 +68,6 @@ const renderPopover = (
 
 const initializeStores = () => {
   flowNodeSelectionStore.init();
-  processInstanceDetailsStatisticsStore.init('processId');
   processInstanceDetailsDiagramStore.init();
   processInstanceDetailsStore.setProcessInstance(
     createInstance({
@@ -84,7 +82,6 @@ const resetStores = () => {
   flowNodeSelectionStore.reset();
   processInstanceDetailsStore.reset();
   modificationsStore.reset();
-  processInstanceDetailsStatisticsStore.reset();
   processInstanceDetailsDiagramStore.reset();
   flowNodeMetaDataStore.reset();
 };

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -27,6 +27,11 @@ describe('Modification Dropdown - Multi Scopes', () => {
     modificationsStore.enableModificationMode();
   });
 
+  afterEach(async () => {
+    modificationsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
   it('should support add modification for task with multiple scopes', async () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/mutliScopes.test.tsx
@@ -19,16 +19,43 @@ import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownod
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 describe('Modification Dropdown - Multi Scopes', () => {
+  const stats = {
+    items: [
+      {
+        elementId: 'OuterSubProcess',
+        active: 1,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+      {
+        elementId: 'InnerSubProcess',
+        active: 10,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+      {
+        elementId: 'TaskB',
+        active: 1,
+        incidents: 0,
+        completed: 0,
+        canceled: 0,
+      },
+    ],
+  };
+
   beforeEach(() => {
     mockFetchProcessXML().withSuccess(open('multipleInstanceSubProcess.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('multipleInstanceSubProcess.bpmn'),
     );
+    mockFetchFlownodeInstancesStatistics().withSuccess(stats);
+    mockFetchFlownodeInstancesStatistics().withSuccess(stats);
     modificationsStore.enableModificationMode();
   });
 
   afterEach(async () => {
-    modificationsStore.reset();
     await new Promise(process.nextTick);
   });
 
@@ -84,32 +111,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
   (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it.skip : it)(
     'should not support add modification for task with multiple inner parent scopes',
     async () => {
-      mockFetchFlownodeInstancesStatistics().withSuccess({
-        items: [
-          {
-            elementId: 'OuterSubProcess',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'InnerSubProcess',
-            active: 10,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'TaskB',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-        ],
-      });
-
       renderPopover();
 
       await waitFor(() =>
@@ -188,32 +189,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
   (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it.skip : it)(
     'should render no modifications available',
     async () => {
-      mockFetchFlownodeInstancesStatistics().withSuccess({
-        items: [
-          {
-            elementId: 'OuterSubProcess',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'InnerSubProcess',
-            active: 10,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'TaskB',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-        ],
-      });
-
       renderPopover();
 
       await waitFor(() =>
@@ -222,9 +197,8 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB', {});
-
       act(() => {
+        modificationsStore.cancelAllTokens('TaskB', {});
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
         });
@@ -245,32 +219,6 @@ describe('Modification Dropdown - Multi Scopes', () => {
   (IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED ? it : it.skip)(
     'should render add modification for flow nodes that has multiple running scopes',
     async () => {
-      mockFetchFlownodeInstancesStatistics().withSuccess({
-        items: [
-          {
-            elementId: 'OuterSubProcess',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'InnerSubProcess',
-            active: 10,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-          {
-            elementId: 'TaskB',
-            active: 1,
-            incidents: 0,
-            completed: 0,
-            canceled: 0,
-          },
-        ],
-      });
-
       renderPopover();
 
       await waitFor(() =>
@@ -279,9 +227,8 @@ describe('Modification Dropdown - Multi Scopes', () => {
         ).not.toBeNull(),
       );
 
-      modificationsStore.cancelAllTokens('TaskB', {});
-
       act(() => {
+        modificationsStore.cancelAllTokens('TaskB', {});
         flowNodeSelectionStore.selectFlowNode({
           flowNodeId: 'TaskB',
         });

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
@@ -78,6 +78,13 @@ describe('selectedRunningInstanceCount', () => {
     );
   });
 
+  afterEach(async () => {
+    flowNodeSelectionStore.reset();
+    processInstanceDetailsDiagramStore.reset();
+    modificationsStore.reset();
+    await new Promise(process.nextTick);
+  });
+
   it('should not render when there are no running instances selected', async () => {
     modificationsStore.enableModificationMode();
 
@@ -125,6 +132,8 @@ describe('selectedRunningInstanceCount', () => {
       await screen.findByText(/Flow Node Modifications/),
     ).toBeInTheDocument();
 
-    expect(screen.getByText(/Selected running instances/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Selected running instances/),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/v2/selectedRunningInstanceCount.test.tsx
@@ -79,9 +79,6 @@ describe('selectedRunningInstanceCount', () => {
   });
 
   afterEach(async () => {
-    flowNodeSelectionStore.reset();
-    processInstanceDetailsDiagramStore.reset();
-    modificationsStore.reset();
     await new Promise(process.nextTick);
   });
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
@@ -37,7 +37,6 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 
 jest.mock('react-transition-group', () => {
@@ -323,7 +322,6 @@ describe('TopPanel', () => {
   });
 
   it('should display move token banner in moving mode', async () => {
-    mockFetchProcessXML().withSuccess(open('diagramForModifications.bpmn'));
     mockFetchProcessDefinitionXml().withSuccess(
       open('diagramForModifications.bpmn'),
     );

--- a/operate/client/src/modules/react-query/mockQueryClient.ts
+++ b/operate/client/src/modules/react-query/mockQueryClient.ts
@@ -9,11 +9,12 @@
 import {QueryClient} from '@tanstack/react-query';
 
 function getMockQueryClient() {
-  return new QueryClient({
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
         gcTime: Infinity,
+        staleTime: Infinity,
       },
       mutations: {
         retry: false,
@@ -21,6 +22,9 @@ function getMockQueryClient() {
       },
     },
   });
+
+  queryClient.clear();
+  return queryClient;
 }
 
 export {getMockQueryClient};


### PR DESCRIPTION
## Description

Operate FE integration tests has recently been [unstable/flaky on main](https://github.com/camunda/camunda/actions/workflows/operate-frontend.yml?query=branch%3Amain). After discussing with the team we believe this is coming from unresolved async API calls after a test ends. Because of the nature of tanstack queries, it might happen because queries are fired as side effects and get carried over to the next test.

As a fix, we're applying the suggestion from [this thread](https://stackoverflow.com/questions/44741102/how-to-make-jest-wait-for-all-asynchronous-code-to-finish-execution-before-expec/51045733#51045733) where we explicitly wait for async code to resolve after each test. I'm also adding additional clears/reset and updated the mock query client configs.