### PR TITLE
feat: implement Java client for PI call hierarchy request

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -81,6 +81,7 @@ import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
+import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
@@ -1898,4 +1899,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the users by group search request
    */
   UsersByGroupSearchRequest newUsersByGroupSearchRequest(String groupId);
+
+  /**
+   * Retrieves the call hierarchy for a given process instance by its key.
+   *
+   * <pre>
+   * camundaClient
+   *   .newProcessInstanceGetCallHierarchyRequest(processInstanceKey)
+   *   .send();
+   * </pre>
+   *
+   * <p>The returned hierarchical structure represents the relationship of the given process
+   * instance to its parent and child process instances, if any.
+   *
+   * @param processInstanceKey the key of the process instance
+   * @return a builder for the request
+   */
+  ProcessInstanceGetCallHierarchyRequest newProcessInstanceGetCallHierarchyRequest(
+      Long processInstanceKey);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/ProcessInstanceGetCallHierarchyRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/ProcessInstanceGetCallHierarchyRequest.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.response;
+package io.camunda.client.api.fetch;
 
-public interface ProcessInstanceReference {
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
+import java.util.List;
 
-  String getInstanceId();
-
-  String getProcessDefinitionId();
-
-  String processDefinitionName();
-}
+public interface ProcessInstanceGetCallHierarchyRequest
+    extends FinalCommandStep<List<ProcessInstanceCallHierarchyEntryResponse>> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstanceCallHierarchyEntryResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstanceCallHierarchyEntryResponse.java
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.zeebe.client.api.search.response;
+package io.camunda.client.api.search.response;
 
