### PR TITLE
feat: Reject denying on `creating` and `canceling` listeners 

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
+import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_DENY_AND_CORRECTIONS_NOT_SUPPORTED_MESSAGE;
+import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_UNKNOWN_CORRECTIONS_NOT_SUPPORTED_MESSAGE;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -1373,12 +1375,7 @@ public class TaskListenerCorrectionsTest {
     Assertions.assertThat(rejection)
         .describedAs("Expect that the job completion is rejected")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            """
-            Expected to complete task listener job with corrections, but the job result is denied. \
-            The corrections would be reverted by the denial. Either complete the job with \
-            corrections without setting denied, or complete the job with a denied result but no \
-            corrections.""");
+        .hasRejectionReason(TL_JOB_COMPLETION_WITH_DENY_AND_CORRECTIONS_NOT_SUPPORTED_MESSAGE);
   }
 
   @Test
@@ -1405,10 +1402,8 @@ public class TaskListenerCorrectionsTest {
         .describedAs("Expect that the job completion is rejected")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            """
-            Expected to complete task listener job with a corrections result, \
-            but property 'unknown_property' cannot be corrected. \
-            Only the following properties can be corrected: \
-            [assignee, candidateGroupsList, candidateUsersList, dueDate, followUpDate, priority].""");
+            TL_JOB_COMPLETION_WITH_UNKNOWN_CORRECTIONS_NOT_SUPPORTED_MESSAGE.formatted(
+                "unknown_property",
+                "[assignee, candidateGroupsList, candidateUsersList, dueDate, followUpDate, priority]"));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
-import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_DENY_AND_CORRECTIONS_NOT_SUPPORTED_MESSAGE;
-import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_UNKNOWN_CORRECTIONS_NOT_SUPPORTED_MESSAGE;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -1375,7 +1373,14 @@ public class TaskListenerCorrectionsTest {
     Assertions.assertThat(rejection)
         .describedAs("Expect that the job completion is rejected")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(TL_JOB_COMPLETION_WITH_DENY_AND_CORRECTIONS_NOT_SUPPORTED_MESSAGE);
+        .hasRejectionReason(
+            """
+                Expected to complete task listener job with corrections, but the job result is denied \
+                (job key '%d', type '%s', processInstanceKey '%d'). \
+                The corrections would be reverted by the denial. Either complete the job with corrections \
+                without setting denied, or complete the job with a denied result but no corrections.
+                """
+                .formatted(rejection.getKey(), listenerType, processInstanceKey));
   }
 
   @Test
@@ -1402,8 +1407,11 @@ public class TaskListenerCorrectionsTest {
         .describedAs("Expect that the job completion is rejected")
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            TL_JOB_COMPLETION_WITH_UNKNOWN_CORRECTIONS_NOT_SUPPORTED_MESSAGE.formatted(
-                "unknown_property",
-                "[assignee, candidateGroupsList, candidateUsersList, dueDate, followUpDate, priority]"));
+            """
+                Expected to complete task listener job with a corrections result, but property 'unknown_property' \
+                cannot be corrected (job key '%d', type '%s', processInstanceKey '%d'). \
+                Only the following properties can be corrected: [assignee, candidateGroupsList, candidateUsersList, dueDate, followUpDate, priority].
+                """
+                .formatted(rejection.getKey(), listenerType, processInstanceKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
+import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_DENY_NOT_SUPPORTED_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -774,5 +776,56 @@ public class TaskListenerDenialsTest {
                 .hasFollowUpDate("")
                 .hasPriority(50)
                 .hasAssignee(""));
+  }
+
+  @Test
+  public void shouldRejectCreatingTaskListenerCompletionWithDeniedResult() {
+    assertDenyResultIsRejectedForNonDeniableListenerType(
+        ZeebeTaskListenerEventType.creating, ignored -> {});
+  }
+
+  @Test
+  public void shouldRejectCancelingTaskListenerCompletionWithDeniedResult() {
+    assertDenyResultIsRejectedForNonDeniableListenerType(
+        ZeebeTaskListenerEventType.canceling,
+        pik -> ENGINE.processInstance().withInstanceKey(pik).expectTerminating().cancel());
+  }
+
+  private void assertDenyResultIsRejectedForNonDeniableListenerType(
+      final ZeebeTaskListenerEventType listenerEventType, final Consumer<Long> triggerTransition) {
+
+    // given: a process instance with a task listener that doesn't support denying
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createUserTaskWithTaskListeners(listenerEventType, this.listenerType));
+
+    // trigger transition
+    triggerTransition.accept(processInstanceKey);
+
+    // when: attempting to complete the task listener job with `denied=true`
+    final var result =
+        ENGINE
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(this.listenerType)
+            .withResult(new JobResult().setDenied(true))
+            .expectRejection()
+            .complete();
+
+    // then: job completion should be rejected
+    final var expectedJobListenerType = helper.mapToJobListenerEventType(listenerEventType);
+    Assertions.assertThat(result)
+        .describedAs(
+            "Task listener of type '%s' should reject job completion with 'denied=true' result",
+            expectedJobListenerType)
+        .hasIntent(JobIntent.COMPLETE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            TL_JOB_COMPLETION_WITH_DENY_NOT_SUPPORTED_MESSAGE.formatted(
+                expectedJobListenerType,
+                "[ASSIGNING, COMPLETING, UPDATING]",
+                result.getKey(),
+                result.getValue().getType(),
+                processInstanceKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDenialsTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
-import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_DENY_NOT_SUPPORTED_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -821,11 +820,15 @@ public class TaskListenerDenialsTest {
         .hasIntent(JobIntent.COMPLETE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            TL_JOB_COMPLETION_WITH_DENY_NOT_SUPPORTED_MESSAGE.formatted(
-                expectedJobListenerType,
-                "[ASSIGNING, COMPLETING, UPDATING]",
-                result.getKey(),
-                result.getValue().getType(),
-                processInstanceKey));
+            """
+                Denying result is not supported for '%s' task listener jobs \
+                (job key '%d', type '%s', processInstanceKey '%d'). \
+                Only the following listener event types support denying: [ASSIGNING, COMPLETING, UPDATING].
+                """
+                .formatted(
+                    expectedJobListenerType,
+                    result.getKey(),
+                    result.getValue().getType(),
+                    processInstanceKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerVariablesTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
-import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -231,8 +230,12 @@ public class TaskListenerVariablesTest {
         .hasIntent(JobIntent.COMPLETE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE.formatted(
-                result.getKey(), listenerType, processInstanceKey));
+            """
+                Task Listener job completion with variables payload provided is not yet supported \
+                (job key '%d', type '%s', processInstanceKey '%d'). \
+                Support will be enabled with the resolution of issue #23702.
+                """
+                .formatted(result.getKey(), listenerType, processInstanceKey));
 
     // complete the listener job without variables to have a completed process
     // and prevent flakiness in other tests


### PR DESCRIPTION
## Description

This PR introduces check to prevent completing task listener jobs with a denied result (`deny=true`) for listener event types that do not support denying: `CREATING` and `CANCELING`. The engine now explicitly rejects such completions, ensuring denial logic is only applicable to [`ASSIGNING`, `UPDATING`, `COMPLETING`] event types. 
Added dedicated tests to verify this behavior.

Also, all job completion rejection messages in `JobCompleteProcessor` have been aligned to includes job-specific context: `(job key, type, processInstanceKey)`. This enhances traceability and clarity in logs and error handling. In tests, formatted messages are inlined for better readability and to keep assertions self-contained and explicit.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29125 
closes #28580 
