### PR TITLE
feat: migrate dependent store methods

### DIFF
--- a/operate/client/src/modules/hooks/flowNodeInstance.ts
+++ b/operate/client/src/modules/hooks/flowNodeInstance.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {
+  FlowNodeInstance,
+  flowNodeInstanceStore,
+} from 'modules/stores/flowNodeInstance';
+
+const useIsInstanceExecutionHistoryAvailable = () => {
+  const {status} = flowNodeInstanceStore.state;
+  const instanceExecutionHistory = useInstanceExecutionHistory();
+
+  return (
+    ['fetched', 'fetching-next', 'fetching-prev'].includes(status) &&
+    instanceExecutionHistory !== null &&
+    Object.keys(instanceExecutionHistory).length > 0
+  );
+};
+
+const useInstanceExecutionHistory = (): FlowNodeInstance | null => {
+  const {data: processInstance} = useProcessInstance();
+  const {status} = flowNodeInstanceStore.state;
+
+  if (!processInstance || ['initial', 'first-fetch'].includes(status)) {
+    return null;
+  }
+
+  return {
+    id: processInstance.processInstanceKey,
+    type: 'PROCESS',
+    state: processInstance.state,
+    treePath: processInstance.processInstanceKey,
+    endDate: null,
+    startDate: '',
+    sortValues: [],
+    flowNodeId: processInstance.processDefinitionId,
+  };
+};
+
+export {useInstanceExecutionHistory, useIsInstanceExecutionHistoryAvailable};

