### PR TITLE
Azure Backup Store: Make the creation of the container configurable.

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -455,7 +455,7 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_BASEPATH
           # basePath:
 
-          # Defines if the container is created initially or if a existing one
+          # Defines if the container is created initially or if an existing one
           # should be used.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_CREATECONTAINER
           # createContainer: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -455,6 +455,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_BASEPATH
           # basePath:
 
+          # Defines if the container is created initially or if a existing one
+          # should be used.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_CREATECONTAINER
+          # createContainer: true
+
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -372,6 +372,12 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_BASEPATH
           # basePath:
 
+          # Defines if the container is created initially or if a existing one
+          # should be used.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_CREATECONTAINER
+          # createContainer: true
+
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -372,7 +372,7 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_BASEPATH
           # basePath:
 
-          # Defines if the container is created initially or if a existing one
+          # Defines if the container is created initially or if an existing one
           # should be used.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_AZURE_CREATECONTAINER
           # createContainer: true

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupConfig.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupConfig.java
@@ -12,7 +12,8 @@ public record AzureBackupConfig(
     String accountName,
     String accountKey,
     String connectionString,
-    String containerName) {
+    String containerName,
+    boolean createContainer) {
 
   public static class Builder {
 
@@ -20,6 +21,7 @@ public record AzureBackupConfig(
     private String accountName;
     private String accountKey;
     private String conectionString;
+    private boolean createContainer = true;
 
     // maps to the basePath env variable
     private String containerName;
@@ -49,10 +51,15 @@ public record AzureBackupConfig(
       return this;
     }
 
+    public Builder withCreateContainer(final boolean createContainer) {
+      this.createContainer = createContainer;
+      return this;
+    }
+
     public AzureBackupConfig build() {
 
       return new AzureBackupConfig(
-          endpoint, accountName, accountKey, conectionString, containerName);
+          endpoint, accountName, accountKey, conectionString, containerName, createContainer);
     }
   }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -98,7 +98,7 @@ public final class AzureBackupStore implements BackupStore {
         client.getBlobContainerClient(config.containerName());
 
     if (!config.createContainer()) {
-      LOG.info(
+      LOG.debug(
           "Setting up Azure Store with existing container: {}",
           blobContainerClient.getBlobContainerName());
       if (!blobContainerClient.exists()) {

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStoreException.java
@@ -13,9 +13,19 @@ public abstract class AzureBackupStoreException extends RuntimeException {
     super(message, cause);
   }
 
+  protected AzureBackupStoreException(final String message) {
+    super(message);
+  }
+
   public static final class BlobAlreadyExists extends AzureBackupStoreException {
     public BlobAlreadyExists(final String message, final Throwable cause) {
       super(message, cause);
+    }
+  }
+
+  public static final class ContainerDoesNotExist extends AzureBackupStoreException {
+    public ContainerDoesNotExist(final String message) {
+      super(message);
     }
   }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -66,11 +66,12 @@ public final class ManifestManager {
           .registerModule(new JavaTimeModule())
           .disable(WRITE_DATES_AS_TIMESTAMPS)
           .setSerializationInclusion(Include.NON_ABSENT);
-  private boolean containerCreated = false;
+  private boolean containerCreated;
   private final BlobContainerClient blobContainerClient;
 
-  ManifestManager(final BlobContainerClient blobContainerClient) {
+  ManifestManager(final BlobContainerClient blobContainerClient, final boolean createContainer) {
     this.blobContainerClient = blobContainerClient;
+    containerCreated = !createContainer;
   }
 
   PersistedManifest createInitialManifest(final Backup backup) {

--- a/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCreationIT.java
+++ b/zeebe/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreContainerCreationIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.azure;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class AzureBackupStoreContainerCreationIT {
+
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+  public AzureBackupConfig azureBackupConfig;
+  public final String containerName = UUID.randomUUID().toString();
+
+  @Test
+  void shouldFailToInitializeStore() {
+    // given
+    azureBackupConfig =
+        new AzureBackupConfig.Builder()
+            .withConnectionString(AZURITE_CONTAINER.getConnectString())
+            .withContainerName(containerName)
+            .withCreateContainer(false)
+            .build();
+
+    // then we should fail to create the store since the container does not
+    // exist yet.
+    assertThrowsExactly(
+        AzureBackupStoreException.ContainerDoesNotExist.class,
+        () -> new AzureBackupStore(azureBackupConfig));
+
+    // when we create the container
+    new BlobServiceClientBuilder()
+        .connectionString(AZURITE_CONTAINER.getConnectString())
+        .buildClient()
+        .getBlobContainerClient(containerName)
+        .create();
+
+    // then we can create the store without any exceptions
+    assertDoesNotThrow(() -> new AzureBackupStore(azureBackupConfig));
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/AzureBackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/AzureBackupStoreConfig.java
@@ -17,6 +17,7 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
   private String accountKey;
   private String connectionString;
   private String basePath;
+  private boolean createContainer = true;
 
   public String getEndpoint() {
     return endpoint;
@@ -62,6 +63,14 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
     this.basePath = basePath;
   }
 
+  public boolean isCreateContainer() {
+    return createContainer;
+  }
+
+  public void setCreateContainer(final boolean createContainer) {
+    this.createContainer = createContainer;
+  }
+
   public static AzureBackupConfig toStoreConfig(final AzureBackupStoreConfig config) {
     return new AzureBackupConfig.Builder()
         .withEndpoint(config.getEndpoint())
@@ -69,12 +78,14 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
         .withAccountKey(config.getAccountKey())
         .withConnectionString(config.getConnectionString())
         .withContainerName(config.getBasePath())
+        .withCreateContainer(config.isCreateContainer())
         .build();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(endpoint, accountName, accountKey, connectionString, basePath);
+    return Objects.hash(
+        endpoint, accountName, accountKey, connectionString, basePath, createContainer);
   }
 
   @Override
@@ -90,7 +101,8 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
         && Objects.equals(accountName, that.accountName)
         && Objects.equals(accountKey, that.accountKey)
         && Objects.equals(connectionString, that.connectionString)
-        && Objects.equals(basePath, that.basePath);
+        && Objects.equals(basePath, that.basePath)
+        && createContainer == that.createContainer;
   }
 
   @Override
@@ -110,6 +122,8 @@ public class AzureBackupStoreConfig implements ConfigurationEntry {
         + '\''
         + ", basePath='"
         + basePath
+        + ", createContainer="
+        + createContainer
         + '\''
         + '}';
   }


### PR DESCRIPTION
## Description

This PR adds the configuration to make the creation of the container in Azure Backup Store optional.
This is a FR since this operation requires elevated privileges which can't be provided in all cases. The option to create the container initialialy is true by default. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Follow up issue:
[Add Azure create container configuration to the docs.](https://github.com/camunda/camunda/issues/31370)

relates https://github.com/camunda/camunda/issues/30503
closes https://github.com/camunda/camunda/issues/31372