### PR TITLE
[PoC] Handle error for batch execution

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationExecutionFailedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationExecutionFailedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+
+public class BatchOperationExecutionFailedApplier
+    implements TypedEventApplier<BatchOperationExecutionIntent, BatchOperationExecutionRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationExecutionFailedApplier(
+      final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(final long key, final BatchOperationExecutionRecord value) {
+    batchOperationState.removeItemKeys(value.getBatchOperationKey(), value.getItemKeys());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -605,6 +605,9 @@ public final class EventAppliers implements EventApplier {
         new BatchOperationExecutingApplier(state.getBatchOperationState()));
     register(BatchOperationExecutionIntent.EXECUTED, NOOP_EVENT_APPLIER);
     register(
+        BatchOperationExecutionIntent.FAILED,
+        new BatchOperationExecutionFailedApplier(state.getBatchOperationState()));
+    register(
         BatchOperationIntent.CANCELED,
         new BatchOperationCanceledApplier(state.getBatchOperationState()));
     register(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
@@ -19,7 +19,8 @@ public enum BatchOperationExecutionIntent implements Intent {
   EXECUTE((short) 0),
   EXECUTING((short) 1),
   EXECUTED((short) 2),
-  COMPLETED((short) 3);
+  COMPLETED((short) 3),
+  FAILED((short) 4);
 
   private final short value;
 
@@ -41,6 +42,8 @@ public enum BatchOperationExecutionIntent implements Intent {
         return EXECUTED;
       case 3:
         return COMPLETED;
+      case 4:
+        return FAILED;
 
       default:
         return Intent.UNKNOWN;
@@ -58,6 +61,7 @@ public enum BatchOperationExecutionIntent implements Intent {
       case EXECUTING:
       case EXECUTED:
       case COMPLETED:
+      case FAILED:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

This adds error handling to the BatchOperationExecuteProcessor, allowing it to deal with errors produced by the followup commands.

For example, consider an error that occurs during individual process instance migration which is part of a batch operation. The streamprocessor rolls back the entire result batch (and transaction), so all progress of the BatchOperationExecution:EXECUTE command is lost anyways. What we can do, is to append a FAILED event for this execution. To continue, we can simply append the next followup command.

To ensure that we can continue with the next execution, the key items must be removed from state when applying the FAILED event.

This solution has three main downsides:

1. All operations in this batch execution have FAILED, even though only one actually encountered a problem.

2. The reason for the encountered problem is lost.

3. If this execution was the one in the batch, then the batch operation is still marked as COMPLETED even though the operation execution FAILED.


<details><summary>Example logs</summary>
<p>


```
C BATCH_OPERATION_CREATION  CREATE     #24-> -1  -1 BatchOperationCreationRecord {"batchOperationKey":-1,"batchOperationType":"MIGRATE_PROCESS_INSTANCE","entityFilterBuffer":{"expandable":false},"migrationPlan":{"targetProcessDefinitionKey":2251799813685252,"mappingInstructions":[{"sourceElementId":"userTask","targetElementId":"userTaskNotExists"}],"empty":false,"encodedLength":118},"entityFilter":"{\"processInstanceKeyOperations\":[],\"processDefinitionIdOperations\":[],\"processDefinitionNameOperations\":[],\"processDefinitionVersionOperations\":[],\"processDefinitionVersionTagOperations\":[],\"processDefinitionKeyOperations\":[],\"parentProcessInstanceKeyOperations\":[],\"parentFlowNodeInstanceKeyOperations\":[],\"startDateOperations\":[],\"endDateOperations\":[],\"stateOperations\":[],\"hasIncident\":null,\"tenantIdOperations\":[],\"variableFilters\":[],\"errorMessageOperations\":[],\"batchOperationIdOperations\":[],\"hasRetriesLeft\":null,\"flowNodeIdOperations\":[],\"hasFlowNodeInstanceIncident\":null,\"flowNodeInstanceStateOperations\":[],\"incidentErrorHashCodes\":[],\"partitionId\":null,\"orFilters\":null}"}
E BATCH_OPERATION_CREATION  CREATED    #25->#24 K12 BatchOperationCreationRecord {"batchOperationKey":2251799813685260,"batchOperationType":"MIGRATE_PROCESS_INSTANCE","entityFilterBuffer":{"expandable":false},"migrationPlan":{"targetProcessDefinitionKey":2251799813685252,"mappingInstructions":[{"sourceElementId":"userTask","targetElementId":"userTaskNotExists"}],"empty":false,"encodedLength":118},"entityFilter":"{\"processInstanceKeyOperations\":[],\"processDefinitionIdOperations\":[],\"processDefinitionNameOperations\":[],\"processDefinitionVersionOperations\":[],\"processDefinitionVersionTagOperations\":[],\"processDefinitionKeyOperations\":[],\"parentProcessInstanceKeyOperations\":[],\"parentFlowNodeInstanceKeyOperations\":[],\"startDateOperations\":[],\"endDateOperations\":[],\"stateOperations\":[],\"hasIncident\":null,\"tenantIdOperations\":[],\"variableFilters\":[],\"errorMessageOperations\":[],\"batchOperationIdOperations\":[],\"hasRetriesLeft\":null,\"flowNodeIdOperations\":[],\"hasFlowNodeInstanceIncident\":null,\"flowNodeInstanceStateOperations\":[],\"incidentErrorHashCodes\":[],\"partitionId\":null,\"orFilters\":null}"}
C BATCH_OPERATION_CREATION  START      #26-> -1 K12 BatchOperationCreationRecord {"batchOperationKey":2251799813685260,"batchOperationType":"MIGRATE_PROCESS_INSTANCE","entityFilterBuffer":{"expandable":false},"migrationPlan":{"targetProcessDefinitionKey":-1,"mappingInstructions":[],"empty":false,"encodedLength":50},"entityFilter":null}
C BATCH_OPERATION_CHUNK     CREATE     #27-> -1 K12 BatchOperationChunkRecord {"batchOperationKey":2251799813685260,"itemKeys":[2251799813685253]}
C BATCH_OPERATION_EXECUTION EXECUTE    #28-> -1 K12 BatchOperationExecutionRecord {"batchOperationKey":2251799813685260,"itemKeys":[]}
E BATCH_OPERATION_CREATION  STARTED    #29->#26 K12 BatchOperationCreationRecord {"batchOperationKey":2251799813685260,"batchOperationType":"MIGRATE_PROCESS_INSTANCE","entityFilterBuffer":{"expandable":false},"migrationPlan":{"targetProcessDefinitionKey":-1,"mappingInstructions":[],"empty":false,"encodedLength":50},"entityFilter":null}
E BATCH_OPERATION_CHUNK     CREATED    #30->#27 K12 BatchOperationChunkRecord {"batchOperationKey":2251799813685260,"itemKeys":[2251799813685253]}
E BATCH_OPERATION_EXECUTION FAILED     #31->#28 K12 BatchOperationExecutionRecord {"batchOperationKey":2251799813685260,"itemKeys":[2251799813685253]}
C BATCH_OPERATION_EXECUTION EXECUTE    #32->#28 K12 BatchOperationExecutionRecord {"batchOperationKey":2251799813685260,"itemKeys":[]}
E BATCH_OPERATION_EXECUTION EXECUTED   #33->#32 K12 BatchOperationExecutionRecord {"batchOperationKey":2251799813685260,"itemKeys":[]}
E BATCH_OPERATION_EXECUTION COMPLETED  #34->#32 K12 BatchOperationExecutionRecord {"batchOperationKey":2251799813685260,"itemKeys":[]}
```

</p>
</details> 

## Related issues

relates to #31335
