### PR TITLE
Incident notifier version bug

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
@@ -13,5 +13,14 @@ import java.util.Map;
 public record CachedProcessEntity(
     String name,
     String versionTag,
+    String version,
     List<String> callElementIds,
-    Map<String, String> flowNodesMap) {}
+    Map<String, String> flowNodesMap) {
+  public CachedProcessEntity(
+      final String name,
+      final String versionTag,
+      final List<String> callElementIds,
+      final Map<String, String> flowNodesMap) {
+    this(name, versionTag, null, callElementIds, flowNodesMap);
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/ProcessDiagramData.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/ProcessDiagramData.java
@@ -10,17 +10,4 @@ package io.camunda.zeebe.exporter.common.cache.process;
 import java.util.List;
 import java.util.Map;
 
-public record CachedProcessEntity(
-    String name,
-    String versionTag,
-    String version,
-    List<String> callElementIds,
-    Map<String, String> flowNodesMap) {
-  public CachedProcessEntity(
-      final String name,
-      final String versionTag,
-      final List<String> callElementIds,
-      final Map<String, String> flowNodesMap) {
-    this(name, versionTag, null, callElementIds, flowNodesMap);
-  }
-}
+public record ProcessDiagramData(List<String> callActivityIds, Map<String, String> flowNodesMap) {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/ProcessDiagramData.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/ProcessDiagramData.java
@@ -10,4 +10,17 @@ package io.camunda.zeebe.exporter.common.cache.process;
 import java.util.List;
 import java.util.Map;
 
-public record ProcessDiagramData(List<String> callActivityIds, Map<String, String> flowNodesMap) {}
+public record CachedProcessEntity(
+    String name,
+    String versionTag,
+    String version,
+    List<String> callElementIds,
+    Map<String, String> flowNodesMap) {
+  public CachedProcessEntity(
+      final String name,
+      final String versionTag,
+      final List<String> callElementIds,
+      final Map<String, String> flowNodesMap) {
+    this(name, versionTag, null, callElementIds, flowNodesMap);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -88,6 +88,7 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
         new CachedProcessEntity(
             entity.getName(),
             entity.getVersionTag(),
+            Integer.toString(entity.getVersion()),
             entity.getCallActivityIds(),
             ProcessCacheUtil.getFlowNodesMap(entity.getFlowNodes()));
     processCache.put(process.getProcessDefinitionKey(), cachedProcessEntity);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.apache.commons.lang3.StringUtils;
@@ -145,16 +144,18 @@ public class IncidentNotifier {
       incidentFields.put(FIELD_NAME_FLOW_NODE_INSTANCE_KEY, inc.getFlowNodeInstanceKey());
       incidentFields.put(FIELD_NAME_JOB_KEY, inc.getJobKey());
       incidentFields.put(FIELD_NAME_PROCESS_KEY, inc.getProcessDefinitionKey());
-      final Optional<CachedProcessEntity> process = processCache.get(inc.getProcessDefinitionKey());
-      if (process.isPresent()) {
-        incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, inc.getBpmnProcessId());
-        incidentFields.put(FIELD_NAME_PROCESS_NAME, process.get().name());
-        final var processVersionField =
-            process.get().versionTag() != null
-                ? process.get().versionTag()
-                : process.get().version();
-        incidentFields.put(FIELD_NAME_PROCESS_VERSION, processVersionField);
-      }
+      processCache
+          .get(inc.getProcessDefinitionKey())
+          .ifPresent(
+              cachedProcess -> {
+                incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, inc.getBpmnProcessId());
+                incidentFields.put(FIELD_NAME_PROCESS_NAME, cachedProcess.name());
+                final var processVersionField =
+                    cachedProcess.versionTag() != null
+                        ? cachedProcess.versionTag()
+                        : cachedProcess.version();
+                incidentFields.put(FIELD_NAME_PROCESS_VERSION, processVersionField);
+              });
       incidentList.add(incidentFields);
     }
     return objectWriter.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -149,7 +149,11 @@ public class IncidentNotifier {
       if (process.isPresent()) {
         incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, inc.getBpmnProcessId());
         incidentFields.put(FIELD_NAME_PROCESS_NAME, process.get().name());
-        incidentFields.put(FIELD_NAME_PROCESS_VERSION, process.get().versionTag());
+        final var processVersionField =
+            process.get().versionTag() != null
+                ? process.get().versionTag()
+                : process.get().version();
+        incidentFields.put(FIELD_NAME_PROCESS_VERSION, processVersionField);
       }
       incidentList.add(incidentFields);
     }


### PR DESCRIPTION
## Description

The version tag which does not always exist is used instead of the process version, this sometimes results in a null value which doesn't display any information, this fixes it.

## Related issues

closes #31192
