### PR TITLE
pg-fni-state-search

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
@@ -63,7 +63,8 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), parentFlowNodeId, processInstanceId, position, type);
+    return Objects.hash(
+        super.hashCode(), parentFlowNodeId, processInstanceId, position, type, state);
   }
 
   @Override
@@ -78,9 +79,10 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
       return false;
     }
     final FlowNodeInstanceEntity that = (FlowNodeInstanceEntity) o;
-    return Objects.equals(parentFlowNodeId, that.parentFlowNodeId)
+    return type == that.type
+        && state == that.state
+        && Objects.equals(parentFlowNodeId, that.parentFlowNodeId)
         && Objects.equals(processInstanceId, that.processInstanceId)
-        && Objects.equals(position, that.position)
-        && type == that.type;
+        && Objects.equals(position, that.position);
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
@@ -15,6 +15,7 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
   private String processInstanceId;
   private Long position;
   private FlowNodeType type;
+  private FlowNodeState state;
 
   public String getProcessInstanceId() {
     return processInstanceId;
@@ -52,6 +53,19 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
     return this;
   }
 
+  public FlowNodeState getState() {
+    return state;
+  }
+
+  public void setState(final FlowNodeState state) {
+    this.state = state;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), parentFlowNodeId, processInstanceId, position, type);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -68,10 +82,5 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
         && Objects.equals(processInstanceId, that.processInstanceId)
         && Objects.equals(position, that.position)
         && type == that.type;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), parentFlowNodeId, processInstanceId, position, type);
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeState.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeState.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.entities;
+
+public enum FlowNodeState {
+  ACTIVE,
+  COMPLETED,
+  TERMINATED
+}

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/FlowNodeInstanceIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/FlowNodeInstanceIndex.java
@@ -23,6 +23,7 @@ public class FlowNodeInstanceIndex extends AbstractIndexDescriptor
   public static final String PARENT_FLOW_NODE_ID = "parentFlowNodeId";
   public static final String TENANT_ID = "tenantId";
   public static final String TYPE = "type";
