### PR TITLE
refactor: add more logs when retrying init schema

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -141,7 +141,9 @@ public class BrokerModuleConfiguration implements CloseableSilently {
 
   protected void stopBroker() {
     try {
-      broker.close();
+      if (broker != null) {
+        broker.close();
+      }
     } finally {
       cleanupWorkingDirectory();
     }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -355,9 +355,10 @@ public class SchemaManager {
   }
 
   private Set<String> existingIndexNames() {
-    return allIndexNames().isBlank()
+    final String allIndexNames = allIndexNames();
+    return allIndexNames.isBlank()
         ? Set.of()
-        : searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet();
+        : searchEngineClient.getMappings(allIndexNames, MappingSource.INDEX).keySet();
   }
 
   private String allIndexNames() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -35,7 +35,7 @@ public class SchemaManagerConfiguration {
 
     public static final Duration DEFAULT_MIN_RETRY_DELAY = Duration.ofMillis(500);
     public static final Duration DEFAULT_MAX_RETRY_DELAY = Duration.ofSeconds(10);
-    public static final int DEFAULT_MAX_RETRIES = 10;
+    public static final int DEFAULT_MAX_RETRIES = 12;
 
     @Override
     public int defaultMaxRetries() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -177,8 +177,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     } catch (final IOException | ElasticsearchException e) {
       throw new SearchEngineException(
           String.format(
-              "Failed retrieving mappings from index/index templates with pattern [%s]",
-              namePattern),
+              "Failed retrieving mappings from index/index templates with pattern [%s]: %s",
+              namePattern, e.getMessage()),
           e);
     }
   }
@@ -258,8 +258,10 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     } catch (final IOException | ElasticsearchException e) {
       throw new SearchEngineException(
           String.format(
-              "Expected to update index template settings '%s' with '%s', but failed ",
-              indexTemplateDescriptor.getTemplateName(), updateIndexTemplateSettingsRequest),
+              "Expected to update index template settings '%s' with '%s', but failed: %s",
+              indexTemplateDescriptor.getTemplateName(),
+              updateIndexTemplateSettingsRequest,
+              e.getMessage()),
           e);
     }
   }

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.schema.opensearch;
 
-import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -183,8 +182,8 @@ public class OpensearchEngineClient implements SearchEngineClient {
     } catch (final IOException | OpenSearchException e) {
       throw new SearchEngineException(
           String.format(
-              "Failed retrieving mappings from index/index templates with pattern [%s]",
-              namePattern),
+              "Failed retrieving mappings from index/index templates with pattern [%s]: %s",
+              namePattern, e.getMessage()),
           e);
     }
   }
@@ -273,11 +272,13 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
     try {
       client.indices().putIndexTemplate(updateIndexTemplateSettingsRequest);
-    } catch (final IOException | ElasticsearchException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new SearchEngineException(
           String.format(
-              "Expected to update index template settings '%s' with '%s', but failed ",
-              indexTemplateDescriptor.getTemplateName(), updateIndexTemplateSettingsRequest),
+              "Expected to update index template settings '%s' with '%s', but failed: %s",
+              indexTemplateDescriptor.getTemplateName(),
+              updateIndexTemplateSettingsRequest,
+              e.getMessage()),
           e);
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -529,7 +529,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                       container.openExporter();
                       return true;
                     } catch (final Exception e) {
-                      LOG.error("Failed to open exporter '{}'. Retrying...", container.getId(), e);
+                      LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());
+                      LOG.debug("Stacktrace:", e);
                       return false;
                     }
                   },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -134,7 +134,7 @@ public class CamundaExporter implements Exporter {
       throw new IllegalStateException("Schema is not ready for use");
     }
 
-    writer = createBatchWriter(); // move before schemaManager.isSchemaReadyForUse()?
+    writer = createBatchWriter();
 
     checkImportersCompletedAndReschedule();
     controller.readMetadata().ifPresent(metadata::deserialize);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in https://camunda.slack.com/archives/C08E60XVBRR/p1745846926119129
The schema manager init retry logs are not explicit enough

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