--- a/operate/client/src/modules/hooks/flowNodeSelection.ts
+++ b/operate/client/src/modules/hooks/flowNodeSelection.ts
@@ -15,6 +15,7 @@ import {
 import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
 import {TOKEN_OPERATIONS} from 'modules/constants';
 import {hasPendingCancelOrMoveModification} from 'modules/utils/modifications';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 
 const useHasPendingCancelOrMoveModification = () => {
   const willAllFlowNodesBeCanceled = useWillAllFlowNodesBeCanceled();
@@ -57,6 +58,15 @@ const useHasRunningOrFinishedTokens = () => {
   );
 };
 
+const useIsRootNodeSelected = () => {
+  const {data: processInstance} = useProcessInstance();
+
+  return (
+    flowNodeSelectionStore.state.selection?.flowNodeInstanceId ===
+    processInstance?.processInstanceKey
+  );
+};
+
 const useNewTokenCountForSelectedNode = () => {
   const modificationsByFlowNode = useModificationsByFlowNode();
   const currentFlowNodeSelection = flowNodeSelectionStore.state.selection;
@@ -89,6 +99,7 @@ const useIsPlaceholderSelected = () => {
 export {
   useHasPendingCancelOrMoveModification,
   useHasRunningOrFinishedTokens,
+  useIsRootNodeSelected,
   useNewTokenCountForSelectedNode,
   useIsPlaceholderSelected,
 };

--- a/operate/client/src/modules/queries/processInstance/useIsProcessInstanceRunning.ts
+++ b/operate/client/src/modules/queries/processInstance/useIsProcessInstanceRunning.ts
@@ -6,16 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
 import {useProcessInstance} from './useProcessInstance';
-
-const isRunningParser = (processInstance: ProcessInstance): boolean => {
-  return (
-    ['ACTIVE'].includes(processInstance.state) || processInstance.hasIncident
-  );
-};
+import {isInstanceRunning} from 'modules/utils/instance';
 
 const useIsProcessInstanceRunning = () =>
-  useProcessInstance<boolean>(isRunningParser);
+  useProcessInstance<boolean>(isInstanceRunning);
 
 export {useIsProcessInstanceRunning};

--- a/operate/client/src/modules/stores/flowNodeInstance/index.tsx
+++ b/operate/client/src/modules/stores/flowNodeInstance/index.tsx
@@ -456,5 +456,5 @@ class FlowNodeInstance extends NetworkReconnectionHandler {
 }
 
 export const flowNodeInstanceStore = new FlowNodeInstance();
-export {MAX_INSTANCES_STORED};
+export {MAX_INSTANCES_STORED, MAX_INSTANCES_PER_REQUEST};
 export type {FlowNodeInstanceType as FlowNodeInstance, FlowNodeInstances};

--- a/operate/client/src/modules/stores/flowNodeSelection.ts
+++ b/operate/client/src/modules/stores/flowNodeSelection.ts
@@ -19,6 +19,7 @@ type Selection = {
   flowNodeType?: string;
   isMultiInstance?: boolean;
   isPlaceholder?: boolean;
+  processInstanceId?: string;
 };
 
 type State = {

--- a/operate/client/src/modules/utils/flowNodeInstance.ts
+++ b/operate/client/src/modules/utils/flowNodeInstance.ts
@@ -1,0 +1,306 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
+import {when} from 'mobx';
+import {
+  FlowNodeInstance,
+  FlowNodeInstances,
+  flowNodeInstanceStore,
+  MAX_INSTANCES_PER_REQUEST,
+  MAX_INSTANCES_STORED,
+} from 'modules/stores/flowNodeInstance';
+import {isInstanceRunning} from './instance';
+import {fetchFlowNodeInstances} from 'modules/api/fetchFlowNodeInstances';
+import {modificationsStore} from 'modules/stores/modifications';
+
+const init = (processInstance?: ProcessInstance) => {
+  flowNodeInstanceStore.instanceExecutionHistoryDisposer = when(
+    () => processInstance?.processInstanceKey !== undefined,
+    () => {
+      const instanceId = processInstance?.processInstanceKey;
+      if (instanceId !== undefined) {
+        flowNodeInstanceStore.fetchInstanceExecutionHistory(instanceId);
+        startPolling(processInstance);
+      }
+    },
+  );
+
+  flowNodeInstanceStore.instanceFinishedDisposer = when(
+    () => !processInstance || !isInstanceRunning(processInstance),
+    () => flowNodeInstanceStore.stopPolling(),
+  );
+};
+
+const pollInstances = async (processInstance?: ProcessInstance) => {
+  const processInstanceId = processInstance?.processInstanceKey;
+  if (
+    !processInstance ||
+    !processInstanceId ||
+    !isInstanceRunning(processInstance)
+  ) {
+    return;
+  }
+
+  const queries = Object.entries(flowNodeInstanceStore.state.flowNodeInstances)
+    .filter(([treePath, flowNodeInstance]) => {
+      return flowNodeInstance.running || treePath === processInstanceId;
+    })
+    .map(([treePath, flowNodeInstance]) => {
+      return {
+        treePath,
+        processInstanceId,
+        pageSize:
+          // round up to a multiple of MAX_INSTANCES_PER_REQUEST
+          Math.ceil(
+            flowNodeInstance.children.length / MAX_INSTANCES_PER_REQUEST,
+          ) * MAX_INSTANCES_PER_REQUEST,
+        searchAfterOrEqual: flowNodeInstance.children[0]?.sortValues,
+      };
+    });
+
+  if (queries.length === 0) {
+    return;
+  }
+
+  flowNodeInstanceStore.isPollRequestRunning = true;
+  const response = await fetchFlowNodeInstances(queries, {isPolling: true});
+
+  if (response.isSuccess) {
+    if (flowNodeInstanceStore.intervalId !== null) {
+      flowNodeInstanceStore.handlePollSuccess(response.data ?? {});
+    }
+  }
+
+  flowNodeInstanceStore.isPollRequestRunning = false;
+};
+
+const startPolling = (
+  processInstance?: ProcessInstance,
+  options: {runImmediately?: boolean} = {runImmediately: false},
+) => {
+  if (
+    document.visibilityState === 'hidden' ||
+    (processInstance && !isInstanceRunning(processInstance)) ||
+    flowNodeInstanceStore.intervalId !== null
+  ) {
+    return;
+  }
+
+  if (options.runImmediately) {
+    pollInstances(processInstance);
+  }
+
+  flowNodeInstanceStore.intervalId = setInterval(() => {
+    if (!flowNodeInstanceStore.isPollRequestRunning) {
+      pollInstances(processInstance);
+    }
+  }, 5000);
+};
+
+const fetchNext = async (
+  treePath: string,
+  processInstance?: ProcessInstance,
+) => {
+  if (
+    ['fetching-next', 'fetching-prev', 'fetching'].includes(
+      flowNodeInstanceStore.state.status,
+    )
+  ) {
+    return;
+  }
+
+  const children =
+    flowNodeInstanceStore.state.flowNodeInstances[treePath]?.children;
+  if (children === undefined) {
+    return;
+  }
+
+  flowNodeInstanceStore.startFetchNext();
+
+  const sortValues = children && children[children.length - 1]?.sortValues;
+
+  if (sortValues === undefined) {
+    flowNodeInstanceStore.handleFetchFailure('sortValues not found');
+    return;
+  }
+
+  const flowNodeInstances = await getFlowNodeInstances({
+    treePath,
+    pageSize: MAX_INSTANCES_PER_REQUEST,
+    searchAfter: sortValues,
+    processInstance,
+  });
+
+  if (flowNodeInstances === undefined) {
+    return;
+  }
+
+  const subTree = flowNodeInstances[treePath];
+  const subTreeChildren =
+    flowNodeInstanceStore.state.flowNodeInstances[treePath]?.children;
+
+  if (subTree === undefined || subTreeChildren === undefined) {
+    flowNodeInstanceStore.handleFetchFailure(`subTree not found: ${treePath}`);
+    return;
+  }
+  const fetchedInstancesCount = subTree.children.length;
+
+  flowNodeInstances[treePath]!.children = [
+    ...subTreeChildren,
+    ...subTree.children,
+  ].slice(-MAX_INSTANCES_STORED);
+
+  flowNodeInstanceStore.handleFetchSuccess(flowNodeInstances);
+  return fetchedInstancesCount;
+};
+
+const fetchPrevious = async (
+  treePath: string,
+  processInstance?: ProcessInstance,
+) => {
+  if (
+    ['fetching-next', 'fetching-prev', 'fetching'].includes(
+      flowNodeInstanceStore.state.status,
+    )
+  ) {
+    return;
+  }
+
+  flowNodeInstanceStore.startFetchPrev();
+
+  const children =
+    flowNodeInstanceStore.state.flowNodeInstances[treePath]?.children;
+  if (children === undefined) {
+    return;
+  }
+
+  const sortValues = children && children[0]?.sortValues;
+
+  if (sortValues === undefined) {
+    flowNodeInstanceStore.handleFetchFailure('sortValues not found');
+    return;
+  }
+
+  const flowNodeInstances = await getFlowNodeInstances({
+    treePath,
+    pageSize: MAX_INSTANCES_PER_REQUEST,
+    searchBefore: sortValues,
+    processInstance,
+  });
+
+  if (flowNodeInstances === undefined) {
+    return;
+  }
+
+  const subTree = flowNodeInstances[treePath];
+  const subTreeChildren =
+    flowNodeInstanceStore.state.flowNodeInstances[treePath]?.children;
+
+  if (subTree === undefined || subTreeChildren === undefined) {
+    flowNodeInstanceStore.handleFetchFailure(`subTree not found: ${treePath}`);
+    return;
+  }
+
+  const fetchedInstancesCount = subTree.children.length;
+
+  flowNodeInstances[treePath]!.children = [
+    ...subTree.children,
+    ...subTreeChildren,
+  ].slice(0, MAX_INSTANCES_STORED);
+
+  flowNodeInstanceStore.handleFetchSuccess(flowNodeInstances);
+
+  return fetchedInstancesCount;
+};
+
+const fetchSubTree = async ({
+  treePath,
+  searchAfter,
+  processInstance,
+}: {
+  treePath: string;
+  searchAfter?: FlowNodeInstance['sortValues'];
+  processInstance?: ProcessInstance;
+}) => {
+  const flowNodeInstances = await getFlowNodeInstances({
+    searchAfter,
+    treePath,
+    pageSize: MAX_INSTANCES_PER_REQUEST,
+    processInstance,
+  });
+  if (flowNodeInstances !== undefined) {
+    flowNodeInstanceStore.handleFetchSuccess(flowNodeInstances);
+  }
+};
+
+const fetchInstanceExecutionHistory = (processInstance?: ProcessInstance) =>
+  flowNodeInstanceStore.retryOnConnectionLost(
+    async (processInstanceId: ProcessInstanceEntity['id']) => {
+      flowNodeInstanceStore.startFetch();
+      const flowNodeInstances = await getFlowNodeInstances({
+        treePath: processInstanceId,
+        pageSize: MAX_INSTANCES_PER_REQUEST,
+        processInstance,
+      });
+      if (flowNodeInstances !== undefined) {
+        flowNodeInstanceStore.handleFetchSuccess(flowNodeInstances);
+      }
+    },
+  );
+
+const getFlowNodeInstances = async ({
+  treePath,
+  pageSize,
+  searchAfter,
+  searchBefore,
+  processInstance,
+}: {
+  treePath: string;
+  pageSize?: number;
+  searchAfter?: FlowNodeInstance['sortValues'];
+  searchBefore?: FlowNodeInstance['sortValues'];
+  processInstance?: ProcessInstance;
+}): Promise<FlowNodeInstances | undefined> => {
+  const processInstanceId = processInstance?.processInstanceKey;
+
+  if (processInstanceId === undefined) {
+    return;
+  }
+
+  flowNodeInstanceStore.stopPolling();
+
+  const response = await fetchFlowNodeInstances([
+    {
+      processInstanceId: processInstanceId,
+      treePath,
+      pageSize,
+      searchAfter,
+      searchBefore,
+    },
+  ]);
+
+  if (!response.isSuccess) {
+    flowNodeInstanceStore.handleFetchFailure();
+  }
+
+  if (!modificationsStore.isModificationModeEnabled) {
+    startPolling(processInstance);
+  }
+
+  return response.data;
+};
+
+export {
+  init,
+  startPolling,
+  fetchNext,
+  fetchPrevious,
+  fetchSubTree,
+  fetchInstanceExecutionHistory,
+};

--- a/operate/client/src/modules/utils/incidents.ts
+++ b/operate/client/src/modules/utils/incidents.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
+import {autorun} from 'mobx';
+import {incidentsStore} from 'modules/stores/incidents';
+import {isInstanceRunning} from './instance';
+
+const init = (processInstance?: ProcessInstance) => {
+  incidentsStore.disposer = autorun(() => {
+    if (processInstance?.hasIncident) {
+      if (incidentsStore.intervalId === null) {
+        incidentsStore.fetchIncidents(processInstance.processInstanceKey);
+        startPolling(processInstance);
+      }
+    } else {
+      incidentsStore.stopPolling();
+    }
+  });
+};
+
+const startPolling = async (
+  processInstance?: ProcessInstance,
+  options: {runImmediately?: boolean} = {runImmediately: false},
+) => {
+  if (
+    document.visibilityState === 'hidden' ||
+    (processInstance && !isInstanceRunning(processInstance)) ||
+    !processInstance?.hasIncident
+  ) {
+    return;
+  }
+
+  if (options.runImmediately) {
+    if (!incidentsStore.isPollRequestRunning) {
+      incidentsStore.handlePolling(processInstance.processInstanceKey);
+    }
+  }
+
+  incidentsStore.intervalId = setInterval(() => {
+    if (!incidentsStore.isPollRequestRunning) {
+      incidentsStore.handlePolling(processInstance.processInstanceKey);
+    }
+  }, 5000);
+};
+
+export {init, startPolling};

--- a/operate/client/src/modules/utils/instance/index.ts
+++ b/operate/client/src/modules/utils/instance/index.ts
@@ -24,6 +24,10 @@ const isRunning = (instance: Pick<ProcessInstanceEntity, 'state'>) => {
   return instance.state === 'ACTIVE' || instance.state === 'INCIDENT';
 };
 
+const isInstanceRunning = (processInstance: ProcessInstance): boolean => {
+  return processInstance.state === 'ACTIVE' || processInstance.hasIncident;
+};
+
 const getProcessName = (instance: ProcessInstanceEntity | null) => {
   if (instance === null) {
     return '';
@@ -50,8 +54,9 @@ const createOperation = (
 
 export {
   hasIncident,
-  isRunning,
   getProcessDefinitionName,
+  isInstanceRunning,
+  isRunning,
   getProcessName,
   createOperation,
 };

--- a/operate/client/src/modules/utils/variables.ts
+++ b/operate/client/src/modules/utils/variables.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
+import {autorun, reaction, when} from 'mobx';
+import {MAX_VARIABLES_PER_REQUEST} from 'modules/constants/variables';
+import {modificationsStore} from 'modules/stores/modifications';
+import {variablesStore} from 'modules/stores/variables';
+import {isInstanceRunning, isRunning} from './instance';
+
+const init = (processInstance?: ProcessInstance) => {
+  variablesStore.instanceId = processInstance?.processInstanceKey || null;
+
+  variablesStore.variablesWithActiveOperationsDisposer = when(
+    () => processInstance?.state === 'TERMINATED',
+    variablesStore.removeVariablesWithActiveOperations,
+  );
+
+  variablesStore.disposer = autorun(() => {
+    if (
+      processInstance &&
+      isRunning(processInstance) &&
+      variablesStore.scopeId !== null
+    ) {
+      if (
+        variablesStore.intervalId === null &&
+        !modificationsStore.isModificationModeEnabled
+      ) {
+        startPolling(processInstance);
+      }
+    } else {
+      variablesStore.stopPolling();
+    }
+  });
+
+  variablesStore.fetchVariablesDisposer = reaction(
+    () => variablesStore.scopeId,
+    (scopeId) => {
+      variablesStore.clearItems();
+
+      if (scopeId !== null) {
+        variablesStore.setPendingItem(null);
+        variablesStore.fetchAbortController?.abort();
+
+        variablesStore.fetchVariables({
+          fetchType: 'initial',
+          instanceId: processInstance?.processInstanceKey,
+          payload: {
+            pageSize: MAX_VARIABLES_PER_REQUEST,
+            scopeId: scopeId ?? processInstance?.processInstanceKey,
+          },
+        });
+      }
+    },
+    {fireImmediately: true},
+  );
+
+  variablesStore.deleteFullVariablesDisposer = reaction(
+    () => modificationsStore.isModificationModeEnabled,
+    (isModification, prevIsModification) => {
+      if (!isModification && prevIsModification) {
+        variablesStore.clearFullVariableValues();
+      }
+    },
+  );
+};
+
+const startPolling = async (
+  processInstance?: ProcessInstance,
+  options: {runImmediately?: boolean} = {runImmediately: false},
+) => {
+  if (
+    document.visibilityState === 'hidden' ||
+    (processInstance && !isInstanceRunning(processInstance))
+  ) {
+    return;
+  }
+
+  if (options.runImmediately && processInstance) {
+    variablesStore.handlePolling(processInstance.processInstanceKey);
+  }
+
+  variablesStore.intervalId = setInterval(() => {
+    if (!variablesStore.isPollRequestRunning && processInstance) {
+      variablesStore.handlePolling(processInstance.processInstanceKey);
+    }
+  }, 5000);
+};
+
+export {init, startPolling};


### PR DESCRIPTION
## Description

This PR introduces replacement methods for stores that depend on `processInstanceDetailsStore`. I've mostly replaced dependencies on `processInstanceKey` or `hasRunning()`.
I have skipped the following stores :
- `processInstanceDetailsDiagram` : as it is being removed
- `sequenceFlows` : as it is also being migrated and later removed

The new methods will give us the tools we need to migrate components that call the old store methods (next PR).

## Related issues

closes #31201