+  public static final String STATE = "state";
 
   @Override
   public String getIndexName() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -244,6 +244,7 @@ public class VariableStoreElasticSearch implements VariableStore {
     final TermsQueryBuilder typeQuery =
         QueryBuilders.termsQuery(
             FlowNodeInstanceIndex.TYPE,
+            FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
             FlowNodeType.USER_TASK.toString(),
             FlowNodeType.SUB_PROCESS.toString(),
             FlowNodeType.EVENT_SUB_PROCESS.toString(),

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -24,11 +24,13 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
 import io.camunda.tasklist.entities.FlowNodeType;
 import io.camunda.tasklist.entities.TaskVariableEntity;
 import io.camunda.tasklist.entities.VariableEntity;
@@ -73,6 +75,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -232,12 +235,15 @@ public class VariableStoreElasticSearch implements VariableStore {
 
     final TermsQueryBuilder processInstanceKeyQuery =
         termsQuery(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID, processInstanceIds);
+    final TermQueryBuilder flowNodeStateQuery =
+        termQuery(FlowNodeInstanceIndex.STATE, FlowNodeState.ACTIVE.name());
+
     queryBuilder.must(processInstanceKeyQuery);
+    queryBuilder.must(flowNodeStateQuery);
 
     final TermsQueryBuilder typeQuery =
         QueryBuilders.termsQuery(
             FlowNodeInstanceIndex.TYPE,
-            FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
             FlowNodeType.USER_TASK.toString(),
             FlowNodeType.SUB_PROCESS.toString(),
             FlowNodeType.EVENT_SUB_PROCESS.toString(),

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toList;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
 import io.camunda.tasklist.entities.FlowNodeType;
 import io.camunda.tasklist.entities.TaskVariableEntity;
 import io.camunda.tasklist.entities.VariableEntity;
@@ -259,6 +260,11 @@ public class VariableStoreOpenSearch implements VariableStore {
                                 .map(FieldValue::of)
                                 .collect(Collectors.toList()))));
 
+    final Query.Builder stateQuery = new Query.Builder();
+    stateQuery.term(
+        t ->
+            t.field(FlowNodeInstanceIndex.STATE).value(FieldValue.of(FlowNodeState.ACTIVE.name())));
+
     final Query.Builder typeQuery = new Query.Builder();
     typeQuery.terms(
         terms ->
@@ -277,7 +283,8 @@ public class VariableStoreOpenSearch implements VariableStore {
 
     final Query.Builder combinedQuery = new Query.Builder();
     combinedQuery.constantScore(
-        cs -> cs.filter(OpenSearchUtil.joinWithAnd(processInstanceKeyQuery, typeQuery)));
+        cs ->
+            cs.filter(OpenSearchUtil.joinWithAnd(processInstanceKeyQuery, typeQuery, stateQuery)));
 
     final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
     searchRequestBuilder

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -56,8 +56,11 @@ import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
 import org.opensearch.client.opensearch.core.*;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
@@ -248,43 +251,52 @@ public class VariableStoreOpenSearch implements VariableStore {
   @Override
   public List<FlowNodeInstanceEntity> getFlowNodeInstances(final List<String> processInstanceIds) {
 
-    final Query.Builder processInstanceKeyQuery = new Query.Builder();
-    processInstanceKeyQuery.terms(
-        terms ->
-            terms
-                .field(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID)
-                .terms(
-                    t ->
-                        t.value(
-                            processInstanceIds.stream()
-                                .map(FieldValue::of)
-                                .collect(Collectors.toList()))));
+    final TermsQuery processInstanceKeyQuery =
+        TermsQuery.of(
+            t ->
+                t.field(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID)
+                    .terms(
+                        terms ->
+                            terms.value(processInstanceIds.stream().map(FieldValue::of).toList())));
 
-    final Query.Builder stateQuery = new Query.Builder();
-    stateQuery.term(
-        t ->
-            t.field(FlowNodeInstanceIndex.STATE).value(FieldValue.of(FlowNodeState.ACTIVE.name())));
+    final TermQuery stateActiveQuery =
+        TermQuery.of(
+            t ->
+                t.field(FlowNodeInstanceIndex.STATE)
+                    .value(FieldValue.of(FlowNodeState.ACTIVE.name())));
+    final BoolQuery stateMissingQuery =
+        BoolQuery.of(b -> b.mustNot(q -> q.exists(e -> e.field(FlowNodeInstanceIndex.STATE))));
+    final BoolQuery stateQuery =
+        BoolQuery.of(
+            b ->
+                b.should(q -> q.term(stateActiveQuery))
+                    .should(q -> q.bool(stateMissingQuery))
+                    .minimumShouldMatch("1"));
 
-    final Query.Builder typeQuery = new Query.Builder();
-    typeQuery.terms(
-        terms ->
-            terms
-                .field(FlowNodeInstanceIndex.TYPE)
-                .terms(
-                    t ->
-                        t.value(
-                            Arrays.asList(
-                                FieldValue.of(FlowNodeType.AD_HOC_SUB_PROCESS.toString()),
-                                FieldValue.of(FlowNodeType.USER_TASK.toString()),
-                                FieldValue.of(FlowNodeType.SUB_PROCESS.toString()),
-                                FieldValue.of(FlowNodeType.EVENT_SUB_PROCESS.toString()),
-                                FieldValue.of(FlowNodeType.MULTI_INSTANCE_BODY.toString()),
-                                FieldValue.of(FlowNodeType.PROCESS.toString())))));
+    final TermsQuery typeQuery =
+        TermsQuery.of(
+            t ->
+                t.field(FlowNodeInstanceIndex.TYPE)
+                    .terms(
+                        terms ->
+                            terms.value(
+                                Arrays.asList(
+                                    FieldValue.of(FlowNodeType.AD_HOC_SUB_PROCESS.toString()),
+                                    FieldValue.of(FlowNodeType.USER_TASK.toString()),
+                                    FieldValue.of(FlowNodeType.SUB_PROCESS.toString()),
+                                    FieldValue.of(FlowNodeType.EVENT_SUB_PROCESS.toString()),
+                                    FieldValue.of(FlowNodeType.MULTI_INSTANCE_BODY.toString()),
+                                    FieldValue.of(FlowNodeType.PROCESS.toString())))));
+
+    final BoolQuery finalQuery =
+        BoolQuery.of(
+            b ->
+                b.must(q -> q.terms(processInstanceKeyQuery))
+                    .must(q -> q.terms(typeQuery))
+                    .must(q -> q.bool(stateQuery)));
 
     final Query.Builder combinedQuery = new Query.Builder();
-    combinedQuery.constantScore(
-        cs ->
-            cs.filter(OpenSearchUtil.joinWithAnd(processInstanceKeyQuery, typeQuery, stateQuery)));
+    combinedQuery.constantScore(cs -> cs.filter(q -> q.bool(finalQuery)));
 
     final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
     searchRequestBuilder

--- a/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-flownode-instance.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-flownode-instance.json
@@ -25,7 +25,10 @@
 			},
 			"tenantId": {
 				"type": "keyword"
-			}
+			},
+      "state": {
+        "type": "keyword"
+      }
 		}
 	}
 }

