### PR TITLE
refactor: batchoperation search root processes + rdbms persist parent process keys

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -220,6 +220,20 @@ public class ProcessInstanceAndElementInstanceSearchTest {
   }
 
   @Test
+  void shouldQueryRootProcessInstances() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.parentProcessInstanceKey(key -> key.exists(false)))
+            .send()
+            .join();
+
+    // then we have exactly PROCESS_INSTANCES.size, since the one subprocess should not be there
+    assertThat(result.items().size()).isEqualTo(PROCESS_INSTANCES.size());
+  }
+
+  @Test
   void shouldQueryProcessInstancesByKeyFilterIn() {
     // given
     final List<Long> processInstanceKeys =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -70,10 +70,17 @@ import java.util.Set;
 
 public class RecordFixtures {
 
+  protected static final long NO_PARENT_EXISTS_KEY = -1L;
+
   protected static final ProtocolFactory FACTORY = new ProtocolFactory(System.nanoTime());
 
   protected static ImmutableRecord<RecordValue> getProcessInstanceStartedRecord(
-      final Long position) {
+      final long position) {
+    return getProcessInstanceStartedRecord(position, 42L);
+  }
+
+  protected static ImmutableRecord<RecordValue> getProcessInstanceStartedRecord(
+      final long position, final long parentProcessInstanceKey) {
     final io.camunda.zeebe.protocol.record.Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.PROCESS_INSTANCE);
     return ImmutableRecord.builder()
@@ -85,13 +92,20 @@ public class RecordFixtures {
             ImmutableProcessInstanceRecordValue.builder()
                 .from((ProcessInstanceRecordValue) recordValueRecord.getValue())
                 .withBpmnElementType(BpmnElementType.PROCESS)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
+                .withParentElementInstanceKey(parentProcessInstanceKey)
                 .withVersion(1)
                 .build())
         .build();
   }
 
   protected static ImmutableRecord<RecordValue> getProcessInstanceCompletedRecord(
-      final Long position, final long processInstanceKey) {
+      final long position, final long processInstanceKey) {
+    return getProcessInstanceCompletedRecord(position, processInstanceKey, 42L);
+  }
+
+  protected static ImmutableRecord<RecordValue> getProcessInstanceCompletedRecord(
+      final Long position, final long processInstanceKey, final long parentProcessInstanceKey) {
     final io.camunda.zeebe.protocol.record.Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.PROCESS_INSTANCE);
     return ImmutableRecord.builder()
@@ -105,6 +119,8 @@ public class RecordFixtures {
                 .from((ProcessInstanceRecordValue) recordValueRecord.getValue())
                 .withProcessInstanceKey(processInstanceKey)
                 .withBpmnElementType(BpmnElementType.PROCESS)
+                .withParentProcessInstanceKey(parentProcessInstanceKey)
+                .withParentElementInstanceKey(parentProcessInstanceKey)
                 .withVersion(1)
                 .build())
         .build();

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -51,8 +52,6 @@ import java.util.function.Function;
 public final class ProcessInstanceServices
     extends SearchQueryService<
         ProcessInstanceServices, ProcessInstanceQuery, ProcessInstanceEntity> {
-
-  public static final long NO_PARENT_EXISTS_KEY = -1L;
 
   private final ProcessInstanceSearchClient processInstanceSearchClient;
 
@@ -163,7 +162,7 @@ public final class ProcessInstanceServices
         filter.toBuilder()
             // It is only possible to cancel root processes in zeebe,
             // whereby zeebe then automatically cancels the sub-processes.
-            .parentProcessInstanceKeys(NO_PARENT_EXISTS_KEY)
+            .parentProcessInstanceKeyOperations(Operation.exists(false))
             .states(ProcessInstanceState.ACTIVE.name())
             .build();
 

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service;
 
-import static io.camunda.service.ProcessInstanceServices.NO_PARENT_EXISTS_KEY;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -173,7 +172,7 @@ public final class ProcessInstanceServiceTest {
     final var enhancedFilter =
         MsgPackConverter.convertToObject(filterBuffer, ProcessInstanceFilter.class);
     assertThat(enhancedFilter.parentProcessInstanceKeyOperations())
-        .containsExactly(Operation.eq(NO_PARENT_EXISTS_KEY));
+        .containsExactly(Operation.exists(false));
     assertThat(enhancedFilter.stateOperations())
         .containsExactly(Operation.eq(ProcessInstanceState.ACTIVE.name()));
   }


### PR DESCRIPTION
## Description

This change is need in order to have a common and working way to search for root processes via search API. 

* For ProcessInstanceFilter which will be used by Batch Operations, we use now `new ProcessInstanceFilterImpl().parentProcessInstanceKey(parentKey -> parentKey.exists(false))` -> This already works in ES/OS
* In RDBMS, this just works if we also persist null as parentKey, which is the other change of this PR. 
* Additional, it introduces an acceptance test for this use case
