### PR TITLE
feat: Reject assignee correction on `creating` listener when assignee is defined on model

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -72,7 +72,9 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           """
           Expected to complete task listener job, but correcting the assignee on 'CREATING' event is \
           not supported when the user task has an assignee defined in the model \
-          (job key '%d', type '%s', processInstanceKey '%d').
+          (job key '%d', type '%s', processInstanceKey '%d'). \
+          Use the 'CREATING' event to set an assignee only if it was not defined. \
+          Use the 'ASSIGNING' event to correct an assignee that is already defined.
           """;
   private static final String MISSING_USER_TASK_KEY_IN_JOB_HEADERS_MESSAGE =
       """

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -51,7 +51,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           (job key '%d', type '%s', processInstanceKey '%d'). \
           Only the following listener event types support denying: %s.
           """;
-
   private static final String TL_JOB_COMPLETION_WITH_DENY_AND_CORRECTIONS_NOT_SUPPORTED_MESSAGE =
       """
           Expected to complete task listener job with corrections, but the job result is denied \
@@ -59,12 +58,18 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           The corrections would be reverted by the denial. Either complete the job with corrections \
           without setting denied, or complete the job with a denied result but no corrections.
           """;
-
   private static final String TL_JOB_COMPLETION_WITH_UNKNOWN_CORRECTIONS_NOT_SUPPORTED_MESSAGE =
       """
           Expected to complete task listener job with a corrections result, but property '%s' \
           cannot be corrected (job key '%d', type '%s', processInstanceKey '%d'). \
           Only the following properties can be corrected: %s.
+          """;
+  private static final String
+      TL_JOB_COMPLETION_WITH_ASSIGNEE_CORRECTION_ON_CREATING_NOT_SUPPORTED_MESSAGE =
+          """
+          Expected to complete task listener job, but correcting the assignee on 'CREATING' event is \
+          not supported when the user task has an assignee defined in the model \
+          (job key '%d', type '%s', processInstanceKey '%d').
           """;
 
   private static final Set<String> CORRECTABLE_PROPERTIES =
@@ -104,6 +109,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
                 this::checkTaskListenerJobForProvidingVariables,
                 this::checkTaskListenerJobForSupportingDenying,
                 this::checkTaskListenerJobForDenyingWithCorrections,
+                this::checkCreatingListenerJobForAssigneeCorrection,
                 this::checkTaskListenerJobForUnknownPropertyCorrections));
     this.jobMetrics = jobMetrics;
     this.eventHandle = eventHandle;
@@ -249,6 +255,37 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     } else {
       return Either.right(job);
     }
+  }
+
+  private Either<Rejection, JobRecord> checkCreatingListenerJobForAssigneeCorrection(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+
+    if (job.getJobKind() != JobKind.TASK_LISTENER) {
+      return Either.right(job);
+    }
+
+    if (job.getJobListenerEventType() != JobListenerEventType.CREATING) {
+      return Either.right(job);
+    }
+
+    final var correctedAttributes = command.getValue().getResult().getCorrectedAttributes();
+
+    if (correctedAttributes.contains(UserTaskRecord.ASSIGNEE)) {
+      final var uerTaskKey =
+          elementInstanceState.getInstance(job.getElementInstanceKey()).getUserTaskKey();
+
+      final var initialAssignee = userTaskState.findInitialAssignee(uerTaskKey);
+
+      if (initialAssignee.isPresent()) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_ARGUMENT,
+                TL_JOB_COMPLETION_WITH_ASSIGNEE_CORRECTION_ON_CREATING_NOT_SUPPORTED_MESSAGE
+                    .formatted(command.getKey(), job.getType(), job.getProcessInstanceKey())));
+      }
+    }
+
+    return Either.right(job);
   }
 
   private Either<Rejection, JobRecord> checkTaskListenerJobForUnknownPropertyCorrections(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -1510,7 +1510,9 @@ public class TaskListenerCorrectionsTest {
             """
                 Expected to complete task listener job, but correcting the assignee on 'CREATING' event is \
                 not supported when the user task has an assignee defined in the model \
-                (job key '%d', type '%s', processInstanceKey '%d').
+                (job key '%d', type '%s', processInstanceKey '%d'). \
+                Use the 'CREATING' event to set an assignee only if it was not defined. \
+                Use the 'ASSIGNING' event to correct an assignee that is already defined.
                 """
                 .formatted(rejection.getKey(), listenerType, processInstanceKey));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerCorrectionsTest.java
@@ -572,7 +572,7 @@ public class TaskListenerCorrectionsTest {
   @Test
   public void shouldTrackChangedAttributesOnlyForActuallyCorrectedValuesOnTaskCreation() {
     verifyChangedAttributesAreTrackedOnlyForActuallyCorrectedValues(
-        ZeebeTaskListenerEventType.creating, true, ignored -> {}, UserTaskIntent.CREATED);
+        ZeebeTaskListenerEventType.creating, false, ignored -> {}, UserTaskIntent.CREATED);
   }
 
   @Test
@@ -1478,6 +1478,41 @@ public class TaskListenerCorrectionsTest {
                 .hasPriority(100)
                 .describedAs("Expect that the most recent correction takes precedence")
                 .hasAssignee("twice_corrected_assignee"));
+  }
+
+  @Test
+  public void shouldRejectAssigneeCorrectionOnCreatingListenerWhenAssigneeDefinedInModel() {
+    // given
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createUserTaskWithTaskListenersAndAssignee(
+                ZeebeTaskListenerEventType.creating, "initial_assignee", listenerType));
+
+    // when
+    final var rejection =
+        ENGINE
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(listenerType)
+            .withResult(
+                new JobResult()
+                    .setCorrections(new JobResultCorrections().setAssignee("new_assignee"))
+                    .setCorrectedAttributes(List.of(UserTaskRecord.ASSIGNEE)))
+            .expectRejection()
+            .complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs(
+            "Expect that completing a CREATING task listener job with assignee correction is rejected when assignee is defined in the model")
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+                Expected to complete task listener job, but correcting the assignee on 'CREATING' event is \
+                not supported when the user task has an assignee defined in the model \
+                (job key '%d', type '%s', processInstanceKey '%d').
+                """
+                .formatted(rejection.getKey(), listenerType, processInstanceKey));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR introduces a check to reject the completion of `CREATING` task listener job that attempt to correct the `"assignee"` if the user task has an assignee defined in the model:
- Adds a new validation precondition to `JobCompleteProcessor` to detect and reject such job completions.
- Introduces a dedicated rejection message to help users understand the violation.
- Adds a dedicated test case to verify that `creating` task listeners cannot correct model-defined assignees.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29126 
