### PR TITLE
feat: implement search batch operations

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilElementInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * TODO: This test is just for the implementation of batch operations in camunda exporter! It can be
+ * delete after the implementation is done.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class TempESBatchOperationCancelProcessInstanceTest {
+
+  static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  public static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+    final List<String> processes =
+        List.of(
+            "service_tasks_v1.bpmn",
+            "service_tasks_v2.bpmn",
+            "incident_process_v1.bpmn",
+            "manual_process.bpmn",
+            "parent_process_v1.bpmn",
+            "child_process_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, DEPLOYED_PROCESSES.size());
+
+    // Does two will not be active when we cancel, since they just have manual steps
+    startProcessInstance(camundaClient, "manual_process");
+    startProcessInstance(camundaClient, "parent_process_v1");
+
+    ACTIVE_PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"bar\"}"));
+    ACTIVE_PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}"));
+    ACTIVE_PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "incident_process_v1"));
+
+    waitForProcessInstancesToStart(camundaClient, 6);
+    waitForElementInstances(camundaClient, 20);
+    waitUntilElementInstanceHasIncidents(camundaClient, 1);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 1);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+    ACTIVE_PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldStartProcessInstancesWithBatch() throws InterruptedException {
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(new ProcessInstanceFilterImpl())
+            .send()
+            .join();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // then
+    assertThat(result).isNotNull();
+
+    // and
+    Awaitility.await("should complete batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getBatchOperationId()).isEqualTo(String.valueOf(batchOperationKey));
+              assertThat(batch.getStartDate()).isNotNull();
+              assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.ACTIVE);
+              assertThat(batch.getEndDate()).isNull();
+            });
+
+    final var activeKeys =
+        ACTIVE_PROCESS_INSTANCES.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
+    for (final Long key : activeKeys) {
+      waitForProcessInstanceToBeTerminated(camundaClient, key);
+    }
+  }
+}

