### PR TITLE
[Backport stable/8.6] fix: ignore vm opts for SVE=0

### DIFF
--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - bootstrap.memory_lock=true
       - xpack.security.enabled=false
       # Disable SVE (Scalable Vector Extension) for Java on M4+ machines with "-XX:UseSVE=0"
-      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0"
-      - "CLI_JAVA_OPTS=-XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m -XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
+      - "CLI_JAVA_OPTS=-XX:UseSVE=0 -XX:+IgnoreUnrecognizedVMOptions"
       - path.repo=/usr/local/els-snapshots
       - action.destructive_requires_name=false
     ulimits:


### PR DESCRIPTION
# Description
Backport of #31526 to `stable/8.6`.

relates to 