### PR TITLE
fix: log failed operation IDs when bulk fails for nested document error

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -810,33 +810,19 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
       final String itemName) {
     if (!operations.isEmpty()) {
       log.info("Executing bulk request on {} items of {}", operations.size(), itemName);
-
       final String errorMessage =
           String.format("There were errors while performing a bulk on %s.", itemName);
       final BulkResponse bulkResponse =
           bulk(bulkReqBuilderSupplier.get().operations(operations), errorMessage);
       if (bulkResponse.errors()) {
-        final Map<String, List<String>> failedNestedDocLimitItemIdsByIndexName =
-            bulkResponse.items().stream()
-                .filter(operation -> Objects.nonNull(operation.error()))
-                .filter(operation -> Objects.nonNull(operation.error().reason()))
-                .filter(operation -> Objects.nonNull(operation.id()))
-                .filter(operation -> operation.error().reason().contains(NESTED_DOC_LIMIT_MESSAGE))
-                .collect(
-                    Collectors.groupingBy(
-                        BulkResponseItem::index,
-                        Collectors.mapping(BulkResponseItem::id, Collectors.toList())));
-        if (!failedNestedDocLimitItemIdsByIndexName.isEmpty()) {
-          final Set<String> failedOperationIds =
-              failedNestedDocLimitItemIdsByIndexName.values().stream()
-                  .flatMap(Collection::stream)
-                  .collect(Collectors.toSet());
+        final Set<String> failedOperationIds = getFailedOperationIds(bulkResponse);
+        if (!failedOperationIds.isEmpty()) {
           log.warn(
               "There were failures while performing bulk on {} due to the nested document limit being reached."
                   + " Removing {} failed items and retrying",
               itemName,
               failedOperationIds.size());
-          log.debug("Failed operation IDs by Index: {}", failedNestedDocLimitItemIdsByIndexName);
+
           final List<BulkOperation> nonFailedOperations =
               operations.stream()
                   .filter(
@@ -846,14 +832,33 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
             doBulkRequestWithNestedDocHandling(
                 bulkReqBuilderSupplier, nonFailedOperations, itemName);
           }
-        } else {
-          throw new OptimizeRuntimeException(
-              String.format("There were failures while performing bulk on %s.", itemName));
         }
+      } else {
+        log.debug("Bulk request on {} not executed because it contains no actions.", itemName);
       }
-    } else {
-      log.debug("Bulk request on {} not executed because it contains no actions.", itemName);
     }
+  }
+
+  private Set<String> getFailedOperationIds(final BulkResponse bulkResponse) {
+    final Map<String, List<String>> failedNestedDocLimitItemIdsByIndexName =
+        bulkResponse.items().stream()
+            .filter(operation -> Objects.nonNull(operation.error()))
+            .filter(operation -> Objects.nonNull(operation.error().reason()))
+            .filter(operation -> Objects.nonNull(operation.id()))
+            .filter(operation -> operation.error().reason().contains(NESTED_DOC_LIMIT_MESSAGE))
+            .collect(
+                Collectors.groupingBy(
+                    BulkResponseItem::index,
+                    Collectors.mapping(BulkResponseItem::id, Collectors.toList())));
+    if (!failedNestedDocLimitItemIdsByIndexName.isEmpty()) {
+      final Set<String> failedOperationIds =
+          failedNestedDocLimitItemIdsByIndexName.values().stream()
+              .flatMap(Collection::stream)
+              .collect(Collectors.toSet());
+      log.debug("Failed operation IDs by Index: {}", failedNestedDocLimitItemIdsByIndexName);
+      return failedOperationIds;
+    }
+    return Set.of();
   }
 
   private void doBulkRequestWithoutRetries(
@@ -865,6 +870,7 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
           String.format("There were errors while performing a bulk on %s.", itemName);
       final BulkResponse bulkResponse = bulk(bulkReqBuilder.operations(operations), errorMessage);
       if (bulkResponse.errors()) {
+        final Set<String> failedOperationIds = getFailedOperationIds(bulkResponse);
         final boolean isReachedNestedDocLimit =
             bulkResponse.items().stream()
                 .map(BulkResponseItem::error)
@@ -874,8 +880,8 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
                 .anyMatch(reason -> reason.contains(NESTED_DOC_LIMIT_MESSAGE));
         throw new OptimizeRuntimeException(
             String.format(
-                "There were failures while performing bulk on %s.%n%s",
-                itemName, getHintForErrorMsg(isReachedNestedDocLimit)));
+                "There were %s failures while performing bulk on %s.%n%s",
+                failedOperationIds.size(), itemName, getHintForErrorMsg(isReachedNestedDocLimit)));
       }
     } else {
       log.debug("Bulk request on {} not executed because it contains no actions.", itemName);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backport of https://github.com/camunda/camunda/pull/31294
