### PR TITLE
Use role ids in CamundaExporter when creating/updating a role and assigning/unassigning members from a role

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -22,7 +22,7 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String MEMBER_ID = "memberId";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =
+  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory<>(
           IdentityJoinRelationshipType.ROLE, IdentityJoinRelationshipType.MEMBER);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -15,7 +15,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
   private String roleId;
   private String name;
   private String description;
-  private EntityJoinRelation<Long> join;
+  private EntityJoinRelation<String> join;
 
   public Long getKey() {
     return key;
@@ -53,16 +53,16 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public EntityJoinRelation<Long> getJoin() {
+  public EntityJoinRelation<String> getJoin() {
     return join;
   }
 
-  public RoleEntity setJoin(final EntityJoinRelation<Long> join) {
+  public RoleEntity setJoin(final EntityJoinRelation<String> join) {
     this.join = join;
     return this;
   }
 
-  public static String getChildKey(final long roleKey, final long memberKey) {
-    return "%d-%d".formatted(roleKey, memberKey);
+  public static String getChildKey(final String roleId, final String memberId) {
+    return "%s-%s".formatted(roleId, memberId);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -12,8 +12,9 @@ import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
   private Long key;
+  private String roleId;
   private String name;
-  private String memberId;
+  private String description;
   private EntityJoinRelation<Long> join;
 
   public Long getKey() {
@@ -34,12 +35,21 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public String getMemberId() {
-    return memberId;
+  public String getRoleId() {
+    return roleId;
   }
 
-  public RoleEntity setMemberKey(final String memberId) {
-    this.memberId = memberId;
+  public RoleEntity setRoleId(final String roleId) {
+    this.roleId = roleId;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public RoleEntity setDescription(final String description) {
+    this.description = description;
     return this;
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleMemberEntity.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.usermanagement;
+
+import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+
+public class RoleMemberEntity extends AbstractExporterEntity<RoleMemberEntity> {
+  private String memberId;
+  private EntityType memberType;
+
+  private EntityJoinRelation<String> join;
+
+  public String getMemberId() {
+    return memberId;
+  }
+
+  public RoleMemberEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
+    return this;
+  }
+
+  public EntityType getMemberType() {
+    return memberType;
+  }
+
+  public RoleMemberEntity setMemberType(final EntityType memberType) {
+    this.memberType = memberType;
+    return this;
+  }
+
+  public EntityJoinRelation<String> getJoin() {
+    return join;
+  }
+
+  public RoleMemberEntity setJoin(final EntityJoinRelation<String> join) {
+    this.join = join;
+    return this;
+  }
+
+  public static String getChildKey(final String roleId, final String memberId) {
+    return String.format("%s-%s", roleId, memberId);
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
@@ -8,10 +8,19 @@
       "key": {
         "type": "long"
       },
+      "roleId": {
+        "type": "keyword"
+      },
       "name": {
         "type": "keyword"
       },
+      "description": {
+        "type": "text"
+      },
       "memberId": {
+        "type": "keyword"
+      },
+      "memberType": {
         "type": "keyword"
       },
       "join": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -8,10 +8,19 @@
       "key": {
         "type": "long"
       },
+      "roleId": {
+        "type": "keyword"
+      },
       "name": {
         "type": "keyword"
       },
+      "description": {
+        "type": "text"
+      },
       "memberId": {
+        "type": "keyword"
+      },
+      "memberType": {
         "type": "keyword"
       },
       "join": {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -43,7 +43,7 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
 
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getRoleId());
   }
 
   @Override
@@ -56,7 +56,9 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
     final RoleRecordValue value = record.getValue();
     entity
         .setKey(value.getRoleKey())
+        .setRoleId(value.getRoleId())
         .setName(value.getName())
+        .setDescription(value.getDescription())
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createParent());
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -11,13 +11,14 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
+import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
-public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
+public class RoleMemberAddedHandler implements ExportHandler<RoleMemberEntity, RoleRecordValue> {
 
   private final String indexName;
 
@@ -31,8 +32,8 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   }
 
   @Override
-  public Class<RoleEntity> getEntityType() {
-    return RoleEntity.class;
+  public Class<RoleMemberEntity> getEntityType() {
+    return RoleMemberEntity.class;
   }
 
   @Override
@@ -44,26 +45,27 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
-    return List.of(RoleEntity.getChildKey(value.getRoleKey(), value.getEntityKey()));
+    return List.of(RoleEntity.getChildKey(value.getRoleId(), value.getEntityId()));
   }
 
   @Override
-  public RoleEntity createNewEntity(final String id) {
-    return new RoleEntity().setId(id);
+  public RoleMemberEntity createNewEntity(final String id) {
+    return new RoleMemberEntity().setId(id);
   }
 
   @Override
-  public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
+  public void updateEntity(final Record<RoleRecordValue> record, final RoleMemberEntity entity) {
+    final RoleRecordValue value = record.getValue();
     entity
-        // todo remove parsing in https://github.com/camunda/camunda/issues/30111
-        .setMemberKey(String.valueOf(record.getValue().getEntityKey()))
-        .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(record.getValue().getRoleKey()));
+        .setMemberId(value.getEntityId())
+        .setMemberType(value.getEntityType())
+        .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(value.getRoleId()));
   }
 
   @Override
-  public void flush(final RoleEntity entity, final BatchRequest batchRequest)
+  public void flush(final RoleMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent().toString());
+    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/RoleMemberRemovedHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.RoleMemberRemovedHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
+import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class RoleMemberRemovedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-role";
+  private final RoleMemberRemovedHandler underTest = new RoleMemberRemovedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.ROLE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(RoleMemberEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<RoleRecordValue> roleRemovedRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.ENTITY_REMOVED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(roleRemovedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<RoleRecordValue> roleRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.ENTITY_REMOVED);
+
+    // when
+    final var idList = underTest.generateIds(roleRecord);
+
+    // then
+    final var value = roleRecord.getValue();
+    assertThat(idList)
+        .containsExactly(RoleMemberEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateRoleEntityOnFlush() throws PersistenceException {
+    // given
+    final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
+    final var inputEntity =
+        new RoleMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableRoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class RoleCreateUpdateHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-role";
+  private final RoleCreateUpdateHandler underTest = new RoleCreateUpdateHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.ROLE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(RoleEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<RoleRecordValue> roleCreatedRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.CREATED);
+    final Record<RoleRecordValue> roleUpdatedRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.UPDATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(roleCreatedRecord)).isTrue();
+    assertThat(underTest.handlesRecord(roleUpdatedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<RoleRecordValue> roleRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.CREATED);
+
+    // when
+    final var idList = underTest.generateIds(roleRecord);
+
+    // then
+    assertThat(idList).containsExactly(roleRecord.getValue().getRoleId());
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long recordKey = 123L;
+
+    final RoleRecordValue roleRecordValue =
+        ImmutableRoleRecordValue.builder()
+            .from(factory.generateObject(RoleRecordValue.class))
+            .withName("updated-role")
+            .withRoleId("updated-roleId")
+            .withRoleKey(recordKey)
+            .build();
+
+    final Record<RoleRecordValue> roleRecord =
+        factory.generateRecord(
+            ValueType.ROLE,
+            r -> r.withIntent(RoleIntent.CREATED).withValue(roleRecordValue).withKey(recordKey));
+
+    // when
+    final RoleEntity roleEntity = new RoleEntity().setName("role").setRoleId("roleId");
+    underTest.updateEntity(roleRecord, roleEntity);
+
+    // then
+    assertThat(roleEntity.getName()).isEqualTo("updated-role");
+    assertThat(roleEntity.getRoleId()).isEqualTo("updated-roleId");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() throws PersistenceException {
+    // given
+    final RoleEntity inputEntity = new RoleEntity().setId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.index.RoleIndex;
+import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class RoleMemberAddedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-role";
+  private final RoleMemberAddedHandler underTest = new RoleMemberAddedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.ROLE);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(RoleMemberEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<RoleRecordValue> roleAddedRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.ENTITY_ADDED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(roleAddedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<RoleRecordValue> roleRecord =
+        factory.generateRecordWithIntent(ValueType.ROLE, RoleIntent.ENTITY_ADDED);
+
+    // when
+    final var idList = underTest.generateIds(roleRecord);
+
+    // then
+    final var value = roleRecord.getValue();
+    assertThat(idList)
+        .containsExactly(RoleMemberEntity.getChildKey(value.getRoleId(), value.getEntityId()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateRoleEntityOnFlush() throws PersistenceException {
+    // given
+    final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
+    final var inputEntity =
+        new RoleMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Modfies the CamundaExporter handlers to use ids when:
- A role is created or updates
- An entity is added to a role
- An entity is removed from a role

Out of scope for this PR:
- A role is deleted

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31348
closes #31350
closes #31351
