### PR TITLE
feat: create camunda batch operation es os schema

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/BatchOperationState.java
@@ -22,5 +22,6 @@ public enum BatchOperationState {
   COMPLETED,
   COMPLETED_WITH_ERRORS,
   CANCELED,
+  INCOMPLETED,
   UNKNOWN_ENUM_VALUE;
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -30,7 +30,8 @@ public record BatchOperationEntity(
     PAUSED,
     COMPLETED,
     COMPLETED_WITH_ERRORS,
-    CANCELED
+    CANCELED,
+    INCOMPLETED // This is just used for running legacy batch operations
   }
 
   public enum BatchOperationItemState {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
@@ -28,6 +28,12 @@ public class BatchOperationTemplate extends AbstractTemplateDescriptor implement
   public static final String FAILED_OPERATIONS_COUNT = "failedOperationsCount";
   public static final String COMPLETED_OPERATIONS_COUNT = "completedOperationsCount";
 
+  // New fields for engine batch operations
+  public static final String BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String STATE = "state";
+  public static final String OPERATIONS_FAILED_COUNT = "operationsFailedCount";
+  public static final String OPERATIONS_COMPLETED_COUNT = "operationsCompletedCount";
+
   public BatchOperationTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/OperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/OperationTemplate.java
@@ -40,6 +40,7 @@ public class OperationTemplate extends AbstractTemplateDescriptor
   public static final String METADATA_AGGREGATION = "metadataAggregation";
   public static final String BATCH_OPERATION_ID_AGGREGATION = "batchOperationIdAggregation";
   public static final String COMPLETED_DATE = "completedDate";
+  public static final String ITEM_KEY = "itemKey";
 
   public OperationTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -266,6 +266,7 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     PAUSED,
     COMPLETED,
     COMPLETED_WITH_ERRORS,
-    CANCELED
+    CANCELED,
+    INCOMPLETED
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.entities.operation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.UUID;
 
 public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationEntity> {
@@ -24,7 +25,22 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   private Integer operationsTotalCount = 0;
   private Integer operationsFinishedCount = 0;
 
+  // new fields for batch operation in zeebe engine
+  private Long batchOperationKey;
+  private BatchOperationState state;
+  private Integer operationsFailedCount = 0; // Just failed / rejected operations
+  private Integer operationsCompletedCount = 0; // Just successfully completed operations
+
   @JsonIgnore private Object[] sortValues;
+
+  public Long getBatchOperationKey() {
+    return batchOperationKey;
+  }
+
+  public BatchOperationEntity setBatchOperationKey(final Long batchOperationKey) {
+    this.batchOperationKey = batchOperationKey;
+    return this;
+  }
 
   public String getName() {
     return name;
@@ -50,6 +66,15 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
 
   public BatchOperationEntity setStartDate(final OffsetDateTime startDate) {
     this.startDate = startDate;
+    return this;
+  }
+
+  public BatchOperationState getState() {
+    return state;
+  }
+
+  public BatchOperationEntity setState(final BatchOperationState state) {
+    this.state = state;
     return this;
   }
 
@@ -98,6 +123,24 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     return this;
   }
 
+  public Integer getOperationsFailedCount() {
+    return operationsFailedCount;
+  }
+
+  public BatchOperationEntity setOperationsFailedCount(final Integer operationsFailedCount) {
+    this.operationsFailedCount = operationsFailedCount;
+    return this;
+  }
+
+  public Integer getOperationsCompletedCount() {
+    return operationsCompletedCount;
+  }
+
+  public BatchOperationEntity setOperationsCompletedCount(final Integer operationsCompletedCount) {
+    this.operationsCompletedCount = operationsCompletedCount;
+    return this;
+  }
+
   public Object[] getSortValues() {
     return sortValues;
   }
@@ -122,8 +165,12 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     result = 31 * result + (username != null ? username.hashCode() : 0);
     result = 31 * result + (instancesCount != null ? instancesCount.hashCode() : 0);
     result = 31 * result + (operationsTotalCount != null ? operationsTotalCount.hashCode() : 0);
+    result = 31 * result + (state != null ? state.hashCode() : 0);
     result =
         31 * result + (operationsFinishedCount != null ? operationsFinishedCount.hashCode() : 0);
+    result =
+        31 * result + (operationsCompletedCount != null ? operationsCompletedCount.hashCode() : 0);
+    result = 31 * result + (operationsFailedCount != null ? operationsFailedCount.hashCode() : 0);
     return result;
   }
 
@@ -166,8 +213,59 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
         : that.operationsTotalCount != null) {
       return false;
     }
+    if (!Objects.equals(state, that.state)) {
+      return false;
+    }
+    if (!Objects.equals(operationsCompletedCount, that.operationsCompletedCount)) {
+      return false;
+    }
+    if (!Objects.equals(operationsFailedCount, that.operationsFailedCount)) {
+      return false;
+    }
+
     return operationsFinishedCount != null
         ? operationsFinishedCount.equals(that.operationsFinishedCount)
         : that.operationsFinishedCount == null;
+  }
+
+  @Override
+  public String toString() {
+    return "BatchOperationEntity{"
+        + "batchOperationKey="
+        + batchOperationKey
+        + "name='"
+        + name
+        + '\''
+        + ", type="
+        + type
+        + ", startDate="
+        + startDate
+        + ", endDate="
+        + endDate
+        + ", username='"
+        + username
+        + '\''
+        + ", instancesCount="
+        + instancesCount
+        + ", operationsTotalCount="
+        + operationsTotalCount
+        + ", operationsFinishedCount="
+        + operationsFinishedCount
+        + ", state="
+        + state
+        + ", operationsFailedCount="
+        + operationsFailedCount
+        + ", operationsCompletedCount="
+        + operationsCompletedCount
+        + '}';
+  }
+
+  public enum BatchOperationState {
+    CREATED,
+    ACTIVE,
+    PAUSED,
+    COMPLETED,
+    COMPLETED_WITH_ERRORS,
+    CANCELED
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -14,6 +14,11 @@ import java.util.UUID;
 
 public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
 
+  /**
+   * Is used by batch operation engine in zeebe to identify the resource (process, incident, ...)
+   */
+  private Long itemKey;
+
   private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
@@ -41,6 +46,15 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   private String migrationPlan;
 
   private OffsetDateTime completedDate;
+
+  public Long getItemKey() {
+    return itemKey;
+  }
+
+  public OperationEntity setItemKey(final Long itemKey) {
+    this.itemKey = itemKey;
+    return this;
+  }
 
   public Long getProcessInstanceKey() {
     return processInstanceKey;
@@ -225,6 +239,7 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   public int hashCode() {
     return Objects.hash(
         super.hashCode(),
+        itemKey,
         processInstanceKey,
         processDefinitionKey,
         bpmnProcessId,
@@ -257,7 +272,8 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
       return false;
     }
     final OperationEntity that = (OperationEntity) o;
-    return Objects.equals(processInstanceKey, that.processInstanceKey)
+    return Objects.equals(itemKey, that.itemKey)
+        && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(decisionDefinitionKey, that.decisionDefinitionKey)
@@ -280,6 +296,8 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   @Override
   public String toString() {
     return "OperationEntity{"
+        + "itemKey="
+        + itemKey
         + "processInstanceKey="
         + processInstanceKey
         + ", processDefinitionKey="

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
@@ -30,7 +30,19 @@
 			},
 			"username": {
 				"type": "keyword"
-			}
-		}
+      },
+      "batchOperationKey": {
+        "type": "long"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "operationsFailedCount": {
+        "type": "long"
+      },
+      "operationsCompletedCount": {
+        "type": "long"
+      }
+    }
 	}
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
@@ -64,6 +64,9 @@
       "completedDate": {
         "format": "date_time || epoch_millis",
         "type": "date"
+      },
+      "itemKey": {
+        "type": "long"
       }
     }
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
@@ -30,7 +30,19 @@
 			},
 			"username": {
 				"type": "keyword"
-			}
+      },
+      "batchOperationKey": {
+        "type": "long"
+      },
+      "state": {
+        "type": "keyword"
+      },
+      "operationsFailedCount": {
+        "type": "long"
+      },
+      "operationsCompletedCount": {
+        "type": "long"
+      }
 		}
 	}
 }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
