### PR TITLE
Retrieve role ids using username and mapping ids in Gateway

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -69,7 +69,7 @@ public class CamundaOAuthPrincipalService {
       LOG.debug("No mappings found for these claims: {}", claims);
     }
 
-    final var assignedRoles = roleServices.getRolesByMemberKeys(mappingKeys);
+    final var assignedRoles = roleServices.getRolesByMemberIds(mappingIds);
 
     return new OAuthContext(
         mappingKeys,

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -54,9 +54,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final Long userKey = storedUser.userKey();
 
-    // todo use username as memberId in https://github.com/camunda/camunda/issues/30111
-    final var roles =
-        roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(String.valueOf(userKey)))));
+    final var roles = roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(username))));
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -83,8 +83,9 @@ public class CamundaOAuthPrincipalServiceTest {
                 new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
                 new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
-    final var roleR1 = new RoleEntity(8L, "Role R1");
-    when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
+    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
+    when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
+        .thenReturn(List.of(roleR1));
     when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "8")))
         .thenReturn(List.of("*"));
 
@@ -118,8 +119,8 @@ public class CamundaOAuthPrincipalServiceTest {
     when(tenantServices.getTenantsByMemberIds(Set.of("map-1", "map-2")))
         .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
-    final var roleR1 = new RoleEntity(10L, "Role R1");
-    when(roleServices.getRolesByMemberKeys(Set.of(1L, 2L))).thenReturn(List.of(roleR1));
+    final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1");
+    when(roleServices.getRolesByMemberIds(Set.of("map-1", "map-2"))).thenReturn(List.of(roleR1));
 
     when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "10")))
         .thenReturn(List.of("app-1", "app-2"));

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -59,7 +59,7 @@ public class CamundaOidcUserServiceTest {
             "role", "R1",
             "group", "G1");
 
