### PR TITLE
refactor: remove modificationsByFlowNode dep from flowNodeSelectionStore

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/VariablesForm.tsx
@@ -18,7 +18,10 @@ import {FormRenderProps} from 'react-final-form';
 import {AddVariableButton, Form, VariablesContainer} from '../styled';
 import Variables from '../../Variables/v2';
 import {useWillAllFlowNodesBeCanceled} from 'modules/hooks/modifications';
-import {useHasPendingCancelOrMoveModification} from 'modules/hooks/flowNodeSelection';
+import {
+  useHasPendingCancelOrMoveModification,
+  useIsPlaceholderSelected,
+} from 'modules/hooks/flowNodeSelection';
 
 const VariablesForm: React.FC<
   FormRenderProps<VariableFormValues, Partial<VariableFormValues>>
@@ -33,6 +36,7 @@ const VariablesForm: React.FC<
         variable.name === undefined ||
         variable.value === undefined,
     );
+  const isPlaceholderSelected = useIsPlaceholderSelected();
 
   const {isModificationModeEnabled} = modificationsStore;
 
@@ -49,7 +53,7 @@ const VariablesForm: React.FC<
     }
 
     return (
-      flowNodeSelectionStore.isPlaceholderSelected ||
+      isPlaceholderSelected ||
       (flowNodeMetaDataStore.isSelectedInstanceRunning &&
         !hasPendingCancelOrMoveModification)
     );

--- a/operate/client/src/modules/hooks/flowNodeMetadata.ts
+++ b/operate/client/src/modules/hooks/flowNodeMetadata.ts
@@ -8,10 +8,14 @@
 
 import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {useHasRunningOrFinishedTokens} from './flowNodeSelection';
+import {
+  useHasRunningOrFinishedTokens,
+  useNewTokenCountForSelectedNode,
+} from './flowNodeSelection';
 
 const useHasMultipleInstances = () => {
   const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
   const {metaData} = flowNodeMetaDataStore.state;
 
   if (
@@ -21,13 +25,10 @@ const useHasMultipleInstances = () => {
   }
 
   if (!hasRunningOrFinishedTokens) {
-    return flowNodeSelectionStore.newTokenCountForSelectedNode > 1;
+    return newTokenCountForSelectedNode > 1;
   }
 
-  return (
-    (metaData?.instanceCount ?? 0) > 1 ||
-    flowNodeSelectionStore.newTokenCountForSelectedNode > 0
-  );
+  return (metaData?.instanceCount ?? 0) > 1 || newTokenCountForSelectedNode > 0;
 };
 
 export {useHasMultipleInstances};

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -76,8 +76,19 @@ const useNewTokenCountForSelectedNode = () => {
   );
 };
 
+const useIsPlaceholderSelected = () => {
+  const hasRunningOrFinishedTokens = useHasRunningOrFinishedTokens();
+  const newTokenCountForSelectedNode = useNewTokenCountForSelectedNode();
+
+  return (
+    flowNodeSelectionStore.state.selection?.isPlaceholder ||
+    (!hasRunningOrFinishedTokens && newTokenCountForSelectedNode === 1)
+  );
+};
+
 export {
   useHasPendingCancelOrMoveModification,
   useHasRunningOrFinishedTokens,
   useNewTokenCountForSelectedNode,
+  useIsPlaceholderSelected,
 };

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -137,14 +137,6 @@ class FlowNodeSelection {
     );
   }
 
-  get isPlaceholderSelected() {
-    return (
-      this.state.selection?.isPlaceholder ||
-      (!this.hasRunningOrFinishedTokens &&
-        this.newTokenCountForSelectedNode === 1)
-    );
-  }
-
   /*
    * DEPRECATED: The `flowNodeSelectionStore.selectedRunningInstanceCount` is being deprecated and replaced with
    * utility functions and hooks in `flowNodeSelection.ts` as part of the Operate v2 migration.
@@ -194,24 +186,6 @@ class FlowNodeSelection {
       processInstanceDetailsStatisticsStore.state.statistics.some(
         ({activityId}) => activityId === currentFlowNodeSelection.flowNodeId,
       )
-    );
-  }
-
-  get newTokenCountForSelectedNode() {
-    const currentFlowNodeSelection = this.state.selection;
-
-    const flowNodeId = currentFlowNodeSelection?.flowNodeId;
-    if (flowNodeId === undefined) {
-      return 0;
-    }
-
-    return (
-      (modificationsStore.modificationsByFlowNode[flowNodeId]?.newTokens ?? 0) +
-      modificationsStore.flowNodeModifications.filter(
-        (modification) =>
-          modification.operation !== 'CANCEL_TOKEN' &&
-          Object.keys(modification.parentScopeIds).includes(flowNodeId),
-      ).length
     );
   }
 


### PR DESCRIPTION
## Description

- remove `modificationStore.modificationsByFlowNode` dependency, which has a dependency to `processInstanceDetailsDiagramStore`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #30591 
