### PR TITLE
feat: migrate assignment/unassignment flow to unified API

### DIFF
--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -14,7 +14,7 @@
     "@tanstack/eslint-plugin-query": "5.68.0",
     "@tanstack/react-query": "5.69.0",
     "@uidotdev/usehooks": "2.4.1",
-    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.37",
+    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.38",
     "bpmn-js": "18.4.0",
     "classnames": "2.5.1",
     "date-fns": "4.1.0",

--- a/tasklist/client/src/v1/TaskDetails/index.tsx
+++ b/tasklist/client/src/v1/TaskDetails/index.tsx
@@ -6,13 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect} from 'react';
-import {
-  useLocation,
-  useNavigate,
-  useOutletContext,
-  useSearchParams,
-} from 'react-router-dom';
+import {useLocation, useNavigate, useOutletContext} from 'react-router-dom';
 import {observer} from 'mobx-react-lite';
 import {
   useCompleteTask,
@@ -25,7 +19,6 @@ import {tracking} from 'common/tracking';
 import {notificationsStore} from 'common/notifications/notifications.store';
 import {getStateLocally, storeStateLocally} from 'common/local-storage';
 import {useTaskFilters} from 'v1/features/tasks/filters/useTaskFilters';
-import {decodeTaskOpenedRef} from 'common/tracking/reftags';
 import {useTasks} from 'v1/api/useTasks.query';
 import {useAutoSelectNextTask} from 'common/tasks/next-task/useAutoSelectNextTask';
 import {autoSelectNextTaskStore} from 'common/tasks/next-task/autoSelectFirstTask';
@@ -58,33 +51,14 @@ const TaskDetails: React.FC = observer(() => {
   const {t} = useTranslation();
   const tasks = data?.pages.flat() ?? [];
   const hasRemainingTasks = tasks.length > 0;
-
   const {id} = useTaskDetailsParams();
   const navigate = useNavigate();
   const location = useLocation();
-
-  const [searchParams, setSearchParams] = useSearchParams();
   const {mutateAsync: completeTask} = useCompleteTask();
   const {mutateAsync: uploadDocuments} = useUploadDocuments();
   const {formKey, processDefinitionKey, formId, id: taskId} = task;
-
   const {enabled: autoSelectNextTaskEnabled} = autoSelectNextTaskStore;
   const {goToTask: autoSelectGoToTask} = useAutoSelectNextTask();
-
-  useEffect(() => {
-    const search = new URLSearchParams(searchParams);
-    const ref = search.get('ref');
-    if (search.has('ref')) {
-      search.delete('ref');
-      setSearchParams(search, {replace: true});
-    }
-
-    const taskOpenedRef = decodeTaskOpenedRef(ref);
-    tracking.track({
-      eventName: 'task-opened',
-      ...(taskOpenedRef ?? {}),
-    });
-  }, [searchParams, setSearchParams, taskId]);
 
   async function handleSubmission(
     variables: Pick<Variable, 'name' | 'value'>[],

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, waitFor} from 'common/testing/testing-library';
+import {AssignButton} from './index';
+import {assignedTask, unassignedTask} from 'v2/mocks/task';
+import {currentUser} from 'common/mocks/current-user';
+import {getMockQueryClient} from 'common/testing/getMockQueryClient';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {nodeMockServer} from 'common/testing/nodeMockServer';
+import {http, HttpResponse} from 'msw';
+import {notificationsStore} from 'common/notifications/notifications.store';
+
+vi.mock('common/notifications/notifications.store', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const getWrapper = () => {
+  const mockClient = getMockQueryClient();
+
+  const Wrapper: React.FC<{
+    children?: React.ReactNode;
+  }> = ({children}) => (
+    <QueryClientProvider client={mockClient}>{children}</QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('AssignButton', () => {
+  it('should assign a task', async () => {
+    const mockUnassignedTask = unassignedTask();
+    const mockAssignedTask = assignedTask();
+    nodeMockServer.use(
+      http.post(
+        '/v2/user-tasks/:userTaskKey/assignment',
+        () => HttpResponse.json(),
+        {once: true},
+      ),
+      http.get(
+        '/v2/user-tasks/:userTaskKey',
+        () => HttpResponse.json(mockAssignedTask),
+        {once: true},
+      ),
+    );
+
+    const {user, rerender} = render(
+      <AssignButton
+        id={mockUnassignedTask.userTaskKey}
+        assignee={undefined}
+        currentUser={currentUser.userId}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+    expect(await screen.findByText('Assignment successful')).toBeVisible();
+    rerender(
+      <AssignButton
+        id={mockAssignedTask.userTaskKey}
+        assignee={currentUser.userId}
+        currentUser={currentUser.userId}
+      />,
+    );
+
+    expect(await screen.findByRole('button', {name: 'Unassign'})).toBeVisible();
+  });
+
+  it('should unassign a task', async () => {
+    const mockUnassignedTask = unassignedTask();
+    const mockAssignedTask = assignedTask();
+    nodeMockServer.use(
+      http.delete(
+        '/v2/user-tasks/:userTaskKey/assignee',
+        () => HttpResponse.json(),
+        {once: true},
+      ),
+      http.get(
+        '/v2/user-tasks/:userTaskKey',
+        () => HttpResponse.json(mockUnassignedTask),
+        {once: true},
+      ),
+    );
+
+    const {user, rerender} = render(
+      <AssignButton
+        id={mockAssignedTask.userTaskKey}
+        assignee={currentUser.userId}
+        currentUser={currentUser.userId}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Unassign'}));
+
+    expect(await screen.findByText('Unassignment successful')).toBeVisible();
+
+    rerender(
+      <AssignButton
+        id={mockUnassignedTask.userTaskKey}
+        assignee={undefined}
+        currentUser={currentUser.userId}
+      />,
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Assign to me'}),
+    ).toBeVisible();
+  });
+
+  it('should handle failed assignment', async () => {
+    const mockUnassignedTask = unassignedTask();
+
+    nodeMockServer.use(
+      http.post(
+        '/v2/user-tasks/:userTaskKey/assignment',
+        () =>
+          HttpResponse.json({error: 'Failed to assign task'}, {status: 400}),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <AssignButton
+        id={mockUnassignedTask.userTaskKey}
+        assignee={undefined}
+        currentUser={currentUser.userId}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Task could not be assigned',
+        isDismissable: true,
+      });
+    });
+  });
+
+  it('should handle failed unassignment', async () => {
+    const mockUnassignedTask = unassignedTask();
+
+    nodeMockServer.use(
+      http.delete(
+        '/v2/user-tasks/:userTaskKey/assignee',
+        () =>
+          HttpResponse.json({error: 'Failed to unassign task'}, {status: 400}),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <AssignButton
+        id={mockUnassignedTask.userTaskKey}
+        assignee={currentUser.userId}
+        currentUser={currentUser.userId}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Unassign'}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Task could not be unassigned',
+        isDismissable: true,
+      });
+    });
+  });
+});

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {t as _t} from 'i18next';
+import {AsyncActionButton} from 'common/components/AsyncActionButton';
+import {notificationsStore} from 'common/notifications/notifications.store';
+import {tracking} from 'common/tracking';
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {useAssignTask} from 'v2/api/useAssignTask.mutation';
+import {useUnassignTask} from 'v2/api/useUnassignTask.mutation';
+import {usePollForAssignmentResult} from 'v2/api/usePollForAssignmentResult.mutation';
+
+type AssignmentStatus =
+  | 'off'
+  | 'assigning'
+  | 'unassigning'
+  | 'assignmentSuccessful'
+  | 'unassignmentSuccessful';
+
+const getAssignmentToggleLabels = () =>
+  ({
+    assigning: _t('taskHeaderAssigning'),
+    unassigning: _t('taskHeaderUnassigning'),
+    assignmentSuccessful: _t('taskHeaderAssignmentSuccessful'),
+    unassignmentSuccessful: _t('taskHeaderUnassignmentSuccessful'),
+  }) as Record<AssignmentStatus, string>;
+
+type Props = {
+  id: string;
+  assignee: string | undefined;
+  currentUser: string;
+};
+
+const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
+  const isAssigned = typeof assignee === 'string';
+  const {t} = useTranslation();
+  const [assignmentStatus, setAssignmentStatus] =
+    useState<AssignmentStatus>('off');
+  const {mutateAsync: pollForAssignmentResult} = usePollForAssignmentResult();
+  const {mutateAsync: assignTask, isPending: assignIsPending} = useAssignTask();
+  const {mutateAsync: unassignTask, isPending: unassignIsPending} =
+    useUnassignTask();
+  const isLoading = (assignIsPending || unassignIsPending) ?? false;
+
+  function getAsyncActionButtonStatus() {
+    if (isLoading || assignmentStatus !== 'off') {
+      const ACTIVE_STATES: AssignmentStatus[] = ['assigning', 'unassigning'];
+
+      return ACTIVE_STATES.includes(assignmentStatus) ? 'active' : 'finished';
+    }
+
+    return 'inactive';
+  }
+
+  const handleAssignmentClick = async () => {
+    try {
+      setAssignmentStatus('assigning');
+      await assignTask({
+        userTaskKey: id,
+        assignee: currentUser,
+      });
+      await pollForAssignmentResult({
+        userTaskKey: id,
+        wasAssigned: false,
+      });
+      setAssignmentStatus('assignmentSuccessful');
+      tracking.track({eventName: 'task-assigned'});
+    } catch {
+      notificationsStore.displayNotification({
+        kind: 'error',
+        title: t('taskDetailsTaskAssignmentError'),
+        isDismissable: true,
+      });
+
+      setAssignmentStatus('off');
+    }
+  };
+
+  const handleUnassignmentClick = async () => {
+    try {
+      setAssignmentStatus('unassigning');
+      await unassignTask(id);
+      await pollForAssignmentResult({
+        userTaskKey: id,
+        wasAssigned: true,
+      });
+      setAssignmentStatus('unassignmentSuccessful');
+      tracking.track({eventName: 'task-unassigned'});
+    } catch {
+      notificationsStore.displayNotification({
+        kind: 'error',
+        title: t('taskDetailsTaskUnassignmentError'),
+        isDismissable: true,
+      });
+
+      setAssignmentStatus('off');
+    }
+  };
+
+  const handleClick = async () => {
+    if (isAssigned) {
+      handleUnassignmentClick();
+    } else {
+      handleAssignmentClick();
+    }
+  };
+
+  return (
+    <AsyncActionButton
+      inlineLoadingProps={{
+        description:
+          assignmentStatus === 'off'
+            ? undefined
+            : getAssignmentToggleLabels()[assignmentStatus],
+        'aria-live': ['assigning', 'unassigning'].includes(assignmentStatus)
+          ? 'assertive'
+          : 'polite',
+        onSuccess: () => {
+          setAssignmentStatus('off');
+        },
+      }}
+      buttonProps={{
+        kind: isAssigned ? 'ghost' : 'primary',
+        size: 'sm',
+        type: 'button',
+        onClick: handleClick,
+        disabled: isLoading,
+        autoFocus: true,
+        id: 'main-content',
+      }}
+      status={getAsyncActionButtonStatus()}
+    >
+      {isAssigned ? t('taskDetailsUnassign') : t('taskDetailsAssignToMe')}
+    </AsyncActionButton>
+  );
+};
+
+export {AssignButton};

--- a/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
@@ -25,6 +25,7 @@ import {notificationsStore} from 'common/notifications/notifications.store';
 import {TaskDetailsHeader} from 'common/tasks/details/TaskDetailsHeader';
 import {tracking} from 'common/tracking';
 import {decodeTaskOpenedRef} from 'common/tracking/reftags';
+import {AssignButton} from './AssignButton';
 
 type OutletContext = {
   task: UserTask;
@@ -121,7 +122,13 @@ const TaskDetailsLayout: React.FC = () => {
           assignee={task.assignee ?? null}
           taskState={task.state}
           user={currentUser}
-          assignButton={null}
+          assignButton={
+            <AssignButton
+              id={task.userTaskKey}
+              assignee={task.assignee}
+              currentUser={currentUser.userId}
+            />
+          }
         />
         <TabListNav label={t('taskDetailsNavLabel')} items={tabs} />
         <Outlet

--- a/tasklist/client/src/v2/api/index.ts
+++ b/tasklist/client/src/v2/api/index.ts
@@ -58,7 +58,36 @@ const api = {
     return new Request(getFullURL(tasklistEndpoints.getTask.getUrl(body)), {
       ...BASE_REQUEST_OPTIONS,
       method: tasklistEndpoints.getTask.method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
     });
+  },
+  assignTask: (params: Pick<UserTask, 'userTaskKey'> & {assignee: string}) => {
+    const {userTaskKey, ...body} = params;
+    return new Request(
+      getFullURL(tasklistEndpoints.assignTask.getUrl({userTaskKey})),
+      {
+        ...BASE_REQUEST_OPTIONS,
+        method: tasklistEndpoints.assignTask.method,
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+  },
+  unassignTask: (body: Pick<UserTask, 'userTaskKey'>) => {
+    return new Request(
+      getFullURL(tasklistEndpoints.unassignTask.getUrl(body)),
+      {
+        ...BASE_REQUEST_OPTIONS,
+        method: tasklistEndpoints.unassignTask.method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
   },
 } as const;
 

--- a/tasklist/client/src/v2/api/useAssignTask.mutation.ts
+++ b/tasklist/client/src/v2/api/useAssignTask.mutation.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation} from '@tanstack/react-query';
+import {api} from 'v2/api';
+import {request} from 'common/api/request';
+
+function useAssignTask() {
+  return useMutation({
+    mutationFn: async (params: Parameters<typeof api.assignTask>[0]) => {
+      const {response, error} = await request(api.assignTask(params));
+
+      if (response !== null) {
+        return null;
+      }
+
+      throw error;
+    },
+  });
+}
+
+export {useAssignTask};

--- a/tasklist/client/src/v2/api/usePollForAssignmentResult.mutation.tsx
+++ b/tasklist/client/src/v2/api/usePollForAssignmentResult.mutation.tsx
@@ -11,6 +11,7 @@ import {api} from 'v2/api';
 import {request} from 'common/api/request';
 import type {UserTask} from '@vzeta/camunda-api-zod-schemas/tasklist';
 import {USE_TASKS_QUERY_KEY} from './useTasks.query';
+import {getUseTaskQueryKey} from './useTask.query';
 
 function usePollForAssignmentResult() {
   const client = useQueryClient();
@@ -39,7 +40,7 @@ function usePollForAssignmentResult() {
       return task;
     },
     onSuccess: (task) => {
-      client.setQueryData(['task', task.userTaskKey], task);
+      client.setQueryData(getUseTaskQueryKey(task.userTaskKey), task);
       client.invalidateQueries({queryKey: [USE_TASKS_QUERY_KEY]});
     },
     gcTime: 0,

--- a/tasklist/client/src/v2/api/usePollForAssignmentResult.mutation.tsx
+++ b/tasklist/client/src/v2/api/usePollForAssignmentResult.mutation.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {api} from 'v2/api';
+import {request} from 'common/api/request';
+import type {UserTask} from '@vzeta/camunda-api-zod-schemas/tasklist';
+import {USE_TASKS_QUERY_KEY} from './useTasks.query';
+
+function usePollForAssignmentResult() {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      userTaskKey,
+      wasAssigned,
+    }: Pick<UserTask, 'userTaskKey'> & {wasAssigned: boolean}) => {
+      const {response, error} = await request(api.getTask({userTaskKey}));
+
+      if (error !== null) {
+        throw error;
+      }
+
+      const task = (await response.json()) as UserTask;
+
+      if (wasAssigned && task?.assignee !== undefined) {
+        throw new Error('Task is assigned');
+      }
+
+      if (!wasAssigned && task?.assignee === undefined) {
+        throw new Error('Task is not assigned');
+      }
+
+      return task;
+    },
+    onSuccess: (task) => {
+      client.setQueryData(['task', task.userTaskKey], task);
+      client.invalidateQueries({queryKey: [USE_TASKS_QUERY_KEY]});
+    },
+    gcTime: 0,
+    retry: 12,
+    retryDelay: 500,
+  });
+}
+
+export {usePollForAssignmentResult};

--- a/tasklist/client/src/v2/api/useTasks.query.ts
+++ b/tasklist/client/src/v2/api/useTasks.query.ts
@@ -19,12 +19,13 @@ import {
 
 const POLLING_INTERVAL = 5000;
 const MAX_TASKS_PER_REQUEST = 50;
+const USE_TASKS_QUERY_KEY = 'task';
 
 function getQueryKey(payload: QueryUserTasksRequestBody) {
   const {filter = {}, page = {}, sort = []} = payload;
 
   return [
-    'tasks',
+    USE_TASKS_QUERY_KEY,
     ...Object.entries(filter).map(([key, value]) => `${key}:${value}`),
     ...Object.entries(page).map(([key, value]) => `${key}:${value}`),
     ...sort.flatMap((item) =>
@@ -97,4 +98,4 @@ function useTasks(
   return result;
 }
 
-export {useTasks};
+export {useTasks, USE_TASKS_QUERY_KEY};

--- a/tasklist/client/src/v2/api/useUnassignTask.mutation.ts
+++ b/tasklist/client/src/v2/api/useUnassignTask.mutation.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation} from '@tanstack/react-query';
+import {api} from 'v2/api';
+import {request} from 'common/api/request';
+import type {UserTask} from '@vzeta/camunda-api-zod-schemas/tasklist';
+
+function useUnassignTask() {
+  return useMutation({
+    mutationFn: async (userTaskKey: UserTask['userTaskKey']) => {
+      const {response, error} = await request(api.unassignTask({userTaskKey}));
+
+      if (response !== null) {
+        return null;
+      }
+
+      throw error;
+    },
+  });
+}
+
+export {useUnassignTask};

--- a/tasklist/client/yarn.lock
+++ b/tasklist/client/yarn.lock
@@ -1993,10 +1993,10 @@
     loupe "^3.1.3"
     tinyrainbow "^2.0.0"
 
-"@vzeta/camunda-api-zod-schemas@0.0.2-beta.37":
-  version "0.0.2-beta.37"
-  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.37.tgz#a45c9fbc9d6bd75bfba7d01f85e762e6b3bacf0f"
-  integrity sha512-IIC2xKqu0d8kKyrVqdO6CPO3sOY0kMsw2r9AMDWv7aSeEmN3baJAVLthsN1vVQKs9AIp1AK8uF6nXRqqyMt6SQ==
+"@vzeta/camunda-api-zod-schemas@0.0.2-beta.38":
+  version "0.0.2-beta.38"
+  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.38.tgz#c4c600fdc1bcaa0aa6eddd00d75cd75160edb942"
+  integrity sha512-yVY6cZG5H6e+3Io2gDEgBgdjrk7Ph+0Z1fQs4nrzfep8A+aOJVKgvj7GYADnBl0NU1dtNyGzwio9ZZwDBADhjw==
 
 "@vzeta/rollup-plugin-sbom@2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR migrates the assignment/unassignment flow. The needed to added a task polling after changing the assignee since the new endpoints don't return the status of the request

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #22937, #22939
