### PR TITLE
Support corrections on `creating` listeners

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -176,24 +176,6 @@ public class TaskListenerBlockedTransitionTest {
   }
 
   @Test
-  public void shouldCreateFirstCreatingTaskListenerJob() {
-    // given
-    final long processInstanceKey =
-        helper.createProcessInstance(
-            helper.createProcessWithCreatingTaskListeners(listenerType + "_creating"));
-
-    // then: expect a job to be activated for the first `creating` listener
-    helper.assertActivatedJob(
-        processInstanceKey,
-        listenerType + "_creating",
-        job -> {
-          assertThat(job.getJobListenerEventType())
-              .describedAs("Expect job to have job listener type 'CREATING'")
-              .isEqualTo(JobListenerEventType.CREATING);
-        });
-  }
-
-  @Test
   public void shouldCreateUserTaskAfterAllCreatingTaskListenersAreExecuted() {
     // given
     final long processInstanceKey =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -1307,10 +1307,7 @@ public class TaskListenerCorrectionsTest {
     final long processInstanceKey =
         helper.createProcessInstance(
             helper.createUserTaskWithTaskListenersAndAssignee(
-                ZeebeTaskListenerEventType.creating,
-                "initial_assignee",
-                listenerType,
-                listenerType + "_2"));
+                ZeebeTaskListenerEventType.creating, "initial_assignee", listenerType));
 
     // when
     ENGINE
@@ -1336,17 +1333,6 @@ public class TaskListenerCorrectionsTest {
                         "followUpDate",
                         "priority")))
         .complete();
-    ENGINE
-        .job()
-        .ofInstance(processInstanceKey)
-        .withType(listenerType + "_2")
-        .withResult(
-            new JobResult()
-                .setCorrections(
-                    new JobResultCorrections()
-                        .setCandidateGroupsList(List.of("twice_corrected_candidate_group")))
-                .setCorrectedAttributes(List.of("candidateGroupsList")))
-        .complete();
 
     // then
     helper.assertUserTaskRecordWithIntent(
@@ -1363,8 +1349,7 @@ public class TaskListenerCorrectionsTest {
                     "followUpDate",
                     "priority")
                 .hasCandidateUsersList("new_candidate_user")
-                .describedAs("Expect that the most recent group correction takes precedence")
-                .hasCandidateGroupsList("twice_corrected_candidate_group")
+                .hasCandidateGroupsList("new_candidate_group")
                 .hasDueDate("new_due_date")
                 .hasFollowUpDate("new_follow_up_date")
                 .hasPriority(100)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -569,6 +569,12 @@ public class TaskListenerCorrectionsTest {
   }
 
   @Test
+  public void shouldTrackChangedAttributesOnlyForActuallyCorrectedValuesOnTaskCreation() {
+    verifyChangedAttributesAreTrackedOnlyForActuallyCorrectedValues(
+        ZeebeTaskListenerEventType.creating, true, ignored -> {}, UserTaskIntent.CREATED);
+  }
+
+  @Test
   public void shouldTrackChangedAttributesOnlyForActuallyCorrectedValuesOnTaskAssignment() {
     verifyChangedAttributesAreTrackedOnlyForActuallyCorrectedValues(
         ZeebeTaskListenerEventType.assigning,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -455,11 +455,12 @@ public class TaskListenerCorrectionsTest {
                       .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType + "_3"));
                 }));
 
-    final var createdUserTaskRecord =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATING)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-    final var userTaskKey = String.valueOf(createdUserTaskRecord.getKey());
+    final var userTaskKey =
+        String.valueOf(
+            RecordingExporter.userTaskRecords(UserTaskIntent.CREATING)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getKey());
 
     // when: trigger the user task transition
     transitionTrigger.accept(processInstanceKey);


### PR DESCRIPTION
## Description

We can have 4 different scenarios:
1. No initial assignee -> no corrections -> `CREATED` event will be written with no `assignee` and no `assigning` listeners will be triggered.
2. No initial assignee -> corrected assignee -> `CREATED` event will be written with the corrected `assignee`, but no `assigning` listeners will be triggered.
3. Initial assignee is present -> no corrections -> `CREATED` event will be written without an `assignee` and `assigning` listeners are triggered.
4. Initial assignee is present -> assignee is corrected -> this case is going to be **rejected**, but it is **not** a part of this PR.

To summarize:

- Current assumption: there can not be corrections of the `assignee` if there is an initial `assignee`.
- If the initial `assignee` is present -> we remove the `assignee` from UT record as we are going to assign user task to initial `assignee` via assigning event.
-  If there is no initial `assignee` -> we keep the `assignee` on the UT record in `CREATED` event and it could be a corrected assignee or no assignee at all.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29124
