### PR TITLE
fix: flaky command distribution tests by disabling the scheduler

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/BatchOperationCfg.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
+
+public class BatchOperationCfg implements ConfigurationEntry {
+  private Duration schedulerInterval =
+      EngineConfiguration.DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL;
+
+  public Duration getSchedulerInterval() {
+    return schedulerInterval;
+  }
+
+  public void setSchedulerInterval(final Duration schedulerInterval) {
+    this.schedulerInterval = schedulerInterval;
+  }
+
+  @Override
+  public String toString() {
+    return "BatchOperationCfg{" + "schedulerInterval=" + schedulerInterval + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -17,6 +17,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private CachesCfg caches = new CachesCfg();
   private JobsCfg jobs = new JobsCfg();
   private ValidatorsCfg validators = new ValidatorsCfg();
+  private BatchOperationCfg batchOperations = new BatchOperationCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
 
   @Override
@@ -24,6 +25,7 @@ public final class EngineCfg implements ConfigurationEntry {
     messages.init(globalConfig, brokerBase);
     caches.init(globalConfig, brokerBase);
     jobs.init(globalConfig, brokerBase);
+    batchOperations.init(globalConfig, brokerBase);
     validators.init(globalConfig, brokerBase);
   }
 
@@ -59,6 +61,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.validators = validators;
   }
 
+  public BatchOperationCfg getBatchOperations() {
+    return batchOperations;
+  }
+
+  public void setBatchOperations(final BatchOperationCfg batchOperations) {
+    this.batchOperations = batchOperations;
+  }
+
   public int getMaxProcessDepth() {
     return maxProcessDepth;
   }
@@ -78,6 +88,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + jobs
         + ", validators="
         + validators
+        + ", batchOperations="
+        + batchOperations
         + ", maxProcessDepth="
         + maxProcessDepth
         + '}';
@@ -94,6 +106,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
         .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())
+        .setBatchOperationSchedulerInterval(batchOperations.getSchedulerInterval())
         .setMaxProcessDepth(getMaxProcessDepth());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -30,6 +30,8 @@ public final class EngineConfiguration {
 
   public static final int DEFAULT_MAX_PROCESS_DEPTH = 1000;
 
+  public static final Duration DEFAULT_BATCH_OPERATION_SCHEDULER_INTERVAL = Duration.ofSeconds(1);
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
   private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
@@ -45,6 +47,8 @@ public final class EngineConfiguration {
   private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
 
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
+
+  private Duration batchOperationSchedulerInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -146,6 +150,16 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setMaxProcessDepth(final int maxProcessDepth) {
     this.maxProcessDepth = maxProcessDepth;
+    return this;
+  }
+
+  public Duration getBatchOperationSchedulerInterval() {
+    return batchOperationSchedulerInterval;
+  }
+
+  public EngineConfiguration setBatchOperationSchedulerInterval(
+      final Duration batchOperationSchedulerInterval) {
+    this.batchOperationSchedulerInterval = batchOperationSchedulerInterval;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -322,6 +322,7 @@ public final class EngineProcessors {
         scheduledTaskStateFactory,
         searchClientsProxy,
         processingState,
+        config,
         partitionId);
 
     return typedRecordProcessors;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationItemProvider.Item;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -49,10 +50,10 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   public BatchOperationExecutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final BatchOperationItemProvider entityKeyProvider,
-      final Duration pollingInterval) {
+      final EngineConfiguration engineConfiguration) {
     batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
     this.entityKeyProvider = entityKeyProvider;
-    this.pollingInterval = pollingInterval;
+    pollingInterval = engineConfiguration.getBatchOperationSchedulerInterval();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.CancelProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.MigrateProcessInstanceBatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.ModifyProcessInstanceBatchOperationExecutor;
@@ -23,7 +24,6 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -37,6 +37,7 @@ public final class BatchOperationSetupProcessors {
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final SearchClientsProxy searchClientsProxy,
       final ProcessingState processingState,
+      final EngineConfiguration engineConfiguration,
       final int partitionId) {
     final var batchExecutionHandlers =
         Map.of(
@@ -93,6 +94,6 @@ public final class BatchOperationSetupProcessors {
             new BatchOperationExecutionScheduler(
                 scheduledTaskStateFactory,
                 new BatchOperationItemProvider(searchClientsProxy),
-                Duration.ofMillis(1000)));
+                engineConfiguration));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationItemProvider.Item;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -81,9 +82,13 @@ public class BatchOperationExecutionSchedulerTest {
         .foreachPendingBatchOperation(any(BatchOperationVisitor.class));
     lenient().when(batchOperationState.exists(anyLong())).thenReturn(true);
 
+    final var engineConfiguration = mock(EngineConfiguration.class);
+    when(engineConfiguration.getBatchOperationSchedulerInterval())
+        .thenReturn(Duration.ofSeconds(1));
+
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, entityKeyProvider, Duration.ofSeconds(1));
+            scheduledTaskStateFactory, entityKeyProvider, engineConfiguration);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -91,6 +91,7 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -122,7 +123,9 @@ public class CommandDistributionIdempotencyTest {
 
   @ClassRule
   public static final EngineRule ENGINE =
-      EngineRule.multiplePartition(2).withSearchClientsProxy(new NoopSearchClientsProxy());
+      EngineRule.multiplePartition(2)
+          .withEngineConfig(c -> c.setBatchOperationSchedulerInterval(Duration.ofDays(1)))
+          .withSearchClientsProxy(new NoopSearchClientsProxy());
 
   private static final Set<Class<?>> DISTRIBUTING_PROCESSORS =
       new HashSet<>(


### PR DESCRIPTION
## Description

This PR tries to fix the flakiness of batch operation CANCEL/PAUSE/RESUME commands in the `CommandDistributionIdempotencyTest` by introducing a new engineConfig `batchOperationSchedulerInterval`.

This enables us to basically deactivate the scheduler in specific tests. This way we make sure, that the batchOperation is not already processed and can be paused/resumed/canceled.
