### PR TITLE
DeleteGroupCommand to use groupId

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1169,7 +1169,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    *
    * camundaClient
-   *  .newDeleteGroupCommand(123L)
+   *  .newDeleteGroupCommand("123")
    *  .send();
    * </pre>
    *
@@ -1177,7 +1177,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  DeleteGroupCommandStep1 newDeleteGroupCommand(long groupKey);
+  DeleteGroupCommandStep1 newDeleteGroupCommand(String groupId);
 
   /**
    * Command to assign a user to a group.

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -786,8 +786,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public DeleteGroupCommandStep1 newDeleteGroupCommand(final long groupKey) {
-    return new DeleteGroupCommandImpl(groupKey, httpClient);
+  public DeleteGroupCommandStep1 newDeleteGroupCommand(final String groupId) {
+    return new DeleteGroupCommandImpl(groupId, httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteGroupCommandImpl.java
@@ -27,12 +27,12 @@ import org.apache.hc.client5.http.config.RequestConfig;
 
 public class DeleteGroupCommandImpl implements DeleteGroupCommandStep1 {
 
-  private final long groupKey;
+  private final String groupId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public DeleteGroupCommandImpl(final long groupKey, final HttpClient httpClient) {
-    this.groupKey = groupKey;
+  public DeleteGroupCommandImpl(final String groupId, final HttpClient httpClient) {
+    this.groupId = groupId;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }
@@ -46,7 +46,7 @@ public class DeleteGroupCommandImpl implements DeleteGroupCommandStep1 {
   @Override
   public CamundaFuture<DeleteGroupResponse> send() {
     final HttpCamundaFuture<DeleteGroupResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/groups/" + groupKey, httpRequestConfig.build(), result);
+    httpClient.delete("/groups/" + groupId, httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/group/DeleteGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/DeleteGroupTest.java
@@ -27,27 +27,27 @@ import org.junit.jupiter.api.Test;
 
 public class DeleteGroupTest extends ClientRestTest {
 
-  private static final long GROUP_KEY = 123L;
+  private static final String GROUP_ID = "groupId";
 
   @Test
   void shouldDeleteGroup() {
     // when
-    client.newDeleteGroupCommand(GROUP_KEY).send().join();
+    client.newDeleteGroupCommand(GROUP_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
-    assertThat(requestPath).isEqualTo(REST_API_PATH + "/groups/" + GROUP_KEY);
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/groups/" + GROUP_ID);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundGroup() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/groups/" + GROUP_ID,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -56,11 +56,11 @@ public class DeleteGroupTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/groups/" + GROUP_ID,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -69,11 +69,11 @@ public class DeleteGroupTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/groups/" + GROUP_ID,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -434,11 +434,11 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertGroupDeleted(
-      final long groupKey, final Consumer<GroupRecordValue> consumer) {
+      final String groupId, final Consumer<GroupRecordValue> consumer) {
     final GroupRecordValue groupRecordValue =
         RecordingExporter.groupRecords()
             .withIntent(GroupIntent.DELETED)
-            .withGroupKey(groupKey)
+            .withGroupId(groupId)
             .getFirst()
             .getValue();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The command now use `groupId` 

## Related issues

closes #30017 
