### PR TITLE
Update `RoleDeleteProcessor` to use `roleId`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -132,7 +132,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
           stateWriter.appendFollowUpEvent(
               record.getRoleKey(),
               RoleIntent.ENTITY_REMOVED,
-              new RoleRecord().setRoleId(roleId).setEntityType(entityType));
+              new RoleRecord().setRoleId(roleId).setEntityId(entityId).setEntityType(entityType));
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -132,10 +132,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
           stateWriter.appendFollowUpEvent(
               record.getRoleKey(),
               RoleIntent.ENTITY_REMOVED,
-              new RoleRecord()
-                  .setRoleId(roleId)
-                  .setEntityType(entityType)
-                  .setEntityKey(Long.parseLong(entityId)));
+              new RoleRecord().setRoleId(roleId).setEntityType(entityType));
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -89,7 +89,6 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     final var persistedRole = persistedRecord.get();
     final var roleKey = persistedRole.getRoleKey();
     record.setRoleKey(roleKey);
-    record.setName(persistedRole.getName());
 
     removeMembers(record);
     deleteAuthorizations(record);
@@ -142,10 +141,10 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
 
   private void deleteAuthorizations(final RoleRecord record) {
     final var roleId = record.getRoleId();
-    final var authorizationKeysForGroup =
+    final var authorizationKeysForRole =
         authorizationState.getAuthorizationKeysForOwner(AuthorizationOwnerType.ROLE, roleId);
 
-    authorizationKeysForGroup.forEach(
+    authorizationKeysForRole.forEach(
         authorizationKey -> {
           final var authorization = new AuthorizationRecord().setAuthorizationKey(authorizationKey);
           stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -34,7 +34,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   private static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
-      "Expected to delete role with key '%s', but a role with this key doesn't exist.";
+      "Expected to delete role with ID '%s', but a role with this ID doesn't exist.";
   private final RoleState roleState;
   private final AuthorizationState authorizationState;
   private final MembershipState membershipState;
@@ -65,18 +65,11 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
   @Override
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
-    final var roleKey = record.getRoleKey();
-    final var persistedRecord = roleState.getRole(roleKey);
-    if (persistedRecord.isEmpty()) {
-      final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(roleKey);
-      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
-      return;
-    }
-
+    final String roleId = record.getRoleId();
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.DELETE)
-            .addResourceId(persistedRecord.get().getName());
+            .addResourceId(roleId);
+
     final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
@@ -84,9 +77,23 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
       responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
-    record.setName(persistedRecord.get().getName());
+
+    final var persistedRecord = roleState.getRole(roleId);
+    if (persistedRecord.isEmpty()) {
+      final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(roleId);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      return;
+    }
+
+    final var persistedRole = persistedRecord.get();
+    final var roleKey = persistedRole.getRoleKey();
+    record.setRoleKey(roleKey);
+    record.setName(persistedRole.getName());
+
     removeMembers(record);
     deleteAuthorizations(record);
+
     stateWriter.appendFollowUpEvent(roleKey, RoleIntent.DELETED, record);
     responseWriter.writeEventOnCommand(roleKey, RoleIntent.DELETED, record, command);
 
@@ -101,7 +108,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
     roleState
-        .getRole(record.getRoleKey())
+        .getRole(record.getRoleId())
         .ifPresentOrElse(
             role -> {
               removeMembers(command.getValue());
@@ -110,7 +117,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
                   command.getKey(), RoleIntent.DELETED, command.getValue());
             },
             () -> {
-              final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleKey());
+              final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleId());
               rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
             });
 
