### PR TITLE
Update role using id (engine)

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -73,6 +73,8 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
       return;
     }
 
+    final var persistedRole = persistedRecord.get();
+    record.setRoleKey(persistedRole.getRoleKey());
     stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.UPDATED, record);
     responseWriter.writeEventOnCommand(record.getRoleKey(), RoleIntent.UPDATED, record, command);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
+  public static final String ROLE_NOT_FOUND_ERROR_MESSAGE = "Expected to update role with key '%s', but a role with this key does not exist.";
   private final RoleState roleState;
   private final KeyGenerator keyGenerator;
   private final AuthorizationCheckBehavior authCheckBehavior;
@@ -55,7 +56,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     final var persistedRecord = roleState.getRole(record.getRoleKey());
     if (persistedRecord.isEmpty()) {
       final var errorMessage =
-          "Expected to update role with key '%s', but a role with this key does not exist."
+          ROLE_NOT_FOUND_ERROR_MESSAGE
               .formatted(record.getRoleKey());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -40,10 +40,9 @@ public class DbRoleState implements MutableRoleState {
   @Override
   public void update(final RoleRecord roleRecord) {
     // retrieve record from the state
-    roleId.wrapString(String.valueOf(roleRecord.getRoleKey()));
+    roleId.wrapString(roleRecord.getRoleId());
     final var persistedRole = roleColumnFamily.get(roleId);
-
-    persistedRole.setRoleKey(roleRecord.getRoleKey()).setName(roleRecord.getName());
+    persistedRole.from(roleRecord);
     roleColumnFamily.update(roleId, persistedRole);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
@@ -55,6 +55,11 @@ public class PersistedRole extends UnpackedObject implements DbValue {
     return BufferUtil.bufferAsString(descriptionProp.getValue());
   }
 
+  public PersistedRole setDescription(final String description) {
+    descriptionProp.setValue(description);
+    return this;
+  }
+
   public PersistedRole copy() {
     final var copy = new PersistedRole();
     copy.copyFrom(this);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -157,8 +157,6 @@ public class CommandDistributionIdempotencyTest {
   public static void assertAllProcessorsTested() {
     // TODO remove with https://github.com/camunda/camunda/issues/30114
     DISTRIBUTING_PROCESSORS.remove(RoleDeleteProcessor.class);
-    // TODO remove with https://github.com/camunda/camunda/issues/30113
-    DISTRIBUTING_PROCESSORS.remove(RoleUpdateProcessor.class);
     if (!DISTRIBUTING_PROCESSORS.isEmpty()) {
       fail("No test scenario found for processors: '%s'".formatted(DISTRIBUTING_PROCESSORS));
     }
@@ -454,22 +452,21 @@ public class CommandDistributionIdempotencyTest {
           //                }),
           //            RoleDeleteProcessor.class
           //          },
-          // TODO fix test in https://github.com/camunda/camunda/issues/30113
-          //          {
-          //            "Role.UPDATE is idempotent",
-          //            new Scenario(
-          //                ValueType.ROLE,
-          //                RoleIntent.UPDATE,
-          //                () -> {
-          //                  final var role = createRole();
-          //                  return ENGINE
-          //                      .role()
-          //                      .updateRole(role.getKey())
-          //                      .withName(UUID.randomUUID().toString())
-          //                      .update();
-          //                }),
-          //            RoleUpdateProcessor.class
-          //          },
+          {
+            "Role.UPDATE is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.UPDATE,
+                () -> {
+                  final var role = createRole();
+                  return ENGINE
+                      .role()
+                      .updateRole(role.getValue().getRoleId())
+                      .withName(UUID.randomUUID().toString())
+                      .update();
+                }),
+            RoleUpdateProcessor.class
+          },
           {
             "Role.ADD_ENTITY is idempotent",
             new Scenario(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
@@ -18,13 +18,13 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,12 +38,11 @@ public class UpdateRoleMultiPartitionTest {
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30113")
   public void shouldDistributeRoleUpdateCommand() {
     // when
-    final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().updateRole(roleKey).withName(name + "-updated").update();
+    final var roleId = Strings.newRandomValidIdentityId();
+    engine.role().newRole(roleId).withName("created").create();
+    engine.role().updateRole(roleId).withName("updated").update();
 
     assertThat(
             RecordingExporter.records()
@@ -92,12 +91,11 @@ public class UpdateRoleMultiPartitionTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30113")
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().updateRole(roleKey).withName(name + "-updated").update();
+    final var roleId = Strings.newRandomValidIdentityId();
+    engine.role().newRole(roleId).withName("created").create();
+    engine.role().updateRole(roleId).withName("updated").update();
 
     // then
     assertThat(
@@ -109,15 +107,14 @@ public class UpdateRoleMultiPartitionTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30113")
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptRoleCreateForPartition(partitionId);
     }
-    final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().updateRole(roleKey).withName(name + "-updated").update();
+    final var roleId = UUID.randomUUID().toString();
+    engine.role().newRole(roleId).withName("created").create();
+    engine.role().updateRole(roleId).withName("updated").update();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -27,8 +27,13 @@ public class RoleClient {
     return new RoleCreateClient(writer, id);
   }
 
+  // TODO remove this method and use the one with role Id
   public RoleUpdateClient updateRole(final long roleKey) {
-    return new RoleUpdateClient(writer, roleKey);
+    return updateRole(String.valueOf(roleKey));
+  }
+
+  public RoleUpdateClient updateRole(final String roleId) {
+    return new RoleUpdateClient(writer, roleId);
   }
 
   // TODO remove this method and use the one with role Id
@@ -125,14 +130,24 @@ public class RoleClient {
     private final RoleRecord roleRecord;
     private Function<Long, Record<RoleRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public RoleUpdateClient(final CommandWriter writer, final long roleKey) {
+    public RoleUpdateClient(final CommandWriter writer, final String roleId) {
       this.writer = writer;
       roleRecord = new RoleRecord();
+      roleRecord.setRoleId(roleId);
+    }
+
+    public RoleUpdateClient withRoleKey(final long roleKey) {
       roleRecord.setRoleKey(roleKey);
+      return this;
     }
 
     public RoleUpdateClient withName(final String name) {
       roleRecord.setName(name);
+      return this;
+    }
+
+    public RoleUpdateClient withDescription(final String description) {
+      roleRecord.setDescription(description);
       return this;
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Modifies the Role update processor and appliers to work with a role id instead of a key.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30113 
