### PR TITLE
ci: add more wait time

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait 15 seconds
-        run: sleep 15s
+        run: sleep 30s
       - id: get_project_count
         uses: octokit/graphql-action@v2.3.2
         with:

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -12,7 +12,7 @@ jobs:
     name: Add issue to team projects if no project assigned and by corresponding component label
     runs-on: ubuntu-latest
     steps:
-      - name: Wait 15 seconds
+      - name: Wait
         run: sleep 30s
       - id: get_project_count
         uses: octokit/graphql-action@v2.3.2


### PR DESCRIPTION
## Description

Adding more wait time to add-to-projects.yml since it does not always work with 15s wait time. The opened-issue-labeler.yml does not have enough time to finish.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
