### PR TITLE
ci: reorganize operate tests

### DIFF
--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -63,7 +63,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DrunCoreFeaturesUTs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDataLayerUTs -DskipIdentityUTs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 

--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -73,6 +73,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate/qa/integration-tests verify -P operateBackendIt -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateCoreFeaturesIT -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Integration Tests
       runner-type: gcp-core-32-default

--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -63,7 +63,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P operateCoreFeaturesUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DrunCoreFeaturesUTs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 

--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -1,8 +1,8 @@
-# description: This workflow runs backend CI tests for Operate. This includes Unit tests, Integration tests, and Opensearch tests. Integration tests are run in two stages, and each stage is defined by a profile. The profile is defined in operate/pom.xml
-# test location: operate/common, operate/schema, operate/webapp
-# owner:
+# description: Runs the CI tests owned by Core Features. Runs a test to make sure that Operate can build, runs java checks (ie spotbugs), unit tests, and integration tests
+# test location: operate/common, operate/qa/integration-tests, operate/schema, operate/webapp
+# owner: Core Features
 ---
-name: Operate CI
+name: Operate Core Features CI
 on:
   workflow_dispatch:
   push:
@@ -41,7 +41,7 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
-  run-build:
+  run-core-features-build:
     name: Operate Build
     uses: ./.github/workflows/operate-ci-build-reusable.yml
     secrets: inherit
@@ -57,32 +57,22 @@ jobs:
       command: ./mvnw -pl operate -am verify -T1C -B -P spotbugs,skipFrontendBuild -DskipTests -DskipDockerProfile -DskipQaBuild
       runner-type: gcp-core-4-default
 
-  run-unit-tests:
-    name: Operate Backend Unit Tests
+  run-core-features-unit-tests:
+    name: Operate Backend Unit Tests - Core Features
     uses: ./.github/workflows/operate-ci-test-reusable.yml
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P operateCoreFeaturesUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 
-  run-integration-tests:
-    name: Operate Backend Integration Tests
+  run-core-features-integration-tests:
+    name: Operate Backend Integration Tests - Core Features
     uses: ./.github/workflows/operate-ci-test-reusable.yml
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
       command: ./mvnw -f operate/qa/integration-tests verify -P operateBackendIt -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Integration Tests
-      runner-type: gcp-core-32-default
-
-  run-opensearch-tests:
-    name: Operate Backend Opensearch ITs
-    uses: ./.github/workflows/operate-ci-test-reusable.yml
-    secrets: inherit
-    with:
-      branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
-      test-type: Opensearch ITs
       runner-type: gcp-core-32-default

