### PR TITLE
feat: create batch operation created handler camunda exporter

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/BatchOperationTemplate.java
@@ -29,7 +29,6 @@ public class BatchOperationTemplate extends AbstractTemplateDescriptor implement
   public static final String COMPLETED_OPERATIONS_COUNT = "completedOperationsCount";
 
   // New fields for engine batch operations
-  public static final String BATCH_OPERATION_KEY = "batchOperationKey";
   public static final String STATE = "state";
   public static final String OPERATIONS_FAILED_COUNT = "operationsFailedCount";
   public static final String OPERATIONS_COMPLETED_COUNT = "operationsCompletedCount";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -221,7 +221,9 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   @Override
   public String toString() {
     return "BatchOperationEntity{"
-        + "name='"
+        + "id='"
+        + getId()
+        + "', name='"
         + name
         + '\''
         + ", type="

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -26,21 +26,11 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   private Integer operationsFinishedCount = 0;
 
   // new fields for batch operation in zeebe engine
-  private Long batchOperationKey;
   private BatchOperationState state;
   private Integer operationsFailedCount = 0; // Just failed / rejected operations
   private Integer operationsCompletedCount = 0; // Just successfully completed operations
 
   @JsonIgnore private Object[] sortValues;
-
-  public Long getBatchOperationKey() {
-    return batchOperationKey;
-  }
-
-  public BatchOperationEntity setBatchOperationKey(final Long batchOperationKey) {
-    this.batchOperationKey = batchOperationKey;
-    return this;
-  }
 
   public String getName() {
     return name;
@@ -231,8 +221,6 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   @Override
   public String toString() {
     return "BatchOperationEntity{"
-        + "batchOperationKey="
-        + batchOperationKey
         + "name='"
         + name
         + '\''

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-batch-operation.json
@@ -31,9 +31,6 @@
 			"username": {
 				"type": "keyword"
       },
-      "batchOperationKey": {
-        "type": "long"
-      },
       "state": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-batch-operation.json
@@ -31,9 +31,6 @@
 			"username": {
 				"type": "keyword"
       },
-      "batchOperationKey": {
-        "type": "long"
-      },
       "state": {
         "type": "keyword"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
@@ -420,7 +421,8 @@ processing records from previous version
             DECISION_EVALUATION,
             PROCESS,
             FORM,
-            USER_TASK);
+            USER_TASK,
+            BATCH_OPERATION_CREATION);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -65,6 +65,8 @@ import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationCreatedHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationStartedHandler;
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
@@ -86,6 +88,7 @@ import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
@@ -271,7 +274,12 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(MetricIndex.class).getFullQualifiedName()),
             new JobHandler(indexDescriptors.get(JobTemplate.class).getFullQualifiedName()),
             new MigratedVariableHandler(
-                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName()));
+                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName()),
+            // Batch Operation Handler
+            new BatchOperationCreatedHandler(
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+            new BatchOperationStartedHandler(
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()));
 
     indicesWithCustomErrorHandlers =
         Map.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import java.util.List;
+
+public class BatchOperationCreatedHandler
+    implements ExportHandler<BatchOperationEntity, BatchOperationCreationRecordValue> {
+
+  private final String indexName;
+
+  public BatchOperationCreatedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_CREATION;
+  }
+
+  @Override
+  public Class<BatchOperationEntity> getEntityType() {
+    return BatchOperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationCreationRecordValue> record) {
+    return record.getIntent().equals(BatchOperationIntent.CREATED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationCreationRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Override
+  public BatchOperationEntity createNewEntity(final String id) {
+    return new BatchOperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationCreationRecordValue> record, final BatchOperationEntity entity) {
+    final BatchOperationCreationRecordValue value = record.getValue();
+    entity
+        .setId(String.valueOf(value.getBatchOperationKey()))
+        .setType(OperationType.valueOf(value.getBatchOperationType().name()))
+        .setState(BatchOperationState.CREATED);
+  }
+
+  @Override
+  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStartedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStartedHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchOperationStartedHandler
+    implements ExportHandler<BatchOperationEntity, BatchOperationCreationRecordValue> {
+
+  private final String indexName;
+
+  public BatchOperationStartedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_CREATION;
+  }
+
+  @Override
+  public Class<BatchOperationEntity> getEntityType() {
+    return BatchOperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationCreationRecordValue> record) {
+    return record.getIntent().equals(BatchOperationIntent.STARTED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationCreationRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Override
+  public BatchOperationEntity createNewEntity(final String id) {
+    return new BatchOperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationCreationRecordValue> record, final BatchOperationEntity entity) {
+    entity
+        .setStartDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .setState(BatchOperationState.ACTIVE);
+  }
+
+  @Override
+  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
+    updateFields.put(BatchOperationTemplate.START_DATE, entity.getStartDate());
+    batchRequest.update(indexName, entity.getId(), updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationCreatedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-" + BatchOperationTemplate.INDEX_NAME;
+  private final BatchOperationCreatedHandler underTest =
+      new BatchOperationCreatedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CREATION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(BatchOperationEntity.class);
+  }
+
+  @Test
+  void shouldHandleCreatedRecord() {
+    // given
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CREATION, BatchOperationIntent.CREATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CREATION, BatchOperationIntent.CREATED);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final var recordValue = factory.generateObject(BatchOperationCreationRecordValue.class);
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_CREATION,
+            r -> r.withIntent(BatchOperationIntent.CREATED).withValue(recordValue));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(recordValue.getBatchOperationKey()));
+    assertThat(entity.getType())
+        .isEqualTo(OperationType.valueOf(recordValue.getBatchOperationType().name()));
+    assertThat(entity.getState()).isEqualTo(BatchOperationEntity.BatchOperationState.CREATED);
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() throws PersistenceException {
+    // given
+    final var entity = new BatchOperationEntity().setId("123");
+    final var mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, entity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStartedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStartedHandlerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationStartedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-" + OperationTemplate.INDEX_NAME;
+  private final BatchOperationStartedHandler underTest =
+      new BatchOperationStartedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CREATION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(BatchOperationEntity.class);
+  }
+
+  @Test
+  void shouldHandleStartedRecord() {
+    // given
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CREATION, BatchOperationIntent.STARTED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CREATION, BatchOperationIntent.STARTED);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final var recordValue = factory.generateObject(BatchOperationCreationRecordValue.class);
+    final Record<BatchOperationCreationRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_CREATION,
+            r -> r.withIntent(BatchOperationIntent.STARTED).withValue(recordValue));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getStartDate()).isNotNull();
+    assertThat(entity.getState()).isEqualTo(BatchOperationState.ACTIVE);
+  }
+
+  @Test
+  void shouldUpdateEntityOnFlush() throws PersistenceException {
+    // given
+    final var entity =
+        new BatchOperationEntity()
+            .setId("123")
+            .setState(BatchOperationState.ACTIVE)
+            .setStartDate(OffsetDateTime.now());
+    final var mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .update(
+            indexName,
+            entity.getId(),
+            Map.of(
+                "state", entity.getState(),
+                "startDate", entity.getStartDate()));
+  }
+}


### PR DESCRIPTION
## Description

Adds a new Created and Started handler for batch operations. (We decided during implementation to move the started part into an own handler)

Acceptance Tests are already in place and currently just active for rdbms, we need to enable them when the camunda exporter part is done. 

For now, I created a small acceptance test, which will be nevertheless part of the the next PR since the search api part is needed for this: https://github.com/camunda/camunda/issues/31059 => PR: https://github.com/camunda/camunda/pull/31467

## Related issues

closes #31045 
