### PR TITLE
refactor: add unknown severity option

### DIFF
--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -42,7 +42,7 @@ body:
     id: severity
     attributes:
       label: <!-- Severity -->
-      description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#starting-on-an-issue"> What is the severity of the bug?
+      description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#severity-and-likelihood-bugs"> What is the severity of the bug?
       options:
         - <!-- Low- -->
         - <!-- Medium- -->
@@ -56,7 +56,7 @@ body:
     id: likelihood
     attributes:
       label: <!-- Likelihood -->
-      description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#starting-on-an-issue"> How likely is it to occur?
+      description: <a href="https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#severity-and-likelihood-bugs"> How likely is it to occur?
       options:
         - <!-- Unknown_ -->
         - <!-- Low_ -->

--- a/.github/ISSUE_TEMPLATE/1. bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1. bug_report.yml
@@ -48,6 +48,7 @@ body:
         - <!-- Medium- -->
         - <!-- High- -->
         - <!-- Critical- -->
+        - <!-- Unknown- -->
       default: null
     validations:
       required: true

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -26,6 +26,8 @@ severity/mid:
   '(Medium-)'
 severity/low:
   '(Low-)'
+severity/unknown:
+  '(Unknown-)'
 likelihood/high:
   '(High_)'
 likelihood/mid:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ For community-maintained Camunda projects, please visit the [Camunda Community H
   - [Code of Conduct](#code-of-conduct)
 - [GitHub issue guidelines](#github-issue-guidelines)
   - [Starting on an issue](#starting-on-an-issue)
+    - [Severity and Likelihood (bugs)](#severity-and-likelihood-bugs)
 - [Build and run Camunda from source](#build-and-run-camunda-from-source)
   - [Build](#build)
   - [Run](#run)
@@ -54,7 +55,7 @@ improve
 - A problem, how we can reproduce it, and what the expected behavior would be
 - A change and the intention of how this would improve the system
 
-Severity and Likelihood (bugs):
+### Severity and Likelihood (bugs):
 To help us prioritize, please also determine the severity and likelihood of the bug. To help you with this, here are the definitions for the options:
 
 Severity:
@@ -69,13 +70,13 @@ Likelihood:
 - *Mid:* occasionally observed
 - *High:* recurring issue
 
-### Determining the severity of an issue
+#### Determining the severity of an issue
 
 Whenever possible, please try to determine the severity of an issue to the best of your knowledge.
 Only select `Unknown` if it's really difficult to tell without spending a non-negligible amount of time (e.g. >1h) to
 figure it out.
 
-#### Zeebe heuristic
+##### Zeebe heuristic
 
 The following is a set of questions which can help determine the severity of a bug in Zeebe:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ improve
 - A change and the intention of how this would improve the system
 
 ### Severity and Likelihood (bugs):
+
 To help us prioritize, please also determine the severity and likelihood of the bug. To help you with this, here are the definitions for the options:
 
 Severity:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,11 +62,28 @@ Severity:
 - *Mid:* Having a noticeable impact on production usage, which does not lead to data loss, or for which there is a known configuration workaround.
 - *High:* Having a noticeable impact on production usage, which does not lead to data loss, but for which there is no known workaround, or the workaround is very complex. Examples include issues which lead to regular crashes and break the availability SLA.
 - *Critical:* Stop-the-world issue with a high impact that can lead to data loss (e.g. corruption, deletion, inconsistency, etc.), unauthorized privileged actions (e.g. remote code execution, data exposure, etc.), and for which there is no existing configuration workaround.
+- *Unknown:* If it's not possible to determine the severity of a bug without in-depth investigation, you can select unknown. This should be treated as high until we have enough information to triage it properly.
 
 Likelihood:
 - *Low:* rarely observed issue/ rather unlikely edge-case
 - *Mid:* occasionally observed
 - *High:* recurring issue
+
+### Determining the severity of an issue
+
+Whenever possible, please try to determine the severity of an issue to the best of your knowledge.
+Only select `Unknown` if it's really difficult to tell without spending a non-negligible amount of time (e.g. >1h) to
+figure it out.
+
+#### Zeebe heuristic
+
+The following is a set of questions which can help determine the severity of a bug in Zeebe:
+
+- Was there any data loss or corruption? Then this is **critical**.
+- Is there a configuration workaround?
+- Did the cluster recover? By itself, or did it require manual intervention?
+- Was processing unavailable?
+- Was exporting unavailable?
 
 ### Starting on an issue
 


### PR DESCRIPTION
## Description

This PR adds a `Unknown` severity option when it's complex/difficult/time-consuming to determine the severity of a bug, and time must be planned to do it. It should map to a `severity/unknown` label.

After some discussion with the team, I also added some leading questions to help determine the severity of a bug.

I can imagine the questions could be supplemented with links to relevant runbooks, but I'm not sure yet if they will be useful, so I didn't want to go overboard.