### PR TITLE
pg-31472-operate-tasklist-tls

### DIFF
--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
       # Disable SVE (Scalable Vector Extension) for Java on M4+ machines with "-XX:UseSVE=0"
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0"
-      - "CLI_JAVA_OPTS=-XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
+      - "CLI_JAVA_OPTS=-XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
     ulimits:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Elasticsearch container VM option `-XX:UseSVE=0`  not recognized for amd64 architecture based Elasticsearch containers. The container used in Operate's IT pipeline was failing to startup.

```
Unrecognized VM option 'UseSVE=0'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