@@ -64,6 +64,9 @@
       "completedDate": {
         "format": "date_time || epoch_millis",
         "type": "date"
+      },
+      "itemKey": {
+        "type": "long"
       }
     }
 	}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8272,6 +8272,7 @@ components:
             - COMPLETED
             - COMPLETED_WITH_ERRORS
             - CANCELED
+            - INCOMPLETED
     BatchOperationSearchQueryResult:
       type: object
       allOf:
@@ -8298,6 +8299,7 @@ components:
             - COMPLETED
             - COMPLETED_WITH_ERRORS
             - CANCELED
+            - INCOMPLETED
         batchOperationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"
         startDate:


### PR DESCRIPTION
## Description

Adds new fields to existing batch operation and operation (batch operation item) schemas and entities. 

**New fields:**

* For Batch operation:
  * batchOperationKey ... Long value to identify the batch operation in zeebe
  * state ... state of the batch operation (Can be     CREATED, ACTIVE, PAUSED, COMPLETED, COMPLETED_WITH_ERRORS, CANCELED)
    * new state was introduced to identify legacy batches that were not completed: INCOMPLETED
  * operationsFailedCount ... how many items are failed / rejected
  * operationsCompletedCount ... how many items are successfully completed

For Operations (Reflects the Batch operation item)

There lot's of fields will not be used since they are just necessary for the legacy "engine".

**New fields:**

* itemKey ... key of the resource on which the operation is working. E.g. ProcessInstanceKey or IncidentKey 

See here for details about the decision to reuse the old index: https://docs.google.com/document/d/1LDZRxcHEEw0_ujg3RV9gzPI0Bp6lo_NfwEwMki4cMsA/edit?tab=t.vvs7b2765r2q#heading=h.pencmg8a9esr

## Related issues

closes #31041 
