### PR TITLE
fix: ignore vm opts for SVE=0

### DIFF
--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
       # Disable SVE (Scalable Vector Extension) for Java on M4+ machines with "-XX:UseSVE=0"
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0"
-      - "CLI_JAVA_OPTS=-XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
+      - "CLI_JAVA_OPTS=-XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
     ulimits:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The `UseSVE=0` flag exists only on ARM64 Elasticsearch images as a Java option. This causes the ES container to fail to startup with: 
```
Unrecognized VM option 'UseSVE=0'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
``` 
on other platforms, including some of the CI jobs for Operate.
ref run: https://github.com/camunda/camunda/actions/runs/14747631627/job/41397862563?pr=31499#step:9:2893
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
