### PR TITLE
ci: allow blank issues again

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
Sometimes the templates are too restrictive and get in the way of work. Especially for creating epic-like issues that just organize work across multiple components and are not a single feature itself.

See this internal discussion: https://camunda.slack.com/archives/C08F5RD5X8B/p1745500256857769