### PR TITLE
Fix authorized applications retrieval

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -9,6 +9,7 @@ package io.camunda.authentication;
 
 import static io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder.aCamundaUser;
 
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.service.AuthorizationServices;
@@ -58,9 +59,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(
-            Stream.concat(
-                    roles.stream().map(r -> r.roleKey().toString()),
-                    Stream.of(storedUser.username()))
+            Stream.concat(roles.stream().map(RoleEntity::roleId), Stream.of(storedUser.username()))
                 .collect(Collectors.toSet()));
 
     final var tenants =

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -23,6 +23,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -58,9 +59,10 @@ public class CamundaUserDetailsServiceTest {
                 null,
                 null));
 
-    when(authorizationServices.getAuthorizedApplications(any()))
+    final var roleId = "admin";
+    when(authorizationServices.getAuthorizedApplications(Set.of(roleId, TEST_USER_ID)))
         .thenReturn(List.of("operate", "identity"));
-    final RoleEntity adminRole = new RoleEntity(2L, "admin", "ADMIN");
+    final RoleEntity adminRole = new RoleEntity(2L, roleId, "ADMIN");
     when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(TEST_USER_ID)))))
         .thenReturn(List.of(adminRole));
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I missed this during the refactoring I did. We need to ensure we don't try to get the authorizations using the role key.
These are now stored on the role id instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

N/A
