### PR TITLE
fix: adjust flownode state filtering

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
@@ -31,6 +31,11 @@ jest.mock('../BatchModificationSummaryModal', () => ({
   ),
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED: false,
+}));
+
 const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
   ({children}) => {
     useEffect(() => {

--- a/operate/client/src/App/Processes/ListView/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/tests/index.test.tsx
@@ -47,6 +47,11 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED: false,
+}));
+
 function getWrapper(initialPath: string = Paths.processes()) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     useEffect(() => {

--- a/operate/client/src/modules/bpmn-js/utils/isProcessEndEvent.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isProcessEndEvent.ts
@@ -17,4 +17,15 @@ const isProcessEndEvent = (businessObject: BusinessObject) => {
   );
 };
 
-export {isProcessEndEvent};
+const isProcessOrSubProcessEndEvent = (businessObject: BusinessObject) => {
+  return (
+    hasType({businessObject, types: ['bpmn:EndEvent']}) &&
+    businessObject?.$parent !== undefined &&
+    hasType({
+      businessObject: businessObject?.$parent,
+      types: ['bpmn:Process', 'bpmn:SubProcess'],
+    })
+  );
+};
+
+export {isProcessEndEvent, isProcessOrSubProcessEndEvent};

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -69,15 +69,18 @@ describe('useProcessInstanceFilters', () => {
         $or: [
           {
             state: {
-              $in: [
-                ProcessInstanceState.ACTIVE,
-                ProcessInstanceState.COMPLETED,
-                ProcessInstanceState.TERMINATED,
-              ],
+              $eq: ProcessInstanceState.ACTIVE,
             },
           },
           {hasIncident: true},
         ],
+        state: {
+          $in: [
+            ProcessInstanceState.ACTIVE,
+            ProcessInstanceState.COMPLETED,
+            ProcessInstanceState.TERMINATED,
+          ],
+        },
         parentProcessInstanceKey: {
           $eq: 'parent1',
         },

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -107,14 +107,20 @@ function mapFiltersToRequest(
   if (completed) state.push(ProcessInstanceState.COMPLETED);
   if (canceled) state.push(ProcessInstanceState.TERMINATED);
 
-  if (state.length > 0 && incidents) {
-    request.filter.$or = [{state: {$in: state}}, {hasIncident: true}];
-  } else if (state.length > 0) {
+  if (incidents) {
+    if (active) {
+      request.filter.$or = [
+        {state: {$eq: ProcessInstanceState.ACTIVE}},
+        {hasIncident: true},
+      ];
+    } else {
+      request.filter.hasIncident = true;
+    }
+  }
+  if (state.length > 0) {
     request.filter.state = {
       $in: state,
     };
-  } else if (incidents) {
-    request.filter.hasIncident = true;
   }
 
   if (variableName && variableValues) {

--- a/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.test.tsx
@@ -55,8 +55,8 @@ describe('useProcessInstancesFlowNodeStates', () => {
       {flowNodeId: 'task1', count: 5, flowNodeState: 'active'},
       {flowNodeId: 'task1', count: 1, flowNodeState: 'incidents'},
       {flowNodeId: 'task1', count: 2, flowNodeState: 'canceled'},
-      {flowNodeId: 'task1', count: 3, flowNodeState: 'completedEndEvents'},
-      {flowNodeId: 'task2', count: 4, flowNodeState: 'completedEndEvents'},
+      {flowNodeId: 'task1', count: 3, flowNodeState: 'completed'},
+      {flowNodeId: 'task2', count: 4, flowNodeState: 'completed'},
     ];
 
     mockFetchProcessInstancesStatistics().withSuccess(mockData);


### PR DESCRIPTION
## Description

As I'm enabling the PI stats feature flag, I ran into [failing visual regression tests](https://github.com/camunda/camunda/actions/runs/14655026473/job/41128471148?pr=31403). I took some time re-verifying the changes and came up with a couple of fixes :
- I updated the `flowNodeStatesParser` to properly check if a flow node is actually an end event instead of just setting `completed` states to `completedEndEvents`
- I updated the `overlayParser` to exclude completed non-end events (since all completed end events are marked as `completedEndEvents`, I'm excluding `completed` states
- I'm counting a completed end event inside a `subProcess` as `completedEndEvents` based on the visual regression reference
- I'm updating the filters structure so the correct data is returned when users check/un-check COMPLETED and CANCELED checkboxes. This bug was just discovered today
- I'm adding feature flag mocks to integration tests that implicitly rely on v1 components so when enabling the feature flag they don't break (the corresponding v2 tests are of course unchanged)

## Related issues

related to #29378
