### PR TITLE
[Backport release-8.8.0-alpha4] test: fix io.camunda.tasklist.es.ElasticsearchConnectorIT

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.tasklist.es;
 
+import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TestPlugin;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -22,7 +26,6 @@ import java.nio.file.Path;
 import net.bytebuddy.ByteBuddy;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -47,7 +50,7 @@ public class ElasticsearchConnectorIT {
   static ElasticsearchContainer elasticsearch =
       new ElasticsearchContainer(
               DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-                  .withTag(RestClient.class.getPackage().getImplementationVersion()))
+                  .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
           .withEnv("xpack.security.enabled", "false")
           .withEnv("xpack.security.http.ssl.enabled", "false");
 
@@ -62,6 +65,7 @@ public class ElasticsearchConnectorIT {
 
   @BeforeAll
   static void beforeAll() {
+    assumeTrue(TestUtil.isElasticSearch());
     WIRE_MOCK_SERVER.start();
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchConnectorIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.os;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -14,6 +16,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TestPlugin;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -57,6 +60,7 @@ public class OpensearchConnectorIT {
 
   @BeforeAll
   static void beforeAll() {
+    assumeTrue(TestUtil.isOpenSearch());
     OPENSEARCH_CONTAINER.start();
     WIRE_MOCK_SERVER.start();
   }


### PR DESCRIPTION
# Description
Backport of #31517 to `release-8.8.0-alpha4`.

relates to 