--- a/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-flownode-instance.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-flownode-instance.json
@@ -1,34 +1,34 @@
 {
-	"mappings": {
-		"dynamic": "strict",
-		"properties": {
-			"partitionId": {
-				"type": "integer"
-			},
-			"parentFlowNodeId": {
-				"type": "keyword"
-			},
-			"processInstanceId": {
-				"type": "keyword"
-			},
-			"id": {
-				"type": "keyword"
-			},
-			"position": {
-				"type": "long"
-			},
-			"type": {
-				"type": "keyword"
-			},
-			"key": {
-				"type": "long"
-			},
-			"tenantId": {
-				"type": "keyword"
-			},
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "partitionId": {
+        "type": "integer"
+      },
+      "parentFlowNodeId": {
+        "type": "keyword"
+      },
+      "processInstanceId": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
       "state": {
         "type": "keyword"
       }
-		}
-	}
+    }
+  }
 }

--- a/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-flownode-instance.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-flownode-instance.json
@@ -24,6 +24,9 @@
     },
     "tenantId": {
       "type": "keyword"
+    },
+    "state": {
+      "type": "keyword"
     }
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
 import io.camunda.tasklist.entities.FlowNodeType;
 import io.camunda.tasklist.entities.ProcessInstanceEntity;
 import io.camunda.tasklist.entities.ProcessInstanceState;
@@ -45,8 +46,21 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProcessInstanceZeebeRecordProcessorElasticSearch.class);
 
-  private static final Set<String> FLOW_NODE_STATES = new HashSet<>();
-  private static final Set<String> PROCESS_INSTANCE_STATES = new HashSet<>();
+  private static final Set<String> FLOW_NODE_STATES =
+      new HashSet<>() {
+        {
+          add(ELEMENT_ACTIVATING.name());
+          add(ELEMENT_COMPLETED.name());
+          add(ELEMENT_TERMINATED.name());
+        }
+      };
+  private static final Set<String> PROCESS_INSTANCE_STATES =
+      new HashSet<>() {
+        {
+          add(ELEMENT_COMPLETED.name());
+          add(ELEMENT_TERMINATED.name());
+        }
+      };
 
   private static final List<BpmnElementType> VARIABLE_SCOPE_TYPES =
       Arrays.asList(
@@ -55,12 +69,6 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
           BpmnElementType.EVENT_SUB_PROCESS,
           BpmnElementType.USER_TASK,
           BpmnElementType.MULTI_INSTANCE_BODY);