--- a/.github/workflows/operate-ci-data-layer.yml
+++ b/.github/workflows/operate-ci-data-layer.yml
@@ -1,0 +1,62 @@
+# description: Runs the CI tests owned by Data Layer. Runs unit tests, and integration tests
+# test location: operate/common, operate/importer, operate/importer-8_7, operate/importer-common, operate/qa/integration-tests, operate/schema, operate/webapp
+# owner: Data Layer
+---
+name: Operate Data Layer CI
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'stable/**'
+      - 'release**'
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+  pull_request:
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate/**'
+      - 'pom.xml'
+      - 'operate.Dockerfile'
+      - 'parent/*'
+      - 'webapps-common/**'
+permissions:
+  contents: read
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  run-data-layer-unit-tests:
+    name: Operate Backend Unit Tests - Data Layers
+    uses: ./.github/workflows/operate-ci-test-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+      command: ./mvnw -f operate verify -T1C -B -P operateDataLayerUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      test-type: Unit Tests
+      runner-type: gcp-core-4-default
+
+  run-data-layer-opensearch-tests:
+    name: Operate Backend Opensearch ITs
+    uses: ./.github/workflows/operate-ci-test-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      test-type: Opensearch ITs
+      runner-type: gcp-core-32-default

--- a/.github/workflows/operate-ci-data-layer.yml
+++ b/.github/workflows/operate-ci-data-layer.yml
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DrunDataLayerUTs -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipCoreFeaturesUTs -DskipIdentityUTs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 

--- a/.github/workflows/operate-ci-data-layer.yml
+++ b/.github/workflows/operate-ci-data-layer.yml
@@ -47,7 +47,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P operateDataLayerUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DrunDataLayerUTs -DskipITs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 

--- a/.github/workflows/operate-ci-identity.yml
+++ b/.github/workflows/operate-ci-identity.yml
@@ -47,6 +47,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P operateIdentityUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DrunIdentityUTs -DskipITs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default

--- a/.github/workflows/operate-ci-identity.yml
+++ b/.github/workflows/operate-ci-identity.yml
@@ -47,6 +47,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DrunIdentityUTs -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipCoreFeaturesUTs -DskipDataLayerUTs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default

--- a/.github/workflows/operate-ci-identity.yml
+++ b/.github/workflows/operate-ci-identity.yml
@@ -1,0 +1,52 @@
+# description: Runs the CI tests owned by Identity. Runs unit tests
+# test location: operate/webapp
+# owner: Identity
+---
+name: Operate Identity CI
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'stable/**'
+      - 'release**'
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+  pull_request:
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate/**'
+      - 'pom.xml'
+      - 'operate.Dockerfile'
+      - 'parent/*'
+      - 'webapps-common/**'
+permissions:
+  contents: read
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  run-identity-unit-tests:
+    name: Operate Backend Unit Tests - Identity
+    uses: ./.github/workflows/operate-ci-test-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+      command: ./mvnw -f operate verify -T1C -B -P operateIdentityUnitTests,skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      test-type: Unit Tests
+      runner-type: gcp-core-4-default

--- a/operate/importer-common/pom.xml
+++ b/operate/importer-common/pom.xml
@@ -11,6 +11,10 @@
 
   <name>Operate Importer Common</name>
 
+  <properties>
+    <excludeITNames>none</excludeITNames>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -137,4 +141,30 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>${excludeITNames}</excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>skipITs</id>
+      <activation>
+        <property>
+          <name>skipITs</name>
+        </property>
+      </activation>
+      <properties>
+        <excludeITNames>**/**/*IT.java</excludeITNames>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Operate Importer</name>
 
+  <properties>
+    <excludeITNames>none</excludeITNames>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -132,9 +136,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <systemPropertyVariables>
-            <spring.profiles.active>test</spring.profiles.active>
-          </systemPropertyVariables>
+          <excludes>${excludeITNames}</excludes>
         </configuration>
       </plugin>
 
@@ -145,5 +147,19 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>skipITs</id>
+      <activation>
+        <property>
+          <name>skipITs</name>
+        </property>
+      </activation>
+      <properties>
+        <excludeITNames>**/**/*IT.java</excludeITNames>
+      </properties>
+    </profile>
+  </profiles>
 
 </project>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -39,6 +39,8 @@
     <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
+    <includeUnitTestNames>*.java</includeUnitTestNames>
+    <excludeUnitTestNames>*IT.java</excludeUnitTestNames>
     <itDatabase>elasticsearch</itDatabase>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
@@ -77,6 +79,12 @@
             <systemPropertyVariables>
               <testForkNumber>$${surefire.forkNumber}</testForkNumber>
             </systemPropertyVariables>
+            <includes>
+              <include>${includeUnitTestNames}</include>
+            </includes>
+            <excludes>
+              <exclude>${excludeUnitTestNames}</exclude>
+            </excludes>
           </configuration>
         </plugin>
 
@@ -166,6 +174,28 @@
         <includeITNames>**/api/v1/**/*IT.java, **/OpenSearch*IT.java, **/Opensearch*IT.java</includeITNames>
         <excludeITNames>none</excludeITNames>
         <skipSurefire>true</skipSurefire>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>operateCoreFeaturesUnitTests</id>
