### PR TITLE
refactor: remove processInstanceDetailsDiagramStore dependency from flowNodeSelectionStore

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/VariablesForm.tsx
@@ -17,7 +17,10 @@ import {FormRenderProps} from 'react-final-form';
 
 import {AddVariableButton, Form, VariablesContainer} from './styled';
 import {useWillAllFlowNodesBeCanceled} from 'modules/hooks/modifications';
-import {useHasPendingCancelOrMoveModification} from 'modules/hooks/flowNodeSelection';
+import {
+  useHasPendingCancelOrMoveModification,
+  useIsPlaceholderSelected,
+} from 'modules/hooks/flowNodeSelection';
 import Variables from '../Variables';
 
 const VariablesForm: React.FC<
@@ -26,6 +29,7 @@ const VariablesForm: React.FC<
   const willAllFlowNodesBeCanceled = useWillAllFlowNodesBeCanceled();
   const hasPendingCancelOrMoveModification =
     useHasPendingCancelOrMoveModification();
+  const isPlaceholderSelected = useIsPlaceholderSelected();
   const hasEmptyNewVariable = (values: VariableFormValues) =>
     values.newVariables?.some(
       (variable) =>
@@ -49,7 +53,7 @@ const VariablesForm: React.FC<
     }
 
     return (
-      flowNodeSelectionStore.isPlaceholderSelected ||
+      isPlaceholderSelected ||
       (flowNodeMetaDataStore.isSelectedInstanceRunning &&
         !hasPendingCancelOrMoveModification)
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
@@ -18,7 +18,10 @@ import {FormRenderProps} from 'react-final-form';
 import {AddVariableButton, Form, VariablesContainer} from '../styled';
 import Variables from '../../Variables/v2';
 import {useWillAllFlowNodesBeCanceled} from 'modules/hooks/modifications';
-import {useHasPendingCancelOrMoveModification} from 'modules/hooks/flowNodeSelection';
+import {
+  useHasPendingCancelOrMoveModification,
+  useIsPlaceholderSelected,
+} from 'modules/hooks/flowNodeSelection';
 
 const VariablesForm: React.FC<
   FormRenderProps<VariableFormValues, Partial<VariableFormValues>>
@@ -33,6 +36,7 @@ const VariablesForm: React.FC<
         variable.name === undefined ||
         variable.value === undefined,
     );
+  const isPlaceholderSelected = useIsPlaceholderSelected();
 
   const {isModificationModeEnabled} = modificationsStore;
 
