### PR TITLE
docs: specify fetchVariable in create PI API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8004,7 +8004,7 @@ components:
           default: false
         fetchVariables:
           description: |
-            List of variables names to be included in the response.
+            List of variables by name to be included in the response when awaitCompletion is set to true.
             If empty, all visible variables in the root scope will be returned.
           type: array
           items:


### PR DESCRIPTION
## Description

The `fetchVariables` property in the create process instance API is considered when `awaitCompletion` is enabled.

We document this dependency for that property so it's clearer to API users.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

* Came up [internally](https://camunda.slack.com/archives/C026U8GBNSW/p1745863870594379)
