### PR TITLE
feat: populate application id in auth context

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -11,7 +11,6 @@ import io.camunda.authentication.entity.AuthenticationContext.AuthenticationCont
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
-import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.service.AuthorizationServices;

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.entity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public record AuthenticationContext(
@@ -18,4 +19,43 @@ public record AuthenticationContext(
     List<String> authorizedApplications,
     List<TenantDTO> tenants,
     List<String> groups)
-    implements Serializable {}
+    implements Serializable {
+
+  public static final class AuthenticationContextBuilder {
+    private String username;
+    private List<RoleEntity> roles = new ArrayList<>();
+    private List<String> authorizedApplications = new ArrayList<>();
+    private List<TenantDTO> tenants = new ArrayList<>();
+    private List<String> groups = new ArrayList<>();
+
+    public AuthenticationContextBuilder withUsername(final String username) {
+      this.username = username;
+      return this;
+    }
+
+    public AuthenticationContextBuilder withRoles(final List<RoleEntity> roles) {
+      this.roles = roles;
+      return this;
+    }
+
+    public AuthenticationContextBuilder withAuthorizedApplications(
+        final List<String> authorizedApplications) {
+      this.authorizedApplications = authorizedApplications;
+      return this;
+    }
+
+    public AuthenticationContextBuilder withTenants(final List<TenantDTO> tenants) {
+      this.tenants = tenants;
+      return this;
+    }
+
+    public AuthenticationContextBuilder withGroups(final List<String> groups) {
+      this.groups = groups;
+      return this;
+    }
+
+    public AuthenticationContext build() {
+      return new AuthenticationContext(username, roles, authorizedApplications, tenants, groups);
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 public record AuthenticationContext(
     String username,
+    String applicationId,
     List<RoleEntity> roles,
     List<String> authorizedApplications,
     List<TenantDTO> tenants,
@@ -23,6 +24,7 @@ public record AuthenticationContext(
 
   public static final class AuthenticationContextBuilder {
     private String username;
+    private String applicationId;
     private List<RoleEntity> roles = new ArrayList<>();
     private List<String> authorizedApplications = new ArrayList<>();
     private List<TenantDTO> tenants = new ArrayList<>();
@@ -30,6 +32,11 @@ public record AuthenticationContext(
 
     public AuthenticationContextBuilder withUsername(final String username) {
       this.username = username;
+      return this;
+    }
+
+    public AuthenticationContextBuilder withApplicationId(final String applicationId) {
+      this.applicationId = applicationId;
       return this;
     }
 
@@ -55,7 +62,8 @@ public record AuthenticationContext(
     }
 
     public AuthenticationContext build() {
-      return new AuthenticationContext(username, roles, authorizedApplications, tenants, groups);
+      return new AuthenticationContext(
+          username, applicationId, roles, authorizedApplications, tenants, groups);
     }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.entity;
 
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.ClusterMetadata;
 import io.camunda.service.TenantServices.TenantDTO;
@@ -188,7 +189,13 @@ public final class CamundaUser extends User implements CamundaPrincipal {
           password,
           email,
           authorities,
-          new AuthenticationContext(username, roles, authorizedApplications, tenants, groups),
+          new AuthenticationContextBuilder()
+              .withUsername(username)
+              .withRoles(roles)
+              .withAuthorizedApplications(authorizedApplications)
+              .withTenants(tenants)
+              .withGroups(groups)
+              .build(),
           salesPlanType,
           c8Links,
           canLogout);

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -7,7 +7,12 @@
  */
 package io.camunda.authentication;
 
+import static io.camunda.authentication.CamundaOAuthPrincipalService.APPLICATION_ID_CLAIM_NOT_FOUND;
+import static io.camunda.authentication.CamundaOAuthPrincipalService.APPLICATION_ID_CLAIM_NOT_STRING;
+import static io.camunda.authentication.CamundaOAuthPrincipalService.USERNAME_CLAIM_NOT_FOUND;
+import static io.camunda.authentication.CamundaOAuthPrincipalService.USERNAME_CLAIM_NOT_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.entity.AuthenticationContext;
@@ -26,114 +31,240 @@ import io.camunda.service.TenantServices;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class CamundaOAuthPrincipalServiceTest {
 
   private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
 
-  @Mock private MappingServices mappingServices;
-  @Mock private TenantServices tenantServices;
-  @Mock private RoleServices roleServices;
-  @Mock private GroupServices groupServices;
-  @Mock private AuthorizationServices authorizationServices;
-  @Mock private SecurityConfiguration securityConfiguration;
-  @Mock private AuthenticationConfiguration authenticationConfiguration;
-  @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+  @Nested
+  class applicationIdClaimConfiguration {
+    private static final String APPLICATION_ID_CLAIM = "application-id";
+    @Mock private MappingServices mappingServices;
+    @Mock private TenantServices tenantServices;
+    @Mock private RoleServices roleServices;
+    @Mock private GroupServices groupServices;
+    @Mock private AuthorizationServices authorizationServices;
+    @Mock private SecurityConfiguration securityConfiguration;
+    @Mock private AuthenticationConfiguration authenticationConfiguration;
+    @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
 
-    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
-    when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
-    when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("sub");
+      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+      when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+      when(oidcAuthenticationConfiguration.getApplicationIdClaim())
+          .thenReturn(APPLICATION_ID_CLAIM);
 
-    camundaOAuthPrincipalService =
-        new CamundaOAuthPrincipalService(
-            mappingServices,
-            tenantServices,
-            roleServices,
-            groupServices,
-            authorizationServices,
-            securityConfiguration);
+      camundaOAuthPrincipalService =
+          new CamundaOAuthPrincipalService(
+              mappingServices,
+              tenantServices,
+              roleServices,
+              groupServices,
+              authorizationServices,
+              securityConfiguration);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNoApplicationIdClaimFound() {
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(null);
+      when(oidcAuthenticationConfiguration.getApplicationIdClaim()).thenReturn("not-found");
+      // given
+      final Map<String, Object> claims = Map.of("sub", "user@example.com");
+
+      // when
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+
+      assertThat(exception.getMessage())
+          .isEqualTo(APPLICATION_ID_CLAIM_NOT_FOUND.formatted(APPLICATION_ID_CLAIM));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenApplicationIdClaimIsNotAString() {
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(null);
+      when(oidcAuthenticationConfiguration.getApplicationIdClaim())
+          .thenReturn(APPLICATION_ID_CLAIM);
+      // given
+      final Map<String, Object> claims = Map.of(APPLICATION_ID_CLAIM, List.of("app-1", "app-2"));
+
+      // when
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
+
+      assertThat(exception.getMessage())
+          .isEqualTo(APPLICATION_ID_CLAIM_NOT_STRING.formatted(APPLICATION_ID_CLAIM));
+    }
+
+    @Test
+    public void shouldLoadUserWhenUsingApplicationIdClaim() {
+      // given
+      final Map<String, Object> claims =
+          Map.of("sub", UUID.randomUUID().toString(), APPLICATION_ID_CLAIM, "app-1");
+
+      // when
+      final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
+
+      // then
+      assertThat(oAuthContext).isNotNull();
+      final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
+      assertThat(authenticationContext.applicationId()).isEqualTo("app-1");
+    }
   }
 
-  @Test
-  public void loadUser() {
-    // given
-    final Map<String, Object> claims =
-        Map.of(
-            "sub", "test|foo@camunda.test",
-            "email", "foo@camunda.test",
-            "role", "R1",
-            "group", "G1");
-    when(mappingServices.getMatchingMappings(claims))
-        .thenReturn(
-            List.of(
-                new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
-                new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
+  @Nested
+  class usernameClaimConfiguration {
+    private static final String USERNAME_CLAIM = "email";
+    @Mock private MappingServices mappingServices;
+    @Mock private TenantServices tenantServices;
+    @Mock private RoleServices roleServices;
+    @Mock private GroupServices groupServices;
+    @Mock private AuthorizationServices authorizationServices;
+    @Mock private SecurityConfiguration securityConfiguration;
+    @Mock private AuthenticationConfiguration authenticationConfiguration;
+    @Mock private OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
 
-    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
-    when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
-        .thenReturn(List.of(roleR1));
-    when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "roleR1")))
-        .thenReturn(List.of("*"));
+    @BeforeEach
+    public void setUp() throws Exception {
+      MockitoAnnotations.openMocks(this).close();
 
-    // when
-    final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
+      when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
+      when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
 
-    // then
-    assertThat(oAuthContext).isNotNull();
-    assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
-    final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
-    assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
-    assertThat(authenticationContext.groups()).isEmpty();
-    assertThat(authenticationContext.tenants()).isEmpty();
-    assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
-  }
+      camundaOAuthPrincipalService =
+          new CamundaOAuthPrincipalService(
+              mappingServices,
+              tenantServices,
+              roleServices,
+              groupServices,
+              authorizationServices,
+              securityConfiguration);
+    }
 
-  @Test
-  public void shouldLoadTenantsFromMappings() {
-    // given
-    final Map<String, Object> claims = Map.of("sub", "user@example.com");
+    @Test
+    public void shouldThrowExceptionWhenNoUsernameClaimFound() {
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("not-found");
+      when(oidcAuthenticationConfiguration.getApplicationIdClaim()).thenReturn(null);
+      // given
+      final Map<String, Object> claims = Map.of("sub", "user@example.com");
 
-    final var mapping1 = new MappingEntity("map-1", 1L, "role", "R1", "role-r1");
-    final var mapping2 = new MappingEntity("map-2", 2L, "group", "G1", "group-g1");
+      // when
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
 
-    when(mappingServices.getMatchingMappings(claims)).thenReturn(List.of(mapping1, mapping2));
+      assertThat(exception.getMessage())
+          .isEqualTo(USERNAME_CLAIM_NOT_FOUND.formatted(USERNAME_CLAIM));
+    }
 
-    final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
-    final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
+    @Test
+    public void shouldThrowExceptionWhenUsernameClaimIsNotAString() {
+      when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(null);
+      when(oidcAuthenticationConfiguration.getApplicationIdClaim()).thenReturn(USERNAME_CLAIM);
+      // given
+      final Map<String, Object> claims = Map.of(USERNAME_CLAIM, List.of("app-1", "app-2"));
 
-    when(tenantServices.getTenantsByMemberIds(Set.of("map-1", "map-2")))
-        .thenReturn(List.of(tenantEntity1, tenantEntity2));
+      // when
+      final var exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
 
-    final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1");
-    when(roleServices.getRolesByMemberIds(Set.of("map-1", "map-2"))).thenReturn(List.of(roleR1));
+      assertThat(exception.getMessage())
+          .isEqualTo(USERNAME_CLAIM_NOT_STRING.formatted(USERNAME_CLAIM));
+    }
 
-    when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "roleR1")))
-        .thenReturn(List.of("app-1", "app-2"));
+    @Test
+    public void loadUser() {
+      // given
+      final Map<String, Object> claims =
+          Map.of(
+              "sub", "test|foo@camunda.test",
+              "email", "foo@camunda.test",
+              "role", "R1",
+              "group", "G1");
+      when(mappingServices.getMatchingMappings(claims))
+          .thenReturn(
+              List.of(
+                  new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
+                  new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
-    // when
-    final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
+      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
+      when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
+          .thenReturn(List.of(roleR1));
+      when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "8")))
+          .thenReturn(List.of("*"));
 
-    // then
-    assertThat(oAuthContext).isNotNull();
-    assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("map-1", "map-2"));
+      // when
+      final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
 
-    final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
-    assertThat(authenticationContext.username()).isEqualTo("user@example.com");
-    assertThat(authenticationContext.roles()).containsExactly(roleR1);
-    assertThat(authenticationContext.groups()).isEmpty();
-    assertThat(authenticationContext.tenants())
-        .containsExactlyInAnyOrder(
-            TenantServices.TenantDTO.fromEntity(tenantEntity1),
-            TenantServices.TenantDTO.fromEntity(tenantEntity2));
-    assertThat(authenticationContext.authorizedApplications())
-        .containsExactlyInAnyOrder("app-1", "app-2");
+      // then
+      assertThat(oAuthContext).isNotNull();
+      assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
+      final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
+      assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
+      assertThat(authenticationContext.groups()).isEmpty();
+      assertThat(authenticationContext.tenants()).isEmpty();
+      assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
+    }
+
+    @Test
+    public void shouldLoadTenantsFromMappings() {
+      // given
+      final Map<String, Object> claims =
+          Map.of("sub", "user@example.com", USERNAME_CLAIM, "scooby-doo");
+
+      final var mapping1 = new MappingEntity("map-1", 1L, "role", "R1", "role-r1");
+      final var mapping2 = new MappingEntity("map-2", 2L, "group", "G1", "group-g1");
+
+      when(mappingServices.getMatchingMappings(claims)).thenReturn(List.of(mapping1, mapping2));
+
+      final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
+      final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
+
+      when(tenantServices.getTenantsByMemberIds(Set.of("map-1", "map-2")))
+          .thenReturn(List.of(tenantEntity1, tenantEntity2));
+
+      final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1");
+      when(roleServices.getRolesByMemberIds(Set.of("map-1", "map-2"))).thenReturn(List.of(roleR1));
+
+      when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "10")))
+          .thenReturn(List.of("app-1", "app-2"));
+
+      // when
+      final OAuthContext oAuthContext = camundaOAuthPrincipalService.loadOAuthContext(claims);
+
+      // then
+      assertThat(oAuthContext).isNotNull();
+      assertThat(oAuthContext.mappingIds()).isEqualTo(Set.of("map-1", "map-2"));
+
+      final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
+      assertThat(authenticationContext.username()).isEqualTo("scooby-doo");
+      assertThat(authenticationContext.roles()).containsExactly(roleR1);
+      assertThat(authenticationContext.groups()).isEmpty();
+      assertThat(authenticationContext.tenants())
+          .containsExactlyInAnyOrder(
+              TenantServices.TenantDTO.fromEntity(tenantEntity1),
+              TenantServices.TenantDTO.fromEntity(tenantEntity2));
+      assertThat(authenticationContext.authorizedApplications())
+          .containsExactlyInAnyOrder("app-1", "app-2");
+    }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -46,7 +46,7 @@ public class CamundaOAuthPrincipalServiceTest {
   private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
 
   @Nested
-  class applicationIdClaimConfiguration {
+  class ApplicationIdClaimConfiguration {
     private static final String APPLICATION_ID_CLAIM = "application-id";
     @Mock private MappingServices mappingServices;
     @Mock private TenantServices tenantServices;
@@ -128,7 +128,7 @@ public class CamundaOAuthPrincipalServiceTest {
   }
 
   @Nested
-  class usernameClaimConfiguration {
+  class UsernameClaimConfiguration {
     private static final String USERNAME_CLAIM = "email";
     @Mock private MappingServices mappingServices;
     @Mock private TenantServices tenantServices;

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -17,7 +17,6 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,12 +64,13 @@ public class CamundaOidcUserServiceTest {
         .thenReturn(
             new OAuthContext(
                 Set.of("test-id", "test-id-2"),
-                new AuthenticationContext(
-                    null,
-                    List.of(roleR1),
-                    List.of("*"),
-                    List.of(new TenantDTO(1L, "tenant-1", "Tenant One", "desc")),
-                    new ArrayList<>())));
+                new AuthenticationContext.AuthenticationContextBuilder()
+                    .withUsername("test")
+                    .withRoles(List.of(roleR1))
+                    .withAuthorizedApplications(List.of("*"))
+                    .withTenants(List.of(new TenantDTO(1L, "tenant-1", "Tenant One", "desc")))
+                    .withGroups(List.of())
+                    .build()));
 
     // when
     final OidcUser oidcUser = camundaOidcUserService.loadUser(createOidcUserRequest(claims));

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -90,7 +90,7 @@ public class CamundaOidcUserServiceTest {
   }
 
   @Test
-  public void givenApplicationIdClaimConfigured_whenLoadingUser_thenApplicationIdIsSet() {
+  public void applicationIdIsSetInAuthContext() {
     // given
     final Map<String, Object> claims = Map.of("sub", "test|foo@camunda.test", "client_id", "blah");
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -97,7 +97,6 @@ public class CamundaOidcUserServiceTest {
     when(camundaOAuthPrincipalService.loadOAuthContext(claims))
         .thenReturn(
             new OAuthContext(
-                Set.of(5L, 7L),
                 Set.of("test-id", "test-id-2"),
                 new AuthenticationContext.AuthenticationContextBuilder()
                     .withApplicationId("blah")

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
@@ -59,12 +59,11 @@ public class PermissionsServiceTest {
     when(camundaUser.getUsername()).thenReturn(username);
     when(camundaUser.getAuthenticationContext())
         .thenReturn(
-            new AuthenticationContext(
-                "test",
-                List.of(new RoleEntity(roleKey, roleId, "roleName")),
-                List.of(),
-                List.of(new TenantDTO(123L, tenantId, "tenantName", "")),
-                List.of()));
+            new AuthenticationContext.AuthenticationContextBuilder()
+                .withUsername("test")
+                .withRoles(List.of(new RoleEntity(roleKey, roleId, "roleName")))
+                .withTenants(List.of(new TenantDTO(123L, tenantId, "tenantName", "")))
+                .build());
     when(mockAuthentication.getPrincipal()).thenReturn(camundaUser);
     final SecurityContext securityContext = mock(SecurityContext.class);
     when(securityContext.getAuthentication()).thenReturn(mockAuthentication);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.camunda.authentication.CamundaJwtAuthenticationToken;
-import io.camunda.authentication.entity.AuthenticationContext;
+import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
 import io.camunda.authentication.entity.CamundaJwtUser;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
@@ -121,7 +121,7 @@ class RequestMapperTest {
             new TenantDTO(1L, "tenant-1", "Tenant One", "First"),
             new TenantDTO(2L, "tenant-2", "Tenant Two", "Second"));
     final var authenticationContext =
-        new AuthenticationContext(username, List.of(), List.of(), tenants, List.of());
+        new AuthenticationContextBuilder().withUsername(username).withTenants(tenants).build();
 
     final var principal =
         new CamundaOidcUser(
@@ -276,8 +276,10 @@ class RequestMapperTest {
                 jwt,
                 new OAuthContext(
                     new HashSet<>(),
-                    new AuthenticationContext(
-                        sub, List.of(), List.of(), List.of(), List.of("g1", "g2")))),
+                    new AuthenticationContextBuilder()
+                        .withUsername(sub)
+                        .withGroups(List.of("g1", "g2"))
+                        .build())),
             null,
             null);
     SecurityContextHolder.getContext().setAuthentication(token);
@@ -300,8 +302,7 @@ class RequestMapperTest {
                         tokenExpiresAt,
                         Map.of("aud", aud, usernameClaim, usernameValue))),
                 Collections.emptySet(),
-                new AuthenticationContext(
-                    usernameValue, List.of(), List.of(), List.of(), List.of())),
+                new AuthenticationContextBuilder().withUsername(usernameValue).build()),
             List.of(),
             "oidc");
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To support application ID within simple mappings we need to be able to retrieve the application ID from claims and populate the authentication context, later on this will then be passed onto the broker requests sent to the engine.

This is for REST, GRPC will be in a separate PR.

## Related issues

related to [#30328](https://github.com/camunda/camunda/issues/30328)