@@ -49,7 +53,7 @@ const VariablesForm: React.FC<
     }
 
     return (
-      flowNodeSelectionStore.isPlaceholderSelected ||
+      isPlaceholderSelected ||
       (flowNodeMetaDataStore.isSelectedInstanceRunning &&
         !hasPendingCancelOrMoveModification)
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/ExistingVariableValue.tsx
@@ -16,10 +16,12 @@ import {modificationsStore} from 'modules/stores/modifications';
 import {createVariableFieldName} from './createVariableFieldName';
 import {mergeValidators} from 'modules/utils/validators/mergeValidators';
 import {variablesStore} from 'modules/stores/variables';
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {Popup} from '@carbon/react/icons';
 import {LoadingTextfield} from './LoadingTextField';
 import {Layer} from '@carbon/react';
+import {getSelectedFlowNodeName} from 'modules/utils/flowNodeSelection';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 
 type Props = {
   id?: string;
@@ -36,6 +38,7 @@ const createModification = ({
   name,
   oldValue,
   newValue,
+  businessObjects,
 }: {
   scopeId: string | null;
   isValid: boolean;
@@ -43,6 +46,7 @@ const createModification = ({
   name: string;
   oldValue: string;
   newValue: string;
+  businessObjects?: BusinessObjects;
 }) => {
   if (
     !modificationsStore.isModificationModeEnabled ||
@@ -71,7 +75,7 @@ const createModification = ({
         operation: 'EDIT_VARIABLE',
         id: name,
         scopeId,
-        flowNodeName: flowNodeSelectionStore.selectedFlowNodeName,
+        flowNodeName: getSelectedFlowNodeName(businessObjects),
         name,
         oldValue,
         newValue,
@@ -87,6 +91,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
     const formState = useFormState();
     const [isModalVisible, setIsModalVisible] = useState(false);
     const form = useForm();
+    const {data: businessObjects} = useBusinessObjects();
 
     const fieldName = isModificationModeEnabled
       ? createVariableFieldName(variableName)
@@ -158,6 +163,7 @@ const ExistingVariableValue: React.FC<Props> = observer(
                   newValue: input.value ?? '',
                   isDirty: variableValue !== input.value,
                   isValid: isValid ?? false,
+                  businessObjects,
                 });
 
                 input.onBlur(event);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Value.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/Value.tsx
@@ -21,6 +21,7 @@ import {Popup} from '@carbon/react/icons';
 import {useVariableFormFields} from './useVariableFormFields';
 import {createModification} from './createModification';
 import {Layer} from '@carbon/react';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 
 type Props = {
   variableName: string;
@@ -32,6 +33,7 @@ const Value: React.FC<Props> = ({variableName, scopeId}) => {
   const form = useForm();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const valueFieldName = createNewVariableFieldName(variableName, 'value');
+  const {data: businessObjects} = useBusinessObjects();
 
   const {
     currentName,
@@ -77,6 +79,7 @@ const Value: React.FC<Props> = ({variableName, scopeId}) => {
                 id: currentId,
                 name: currentName,
                 value: currentValue,
+                businessObjects,
               });
             }}
           />

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/createModification.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/NewVariableModification/createModification.ts
@@ -6,8 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {modificationsStore} from 'modules/stores/modifications';
+import {getSelectedFlowNodeName} from 'modules/utils/flowNodeSelection';
 
 const createModification = ({
   scopeId,
@@ -15,12 +16,14 @@ const createModification = ({
   id,
   name,
   value,
+  businessObjects,
 }: {
   scopeId: string | null;
   areFormFieldsValid: boolean;
   id: string;
   name: string;
   value: string;
+  businessObjects?: BusinessObjects;
 }) => {
   if (scopeId === null || !areFormFieldsValid || name === '' || value === '') {
     return;
@@ -43,7 +46,7 @@ const createModification = ({
         operation: 'ADD_VARIABLE',
         scopeId,
         id,
-        flowNodeName: flowNodeSelectionStore.selectedFlowNodeName,
+        flowNodeName: getSelectedFlowNodeName(businessObjects),
         name,
         newValue: value,
       },

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/existingVariableModification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/existingVariableModification.test.tsx
@@ -19,6 +19,9 @@ import {OnLastVariableModificationRemoved} from '../OnLastVariableModificationRe
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {createInstance} from 'modules/testUtils';
 import {useEffect} from 'react';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 type Props = {
   children?: React.ReactNode;
@@ -35,19 +38,23 @@ const Wrapper: React.FC<Props> = ({children}) => {
   }, []);
 
   return (
-    <MemoryRouter>
-      <Form onSubmit={() => {}} mutators={{...arrayMutators}}>
-        {({handleSubmit}) => {
-          return (
-            <>
-              <form onSubmit={handleSubmit}>{children} </form>
-              <OnLastVariableModificationRemoved />
-              <LastModification />
-            </>
-          );
-        }}
-      </Form>
-    </MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter>
+          <Form onSubmit={() => {}} mutators={{...arrayMutators}}>
+            {({handleSubmit}) => {
+              return (
+                <>
+                  <form onSubmit={handleSubmit}>{children} </form>
+                  <OnLastVariableModificationRemoved />
+                  <LastModification />
+                </>
+              );
+            }}
+          </Form>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -388,6 +388,7 @@ describe('Add variable', () => {
     const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
     const withinVariable = within(screen.getByTestId('variable-clientNo'));

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
@@ -121,6 +121,7 @@ describe('Edit variable', () => {
     expect(
       await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
     );
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       withinFirstVariable.getByRole('button', {name: /edit variable/i}),
     );
@@ -161,6 +162,7 @@ describe('Edit variable', () => {
     expect(
       await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
     );
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       withinFirstVariable.getByRole('button', {name: /edit variable/i}),
     );
@@ -197,9 +199,11 @@ describe('Edit variable', () => {
       screen.getByTestId(`variable-${firstVariable!.name}`),
     );
 
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       withinFirstVariable.getByRole('button', {name: /edit variable/i}),
     );
+
     await user.type(
       screen.getByTestId('edit-variable-value'),
       "{{invalidKey: 'value'}}",
@@ -255,6 +259,7 @@ describe('Edit variable', () => {
     );
 
     expect(await screen.findByTestId('variable-clientNo'));
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       within(screen.getByTestId('variable-clientNo')).getByRole('button', {
         name: /edit variable/i,
@@ -303,6 +308,7 @@ describe('Edit variable', () => {
     mockFetchVariable().withDelayedServerError();
 
     expect(await screen.findByTestId('variable-testVariableName'));
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       within(screen.getByTestId('variable-testVariableName')).getByRole(
         'button',
@@ -341,6 +347,7 @@ describe('Edit variable', () => {
     expect(screen.getByText('"full-value"')).toBeInTheDocument();
 
     expect(await screen.findByTestId('variable-testVariableName'));
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       within(screen.getByTestId('variable-testVariableName')).getByRole(
         'button',
@@ -386,6 +393,7 @@ describe('Edit variable', () => {
       createVariable({isPreview: false, value: '123456'}),
     );
 
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByTestId('edit-variable-value'));
 
     expect(screen.getByTestId('full-variable-loader')).toBeInTheDocument();
@@ -427,6 +435,7 @@ describe('Edit variable', () => {
       createVariable({isPreview: false, value: '123456'}),
     );
 
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       screen.getByRole('button', {name: /open json editor modal/i}),
     );
@@ -452,6 +461,7 @@ describe('Edit variable', () => {
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(await screen.findByRole('button', {name: /edit variable/i}));
+    mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByRole('button', {name: /edit variable/i}));
     await user.click(
       screen.getByRole('button', {name: /open json editor modal/i}),

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
@@ -37,7 +37,6 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {mockFetchProcessSequenceFlows} from 'modules/mocks/api/v2/flownodeInstances/sequenceFlows';
 import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
 
@@ -133,6 +132,7 @@ describe('TopPanel', () => {
         },
       ],
     });
+    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
   });
 
   afterEach(() => {
@@ -372,8 +372,7 @@ describe('TopPanel', () => {
       screen.queryByText(/select the target flow node in the diagram/i),
     ).not.toBeInTheDocument();
 
-    await processInstanceDetailsDiagramStore.fetchProcessXml('processId');
-    await user.click(screen.getByRole('button', {name: /move/i}));
+    await user.click(await screen.findByRole('button', {name: /move/i}));
 
     expect(
       await screen.findByText(/select the target flow node in the diagram/i),

--- a/operate/client/src/modules/hooks/flowNodeMetadata.ts
+++ b/operate/client/src/modules/hooks/flowNodeMetadata.ts
@@ -8,10 +8,14 @@
 
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {useHasRunningOrFinishedTokens} from './flowNodeSelection';
+import {
+  useHasRunningOrFinishedTokens,
+  useNewTokenCountForSelectedNode,
+} from './flowNodeSelection';
 
 const useHasMultipleInstances = () => {
   const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
   const {metaData} = flowNodeMetaDataStore.state;
 
   if (
@@ -21,13 +25,10 @@ const useHasMultipleInstances = () => {
   }
 
   if (!hasRunningOrFinishedTokens) {
-    return flowNodeSelectionStore.newTokenCountForSelectedNode > 1;
+    return newTokenCountForSelectedNode > 1;
   }
 
-  return (
-    (metaData?.instanceCount ?? 0) > 1 ||
-    flowNodeSelectionStore.newTokenCountForSelectedNode > 0
-  );
+  return (metaData?.instanceCount ?? 0) > 1 || newTokenCountForSelectedNode > 0;
 };
 
 export {useHasMultipleInstances};

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -76,8 +76,19 @@ const useNewTokenCountForSelectedNode = () => {
   );
 };
 
+const useIsPlaceholderSelected = () => {
+  const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+
+  return (
+    flowNodeSelectionStore.state.selection?.isPlaceholder ||
+    (!hasRunningOrFinishedTokens && newTokenCountForSelectedNode === 1)
+  );
+};
+
 export {
   useHasPendingCancelOrMoveModification,
   useHasRunningOrFinishedTokens,
   useNewTokenCountForSelectedNode,
+  useIsPlaceholderSelected,
 };

--- a/operate/client/src/modules/stores/flowNodeSelection.test.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.test.ts
@@ -192,20 +192,6 @@ describe('stores/flowNodeSelection', () => {
     expect(flowNodeSelectionStore.state.selection).toEqual(rootNode);
   });
 
-  it('should get selected flow node name', async () => {
-    const selection = {
-      flowNodeId: 'startEvent',
-      flowNodeInstanceId: '2251799813689409',
-    };
-
-    expect(flowNodeSelectionStore.selectedFlowNodeName).toBe(
-      'some process name',
-    );
-
-    flowNodeSelectionStore.selectFlowNode(selection);
-    expect(flowNodeSelectionStore.selectedFlowNodeName).toBe('startEvent');
-  });
-
   it('should clear selection when last modification is removed which results in selected scope being removed', () => {
     const rootNode = {
       flowNodeInstanceId: PROCESS_INSTANCE_ID,

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -137,14 +137,6 @@ class FlowNodeSelection {
     );
   }
 
-  get isPlaceholderSelected() {
-    return (
-      this.state.selection?.isPlaceholder ||
-      (!this.hasRunningOrFinishedTokens &&
-        this.newTokenCountForSelectedNode === 1)
-    );
-  }
-
   /*
    * DEPRECATED: The `flowNodeSelectionStore.selectedRunningInstanceCount` is being deprecated and replaced with
    * utility functions and hooks in `flowNodeSelection.ts` as part of the Operate v2 migration.
@@ -194,24 +186,6 @@ class FlowNodeSelection {
       processInstanceDetailsStatisticsStore.state.statistics.some(
         ({activityId}) => activityId === currentFlowNodeSelection.flowNodeId,
       )
-    );
-  }
-
-  get newTokenCountForSelectedNode() {
-    const currentFlowNodeSelection = this.state.selection;
-
-    const flowNodeId = currentFlowNodeSelection?.flowNodeId;
-    if (flowNodeId === undefined) {
-      return 0;
-    }
-
-    return (
-      (modificationsStore.modificationsByFlowNode[flowNodeId]?.newTokens ?? 0) +
-      modificationsStore.flowNodeModifications.filter(
-        (modification) =>
-          modification.operation !== 'CANCEL_TOKEN' &&
-          Object.keys(modification.parentScopeIds).includes(flowNodeId),
-      ).length
     );
   }
 

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -10,7 +10,6 @@ import {IReactionDisposer, makeAutoObservable, when, reaction} from 'mobx';
 import {FlowNodeInstance} from './flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {modificationsStore} from './modifications';
-import {processInstanceDetailsDiagramStore} from './processInstanceDetailsDiagram';
 import {processInstanceDetailsStatisticsStore} from './processInstanceDetailsStatistics';
 import {flowNodeMetaDataStore} from './flowNodeMetaData';
 
@@ -184,27 +183,6 @@ class FlowNodeSelection {
     return (
       this.state.selection?.flowNodeInstanceId ??
       flowNodeMetaDataStore.state.metaData?.flowNodeInstanceId
-    );
-  }
-
-  get selectedFlowNodeName() {
-    if (
-      processInstanceDetailsStore.state.processInstance === null ||
-      this.state.selection === null
-    ) {
-      return '';
-    }
-
-    if (this.isRootNodeSelected) {
-      return processInstanceDetailsStore.state.processInstance.processName;
-    }
-
-    if (this.state.selection.flowNodeId === undefined) {
-      return '';
-    }
-
-    return processInstanceDetailsDiagramStore.getFlowNodeName(
-      this.state.selection.flowNodeId,
     );
   }
 

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -137,14 +137,15 @@ class Modifications {
     sourceFlowNodeId: string,
     sourceFlowNodeInstanceKey?: string,
   ) => {
-    this.state.status = 'moving-token';
-    this.state.sourceFlowNodeIdForMoveOperation = sourceFlowNodeId;
-    this.state.sourceFlowNodeInstanceKeyForMoveOperation =
-      sourceFlowNodeInstanceKey ?? null;
+    this.setStatus('moving-token');
+    this.setSourceFlowNodeIdForMoveOperation(sourceFlowNodeId);
+    this.setSourceFlowNodeInstanceKeyForMoveOperation(
+      sourceFlowNodeInstanceKey ?? null,
+    );
   };
 
   startAddingToken = (sourceFlowNodeId: string) => {
-    this.state.status = 'adding-token';
+    this.setStatus('adding-token');
     this.state.sourceFlowNodeIdForAddOperation = sourceFlowNodeId;
   };
 
@@ -206,23 +207,38 @@ class Modifications {
       });
     }
 
-    this.state.status = 'enabled';
+    this.setStatus('enabled');
     this.state.sourceFlowNodeIdForAddOperation = null;
+  };
+
+  setStatus = (status: State['status']) => {
+    this.state.status = status;
+  };
+
+  setSourceFlowNodeIdForMoveOperation = (sourceFlowNodeId: string | null) => {
+    this.state.sourceFlowNodeIdForMoveOperation = sourceFlowNodeId;
+  };
+
+  setSourceFlowNodeInstanceKeyForMoveOperation = (
+    sourceFlowNodeInstanceKey: string | null,
+  ) => {
+    this.state.sourceFlowNodeInstanceKeyForMoveOperation =
+      sourceFlowNodeInstanceKey;
   };
 
   enableModificationMode = () => {
     tracking.track({
       eventName: 'enable-modification-mode',
     });
-    this.state.status = 'enabled';
+    this.setStatus('enabled');
   };
 
   disableModificationMode = () => {
-    this.state.status = 'disabled';
+    this.setStatus('disabled');
   };
 
   startApplyingModifications = () => {
-    this.state.status = 'applying-modifications';
+    this.setStatus('applying-modifications');
   };
 
   addModification = (modification: Modification) => {

--- a/operate/client/src/modules/utils/flowNodeSelection.test.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.test.ts
@@ -6,14 +6,23 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {getSelectedRunningInstanceCount} from './flowNodeSelection';
+import {
+  getSelectedFlowNodeName,
+  getSelectedRunningInstanceCount,
+} from './flowNodeSelection';
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {createInstance} from 'modules/testUtils';
 
 describe('getSelectedRunningInstanceCount', () => {
   beforeEach(() => {
     flowNodeSelectionStore.reset();
     flowNodeMetaDataStore.reset();
+  });
+
+  afterEach(() => {
+    processInstanceDetailsStore.reset();
   });
 
   it('should return 0 if no selection is made', () => {
@@ -58,5 +67,29 @@ describe('getSelectedRunningInstanceCount', () => {
     flowNodeSelectionStore.setSelection({});
     const result = getSelectedRunningInstanceCount(10);
     expect(result).toBe(0);
+  });
+
+  it('should retrieve selected flow node name from business object', () => {
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: 'instance_id',
+        state: 'ACTIVE',
+      }),
+    );
+
+    flowNodeSelectionStore.setSelection({
+      flowNodeId: 'startEvent',
+      flowNodeInstanceId: '2251799813689409',
+    });
+
+    const result = getSelectedFlowNodeName({
+      startEvent: {
+        id: 'startEvent',
+        name: 'Start Event',
+        $type: 'bpmn:StartEvent',
+      },
+    });
+
+    expect(result).toBe('Start Event');
   });
 });

--- a/operate/client/src/modules/utils/flowNodeSelection.ts
+++ b/operate/client/src/modules/utils/flowNodeSelection.ts
@@ -8,6 +8,9 @@
 
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {getFlowNodeName} from './flowNodes';
+import {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 
 const getSelectedRunningInstanceCount = (
   totalRunningInstancesForFlowNode: number,
@@ -33,4 +36,26 @@ const getSelectedRunningInstanceCount = (
   return totalRunningInstancesForFlowNode;
 };
 
-export {getSelectedRunningInstanceCount};
+const getSelectedFlowNodeName = (businessObjects?: BusinessObjects) => {
+  if (
+    processInstanceDetailsStore.state.processInstance === null ||
+    flowNodeSelectionStore.state.selection === null
+  ) {
+    return '';
+  }
+
+  if (flowNodeSelectionStore.isRootNodeSelected) {
+    return processInstanceDetailsStore.state.processInstance.processName;
+  }
+
+  if (flowNodeSelectionStore.state.selection.flowNodeId === undefined) {
+    return '';
+  }
+
+  return getFlowNodeName({
+    businessObjects,
+    flowNodeId: flowNodeSelectionStore.state.selection.flowNodeId,
+  });
+};
+
+export {getSelectedRunningInstanceCount, getSelectedFlowNodeName};

--- a/operate/client/src/modules/utils/modification.test.ts
+++ b/operate/client/src/modules/utils/modification.test.ts
@@ -21,6 +21,9 @@ jest.mock('modules/stores/modifications', () => ({
     },
     addCancelModification: jest.fn(),
     addMoveModification: jest.fn(),
+    setStatus: jest.fn(),
+    setSourceFlowNodeIdForMoveOperation: jest.fn(),
+    setSourceFlowNodeInstanceKeyForMoveOperation: jest.fn(),
   },
 }));
 
@@ -135,12 +138,12 @@ describe('finishMovingToken', () => {
   it('should reset the modification state after finishing the move', () => {
     finishMovingToken(5, 3, businessObjects, 'targetNode');
 
-    expect(modificationsStore.state.status).toBe('enabled');
+    expect(modificationsStore.setStatus).toHaveBeenCalledWith('enabled');
     expect(
-      modificationsStore.state.sourceFlowNodeIdForMoveOperation,
-    ).toBeNull();
+      modificationsStore.setSourceFlowNodeIdForMoveOperation,
+    ).toHaveBeenCalledWith(null);
     expect(
-      modificationsStore.state.sourceFlowNodeInstanceKeyForMoveOperation,
-    ).toBeNull();
+      modificationsStore.setSourceFlowNodeInstanceKeyForMoveOperation,
+    ).toHaveBeenCalledWith(null);
   });
 });

--- a/operate/client/src/modules/utils/modifications.ts
+++ b/operate/client/src/modules/utils/modifications.ts
@@ -69,9 +69,9 @@ const finishMovingToken = (
     });
   }
 
-  modificationsStore.state.status = 'enabled';
-  modificationsStore.state.sourceFlowNodeIdForMoveOperation = null;
-  modificationsStore.state.sourceFlowNodeInstanceKeyForMoveOperation = null;
+  modificationsStore.setStatus('enabled');
+  modificationsStore.setSourceFlowNodeIdForMoveOperation(null);
+  modificationsStore.setSourceFlowNodeInstanceKeyForMoveOperation(null);
 };
 
 const generateParentScopeIds = (


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- remove processInstanceDetailsDiagramStore dependency from flowNodeSelectionStore
- move selectedFlowNodeName to utils
- introduce actions to properly update state (`setStatus,` `setSourceFlowNodeIdForMoveOperation` and `setSourceFlowNodeInstanceKeyForMoveOperation`)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