-    final var roleR1 = new RoleEntity(8L, "Role R1");
+    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
 
     when(camundaOAuthPrincipalService.loadOAuthContext(claims))
         .thenReturn(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -60,8 +60,8 @@ public class CamundaUserDetailsServiceTest {
 
     when(authorizationServices.getAuthorizedApplications(any()))
         .thenReturn(List.of("operate", "identity"));
-    final RoleEntity adminRole = new RoleEntity(2L, "ADMIN");
-    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId("100")))))
+    final RoleEntity adminRole = new RoleEntity(2L, "admin", "ADMIN");
+    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(TEST_USER_ID)))))
         .thenReturn(List.of(adminRole));
 
     // when

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -46,7 +46,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole")))
+                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole")))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);
@@ -138,7 +138,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole")))
+                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole")))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -51,6 +51,8 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
   private RoleEntity map(final RoleDbModel model) {
     return new RoleEntity(
         model.roleKey(),
+        // TODO use id instead of key https://github.com/camunda/camunda/issues/30127
+        String.valueOf(model.roleKey()),
         model.name(),
         model.members().stream().map(RoleMemberDbModel::entityId).collect(Collectors.toSet()));
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -206,14 +206,14 @@ public class PermissionsService {
     return null;
   }
 
-  private List<Long> getAuthenticatedUserRoleKeys() {
+  private List<String> getAuthenticatedUserRoleIds() {
     final Authentication requestAuthentication =
         SecurityContextHolder.getContext().getAuthentication();
     if (requestAuthentication != null) {
       final Object principal = requestAuthentication.getPrincipal();
       if (principal instanceof final CamundaPrincipal authenticatedPrincipal) {
         return authenticatedPrincipal.getAuthenticationContext().roles().stream()
-            .map(RoleEntity::roleKey)
+            .map(RoleEntity::roleId)
             .toList();
       }
     }
@@ -249,12 +249,12 @@ public class PermissionsService {
 
   private io.camunda.security.auth.Authentication getAuthentication() {
     final var authenticatedUsername = getAuthenticatedUsername();
-    final List<Long> authenticatedRoleKeys = getAuthenticatedUserRoleKeys();
+    final List<String> authenticatedRoleIds = getAuthenticatedUserRoleIds();
     final List<String> authenticatedTenantIds = getAuthenticatedUserTenantIds();
     // groups  will come later
     return new io.camunda.security.auth.Authentication.Builder()
         .user(authenticatedUsername)
-        .roleKeys(authenticatedRoleKeys)
+        .roleIds(authenticatedRoleIds)
         .tenants(authenticatedTenantIds)
         .build();
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
@@ -42,6 +42,7 @@ public class PermissionsServiceTest {
   private final String username = "foo";
   private final String tenantId = "default";
   private final long roleKey = 456L;
+  private final String roleId = "roleId";
 
   @BeforeEach
   public void setUp() {
@@ -60,7 +61,7 @@ public class PermissionsServiceTest {
         .thenReturn(
             new AuthenticationContext(
                 "test",
-                List.of(new RoleEntity(roleKey, "roleName")),
+                List.of(new RoleEntity(roleKey, roleId, "roleName")),
                 List.of(),
                 List.of(new TenantDTO(123L, tenantId, "tenantName", "")),
                 List.of()));
@@ -90,7 +91,7 @@ public class PermissionsServiceTest {
   public void testGetProcessDefinitionPermission() {
 
     final io.camunda.security.auth.Authentication authentication =
-        createCamundaAuthentication(username, List.of(tenantId), List.of(roleKey));
+        createCamundaAuthentication(username, List.of(tenantId), List.of(roleId));
 
     when(mockAuthorizationChecker.collectPermissionTypes(
             "bpmnProcessId", AuthorizationResourceType.PROCESS_DEFINITION, authentication))
@@ -112,7 +113,7 @@ public class PermissionsServiceTest {
   public void testGetDecisionDefinitionPermission() {
 
     final io.camunda.security.auth.Authentication authentication =
-        createCamundaAuthentication(username, List.of(tenantId), List.of(roleKey));
+        createCamundaAuthentication(username, List.of(tenantId), List.of(roleId));
 
     when(mockAuthorizationChecker.collectPermissionTypes(
             "decisionId", AuthorizationResourceType.DECISION_DEFINITION, authentication))
@@ -141,11 +142,11 @@ public class PermissionsServiceTest {
   }
 
   private io.camunda.security.auth.Authentication createCamundaAuthentication(
-      final String username, final List<String> tenants, final List<Long> roleKeys) {
+      final String username, final List<String> tenants, final List<String> roleIds) {
     return new io.camunda.security.auth.Authentication.Builder()
         .user(username)
         .tenants(tenants)
-        .roleKeys(roleKeys)
+        .roleIds(roleIds)
         .build();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -24,12 +24,14 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.sort.RoleSort;
 import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+@Disabled("https://github.com/camunda/camunda/issues/30127")
 public class RoleIT {
 
   public static final Long PARTITION_ID = 0L;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
@@ -17,6 +17,6 @@ public class RoleEntityTransformer
   @Override
   public RoleEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.RoleEntity value) {
-    return new RoleEntity(value.getKey(), value.getName());
+    return new RoleEntity(value.getKey(), value.getRoleId(), value.getName());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -12,9 +12,9 @@ import java.io.Serializable;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String name, Set<String> assignedMemberIds)
+public record RoleEntity(Long roleKey, String roleId, String name, Set<String> assignedMemberIds)
     implements Serializable {
-  public RoleEntity(final Long roleKey, final String name) {
-    this(roleKey, name, Set.of());
+  public RoleEntity(final Long roleKey, final String roleId, final String name) {
+    this(roleKey, roleId, name, Set.of());
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 public final class Authentication {
   private final String authenticatedUsername;
   private final List<Long> authenticatedGroupKeys;
-  private final List<Long> authenticatedRoleKeys;
+  private final List<String> authenticatedRoleIds;
   private final List<String> authenticatedTenantIds;
   private final List<String> authenticatedMappingIds;
   private final Map<String, Object> claims;
@@ -32,13 +32,13 @@ public final class Authentication {
   public Authentication(
       final @JsonProperty("authenticated_username") String authenticatedUsername,
       final @JsonProperty("authenticated_group_keys") List<Long> authenticatedGroupKeys,
-      final @JsonProperty("authenticated_role_keys") List<Long> authenticatedRoleKeys,
+      final @JsonProperty("authenticated_role_ids") List<String> authenticatedRoleIds,
       final @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
       final @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
       final @JsonProperty("claims") Map<String, Object> claims) {
     this.authenticatedUsername = authenticatedUsername;
     this.authenticatedGroupKeys = authenticatedGroupKeys;
-    this.authenticatedRoleKeys = authenticatedRoleKeys;
+    this.authenticatedRoleIds = authenticatedRoleIds;
     this.authenticatedTenantIds = authenticatedTenantIds;
     this.authenticatedMappingIds = authenticatedMappingIds;
     this.claims = claims;
@@ -60,8 +60,8 @@ public final class Authentication {
     return authenticatedGroupKeys;
   }
 
-  public List<Long> authenticatedRoleKeys() {
-    return authenticatedRoleKeys;
+  public List<String> authenticatedRoleIds() {
+    return authenticatedRoleIds;
   }
 
   public List<String> authenticatedTenantIds() {
@@ -81,7 +81,7 @@ public final class Authentication {
     return Objects.hash(
         authenticatedUsername,
         authenticatedGroupKeys,
-        authenticatedRoleKeys,
+        authenticatedRoleIds,
         authenticatedTenantIds,
         authenticatedMappingIds,
         claims);
@@ -98,7 +98,7 @@ public final class Authentication {
     final Authentication that = (Authentication) obj;
     return Objects.equals(authenticatedUsername, that.authenticatedUsername)
         && Objects.equals(authenticatedGroupKeys, that.authenticatedGroupKeys)
-        && Objects.equals(authenticatedRoleKeys, that.authenticatedRoleKeys)
+        && Objects.equals(authenticatedRoleIds, that.authenticatedRoleIds)
         && Objects.equals(authenticatedTenantIds, that.authenticatedTenantIds)
         && Objects.equals(authenticatedMappingIds, that.authenticatedMappingIds)
         && Objects.equals(claims, that.claims);
@@ -107,14 +107,14 @@ public final class Authentication {
   @Override
   public String toString() {
     return "Authentication["
-        + "authenticatedUserKey="
+        + "authenticatedUsername="
         + authenticatedUsername
         + ", "
         + "authenticatedGroupKeys="
         + authenticatedGroupKeys
         + ", "
-        + "authenticatedRoleKeys="
-        + authenticatedRoleKeys
+        + "authenticatedRoleIds="
+        + authenticatedRoleIds
         + ", "
         + "authenticatedTenantIds="
         + authenticatedTenantIds
@@ -131,7 +131,7 @@ public final class Authentication {
 
     private String username;
     private final List<Long> groupKeys = new ArrayList<>();
-    private final List<Long> roleKeys = new ArrayList<>();
+    private final List<String> roleIds = new ArrayList<>();
     private final List<String> tenants = new ArrayList<>();
     private final List<String> mappings = new ArrayList<>();
     private Map<String, Object> claims;
@@ -152,13 +152,13 @@ public final class Authentication {
       return this;
     }
 
-    public Builder role(final Long value) {
-      return roleKeys(Collections.singletonList(value));
+    public Builder role(final String value) {
+      return roleIds(Collections.singletonList(value));
     }
 
-    public Builder roleKeys(final List<Long> values) {
+    public Builder roleIds(final List<String> values) {
       if (values != null) {
-        roleKeys.addAll(values);
+        roleIds.addAll(values);
       }
       return this;
     }
@@ -194,7 +194,7 @@ public final class Authentication {
       return new Authentication(
           username,
           unmodifiableList(groupKeys),
-          unmodifiableList(roleKeys),
+          unmodifiableList(roleIds),
           unmodifiableList(tenants),
           unmodifiableList(mappings),
           claims);

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -133,11 +133,7 @@ public class AuthorizationChecker {
         authentication.authenticatedGroupKeys().stream()
             .map(Object::toString)
             .collect(Collectors.toSet()));
-    ownerIds.addAll(
-        // TODO remove this mapping when refactoring Roles to IDs
-        authentication.authenticatedRoleKeys().stream()
-            .map(Object::toString)
-            .collect(Collectors.toSet()));
+    ownerIds.addAll(authentication.authenticatedRoleIds());
     return ownerIds;
   }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, RoleEntity> {
 
@@ -61,9 +60,7 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
             .build());
   }
 
-  public List<RoleEntity> getRolesByMemberKeys(final Set<Long> memberKeys) {
-    // todo use memberIds (String) in https://github.com/camunda/camunda/issues/30111
-    final var memberIds = memberKeys.stream().map(String::valueOf).collect(Collectors.toSet());
+  public List<RoleEntity> getRolesByMemberIds(final Set<String> memberIds) {
     return findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds))));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -601,7 +601,7 @@ public class RequestMapper {
   public static Authentication getAuthentication() {
     String authenticatedUsername = null;
     final Map<String, Object> claims = new HashMap<>();
-    final List<Long> authenticatedRoleKeys = new ArrayList<>();
+    final List<String> authenticatedRoleIds = new ArrayList<>();
     final List<String> authenticatedTenantIds = new ArrayList<>();
     final List<String> authenticatedMappingIds = new ArrayList<>();
 
@@ -611,8 +611,8 @@ public class RequestMapper {
           instanceof final CamundaPrincipal authenticatedPrincipal) {
         final var authenticationContext = authenticatedPrincipal.getAuthenticationContext();
 
-        authenticatedRoleKeys.addAll(
-            authenticationContext.roles().stream().map(RoleEntity::roleKey).toList());
+        authenticatedRoleIds.addAll(
+            authenticationContext.roles().stream().map(RoleEntity::roleId).toList());
 
         authenticatedTenantIds.addAll(
             authenticationContext.tenants().stream().map(TenantDTO::tenantId).toList());
@@ -634,7 +634,7 @@ public class RequestMapper {
     return new Builder()
         .claims(claims)
         .user(authenticatedUsername)
-        .roleKeys(authenticatedRoleKeys)
+        .roleIds(authenticatedRoleIds)
         .tenants(authenticatedTenantIds)
         .mapping(authenticatedMappingIds)
         .build();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -42,7 +42,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   @Test
   void getRoleShouldReturnOk() {
     // given
-    final var role = new RoleEntity(100L, "Role Name");
+    final var role = new RoleEntity(100L, "roleId", "Role Name");
     when(roleServices.getRole(role.roleKey())).thenReturn(role);
 
     // when
@@ -109,9 +109,9 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
-                        new RoleEntity(100L, "Role 1"),
-                        new RoleEntity(200L, "Role 2"),
-                        new RoleEntity(300L, "Role 12")))
+                        new RoleEntity(100L, "role1", "Role 1"),
+                        new RoleEntity(200L, "role2", "Role 2"),
+                        new RoleEntity(300L, "role12", "Role 12")))
                 .build());
 
     // when / then
@@ -163,9 +163,9 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 .total(3)
                 .items(
                     List.of(
-                        new RoleEntity(100L, "Role 1"),
-                        new RoleEntity(300L, "Role 12"),
-                        new RoleEntity(200L, "Role 2")))
+                        new RoleEntity(100L, "role1", "Role 1"),
+                        new RoleEntity(300L, "role12", "Role 12"),
+                        new RoleEntity(200L, "role2", "Role 2")))
                 .build());
 
     // when / then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Retrieve a user's assigned roles using the username
- Retrieve a mapping's assigned roles using the mapping id
- Put the retrieved role ids on the authentication so they are used during authorization checks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31358 
