### PR TITLE
fix: the stop command is now called when the health check fails

### DIFF
--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -59,8 +59,6 @@ defaults:
     shell: bash
 
 jobs:
-<<<<<<< HEAD
-=======
   init:
     name: Create C8Run tag/release
     runs-on: ubuntu-latest
@@ -89,7 +87,6 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
->>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
   release:
     name: C8Run - ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.id }}
@@ -170,10 +167,6 @@ jobs:
         with:
           go-version: ">=1.23.1"
           cache: false # disabling since not working anyways without a cache-dependency-path specified
-<<<<<<< HEAD
-
-=======
->>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
       - name: Build artifact runtime distro
         working-directory: ${{ matrix.os.workingDir }}
         run: go build -o ${{ matrix.os.c8runArtifactName }} ./cmd/c8run

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -59,6 +59,37 @@ defaults:
     shell: bash
 
 jobs:
+<<<<<<< HEAD
+=======
+  init:
+    name: Create C8Run tag/release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: ℹ️ Print workflow inputs ℹ️
+        env:
+          WORKFLOW_INPUTS: ${{ toJson(inputs) }}
+        run: |
+          echo "Action Inputs:"
+          echo "${WORKFLOW_INPUTS}"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Create the release if needed
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh release view ${{ env.CAMUNDA_RUN_NAME }} ||
+            gh release create ${{ env.CAMUNDA_RUN_NAME }} --title ${{ env.CAMUNDA_RUN_NAME }} \
+              --target ${{ inputs.branch }} --notes "${{ env.CAMUNDA_RUN_NAME }}"
+      - name: Update release tag
+        run: |
+          git tag --force ${{ env.CAMUNDA_RUN_NAME }}
+          git push --force origin ${{ env.CAMUNDA_RUN_NAME }}
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+>>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
   release:
     name: C8Run - ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.id }}
@@ -139,7 +170,10 @@ jobs:
         with:
           go-version: ">=1.23.1"
           cache: false # disabling since not working anyways without a cache-dependency-path specified
+<<<<<<< HEAD
 
+=======
+>>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
       - name: Build artifact runtime distro
         working-directory: ${{ matrix.os.workingDir }}
         run: go build -o ${{ matrix.os.c8runArtifactName }} ./cmd/c8run

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -12,6 +12,10 @@ import (
 
 	"github.com/camunda/camunda/c8run/internal/health"
 	"github.com/camunda/camunda/c8run/internal/overrides"
+<<<<<<< HEAD
+=======
+	"github.com/camunda/camunda/c8run/internal/shutdown"
+>>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
 	"github.com/camunda/camunda/c8run/internal/types"
 	"github.com/camunda/camunda/c8run/internal/unix"
 	"github.com/camunda/camunda/c8run/internal/windows"
@@ -349,7 +353,11 @@ func main() {
 	case "start":
 		startCommand(c8, settings, processInfo, parentDir, javaBinary, expectedJavaVersion)
 	case "stop":
+<<<<<<< HEAD
 		stopCommand(c8, settings, processInfo)
+=======
+		shutdown.ShutdownProcesses(c8, settings, processInfo)
+>>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
 	}
 }
 