-import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
+public interface ProcessInstanceCallHierarchyEntryResponse {
 
-/**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link ProcessInstanceCallHierarchyEntryResponse}
- */
-@Deprecated
-public interface ProcessInstanceReference {
+  Long getProcessInstanceKey();
 
-  String getInstanceId();
+  Long getProcessDefinitionKey();
 
-  String getProcessDefinitionId();
-
-  String processDefinitionName();
+  String getProcessDefinitionName();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -92,6 +92,7 @@ import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
+import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
@@ -179,6 +180,7 @@ import io.camunda.client.impl.fetch.IncidentGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetFormRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
+import io.camunda.client.impl.fetch.ProcessInstanceGetCallHierarchyRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetFormRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
@@ -1010,6 +1012,12 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UsersByGroupSearchRequest newUsersByGroupSearchRequest(final String groupId) {
     return new UsersByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
+  }
+
+  @Override
+  public ProcessInstanceGetCallHierarchyRequest newProcessInstanceGetCallHierarchyRequest(
+      final Long processInstanceKey) {
+    return new ProcessInstanceGetCallHierarchyRequestImpl(httpClient, processInstanceKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessInstanceGetCallHierarchyRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessInstanceGetCallHierarchyRequestImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
+import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.ProcessInstanceCallHierarchyEntry;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ProcessInstanceGetCallHierarchyRequestImpl
+    implements ProcessInstanceGetCallHierarchyRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long processInstanceKey;
+
+  public ProcessInstanceGetCallHierarchyRequestImpl(
+      final HttpClient httpClient, final long processInstanceKey) {
+    this.httpClient = httpClient;
+    this.processInstanceKey = processInstanceKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public ProcessInstanceGetCallHierarchyRequest requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<List<ProcessInstanceCallHierarchyEntryResponse>> send() {
+    final HttpCamundaFuture<List<ProcessInstanceCallHierarchyEntryResponse>> result =
+        new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/process-instances/%d/call-hierarchy", processInstanceKey),
+        httpRequestConfig.build(),
+        ProcessInstanceCallHierarchyEntry[].class,
+        SearchResponseMapper::toProcessInstanceCallHierarchyEntryResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceCallHierarchyEntryResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceCallHierarchyEntryResponseImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
+import io.camunda.client.impl.util.ParseUtil;
+import io.camunda.client.protocol.rest.ProcessInstanceCallHierarchyEntry;
+
+public class ProcessInstanceCallHierarchyEntryResponseImpl
+    implements ProcessInstanceCallHierarchyEntryResponse {
+
+  private final Long processInstanceKey;
+  private final Long processDefinitionKey;
+  private final String processDefinitionName;
+
+  public ProcessInstanceCallHierarchyEntryResponseImpl(
+      final ProcessInstanceCallHierarchyEntry entry) {
+    processInstanceKey = ParseUtil.parseLongOrNull(entry.getProcessInstanceKey());
+    processDefinitionKey = ParseUtil.parseLongOrNull(entry.getProcessDefinitionKey());
+    processDefinitionName = entry.getProcessDefinitionName();
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  @Override
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(processInstanceKey, processDefinitionKey, processDefinitionName);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final ProcessInstanceCallHierarchyEntryResponseImpl other =
+        (ProcessInstanceCallHierarchyEntryResponseImpl) obj;
+    return java.util.Objects.equals(processInstanceKey, other.processInstanceKey)
+        && java.util.Objects.equals(processDefinitionKey, other.processDefinitionKey)
+        && java.util.Objects.equals(processDefinitionName, other.processDefinitionName);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ProcessInstanceCallHierarchyEntryImpl{processInstanceKey=%d, processDefinitionKey=%d, processDefinitionName='%s'}",
+        processInstanceKey, processDefinitionKey, processDefinitionName);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.SearchResponsePage;
 import io.camunda.client.api.search.response.User;
@@ -33,6 +34,7 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -180,6 +182,13 @@ public final class SearchResponseMapper {
     final List<User> instances =
         toSearchResponseInstances(response.getItems(), SearchResponseMapper::toUserResponse);
     return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static List<ProcessInstanceCallHierarchyEntryResponse>
+      toProcessInstanceCallHierarchyEntryResponse(
+          final ProcessInstanceCallHierarchyEntry[] entries) {
+    return toSearchResponseInstances(
+        Arrays.asList(entries), ProcessInstanceCallHierarchyEntryResponseImpl::new);
   }
 
   private static <T, R> List<R> toSearchResponseInstances(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
@@ -15,11 +15,8 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
-import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
-
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
- *     ProcessInstanceCallHierarchyEntryResponse}
+ * @deprecated this class will be removed with version 8.8.
  */
 @Deprecated
 public interface ProcessInstanceReference {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated this class will be removed with version 8.8.
+ * @deprecated this class will be removed with version 8.9.
  */
 @Deprecated
 public interface ProcessInstanceReference {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
@@ -18,7 +18,8 @@ package io.camunda.zeebe.client.api.search.response;
 import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link ProcessInstanceCallHierarchyEntryResponse}
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     ProcessInstanceCallHierarchyEntryResponse}
  */
 @Deprecated
 public interface ProcessInstanceReference {

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -364,6 +364,18 @@ public class QueryProcessInstanceTest extends ClientRestTest {
         .isEqualTo(expectedExtras);
   }
 
+  @Test
+  public void shouldFetchProcessInstanceCallHierarchy() {
+    // when
+    client.newProcessInstanceGetCallHierarchyRequest(123L).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/123/call-hierarchy");
+    assertThat(request.getBodyAsString()).isEmpty();
+  }
+
   private static Set<String> publicMethodSignatures(final Class<?> clazz) {
     return Arrays.stream(clazz.getMethods())
         .filter(m -> Modifier.isPublic(m.getModifiers()) && !m.isSynthetic())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -1692,9 +1692,9 @@ public class ProcessInstanceAndElementInstanceSearchTest {
             .join();
 
     // then
-    assertThat(result).isNotNull();
-    assertThat(result).hasSize(2);
     assertThat(result)
+        .isNotNull()
+        .hasSize(2)
         .extracting("processDefinitionName")
         .containsExactly("Parent process v1", "Child process v1");
   }
@@ -1720,7 +1720,6 @@ public class ProcessInstanceAndElementInstanceSearchTest {
             .join();
 
     // then
-    assertThat(result).isNotNull();
-    assertThat(result).isEmpty();
+    assertThat(result).isNotNull().isEmpty();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -1670,4 +1670,57 @@ public class ProcessInstanceAndElementInstanceSearchTest {
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v2");
   }
+
+  @Test
+  void shouldQueryProcessInstanceCallHierarchy() {
+    // given
+    final long childProcessInstanceKey =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId("child_process_v1"))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetCallHierarchyRequest(childProcessInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).hasSize(2);
+    assertThat(result)
+        .extracting("processDefinitionName")
+        .containsExactly("Parent process v1", "Child process v1");
+  }
+
+  @Test
+  void shouldReturnEmptyCallHierarchyForParentProcessInstance() {
+    // given
+    final long parentProcessInstanceKey =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId("parent_process_v1"))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceGetCallHierarchyRequest(parentProcessInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR implements Java client support for the new V2 API endpoint `/v2/process-instances/{key}/call-hierarchy`, allowing clients to retrieve the call hierarchy for a given process instance.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31062
