### PR TITLE
[Backport stable/8.6] fix: use version tag filter for process definition search

### DIFF
--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+      # Disable SVE (Scalable Vector Extension) for Java on M4+ machines with "-XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0"
+      - "CLI_JAVA_OPTS=-XX:UseSVE=0"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
     ulimits:

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
@@ -37,12 +37,15 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Autowired private ProcessIndex processIndex;
 
+  private ProcessEntity pe1;
+  private ProcessEntity pe2;
+  private ProcessEntity pe3;
+
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {
-    String resourceXml =
+    final String resourceXml1 =
         testResourceManager.readResourceFileContentsAsString("demoProcess_v_1.bpmn");
-    testSearchRepository.createOrUpdateDocumentFromObject(
-        processIndex.getFullQualifiedName(),
+    pe1 =
         new ProcessEntity()
             .setKey(2251799813685249L)
             .setTenantId(DEFAULT_TENANT_ID)
@@ -50,11 +53,12 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setVersion(1)
             .setVersionTag("v1")
             .setBpmnProcessId("demoProcess")
-            .setBpmnXml(resourceXml));
+            .setBpmnXml(resourceXml1);
+    testSearchRepository.createOrUpdateDocumentFromObject(processIndex.getFullQualifiedName(), pe1);
 
-    resourceXml = testResourceManager.readResourceFileContentsAsString("errorProcess.bpmn");
-    testSearchRepository.createOrUpdateDocumentFromObject(
-        processIndex.getFullQualifiedName(),
+    final String resourceXml2 =
+        testResourceManager.readResourceFileContentsAsString("errorProcess.bpmn");
+    pe2 =
         new ProcessEntity()
             .setKey(2251799813685251L)
             .setTenantId(DEFAULT_TENANT_ID)
@@ -62,18 +66,20 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setVersion(1)
             .setVersionTag("version1")
             .setBpmnProcessId("errorProcess")
-            .setBpmnXml(resourceXml));
+            .setBpmnXml(resourceXml2);
+    testSearchRepository.createOrUpdateDocumentFromObject(processIndex.getFullQualifiedName(), pe2);
 
-    resourceXml = testResourceManager.readResourceFileContentsAsString("complexProcess_v_3.bpmn");
-    testSearchRepository.createOrUpdateDocumentFromObject(
-        processIndex.getFullQualifiedName(),
+    final String resourceXml3 =
+        testResourceManager.readResourceFileContentsAsString("complexProcess_v_3.bpmn");
+    pe3 =
         new ProcessEntity()
             .setKey(2251799813685253L)
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Complex process")
             .setVersion(1)
             .setBpmnProcessId("complexProcess")
-            .setBpmnXml(resourceXml));
+            .setBpmnXml(resourceXml3);
+    testSearchRepository.createOrUpdateDocumentFromObject(processIndex.getFullQualifiedName(), pe3);
 
     searchContainerManager.refreshIndices("*operate-process*");
   }
@@ -85,14 +91,15 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     assertThat(processDefinitionResults.getTotal()).isEqualTo(3);
     assertThat(processDefinitionResults.getItems())
         .extracting(BPMN_PROCESS_ID)
-        .containsExactlyInAnyOrder("demoProcess", "errorProcess", "complexProcess");
+        .containsExactlyInAnyOrder(
+            pe1.getBpmnProcessId(), pe2.getBpmnProcessId(), pe3.getBpmnProcessId());
   }
 
   @Test
   public void shouldReturnWhenByKey() {
-    final ProcessDefinition processDefinition = dao.byKey(2251799813685249L);
+    final ProcessDefinition processDefinition = dao.byKey(pe1.getKey());
 
-    assertThat(processDefinition.getBpmnProcessId()).isEqualTo("demoProcess");
+    assertThat(processDefinition.getBpmnProcessId()).isEqualTo(pe1.getBpmnProcessId());
     assertThat(processDefinition.getTenantId()).isEqualTo(DEFAULT_TENANT_ID);
   }
 
@@ -103,9 +110,9 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
   @Test
   public void shouldReturnWhenXmlByKey() {
-    final String processDefinitionAsXml = dao.xmlByKey(2251799813685249L);
+    final String processDefinitionAsXml = dao.xmlByKey(pe1.getKey());
 
-    assertThat(processDefinitionAsXml).contains("demoProcess");
+    assertThat(processDefinitionAsXml).contains(pe1.getBpmnProcessId());
 
     // Verify the returned string is xml
     try {
@@ -130,10 +137,10 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     final Results<ProcessDefinition> processDefinitionResults =
         dao.search(
             new Query<ProcessDefinition>()
-                .setFilter(new ProcessDefinition().setBpmnProcessId("demoProcess")));
+                .setFilter(new ProcessDefinition().setBpmnProcessId(pe1.getBpmnProcessId())));
 
     assertThat(processDefinitionResults.getItems().get(0).getBpmnProcessId())
-        .isEqualTo("demoProcess");
+        .isEqualTo(pe1.getBpmnProcessId());
   }
 
   @Test