+      <properties>
+        <includeUnitTestNames>*.java</includeUnitTestNames>
+        <excludeUnitTestNames>*IT.java,**/identity/**/*.java,**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</excludeUnitTestNames>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>operateDataLayerUnitTests</id>
+      <properties>
+        <includeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</includeUnitTestNames>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>operateIdentityUnitTests</id>
+      <properties>
+        <includeUnitTestNames>**/identity/**/*.java</includeUnitTestNames>
       </properties>
     </profile>
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -191,6 +191,18 @@
     </profile>
 
     <profile>
+      <id>skipOperateCoreFeaturesUnitTests</id>
+      <activation>
+        <property>
+          <name>skipCoreFeaturesUTs</name>
+        </property>
+      </activation>
+      <properties>
+        <excludeUnitTestNames>*IT.java,**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java</excludeUnitTestNames>
+      </properties>
+    </profile>
+
+    <profile>
       <id>operateDataLayerUnitTests</id>
       <activation>
         <property>
@@ -199,6 +211,18 @@
       </activation>
       <properties>
         <includeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</includeUnitTestNames>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>skipOperateDataLayerUnitTests</id>
+      <activation>
+        <property>
+          <name>skipDataLayerUTs</name>
+        </property>
+      </activation>
+      <properties>
+        <excludeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</excludeUnitTestNames>
       </properties>
     </profile>
 
@@ -213,6 +237,19 @@
         <includeUnitTestNames>**/identity/**/*.java</includeUnitTestNames>
       </properties>
     </profile>
+
+    <profile>
+      <id>skipOperateIdentityUnitTests</id>
+      <activation>
+        <property>
+          <name>skipIdentityUTs</name>
+        </property>
+      </activation>
+      <properties>
+        <excludeUnitTestNames>**/identity/**/*.java</excludeUnitTestNames>
+      </properties>
+    </profile>
+
 
     <!--
       The QA module is enabled per default, but having it in a profile allows us to exclude it easily.

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -39,8 +39,8 @@
     <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
-    <includeUnitTestNames>*.java</includeUnitTestNames>
-    <excludeUnitTestNames>*IT.java</excludeUnitTestNames>
+    <includeUnitTestNames>**/*.java</includeUnitTestNames>
+    <excludeUnitTestNames>**/*IT.java</excludeUnitTestNames>
     <itDatabase>elasticsearch</itDatabase>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
@@ -179,6 +179,11 @@
 
     <profile>
       <id>operateCoreFeaturesUnitTests</id>
+      <activation>
+        <property>
+          <name>runCoreFeaturesUTs</name>
+        </property>
+      </activation>
       <properties>
         <includeUnitTestNames>*.java</includeUnitTestNames>
         <excludeUnitTestNames>*IT.java,**/identity/**/*.java,**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</excludeUnitTestNames>
@@ -187,6 +192,11 @@
 
     <profile>
       <id>operateDataLayerUnitTests</id>
+      <activation>
+        <property>
+          <name>runDataLayerUTs</name>
+        </property>
+      </activation>
       <properties>
         <includeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</includeUnitTestNames>
       </properties>
@@ -194,6 +204,11 @@
 
     <profile>
       <id>operateIdentityUnitTests</id>
+      <activation>
+        <property>
+          <name>runIdentityUTs</name>
+        </property>
+      </activation>
       <properties>
         <includeUnitTestNames>**/identity/**/*.java</includeUnitTestNames>
       </properties>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -178,19 +178,6 @@
     </profile>
 
     <profile>
-      <id>operateCoreFeaturesUnitTests</id>
-      <activation>
-        <property>
-          <name>runCoreFeaturesUTs</name>
-        </property>
-      </activation>
-      <properties>
-        <includeUnitTestNames>*.java</includeUnitTestNames>
-        <excludeUnitTestNames>*IT.java,**/identity/**/*.java,**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</excludeUnitTestNames>
-      </properties>
-    </profile>
-
-    <profile>
       <id>skipOperateCoreFeaturesUnitTests</id>
       <activation>
         <property>
@@ -199,18 +186,6 @@
       </activation>
       <properties>
         <excludeUnitTestNames>*IT.java,**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java</excludeUnitTestNames>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>operateDataLayerUnitTests</id>
