### PR TITLE
feat: add ActorFuture.thenApply(Function) w/o executor parameter

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -143,4 +143,24 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @param <U> the type of the new future
    */
   <U> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
+
+  /**
+   * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
+   * result of this future, allowing you to change types on the fly.
+   *
+   * <p>Implementations may be somewhat inefficient and create intermediate futures, schedule
+   * completion callbacks on the provided executor etc. As such, it should normally be used for
+   * orchestrating futures in a non-performance critical context, for example for startup and
+   * shutdown sequence.
+   *
+   * <p>If the caller is not an actor, {@link ActorFuture#thenApply(Function, Executor)} must be
+   * used to avoid blocking the actor execution context.
+   *
+   * @param next function to apply to the result of this future.
+   * @return a new future that completes with the result of applying the function to the result of
+   *     this future or exceptionally if this future completes exceptionally. This future can be
+   *     used for further chaining.
+   * @param <U> the type of the new future
+   */
+  <U> ActorFuture<U> thenApply(final Function<V, U> next);
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -224,7 +224,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       // to use this in production code.
       Loggers.ACTOR_LOGGER.warn(
           """
-              No executor provided for ActorFuture#onComplete callback.\
+              [PotentiallyBlocking] No executor provided for ActorFuture#onComplete callback.\
                This could block the actor that completes the future.\
                Use onComplete(consumer, executor) instead.""");
       onComplete(consumer, Runnable::run);
@@ -342,7 +342,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       // to use this in production code.
       Loggers.ACTOR_LOGGER.warn(
           """
-              No executor provided for ActorFuture#thenApply method.\
+              [PotentiallyBlocking] No executor provided for ActorFuture#thenApply method.\
                This could block the actor that completes the future.\
                Use thenApply(consumer, executor) instead.""");
       return thenApply(next, Runnable::run);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -223,9 +223,10 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
       // We don't reject this because, this is useful for tests. But the warning is a reminder not
       // to use this in production code.
       Loggers.ACTOR_LOGGER.warn(
-          "No executor provided for ActorFuture#onComplete callback."
-              + " This could block the actor that completes the future."
-              + " Use onComplete(consumer, executor) instead.");
+          """
+              No executor provided for ActorFuture#onComplete callback.\
+               This could block the actor that completes the future.\
+               Use onComplete(consumer, executor) instead.""");
       onComplete(consumer, Runnable::run);
     }
   }
@@ -329,6 +330,23 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
         },
         executor);
     return nextFuture;
+  }
+
+  @Override
+  public <U> ActorFuture<U> thenApply(final Function<V, U> next) {
+    if (ActorThread.isCalledFromActorThread()) {
+      final ActorControl actorControl = ActorControl.current();
+      return thenApply(next, actorControl);
+    } else {
+      // We don't reject this because, this is useful for tests. But the warning is a reminder not
+      // to use this in production code.
+      Loggers.ACTOR_LOGGER.warn(
+          """
+              No executor provided for ActorFuture#thenApply method.\
+               This could block the actor that completes the future.\
+               Use thenApply(consumer, executor) instead.""");
+      return thenApply(next, Runnable::run);
+    }
   }
 
   private void notifyAllBlocked() {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestActorFuture.java
@@ -159,6 +159,11 @@ public final class TestActorFuture<V> implements ActorFuture<V> {
     return nextFuture;
   }
 
+  @Override
+  public <U> ActorFuture<U> thenApply(final Function<V, U> next) {
+    return thenApply(next, Runnable::run);
+  }
+
   private void triggerOnCompleteListeners() {
     onCompleteCallbacks.forEach(this::triggerOnCompleteListener);
   }


### PR DESCRIPTION
## Description
`ActorFuture` was missing a `thenApply(Function),` similar to `onComplete(Function)`.
In many places in the codebase `onComplete` was used as a substitute because an `Executor` was not in scope, but it was called from inside and `Actor`.


## Related issues

closes #