--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -41,6 +41,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -460,7 +460,8 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return getSearchExecutor()
+        .search(query, io.camunda.webapps.schema.entities.operation.BatchOperationEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -24,6 +24,7 @@ import io.camunda.search.clients.transformers.aggregation.result.AggregationResu
 import io.camunda.search.clients.transformers.aggregation.result.ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
+import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionRequirementsEntityTransformer;
@@ -43,6 +44,7 @@ import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
+import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DateValueFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionInstanceFilterTransformer;
@@ -69,6 +71,7 @@ import io.camunda.search.clients.transformers.result.DecisionInstanceResultConfi
 import io.camunda.search.clients.transformers.result.DecisionRequirementsResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionRequirementsFieldSortingTransformer;
@@ -87,6 +90,7 @@ import io.camunda.search.clients.transformers.sort.UserFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
 import io.camunda.search.filter.AuthorizationFilter;
+import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
@@ -109,6 +113,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
@@ -132,6 +137,7 @@ import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
 import io.camunda.search.sort.AuthorizationSort;
+import io.camunda.search.sort.BatchOperationSort;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
@@ -162,6 +168,7 @@ import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.index.UserIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
@@ -178,6 +185,7 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.form.FormEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -252,6 +260,7 @@ public final class ServiceTransformers {
     // query -> request
     Stream.of(
             AuthorizationQuery.class,
+            BatchOperationQuery.class,
             DecisionDefinitionQuery.class,
             DecisionInstanceQuery.class,
             DecisionRequirementsQuery.class,
@@ -292,6 +301,7 @@ public final class ServiceTransformers {
     mappers.put(UserEntity.class, new UserEntityTransformer());
     mappers.put(MappingEntity.class, new MappingEntityTransformer());
     mappers.put(UsageMetricsEntity.class, new UsageMetricsEntityTransformer());
+    mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
@@ -312,6 +322,7 @@ public final class ServiceTransformers {
     mappers.put(UserSort.class, new UserFieldSortingTransformer());
     mappers.put(MappingSort.class, new MappingFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
+    mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -374,6 +385,9 @@ public final class ServiceTransformers {
         ProcessInstanceStatisticsFilter.class,
         new ProcessInstanceStatisticsFilterTransformer(
             indexDescriptors.get(ListViewTemplate.class)));
+    mappers.put(
+        BatchOperationFilter.class,
+        new BatchOperationFilterTransformer(indexDescriptors.get(BatchOperationTemplate.class)));
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import org.apache.commons.lang3.StringUtils;
+
+public class BatchOperationEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.operation.BatchOperationEntity, BatchOperationEntity> {
+
+  @Override
+  public BatchOperationEntity apply(
+      final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
+    if (source == null) {
+      return null;
+    }
+
+    return isLegacy(source) ? mapLegacyBatchOperation(source) : mapBatchOperation(source);
+  }
+
+  /**
+   * Checks if the batch operation is legacy or not. This is done be checking if the ID is NOT
+   * numeric. New batch operations use a Long value, old ones use a UUID
+   *
+   * @param source the batch operation entity
+   * @return true if the batch operation is legacy, false otherwise
+   */
+  private static boolean isLegacy(
+      final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
+    return !StringUtils.isNumeric(source.getId());
+  }
+
+  private BatchOperationEntity mapBatchOperation(
+      final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
+    return new BatchOperationEntity(
+        source.getId(),
+        BatchOperationState.valueOf(source.getState().name()),
+        source.getType().name(),
+        source.getStartDate(),
+        source.getEndDate(),
+        source.getOperationsTotalCount(),
+        source.getOperationsFailedCount(),
+        source.getOperationsCompletedCount());
+  }
+
+  private BatchOperationEntity mapLegacyBatchOperation(
+      final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
+    return new BatchOperationEntity(
+        source.getId(),
+        BatchOperationState.INCOMPLETED,
+        source.getType() != null ? source.getType().name() : null,
+        source.getStartDate(),
+        source.getEndDate(),
+        source.getOperationsTotalCount(),
+        0,
+        source.getOperationsFinishedCount());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.*;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.*;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.BatchOperationFilter;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+import java.util.Optional;
+
+public final class BatchOperationFilterTransformer
+    extends IndexFilterTransformer<BatchOperationFilter> {
+
+  public BatchOperationFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final BatchOperationFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    Optional.ofNullable(stringTerms(ID, filter.batchOperationIds())).ifPresent(queries::add);
+    Optional.ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
+    Optional.ofNullable(stringTerms(TYPE, filter.operationTypes())).ifPresent(queries::add);
+
+    return and(queries);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.END_DATE;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.ID;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.START_DATE;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.STATE;
+import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.TYPE;
+
+public class BatchOperationFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "batchOperationId" -> ID;
+      case "state" -> STATE;
+      case "operationType" -> TYPE;
+      case "startDate" -> START_DATE;
+      case "endDate" -> END_DATE;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return ID;
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByBatchOperationId() {
+    // given
+    final var filter = FilterBuilders.batchOperation(f -> f.batchOperationIds("123"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("id");
+              assertThat(t.value().stringValue()).isEqualTo("123");
+            });
+  }
+
+  @Test
+  void shouldQueryLegacyByBatchOperationId() {
+    // given
+    final var batchIdUuid = UUID.randomUUID().toString();
+    final var filter = FilterBuilders.batchOperation(f -> f.batchOperationIds(batchIdUuid));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("id");
+              assertThat(t.value().stringValue()).isEqualTo(batchIdUuid);
+            });
+  }
+
+  @Test
+  void shouldQueryByState() {
+    // given
+    final var filter = FilterBuilders.batchOperation(f -> f.state("ACTIVE"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("state");
+              assertThat(t.value().stringValue()).isEqualTo("ACTIVE");
+            });
+  }
+
+  @Test
+  void shouldQueryByOperationType() {
+    // given
+    final var filter = FilterBuilders.batchOperation(f -> f.operationTypes("CREATE"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue()).isEqualTo("CREATE");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    // given
+    final var filter =
+        FilterBuilders.batchOperation(
+            f -> f.batchOperationIds("123").state("ACTIVE").operationTypes("CREATE"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(3);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("id");
+              assertThat(t.value().stringValue()).isEqualTo("123");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("state");
+              assertThat(t.value().stringValue()).isEqualTo("ACTIVE");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(2).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue()).isEqualTo("CREATE");
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationFieldSortingTransformerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.BatchOperationSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BatchOperationFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("id", SortOrder.ASC, s -> s.batchOperationId().asc()),
+        new TestArguments("state", SortOrder.DESC, s -> s.state().desc()),
+        new TestArguments("type", SortOrder.ASC, s -> s.operationType().asc()),
+        new TestArguments("startDate", SortOrder.DESC, s -> s.startDate().desc()),
+        new TestArguments("endDate", SortOrder.ASC, s -> s.endDate().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<BatchOperationSort.Builder, ObjectBuilder<BatchOperationSort>> fn) {
+    // when
+    final var request = SearchQueryBuilders.batchOperationQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(field);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("id");
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<BatchOperationSort.Builder, ObjectBuilder<BatchOperationSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -23,6 +23,7 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
 
   private Integer instancesCount = 0;
   private Integer operationsTotalCount = 0;
+  // Legacy - Contains all operations (completed + failed)
   private Integer operationsFinishedCount = 0;
 
   // new fields for batch operation in zeebe engine


### PR DESCRIPTION
## Description

This PR mostly adds all needed transformers for the entities, filters and filedSorting in order to implement `DocumentBasedSearchClients.searchBatchOperations`.

**NOTE**: Since we will NOT migrate the old batch operations from operate, we will calculate the state "INCOMPLETED" on the fly in the BatchOperationEntityTransformer.

## Related issues

closes #31059 