@@ -118,26 +125,25 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
   }
 
   private void removeMembers(final RoleRecord record) {
-    final var roleKey = record.getRoleKey();
+    final var roleId = record.getRoleId();
     membershipState.forEachMember(
         RelationType.ROLE,
-        String.valueOf(roleKey),
+        roleId,
         (entityType, entityId) -> {
           stateWriter.appendFollowUpEvent(
-              roleKey,
+              record.getRoleKey(),
               RoleIntent.ENTITY_REMOVED,
               new RoleRecord()
-                  .setRoleKey(roleKey)
+                  .setRoleId(roleId)
                   .setEntityType(entityType)
                   .setEntityKey(Long.parseLong(entityId)));
         });
   }
 
   private void deleteAuthorizations(final RoleRecord record) {
-    final var roleKey = record.getRoleKey();
+    final var roleId = record.getRoleId();
     final var authorizationKeysForGroup =
-        authorizationState.getAuthorizationKeysForOwner(
-            AuthorizationOwnerType.ROLE, String.valueOf(roleKey));
+        authorizationState.getAuthorizationKeysForOwner(AuthorizationOwnerType.ROLE, roleId);
 
     authorizationKeysForGroup.forEach(
         authorizationKey -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -48,7 +48,7 @@ public class DbRoleState implements MutableRoleState {
 
   @Override
   public void delete(final RoleRecord roleRecord) {
-    roleId.wrapString(String.valueOf(roleRecord.getRoleKey()));
+    roleId.wrapString(roleRecord.getRoleId());
     roleColumnFamily.deleteExisting(roleId);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -754,7 +754,7 @@ public class CommandDistributionIdempotencyTest {
   }
 
   private static Record<RoleRecordValue> createRole(final String roleId) {
-    return ENGINE.role().newRole(roleId).withName(UUID.randomUUID().toString()).create();
+    return ENGINE.role().newRole(roleId).create();
   }
 
   private static Record<TenantRecordValue> createTenant() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -435,11 +435,7 @@ public class CommandDistributionIdempotencyTest {
           {
             "Role.CREATE is idempotent",
             new Scenario(
-                ValueType.ROLE,
-                RoleIntent.CREATE,
-                () ->
-                    CommandDistributionIdempotencyTest.createRole(
-                        Strings.newRandomValidIdentityId())),
+                ValueType.ROLE, RoleIntent.CREATE, CommandDistributionIdempotencyTest::createRole),
             RoleCreateProcessor.class
           },
           {
@@ -448,9 +444,8 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.ROLE,
                 RoleIntent.DELETE,
                 () -> {
-                  final var roleId = Strings.newRandomValidIdentityId();
-                  createRole(roleId);
-                  return ENGINE.role().deleteRole(roleId).delete();
+                  final Record<RoleRecordValue> role = createRole();
+                  return ENGINE.role().deleteRole(role.getValue().getRoleId()).delete();
                 }),
             RoleDeleteProcessor.class
           },
@@ -475,8 +470,7 @@ public class CommandDistributionIdempotencyTest {
                 ValueType.ROLE,
                 RoleIntent.ADD_ENTITY,
                 () -> {
-                  final var roleId = Strings.newRandomValidIdentityId();
-                  final var role = createRole(roleId);
+                  final var role = createRole();
                   final var user = createUser();
                   return ENGINE
                       .role()
@@ -753,8 +747,8 @@ public class CommandDistributionIdempotencyTest {
     return ENGINE.group().newGroup(groupId).withName(UUID.randomUUID().toString()).create();
   }
 
-  private static Record<RoleRecordValue> createRole(final String roleId) {
-    return ENGINE.role().newRole(roleId).create();
+  private static Record<RoleRecordValue> createRole() {
+    return ENGINE.role().newRole(UUID.randomUUID().toString()).create();
   }
 
   private static Record<TenantRecordValue> createTenant() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,12 +37,12 @@ public class DeleteRoleMultiPartitionTest {
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30114")
   public void shouldDistributeRoleDeleteCommand() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().deleteRole(roleKey).delete();
+    final var roleId = UUID.randomUUID().toString();
+    engine.role().newRole(roleId).withName(name).create();
+    engine.role().deleteRole(roleId).delete();
 
     assertThat(
             RecordingExporter.records()
@@ -92,12 +91,12 @@ public class DeleteRoleMultiPartitionTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30114")
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().deleteRole(roleKey).delete();
+    final var roleId = UUID.randomUUID().toString();
+    engine.role().newRole(roleId).withName(name).create();
+    engine.role().deleteRole(roleId).delete();
 
     // then
     assertThat(
@@ -109,15 +108,15 @@ public class DeleteRoleMultiPartitionTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30114")
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var name = UUID.randomUUID().toString();
+    final var roleId = UUID.randomUUID().toString();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptRoleCreateForPartition(partitionId);
     }
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().deleteRole(roleKey).delete();
+    engine.role().newRole(roleId).withName(name).create();
+    engine.role().deleteRole(roleId).delete();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
@@ -40,7 +41,7 @@ public class DeleteRoleMultiPartitionTest {
   public void shouldDistributeRoleDeleteCommand() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var roleId = UUID.randomUUID().toString();
+    final var roleId = Strings.newRandomValidIdentityId();
     engine.role().newRole(roleId).withName(name).create();
     engine.role().deleteRole(roleId).delete();
 
@@ -94,7 +95,7 @@ public class DeleteRoleMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var roleId = UUID.randomUUID().toString();
+    final var roleId = Strings.newRandomValidIdentityId();
     engine.role().newRole(roleId).withName(name).create();
     engine.role().deleteRole(roleId).delete();
 
@@ -111,7 +112,7 @@ public class DeleteRoleMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    final var roleId = UUID.randomUUID().toString();
+    final var roleId = Strings.newRandomValidIdentityId();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptRoleCreateForPartition(partitionId);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -332,28 +332,28 @@ public class RoleTest {
   }
 
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/30114")
   public void shouldDeleteRole() {
     // given
+    final var roleId = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
-    final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    // when
-    final var deletedRole = engine.role().deleteRole(roleKey).delete().getValue();
+    engine.role().newRole(roleId).withName(name).create();
 
-    Assertions.assertThat(deletedRole).isNotNull().hasFieldOrPropertyWithValue("roleKey", roleKey);
+    // when
+    final var deletedRole = engine.role().deleteRole(roleId).delete().getValue();
+    assertThat(deletedRole).hasRoleId(roleId).hasName(name);
   }
 
   @Test
   public void shouldRejectIfRoleIsNotPresentOnDeletion() {
     // when
-    final var notPresentRoleKey = 1L;
+    final var notPresentRoleId = UUID.randomUUID().toString();
     final var notPresentUpdateRecord =
-        engine.role().deleteRole(notPresentRoleKey).expectRejection().delete();
+        engine.role().deleteRole(notPresentRoleId).expectRejection().delete();
 
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to delete role with key '%s', but a role with this key doesn't exist."
-                .formatted(notPresentRoleKey));
+            "Expected to delete role with ID '%s', but a role with this ID doesn't exist."
+                .formatted(notPresentRoleId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -334,7 +334,7 @@ public class RoleTest {
   @Test
   public void shouldDeleteRole() {
     // given
-    final var roleId = UUID.randomUUID().toString();
+    final var roleId = Strings.newRandomValidIdentityId();
     final var name = UUID.randomUUID().toString();
     engine.role().newRole(roleId).withName(name).create();
 
@@ -346,7 +346,7 @@ public class RoleTest {
   @Test
   public void shouldRejectIfRoleIsNotPresentOnDeletion() {
     // when
-    final var notPresentRoleId = UUID.randomUUID().toString();
+    final var notPresentRoleId = Strings.newRandomValidIdentityId();
     final var notPresentUpdateRecord =
         engine.role().deleteRole(notPresentRoleId).expectRejection().delete();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -340,7 +340,7 @@ public class RoleTest {
 
     // when
     final var deletedRole = engine.role().deleteRole(roleId).delete().getValue();
-    assertThat(deletedRole).hasRoleId(roleId).hasName(name);
+    assertThat(deletedRole).hasRoleId(roleId);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.Set;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -88,7 +87,7 @@ public class RoleAppliersTest {
   @Test
   void shouldDeleteRole() {
     // given
-    final String roleId = UUID.randomUUID().toString();
+    final String roleId = Strings.newRandomValidIdentityId();
     final String roleName = "foo";
     final var roleRecord = new RoleRecord().setRoleId(roleId).setName(roleName);
     roleState.create(roleRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -85,13 +86,11 @@ public class RoleAppliersTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/30114")
   void shouldDeleteRole() {
     // given
-    final long roleKey = 11L;
-    final String roleId = String.valueOf(roleKey);
+    final String roleId = UUID.randomUUID().toString();
     final String roleName = "foo";
-    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var roleRecord = new RoleRecord().setRoleId(roleId).setName(roleName);
     roleState.create(roleRecord);
     authorizationState.create(
         1L,
@@ -113,10 +112,10 @@ public class RoleAppliersTest {
             .setOwnerId(roleId));
 
     // when
-    roleDeletedApplier.applyState(roleKey, roleRecord);
+    roleDeletedApplier.applyState(1L, roleRecord);
 
     // then
-    assertThat(roleState.getRole(roleKey)).isEmpty();
+    assertThat(roleState.getRole(roleId)).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.test.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -86,18 +87,16 @@ public class RoleStateTest {
   @Test
   void shouldDeleteRole() {
     // given
-    // TODO use a proper role id https://github.com/camunda/camunda/issues/30114
-    final var roleKey = 123L;
-    final var roleId = "123";
+    final var roleId = Strings.newRandomValidIdentityId();
     final var roleName = "foo";
-    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setRoleId(roleId).setName(roleName);
+    final var roleRecord = new RoleRecord().setRoleId(roleId).setName(roleName);
     roleState.create(roleRecord);
 
     // when
     roleState.delete(roleRecord);
 
     // then
-    final var deletedRole = roleState.getRole(roleKey);
+    final var deletedRole = roleState.getRole(roleId);
     assertThat(deletedRole).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -54,8 +54,8 @@ public class RoleClient {
     return new RoleRemoveEntityClient(writer, roleId);
   }
 
-  public RoleDeleteClient deleteRole(final long key) {
-    return new RoleDeleteClient(writer, key);
+  public RoleDeleteClient deleteRole(final String roleId) {
+    return new RoleDeleteClient(writer, roleId);
   }
 
   public static class RoleCreateClient {
@@ -291,10 +291,10 @@ public class RoleClient {
     private final RoleRecord roleRecord;
     private Function<Long, Record<RoleRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public RoleDeleteClient(final CommandWriter writer, final long key) {
+    public RoleDeleteClient(final CommandWriter writer, final String roleId) {
       this.writer = writer;
       roleRecord = new RoleRecord();
-      roleRecord.setRoleKey(key);
+      roleRecord.setRoleId(roleId);
     }
 
     public Record<RoleRecordValue> delete() {


### PR DESCRIPTION
## Description

Modifies the Role delete processor and appliers to work with a `roleId` instead of a key.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30114