-      <activation>
-        <property>
-          <name>runDataLayerUTs</name>
-        </property>
-      </activation>
-      <properties>
-        <includeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</includeUnitTestNames>
       </properties>
     </profile>
 
@@ -227,18 +202,6 @@
     </profile>
 
     <profile>
-      <id>operateIdentityUnitTests</id>
-      <activation>
-        <property>
-          <name>runIdentityUTs</name>
-        </property>
-      </activation>
-      <properties>
-        <includeUnitTestNames>**/identity/**/*.java</includeUnitTestNames>
-      </properties>
-    </profile>
-
-    <profile>
       <id>skipOperateIdentityUnitTests</id>
       <activation>
         <property>
@@ -249,7 +212,6 @@
         <excludeUnitTestNames>**/identity/**/*.java</excludeUnitTestNames>
       </properties>
     </profile>
-
 
     <!--
       The QA module is enabled per default, but having it in a profile allows us to exclude it easily.

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -185,7 +185,7 @@
         </property>
       </activation>
       <properties>
-        <excludeUnitTestNames>*IT.java,**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java</excludeUnitTestNames>
+        <excludeUnitTestNames>**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java</excludeUnitTestNames>
       </properties>
     </profile>
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -152,7 +152,7 @@
 
   <profiles>
     <profile>
-      <id>operateBackendIt</id>
+      <id>operateCoreFeaturesIT</id>
       <properties>
         <includeITNames>**/*IT.java</includeITNames>
         <excludeITNames>**/*ZeebeIT.java, **/*ZeebeImportIT.java, **/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -39,7 +39,6 @@
     <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
-    <includeUnitTestNames>**/*.java</includeUnitTestNames>
     <excludeUnitTestNames>**/*IT.java</excludeUnitTestNames>
     <itDatabase>elasticsearch</itDatabase>
     <maven.javadoc.skip>true</maven.javadoc.skip>
@@ -79,9 +78,6 @@
             <systemPropertyVariables>
               <testForkNumber>$${surefire.forkNumber}</testForkNumber>
             </systemPropertyVariables>
-            <includes>
-              <include>${includeUnitTestNames}</include>
-            </includes>
             <excludes>
               <exclude>${excludeUnitTestNames}</exclude>
             </excludes>

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -530,6 +530,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>${skipITs}</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.2</version>
         <configuration>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/ProbesTestIT.java
@@ -30,7 +30,7 @@ class ProbesTestIT {
   @SpringBootTest(
       classes = TestApplication.class,
       webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-  class SchemaExistsTest {
+  class SchemaExistsIT {
     @Autowired private IndicesCheck indicesCheck;
 
     @Autowired private TestSchemaManager testSchemaManager;
@@ -57,7 +57,7 @@ class ProbesTestIT {
   @SpringBootTest(
       classes = TestApplication.class,
       webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-  class SchemaNotExistsTest {
+  class SchemaNotExistsIT {
     @Autowired private IndicesCheck indicesCheck;
 
     @DynamicPropertySource


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Split apart the `operate-ci.yml` file into different CI files, one that will be owned by the Core Features team (`operate-ci-core-features.yml`), Data Layer team (`operate-ci-data-layer.yml`), and Identity team (`operate-ci-identity.yml`). Each CI file should run tests relevant to that team

The Data Layer CI will run tests related to interacting with Elasticsearch/Opensearch and importing. Core Features will own all business logic tests. Identity owns the tests that interact with the identity module

Unit tests were split apart by file path and file name. Files or paths that contain things like `elasticsearch` or `zeebeimport` will be considered to be Data layer. Identity tests have `identity` in the file path. Core features Unit tests will be tests that are not a part of either Data Layer or Identity test suite

Maven profiles are used to determine which tests to run. The profile uses file names and paths to determine which suit of tests to run

The inner classes for `ProbesTestIT` were renamed so that they are easier to skip when running unit tests. Adding the `IT` suffix allows it to be a part of the skipping regex used in the new maven profile

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/product-hub/issues/2853
- PR splits apart the Operate Tests by team & their functions