@@ -141,12 +148,12 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     final Results<ProcessDefinition> processDefinitionResults =
         dao.search(
             new Query<ProcessDefinition>()
-                .setFilter(new ProcessDefinition().setVersionTag("version1")));
+                .setFilter(new ProcessDefinition().setVersionTag(pe2.getVersionTag())));
 
     assertThat(processDefinitionResults.getItems()).hasSize(1);
-    final var processDefinition = processDefinitionResults.getItems().get(0);
-    assertThat(processDefinition.getKey()).isEqualTo(2251799813685251L);
-    assertThat(processDefinition.getVersionTag()).isEqualTo("version1");
+    final var processDefinition = processDefinitionResults.getItems().getFirst();
+    assertThat(processDefinition.getKey()).isEqualTo(pe2.getKey());
+    assertThat(processDefinition.getVersionTag()).isEqualTo(pe2.getVersionTag());
   }
 
   @Test
@@ -159,7 +166,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     assertThat(processDefinitionResults.getTotal()).isEqualTo(3);
     assertThat(processDefinitionResults.getItems())
         .extracting(BPMN_PROCESS_ID)
-        .containsExactly("errorProcess", "demoProcess", "complexProcess");
+        .containsExactly(pe2.getBpmnProcessId(), pe1.getBpmnProcessId(), pe3.getBpmnProcessId());
   }
 
   @Test
@@ -172,7 +179,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     assertThat(processDefinitionResults.getTotal()).isEqualTo(3);
     assertThat(processDefinitionResults.getItems())
         .extracting(BPMN_PROCESS_ID)
-        .containsExactly("complexProcess", "demoProcess", "errorProcess");
+        .containsExactly(pe3.getBpmnProcessId(), pe1.getBpmnProcessId(), pe2.getBpmnProcessId());
   }
 
   @Test
@@ -188,7 +195,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
     assertThat(processDefinitionResults.getItems())
         .extracting(BPMN_PROCESS_ID)
-        .containsExactly("errorProcess", "demoProcess");
+        .containsExactly(pe2.getBpmnProcessId(), pe1.getBpmnProcessId());
 
     final Object[] searchAfter = processDefinitionResults.getSortValues();
     assertThat(processDefinitionResults.getItems().get(1).getBpmnProcessId())
@@ -205,6 +212,6 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
     assertThat(processDefinitionResults.getItems()).hasSize(1);
 
     assertThat(processDefinitionResults.getItems().get(0).getBpmnProcessId())
-        .isEqualTo("complexProcess");
+        .isEqualTo(pe3.getBpmnProcessId());
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/ProcessDefinitionDaoIT.java
@@ -48,6 +48,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Demo process")
             .setVersion(1)
+            .setVersionTag("v1")
             .setBpmnProcessId("demoProcess")
             .setBpmnXml(resourceXml));
 
@@ -59,6 +60,7 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
             .setTenantId(DEFAULT_TENANT_ID)
             .setName("Error process")
             .setVersion(1)
+            .setVersionTag("version1")
             .setBpmnProcessId("errorProcess")
             .setBpmnXml(resourceXml));
 
@@ -132,6 +134,19 @@ public class ProcessDefinitionDaoIT extends OperateSearchAbstractIT {
 
     assertThat(processDefinitionResults.getItems().get(0).getBpmnProcessId())
         .isEqualTo("demoProcess");
+  }
+
+  @Test
+  public void shouldFilterProcessDefinitionsByVersionTag() {
+    final Results<ProcessDefinition> processDefinitionResults =
+        dao.search(
+            new Query<ProcessDefinition>()
+                .setFilter(new ProcessDefinition().setVersionTag("version1")));
+
+    assertThat(processDefinitionResults.getItems()).hasSize(1);
+    final var processDefinition = processDefinitionResults.getItems().get(0);
+    assertThat(processDefinition.getKey()).isEqualTo(2251799813685251L);
+    assertThat(processDefinition.getVersionTag()).isEqualTo("version1");
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDao.java
@@ -123,6 +123,7 @@ public class ElasticsearchProcessDefinitionDao extends ElasticsearchDao<ProcessD
           buildTermQuery(ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId()));
       queryBuilders.add(buildTermQuery(ProcessDefinition.TENANT_ID, filter.getTenantId()));
       queryBuilders.add(buildTermQuery(ProcessDefinition.VERSION, filter.getVersion()));
