### PR TITLE
Fix/camunda exporter parent process handling

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -220,6 +220,30 @@ public class ProcessInstanceAndElementInstanceSearchTest {
   }
 
   @Test
+  void shouldQueryAllProcessInstances() {
+    // when
+    final var result = camundaClient.newProcessInstanceSearchRequest().send().join();
+
+    // then we have exactly PROCESS_INSTANCES.size + 1, since the one subprocess should also be
+    // there
+    assertThat(result.items().size()).isEqualTo(PROCESS_INSTANCES.size() + 1);
+  }
+
+  @Test
+  void shouldQueryRootProcessInstances() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.parentProcessInstanceKey(-1L))
+            .send()
+            .join();
+
+    // then we have exactly PROCESS_INSTANCES.size, since the one subprocess should not be there
+    assertThat(result.items().size()).isEqualTo(PROCESS_INSTANCES.size());
+  }
+
+  @Test
   void shouldQueryProcessInstancesByKeyFilterIn() {
     // given
     final List<Long> processInstanceKeys =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public class ListViewProcessInstanceFromProcessInstanceHandler
     implements ExportHandler<ProcessInstanceForListViewEntity, ProcessInstanceRecordValue> {
 
-  protected static final int EMPTY_PARENT_PROCESS_INSTANCE_ID = -1;
-
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewProcessInstanceFromProcessInstanceHandler.class);
 
@@ -99,6 +97,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     piEntity
         .setId(String.valueOf(recordValue.getProcessInstanceKey()))
         .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setParentProcessInstanceKey(recordValue.getParentProcessInstanceKey())
+        .setParentFlowNodeInstanceKey(recordValue.getParentElementInstanceKey())
         .setKey(recordValue.getProcessInstanceKey())
         .setTenantId(tenantOrDefault(recordValue.getTenantId()))
         .setPartitionId(record.getPartitionId())
@@ -112,8 +112,6 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
 
     final OffsetDateTime timestamp =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);
-    final boolean isRootProcessInstance =
-        recordValue.getParentProcessInstanceKey() == EMPTY_PARENT_PROCESS_INSTANCE_ID;
     if (intent.equals(ELEMENT_COMPLETED) || intent.equals(ELEMENT_TERMINATED)) {
       incrementFinishedCount();
       piEntity.setEndDate(timestamp);
@@ -134,12 +132,6 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       piEntity.setTreePath(treePath.toString()).setState(ProcessInstanceState.ACTIVE);
     } else {
       piEntity.setState(ProcessInstanceState.ACTIVE);
-    }
-    // call activity related fields
-    if (!isRootProcessInstance) {
-      piEntity
-          .setParentProcessInstanceKey(recordValue.getParentProcessInstanceKey())
-          .setParentFlowNodeInstanceKey(recordValue.getParentElementInstanceKey());
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -293,6 +293,40 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
   }
 
   @Test
+  void shouldUpdateEntityFromRootProcessEntity() {
+    // given
+    final long timestamp = new Date().getTime();
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .withParentProcessInstanceKey(-1L)
+            .withParentElementInstanceKey(-1L)
+            .build();
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withKey(111)
+                    .withIntent(ELEMENT_ACTIVATING)
+                    .withTimestamp(timestamp)
+                    .withPartitionId(3)
+                    .withPosition(55L)
+                    .withValue(processInstanceRecordValue));
+
+    // when
+    final ProcessInstanceForListViewEntity processInstanceForListViewEntity =
+        new ProcessInstanceForListViewEntity();
+    underTest.updateEntity(processInstanceRecord, processInstanceForListViewEntity);
+
+    // then
+    assertThat(processInstanceForListViewEntity.getParentProcessInstanceKey())
+        .isEqualTo(processInstanceRecordValue.getParentProcessInstanceKey());
+    assertThat(processInstanceForListViewEntity.getParentFlowNodeInstanceKey())
+        .isEqualTo(processInstanceRecordValue.getParentElementInstanceKey());
+  }
+
+  @Test
   public void shouldUpdateTreePathFromRecordWithCallActivity() {
     // given
     final long processDefinitionKey1 = 999L;


### PR DESCRIPTION
## Description

Always set parentProcessInstanceKey when exporting in the Camunda Exporter to be able to search for root processes.

Without this fix it is not possible to search root processes, as it is not allowed to use null values in the search api. (In this case, we would have to search for parentProcessInstanceKey = null)
The engine uses -1 for the parentProcessInstanceKey, so with this fix root processes with -1 as parentProcessInstanceKey can be searched.
