### PR TITLE
 refactor: replace mappingKey with mappingId, keep key for internal tracing

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -61,18 +61,15 @@ public class CamundaOAuthPrincipalService {
   public OAuthContext loadOAuthContext(final Map<String, Object> claims)
       throws OAuth2AuthenticationException {
     final List<MappingEntity> mappings = mappingServices.getMatchingMappings(claims);
-    final Set<Long> mappingKeys =
-        mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
     final Set<String> mappingIds =
         mappings.stream().map(MappingEntity::mappingId).collect(Collectors.toSet());
-    if (mappingKeys.isEmpty() && mappingIds.isEmpty()) {
+    if (mappingIds.isEmpty()) {
       LOG.debug("No mappings found for these claims: {}", claims);
     }
 
     final var assignedRoles = roleServices.getRolesByMemberIds(mappingIds);
 
     return new OAuthContext(
-        mappingKeys,
         mappingIds,
         new AuthenticationContext(
             getUsernameFromClaims(claims),

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaJwtUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaJwtUser.java
@@ -8,7 +8,6 @@
 package io.camunda.authentication.entity;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -20,7 +19,7 @@ public class CamundaJwtUser implements CamundaOAuthPrincipal, Serializable {
   public CamundaJwtUser(
       final Jwt jwt, final Set<String> mappingIds, final AuthenticationContext authentication) {
     this.jwt = jwt;
-    oauthContext = new OAuthContext(new HashSet<>(), mappingIds, authentication);
+    oauthContext = new OAuthContext(mappingIds, authentication);
   }
 
   public CamundaJwtUser(final Jwt jwt, final OAuthContext oauthContext) {

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -22,11 +22,10 @@ public class CamundaOidcUser implements OidcUser, CamundaOAuthPrincipal, Seriali
 
   public CamundaOidcUser(
       final OidcUser oidcUser,
-      final Set<Long> mappingKeys,
       final Set<String> mappingIds,
       final AuthenticationContext authentication) {
     user = oidcUser;
-    oAuthContext = new OAuthContext(mappingKeys, mappingIds, authentication);
+    oAuthContext = new OAuthContext(mappingIds, authentication);
   }
 
   public CamundaOidcUser(final OidcUser user, final OAuthContext oAuthContext) {
@@ -77,10 +76,6 @@ public class CamundaOidcUser implements OidcUser, CamundaOAuthPrincipal, Seriali
   @Override
   public String getName() {
     return user.getName();
-  }
-
-  public Set<Long> getMappingKeys() {
-    return oAuthContext.mappingKeys();
   }
 
   public Set<String> getMappingIds() {

--- a/authentication/src/main/java/io/camunda/authentication/entity/OAuthContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/OAuthContext.java
@@ -10,6 +10,5 @@ package io.camunda.authentication.entity;
 import java.io.Serializable;
 import java.util.Set;
 
-public record OAuthContext(
-    Set<Long> mappingKeys, Set<String> mappingIds, AuthenticationContext authenticationContext)
+public record OAuthContext(Set<String> mappingIds, AuthenticationContext authenticationContext)
     implements Serializable {}

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -94,7 +94,6 @@ public class CamundaOAuthPrincipalServiceTest {
 
     // then
     assertThat(oAuthContext).isNotNull();
-    assertThat(oAuthContext.mappingKeys()).isEqualTo(Set.of(5L, 7L));
     assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
     final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
@@ -130,7 +129,6 @@ public class CamundaOAuthPrincipalServiceTest {
 
     // then
     assertThat(oAuthContext).isNotNull();
-    assertThat(oAuthContext.mappingKeys()).isEqualTo(Set.of(1L, 2L));
     assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("map-1", "map-2"));
 
     final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -64,7 +64,6 @@ public class CamundaOidcUserServiceTest {
     when(camundaOAuthPrincipalService.loadOAuthContext(claims))
         .thenReturn(
             new OAuthContext(
-                Set.of(5L, 7L),
                 Set.of("test-id", "test-id-2"),
                 new AuthenticationContext(
                     null,
@@ -81,7 +80,6 @@ public class CamundaOidcUserServiceTest {
     assertThat(oidcUser).isInstanceOf(CamundaOidcUser.class);
     final var camundaUser = (CamundaOidcUser) oidcUser;
     assertThat(camundaUser.getEmail()).isEqualTo("foo@camunda.test");
-    assertThat(camundaUser.getMappingKeys()).isEqualTo(Set.of(5L, 7L));
     assertThat(camundaUser.getMappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1620,7 +1620,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>
    * camundaClient
    *   .newAssignMappingToTenantCommand(tenantId)
-   *   .mappingKey(mappingKey)
+   *   .mappingId(mappingId)
    *   .send();
    * </pre>
    *

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -372,9 +372,10 @@
 
   <changeSet id="create_mapping_table" author="pwunderlich">
     <createTable tableName="${prefix}MAPPINGS">
-      <column name="MAPPING_KEY" type="BIGINT">
+      <column name="MAPPING_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
+      <column name="MAPPING_KEY" type="BIGINT"/>
       <column name="CLAIM_NAME" type="VARCHAR(255)"/>
       <column name="CLAIM_VALUE" type="VARCHAR(255)"/>
       <column name="NAME" type="VARCHAR(255)"/>
@@ -509,29 +510,6 @@
       <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
       <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
     </modifySql>
-  </changeSet>
-
-  <changeSet id="migrate_mapping_id_from_key" author="Oleksii Ivanov">
-    <!-- Step 1: Add ID column -->
-    <addColumn tableName="${prefix}MAPPINGS">
-      <column name="MAPPING_ID" type="VARCHAR(255)">
-        <constraints nullable="true"/>
-      </column>
-    </addColumn>
-
-    <!-- Step 2: Copy values from MAPPING_KEY to ID as string -->
-    <update tableName="${prefix}MAPPINGS">
-      <column name="MAPPING_ID" valueComputed="CAST(MAPPING_KEY AS CHAR(255))"/>
-    </update>
-
-    <!-- Step 3: Set ID as NOT NULL (after it's populated) -->
-    <addNotNullConstraint tableName="${prefix}MAPPINGS" columnName="MAPPING_ID" columnDataType="VARCHAR(255)"/>
-
-    <!-- Step 4: Drop old PK on MAPPING_KEY -->
-    <dropPrimaryKey tableName="${prefix}MAPPINGS"/>
-
-    <!-- Step 5: Make ID the new PK -->
-    <addPrimaryKey tableName="${prefix}MAPPINGS" columnNames="MAPPING_ID" constraintName="${prefix}PK_MAPPINGS_ID"/>
   </changeSet>
 
   <changeSet id="create_job_table" author="tsedekey">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MappingMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/MappingMapper.java
@@ -20,5 +20,5 @@ public interface MappingMapper {
 
   List<MappingEntity> search(MappingDbQuery filter);
 
-  void delete(Long mappingKey);
+  void delete(String mappingId);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
@@ -26,7 +26,7 @@ public class MappingWriter {
         new QueueItem(
             ContextType.MAPPING,
             WriteStatementType.INSERT,
-            mapping.mappingKey(),
+            mapping.mappingId(),
             "io.camunda.db.rdbms.sql.MappingMapper.insert",
             mapping));
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UsersGroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UsersGroupMigrationHandler.java
@@ -59,14 +59,14 @@ public class UsersGroupMigrationHandler extends MigrationHandler<UserGroups> {
               userGroups.username() + "_mapping",
               userGroups.username() + "_mapping");
 
-      final long mappingKey =
+      final var mappingId =
           mappingServices
               .findMapping(mapping)
-              .map(MappingEntity::mappingKey)
-              .orElseGet(() -> mappingServices.createMapping(mapping).join().getMappingKey());
+              .map(MappingEntity::mappingId)
+              .orElseGet(() -> mappingServices.createMapping(mapping).join().getMappingId());
       for (final Group userGroup : userGroups.groups()) {
         final var groupKey = groupServices.getGroupByName(userGroup.name()).groupKey();
-        assignMemberToGroup(groupKey, mappingKey);
+        assignMemberToGroup(groupKey, mappingId);
       }
       return managementIdentityTransformer.toMigrationStatusUpdateRequest(userGroups, null);
     } catch (final Exception e) {
@@ -74,7 +74,7 @@ public class UsersGroupMigrationHandler extends MigrationHandler<UserGroups> {
     }
   }
 
-  private void assignMemberToGroup(final long groupKey, final long mappingKey) {
+  private void assignMemberToGroup(final long groupKey, final String mappingId) {
     try {
       // TODO: revisit this while implementing the migration
       // https://github.com/camunda/camunda/issues/26973

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
@@ -158,6 +158,7 @@ public class MappingIT {
             new MappingQuery(
                 new MappingFilter.Builder()
                     .mappingKey(randomizedMapping.mappingKey())
+                    .mappingId(randomizedMapping.mappingId())
                     .claimName(randomizedMapping.claimName())
                     .claimValue(randomizedMapping.claimValue())
                     .name(randomizedMapping.name())
@@ -167,7 +168,7 @@ public class MappingIT {
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().mappingKey())
-        .isEqualTo(randomizedMapping.mappingKey());
+    assertThat(searchResult.items().getFirst().mappingId())
+        .isEqualTo(randomizedMapping.mappingId());
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3034,7 +3034,7 @@ paths:
         - name: mappingId
           in: path
           required: true
-          description: The id of the mapping rule to update.
+          description: The ID of the mapping rule to update.
           schema:
             type: string
       requestBody:
@@ -3073,7 +3073,7 @@ paths:
       operationId: deleteMappingRule
       summary: Delete a mapping rule (Work-in-Progress)
       description: |
-        Deletes the mapping rule with the given key.
+        Deletes the mapping rule with the given ID.
 
         This API is in a Work-in-Progress state and will undergo potential breaking changes until
         its release with an upcoming minor release.
@@ -3081,7 +3081,7 @@ paths:
         - name: mappingId
           in: path
           required: true
-          description: The key of the mapping rule to delete.
+          description: The ID of the mapping rule to delete.
           schema:
             type: string
       responses:
@@ -3090,7 +3090,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
-          description: The mapping rule with the mappingKey was not found.
+          description: The mapping rule with the mappingId was not found.
           content:
             application/problem+json:
               schema:
@@ -6199,7 +6199,6 @@ components:
           description: The field to sort by.
           type: string
           enum:
-            - mappingKey
             - mappingId
             - claimName
             - claimValue
@@ -6604,7 +6603,7 @@ components:
       properties:
         mappingId:
           type: string
-          description: The unique external id of the mapping.
+          description: The unique ID of the mapping.
       required:
         - mappingId
     MappingRuleUpdateRequest:
@@ -6625,10 +6624,7 @@ components:
           description: The name of the mapping.
         mappingId:
           type: string
-          description: The unique external id of the mapping.
-        mappingKey:
-          description: The key of the created mapping rule.
-          type: string
+          description: The unique ID of the mapping.
     MappingRuleCreateResult:
       type: object
       allOf:
@@ -6662,9 +6658,6 @@ components:
         mappingId:
           type: string
           description: The ID of the mapping.
-        mappingKey:
-          description: The key of the created mapping rule.
-          type: string
 
     TopologyResponse:
       description: The response of a topology request.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -633,7 +633,7 @@ public class RequestMapper {
         if (authenticatedPrincipal instanceof final CamundaOAuthPrincipal principal) {
           authenticatedMappingIds.addAll(principal.getOAuthContext().mappingIds());
           authenticatedMappingIds.addAll(
-              principal.getOAuthContext().mappingKeys().stream().map(Object::toString).toList());
+              principal.getOAuthContext().mappingIds().stream().map(Object::toString).toList());
           principal
               .getClaims()
               .forEach((key, value) -> ClaimTransformer.applyUserClaim(claims, key, value));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -579,7 +579,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toMappingCreateResponse(final MappingRecord record) {
     final var response =
         new MappingRuleCreateResult()
-            .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
             .mappingId(record.getMappingId())
@@ -590,7 +589,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toMappingUpdateResponse(final MappingRecord record) {
     final var response =
         new MappingRuleUpdateResult()
-            .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
             .mappingId(record.getMappingId())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1052,7 +1052,6 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case MAPPING_KEY -> builder.mappingKey();
         case MAPPING_ID -> builder.mappingId();
         case CLAIM_NAME -> builder.claimName();
         case CLAIM_VALUE -> builder.claimValue();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -417,7 +417,6 @@ public final class SearchQueryResponseMapper {
 
   public static MappingResult toMapping(final MappingEntity mappingEntity) {
     return new MappingResult()
-        .mappingKey(KeyUtil.keyToString(mappingEntity.mappingKey()))
         .claimName(mappingEntity.claimName())
         .claimValue(mappingEntity.claimValue())
         .mappingId(mappingEntity.mappingId())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -133,7 +133,6 @@ class RequestMapperTest {
                     Instant.now().plusSeconds(3600),
                     Map.of("sub", username))),
             Collections.emptySet(),
-            Collections.emptySet(),
             authenticationContext);
 
     final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
@@ -277,7 +276,6 @@ class RequestMapperTest {
                 jwt,
                 new OAuthContext(
                     new HashSet<>(),
-                    new HashSet<>(),
                     new AuthenticationContext(
                         sub, List.of(), List.of(), List.of(), List.of("g1", "g2")))),
             null,
@@ -301,7 +299,6 @@ class RequestMapperTest {
                         tokenIssuedAt,
                         tokenExpiresAt,
                         Map.of("aud", aud, usernameClaim, usernameValue))),
-                Collections.emptySet(),
                 Collections.emptySet(),
                 new AuthenticationContext(
                     usernameValue, List.of(), List.of(), List.of(), List.of())),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -49,8 +49,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   private static final List<MappingEntity> MAPPING_ENTITIES =
       List.of(
-          new MappingEntity("mapping-id-1", 100L, "claim1", "value1", "cv1"),
-          new MappingEntity("mapping-id-2", 200L, "claim2", "value2", "cv2"));
+          new MappingEntity("mapping-id-1", 1L, "claim1", "value1", "cv1"),
+          new MappingEntity("mapping-id-2", 2L, "claim2", "value2", "cv2"));
 
   private static final String RESPONSE =
       """
@@ -106,14 +106,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
              "name": "%s",
              "claimName": "%s",
              "claimValue": "%s",
-             "mappingKey": %s,
              "mappingId": %s
            },
            {
              "name": "%s",
              "claimName": "%s",
              "claimValue": "%s",
-             "mappingKey": %s,
              "mappingId": "%s"
            }
          ],
@@ -130,12 +128,10 @@ public class TenantQueryControllerTest extends RestControllerTest {
           MAPPING_ENTITIES.get(0).name(),
           MAPPING_ENTITIES.get(0).claimName(),
           MAPPING_ENTITIES.get(0).claimValue(),
-          "\"%s\"".formatted(MAPPING_ENTITIES.get(0).mappingKey()),
           MAPPING_ENTITIES.get(0).mappingId(),
           MAPPING_ENTITIES.get(1).name(),
           MAPPING_ENTITIES.get(1).claimName(),
           MAPPING_ENTITIES.get(1).claimValue(),
-          "\"%s\"".formatted(MAPPING_ENTITIES.get(1).mappingKey()),
           MAPPING_ENTITIES.get(1).mappingId(),
           MAPPING_ENTITIES.size());
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -57,7 +57,6 @@ public class MappingQueryControllerTest extends RestControllerTest {
         .json(
             """
                           {
-                            "mappingKey": "100",
                             "claimName": "Claim Name",
                             "claimValue": "Claim Value",
                             "name": "Map Name"
@@ -135,19 +134,16 @@ public class MappingQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "mappingKey": "100",
                  "claimName": "Claim Name1",
                  "claimValue": "Claim Value1",
                  "name": "Map Name1"
                },
                {
-                 "mappingKey": "200",
                  "claimName": "Claim Name2",
                  "claimValue": "Claim Value2",
                  "name": "Map Name2"
                },
                {
-                 "mappingKey": "300",
                  "claimName": "Claim Name3",
                  "claimValue": "Claim Value3",
                  "name": "Map Name3"

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1068,6 +1068,8 @@ public class CompactRecordLogger {
     builder
         .append("Key=")
         .append(shortenKey(value.getMappingKey()))
+        .append(", mappingId=")
+        .append(formatId(value.getMappingId()))
         .append(", claimName=")
         .append(value.getClaimName())
         .append(", claimValue=")

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MappingRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MappingRecordStream.java
@@ -23,10 +23,6 @@ public class MappingRecordStream
     return new MappingRecordStream(wrappedStream);
   }
 
-  public MappingRecordStream withKey(final long mappingKey) {
-    return valueFilter(v -> v.getMappingKey() == mappingKey);
-  }
-
   public MappingRecordStream withClaimName(final String claimName) {
     return valueFilter(v -> v.getClaimName().equals(claimName));
   }


### PR DESCRIPTION
## Description

This PR refactors the code to replace public usage of mappingKey with mappingId throughout the APIs and associated tests while ensuring that the internal tracing mechanisms are preserved.

Removed mappingKey references from public API responses and test fixtures.
Updated builder methods, switch cases, and tests to use mappingId.
Adjusted method signatures and internal mapping processing to reflect the new mappingId type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31423