-
-  static {
-    FLOW_NODE_STATES.add(ELEMENT_ACTIVATING.name());
-    PROCESS_INSTANCE_STATES.add(ELEMENT_COMPLETED.name());
-    PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
-  }
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -104,6 +112,7 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
   private FlowNodeInstanceEntity createFlowNodeInstance(final Record record) {
     final ProcessInstanceRecordValueImpl recordValue =
         (ProcessInstanceRecordValueImpl) record.getValue();
+    final String intentStr = record.getIntent().name();
     final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity();
     entity.setId(ConversionUtils.toStringOrNull(record.getKey()));
     entity.setKey(record.getKey());
@@ -116,6 +125,13 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
                 ? null
                 : recordValue.getBpmnElementType().name()));
     entity.setPosition(record.getPosition());
+    if (ELEMENT_ACTIVATING.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.ACTIVE);
+    } else if (ELEMENT_COMPLETED.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.COMPLETED);
+    } else if (ELEMENT_TERMINATED.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.TERMINATED);
+    }
     return entity;
   }
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
 import io.camunda.tasklist.entities.FlowNodeType;
 import io.camunda.tasklist.entities.ProcessInstanceEntity;
 import io.camunda.tasklist.entities.ProcessInstanceState;
@@ -45,8 +46,21 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProcessInstanceZeebeRecordProcessorOpenSearch.class);
 
-  private static final Set<String> FLOW_NODE_STATES = new HashSet<>();
-  private static final Set<String> PROCESS_INSTANCE_STATES = new HashSet<>();
+  private static final Set<String> FLOW_NODE_STATES =
+      new HashSet<>() {
+        {
+          add(ELEMENT_ACTIVATING.name());
+          add(ELEMENT_COMPLETED.name());
+          add(ELEMENT_TERMINATED.name());
+        }
+      };
+  private static final Set<String> PROCESS_INSTANCE_STATES =
+      new HashSet<>() {
+        {
+          add(ELEMENT_COMPLETED.name());
+          add(ELEMENT_TERMINATED.name());
+        }
+      };
 
   private static final List<BpmnElementType> VARIABLE_SCOPE_TYPES =
       Arrays.asList(
@@ -56,12 +70,6 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
           BpmnElementType.USER_TASK,
           BpmnElementType.MULTI_INSTANCE_BODY,
           BpmnElementType.AD_HOC_SUB_PROCESS);
-
-  static {
-    FLOW_NODE_STATES.add(ELEMENT_ACTIVATING.name());
-    PROCESS_INSTANCE_STATES.add(ELEMENT_COMPLETED.name());
-    PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
-  }
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -105,6 +113,7 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
   private FlowNodeInstanceEntity createFlowNodeInstance(final Record record) {
     final ProcessInstanceRecordValueImpl recordValue =
         (ProcessInstanceRecordValueImpl) record.getValue();
+    final String intentStr = record.getIntent().name();
     final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity();
     entity.setId(ConversionUtils.toStringOrNull(record.getKey()));
     entity.setKey(record.getKey());
@@ -117,6 +126,13 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
                 ? null
                 : recordValue.getBpmnElementType().name()));
     entity.setPosition(record.getPosition());
+    if (ELEMENT_ACTIVATING.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.ACTIVE);
+    } else if (ELEMENT_COMPLETED.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.COMPLETED);
+    } else if (ELEMENT_TERMINATED.name().equals(intentStr)) {
+      entity.setState(FlowNodeState.TERMINATED);
+    }
     return entity;
   }
 

--- a/tasklist/qa/integration-tests/src/test/resources/variable_search.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/variable_search.bpmn
@@ -117,7 +117,6 @@
     </bpmn:userTask>
     <bpmn:userTask id="Activity_JW">
       <bpmn:extensionElements>
-        <zeebe:userTask />
         <zeebe:ioMapping>
           <zeebe:input source="=var1" target="jwvar1" />
           <zeebe:input source="=inputvar + &#34;jw&#34;" target="taskvar" />


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
A smaller set of search improvements regarding search Tasks by variables to limit the total number of FNIs retrieved during the operation based on the FNI State.

- Persist FlowNode State
- Filter only `ACTIVE` FNIs on Variable Search

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #https://github.com/camunda/camunda/issues/31458