@@ -451,6 +459,7 @@ type processes struct {
 type process struct {
 	version string
 	pid     string
+<<<<<<< HEAD
 }
 
 func stopCommand(c8 types.C8Run, settings types.C8RunSettings, processes processes) {
@@ -471,6 +480,8 @@ func stopCommand(c8 types.C8Run, settings types.C8RunSettings, processes process
 		fmt.Printf("%+v", err)
 	}
 	fmt.Println("Camunda is stopped.")
+=======
+>>>>>>> 7054ed09d55 (fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary (#31694))
 }
 
 func startApplication(cmd *exec.Cmd, pid string, logPath string) {

--- a/c8run/internal/shutdown/shutdownhandler.go
+++ b/c8run/internal/shutdown/shutdownhandler.go
@@ -77,7 +77,7 @@ func stopProcess(c8 types.C8Run, pidfile string) error {
 		}
 
 		for _, process := range c8.ProcessTree(int(commandPid)) {
-			fmt.Printf("Stopping process %d\n", process.Pid())
+			fmt.Printf("Stopping process %d\n", process.Pid)
 			err = process.Kill()
 			if err != nil {
 				return fmt.Errorf("stopProcess: could not kill process %d, %w", commandPid, err)

--- a/c8run/internal/shutdown/shutdownhandler.go
+++ b/c8run/internal/shutdown/shutdownhandler.go
@@ -1,0 +1,90 @@
+package shutdown
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/camunda/camunda/c8run/internal/types"
+)
+
+func ShutdownProcesses(c8 types.C8Run, settings types.C8RunSettings, processInfo types.Processes) {
+	timeout := 30 * time.Second
+	fmt.Println("Stopping all services... timeout set to ", timeout)
+
+	progressChars := []string{"|", "/", "-", "\\"}
+	tick := time.NewTicker(100 * time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-tick.C:
+				fmt.Printf("\rStopping all services... %s", progressChars[i%len(progressChars)])
+				i++
+			case <-done:
+				tick.Stop()
+				return
+			}
+		}
+	}()
+
+	go func() {
+		stopCommand(c8, settings, processInfo)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		fmt.Println()
+		fmt.Println("All services have been stopped.")
+	case <-time.After(timeout):
+		fmt.Println()
+		fmt.Println("Warning: Timeout while stopping services. Some processes may still be running.")
+	}
+}
+
+func stopCommand(c8 types.C8Run, settings types.C8RunSettings, processes types.Processes) {
+	if !settings.DisableElasticsearch {
+		err := stopProcess(c8, processes.Elasticsearch.Pid)
+		if err != nil {
+			fmt.Printf("%+v\n", err)
+		}
+		fmt.Println("Elasticsearch is stopped.")
+	}
+	err := stopProcess(c8, processes.Connectors.Pid)
+	if err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+	fmt.Println("Connectors is stopped.")
+	err = stopProcess(c8, processes.Camunda.Pid)
+	if err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+	fmt.Println("Camunda is stopped.")
+}
+
+func stopProcess(c8 types.C8Run, pidfile string) error {
+	fmt.Println("Stopping process with pidfile: ", pidfile)
+	if _, err := os.Stat(pidfile); err == nil {
+		commandPidText, _ := os.ReadFile(pidfile)
+		commandPidStripped := strings.TrimSpace(string(commandPidText))
+		commandPid, err := strconv.Atoi(string(commandPidStripped))
+		if err != nil {
+			return fmt.Errorf("stopProcess: could not stop process %d, %w", commandPid, err)
+		}
+
+		for _, process := range c8.ProcessTree(int(commandPid)) {
+			fmt.Printf("Stopping process %d\n", process.Pid())
+			err = process.Kill()
+			if err != nil {
+				return fmt.Errorf("stopProcess: could not kill process %d, %w", commandPid, err)
+			}
+		}
+		os.Remove(pidfile)
+
+	}
+	return nil
+}

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -32,3 +32,13 @@ func (c C8RunSettings) HasKeyStore() bool {
 	return c.Keystore != "" && c.KeystorePassword != ""
 }
 
+type Processes struct {
+	Camunda       Process
+	Connectors    Process
+	Elasticsearch Process
+}
+
+type Process struct {
+	Version string
+	Pid     string
+}


### PR DESCRIPTION
## Description

- the stop command was moved to its own package to help with testing
- the os.Process has a light indirection to allow testing
- the shutdown sequence runs for at most 30 second and then quits if the stop is stuck
- stopCommand and stopProcess are moved to the shutdown package. They are unchanged

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

https://github.com/camunda/camunda/issues/27554

closes #
