### PR TITLE
Don't initialize a default mapping rule

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -11,6 +11,7 @@ import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.service.AuthorizationServices;
@@ -78,9 +79,7 @@ public class CamundaOAuthPrincipalService {
             getUsernameFromClaims(claims),
             assignedRoles,
             authorizationServices.getAuthorizedApplications(
-                Stream.concat(
-                        assignedRoles.stream().map(r -> r.roleKey().toString()),
-                        mappingIds.stream())
+                Stream.concat(assignedRoles.stream().map(RoleEntity::roleId), mappingIds.stream())
                     .collect(Collectors.toSet())),
             tenantServices.getTenantsByMemberIds(mappingIds).stream()
                 .map(TenantDTO::fromEntity)

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -23,8 +23,6 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,10 +32,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class CamundaOAuthPrincipalServiceTest {
-  private static final String REGISTRATION_ID = "test";
-  private static final String TOKEN_VALUE = "{}";
-  private static final Instant TOKEN_ISSUED_AT = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-  private static final Instant TOKEN_EXPIRES_AT = TOKEN_ISSUED_AT.plus(1, ChronoUnit.DAYS);
 
   private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -86,7 +86,7 @@ public class CamundaOAuthPrincipalServiceTest {
     final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
     when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
         .thenReturn(List.of(roleR1));
-    when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "8")))
+    when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "roleR1")))
         .thenReturn(List.of("*"));
 
     // when
@@ -122,7 +122,7 @@ public class CamundaOAuthPrincipalServiceTest {
     final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1");
     when(roleServices.getRolesByMemberIds(Set.of("map-1", "map-2"))).thenReturn(List.of(roleR1));
 
-    when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "10")))
+    when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "roleR1")))
         .thenReturn(List.of("app-1", "app-2"));
 
     // when

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -81,10 +81,6 @@ spring.datasource.url=${camunda.database.url:}
 spring.datasource.username=${camunda.database.username:}
 spring.datasource.password=${camunda.database.password:}
 mybatis.mapper-locations:classpath:mapper/**/*-mapper.xml
-# Security configuration
-camunda.security.initialization.mappings[0].mappingId=${INITIAL_MAPPING_ID:admin-mapping}
-camunda.security.initialization.mappings[0].claimName=${INITIAL_CLAIM_NAME:oid}
-camunda.security.initialization.mappings[0].claimValue=${INITIAL_CLAIM_VALUE}
 
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This was problematic as we had sensible defaults for the id and the claim name. However, we didn't have one for the claim value. As a result the value would become` ${INITIAL_CLAIM_VALUE}` which is not desirable.

In general we don't really have to initialize a default mapping rule. It provides no value for now. We can easily re-add
 it in the future if our perspective changes.

⚠️ Note that the issue only occurred because of our in-progress refactoring. By now we have checks that prevent a scenario like this in our initializer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31512