+      queryBuilders.add(buildTermQuery(ProcessDefinition.VERSION_TAG, filter.getVersionTag()));
       queryBuilders.add(buildTermQuery(ProcessDefinition.KEY, filter.getKey()));
       searchSourceBuilder.query(
           ElasticsearchUtil.joinWithAnd(queryBuilders.toArray(new QueryBuilder[] {})));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDao.java
@@ -110,6 +110,7 @@ public class OpensearchProcessDefinitionDao
                       ProcessDefinition.BPMN_PROCESS_ID, filter.getBpmnProcessId()),
                   queryDSLWrapper.term(ProcessDefinition.TENANT_ID, filter.getTenantId()),
                   queryDSLWrapper.term(ProcessDefinition.VERSION, filter.getVersion()),
+                  queryDSLWrapper.term(ProcessDefinition.VERSION_TAG, filter.getVersionTag()),
                   queryDSLWrapper.term(ProcessDefinition.KEY, filter.getKey()))
               .filter(Objects::nonNull)
               .collect(Collectors.toList());

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchProcessDefinitionDaoTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.dao.elasticsearch;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchProcessDefinitionDaoTest {
+
+  @Spy
+  ElasticsearchProcessDefinitionDao processDefinitionDao = new ElasticsearchProcessDefinitionDao();
+
+  @Test
+  public void shouldApplyFilters() {
+    // given
+    final ProcessDefinition processDefinition =
+        new ProcessDefinition()
+            .setKey(1L)
+            .setName("testProcess")
+            .setBpmnProcessId("123")
+            .setTenantId("<default>")
+            .setVersion(1)
+            .setVersionTag("testTag");
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>().setFilter(processDefinition);
+    final SearchSourceBuilder searchSourceBuilder = spy(new SearchSourceBuilder());
+
+    // when
+    processDefinitionDao.buildQueryOn(query, ProcessDefinition.KEY, searchSourceBuilder);
+
+    // then
+    verify(processDefinitionDao, times(1)).buildFiltering(query, searchSourceBuilder);
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.NAME, processDefinition.getName());
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.BPMN_PROCESS_ID, processDefinition.getBpmnProcessId());
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.TENANT_ID, processDefinition.getTenantId());
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.VERSION, processDefinition.getVersion());
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
+    verify(processDefinitionDao, times(1))
+        .buildTermQuery(ProcessDefinition.KEY, processDefinition.getKey());
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchProcessDefinitionDaoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.api.v1.dao.opensearch;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.operate.schema.indices.ProcessIndex;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.webapp.api.v1.entities.ProcessDefinition;
+import io.camunda.operate.webapp.api.v1.entities.Query;
+import io.camunda.operate.webapp.opensearch.OpensearchQueryDSLWrapper;
+import io.camunda.operate.webapp.opensearch.OpensearchRequestDSLWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.core.SearchRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchProcessDefinitionDaoTest {
+
+  private OpensearchProcessDefinitionDao processDefinitionDao;
+
+  private OpensearchQueryDSLWrapper wrapper;
+
+  @BeforeEach
+  public void setup() {
+    wrapper = spy(new OpensearchQueryDSLWrapper());
+    processDefinitionDao =
+        new OpensearchProcessDefinitionDao(
+            wrapper,
+            mock(OpensearchRequestDSLWrapper.class),
+            mock(RichOpenSearchClient.class),
+            new ProcessIndex());
+  }
+
+  @Test
+  public void shouldApplyFilters() {
+    // given
+    final ProcessDefinition processDefinition =
+        new ProcessDefinition()
+            .setKey(1L)
+            .setName("testProcess")
+            .setBpmnProcessId("123")
+            .setTenantId("<default>")
+            .setVersion(1)
+            .setVersionTag("testTag");
+    final Query<ProcessDefinition> query =
+        new Query<ProcessDefinition>().setFilter(processDefinition);
+
+    // when
+    processDefinitionDao.buildFiltering(query, mock(SearchRequest.Builder.class));
+
+    // then
+    verify(wrapper, times(1)).term(ProcessDefinition.NAME, processDefinition.getName());
+    verify(wrapper, times(1))
+        .term(ProcessDefinition.BPMN_PROCESS_ID, processDefinition.getBpmnProcessId());
+    verify(wrapper, times(1)).term(ProcessDefinition.TENANT_ID, processDefinition.getTenantId());
+    verify(wrapper, times(1)).term(ProcessDefinition.VERSION, processDefinition.getVersion());
+    verify(wrapper, times(1))
+        .term(ProcessDefinition.VERSION_TAG, processDefinition.getVersionTag());
+    verify(wrapper, times(1)).term(ProcessDefinition.KEY, processDefinition.getKey());
+  }
+}


### PR DESCRIPTION
# Description
Backport of #31268 to `stable/8.6`.

relates to #30374