### PR TITLE
feat: applications can be granted permissions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/OwnerType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/OwnerType.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.enums;
 
 public enum OwnerType {
   USER,
+  APPLICATION,
   ROLE,
   GROUP,
   MAPPING,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -7,13 +7,25 @@
  */
 package io.camunda.it.auth;
 
+import static io.camunda.client.api.search.enums.OwnerType.APPLICATION;
+import static io.camunda.client.api.search.enums.OwnerType.USER;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.DELETE;
 import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.CreateAuthorizationResponse;
+import io.camunda.client.api.response.DeleteAuthorizationResponse;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
@@ -29,6 +41,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -52,7 +66,12 @@ class AuthorizationSearchIT {
   @UserDefinition
   private static final User ADMIN_USER =
       new User(
-          ADMIN, DEFAULT_PASSWORD, List.of(new Permissions(AUTHORIZATION, READ, List.of("*"))));
+          ADMIN,
+          DEFAULT_PASSWORD,
+          List.of(
+              new Permissions(AUTHORIZATION, READ, List.of("*")),
+              new Permissions(AUTHORIZATION, CREATE, List.of("*")),
+              new Permissions(AUTHORIZATION, DELETE, List.of("*"))));
 
   @UserDefinition
   private static final User RESTRICTED_USER = new User(RESTRICTED, DEFAULT_PASSWORD, List.of());
@@ -73,6 +92,91 @@ class AuthorizationSearchIT {
     final var response =
         searchAuthorizations(client.getConfiguration().getRestAddress().toString(), RESTRICTED);
     assertThat(response.items()).isEmpty();
+  }
+
+  @Test
+  void shouldBeAbleToQueryAuthorizationAfterAdding(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    // given
+    final var resourceId = "test-resource-" + UUID.randomUUID();
+
+    adminClient
+        .newCreateAuthorizationCommand()
+        .ownerId(ADMIN)
+        .ownerType(USER)
+        .resourceId(resourceId)
+        .resourceType(PROCESS_DEFINITION)
+        .permissionTypes(CREATE_PROCESS_INSTANCE)
+        .send()
+        .join()
+        .getAuthorizationKey();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        searchAuthorizations(
+                                adminClient.getConfiguration().getRestAddress().toString(), ADMIN)
+                            .items())
+                    .filteredOn(
+                        auth ->
+                            auth.resourceId().equals(resourceId)
+                                && auth.resourceType().equals(PROCESS_DEFINITION)
+                                && auth.ownerId().equals(ADMIN))
+                    .isEmpty());
+  }
+
+  @Test
+  void shouldNotShowAuthorizationAfterRemoval(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws Exception {
+    // Given
+    final String resourceId = "test-resource-" + UUID.randomUUID();
+    final CreateAuthorizationResponse createResponse =
+        adminClient
+            .newCreateAuthorizationCommand()
+            .ownerId(ADMIN)
+            .ownerType(APPLICATION)
+            .resourceId(resourceId)
+            .resourceType(PROCESS_DEFINITION)
+            .permissionTypes(READ_PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE)
+            .send()
+            .join();
+
+    // Verify it was created
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        searchAuthorizations(
+                                adminClient.getConfiguration().getRestAddress().toString(), ADMIN)
+                            .items())
+                    .anyMatch(
+                        auth ->
+                            auth.resourceId().equals(resourceId)
+                                && auth.resourceType().equals(PROCESS_DEFINITION)
+                                && auth.ownerId().equals(ADMIN)));
+
+    // When
+    final DeleteAuthorizationResponse deleteResponse =
+        adminClient
+            .newDeleteAuthorizationCommand(createResponse.getAuthorizationKey())
+            .send()
+            .join();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        searchAuthorizations(
+                                adminClient.getConfiguration().getRestAddress().toString(), ADMIN)
+                            .items())
+                    .noneMatch(
+                        auth ->
+                            auth.resourceId().equals(resourceId)
+                                && auth.resourceType().equals(PROCESS_DEFINITION)
+                                && auth.ownerId().equals(ADMIN)));
   }
 
   // TODO once available, this test should use the client to make the request
@@ -96,5 +200,11 @@ class AuthorizationSearchIT {
 
   private record AuthorizationSearchResponse(List<AuthorizationResponse> items) {}
 
-  private record AuthorizationResponse(String resourceId) {}
+  private record AuthorizationResponse(
+      String ownerId,
+      OwnerType ownerType,
+      ResourceType resourceType,
+      String resourceId,
+      List<PermissionType> permissionTypes,
+      String authorizationKey) {}
 }

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationOwnerType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationOwnerType.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum AuthorizationOwnerType {
   USER,
+  APPLICATION,
   ROLE,
   GROUP,
   MAPPING,

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6002,6 +6002,7 @@ components:
       description: The type of the owner of permissions.
       enum:
         - USER
+        - APPLICATION
         - ROLE
         - GROUP
         - MAPPING

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -39,15 +39,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(AuthorizationController.class)
 public class AuthorizationControllerTest extends RestControllerTest {
 
-  @MockBean private AuthorizationServices authorizationServices;
+  @MockitoBean private AuthorizationServices authorizationServices;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = AuthorizationController.class)
 public class AuthorizationQueryControllerTest extends RestControllerTest {
@@ -77,7 +77,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
           .lastSortValues(new Object[] {"v"})
           .build();
 
-  @MockBean private AuthorizationServices authorizationServices;
+  @MockitoBean private AuthorizationServices authorizationServices;
 
   @BeforeEach
   void setup() {


### PR DESCRIPTION
This adds the owner type `APPLICATION` in the API layer. Exporters were already supporting any arbitrary owner id by string.

I've extended the general `AuthorizationSearchIT`  a bit and added one test case that makes use of `APPLICATION`, showing that it can be added, exported and queried again.

closes #31381