### PR TITLE
Feature/29070 decision evaluation assertions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionInstance.java
@@ -97,6 +97,11 @@ public interface DecisionInstance {
   List<MatchedDecisionRule> getMatchedRules();
 
   /**
+   * @return the evaluation result
+   */
+  String getResult();
+
+  /**
    * @return the entity encoded as JSON
    */
   String toJson();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
@@ -51,6 +51,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   private final String tenantId;
   private final List<EvaluatedDecisionInput> evaluatedInputs;
   private final List<MatchedDecisionRule> matchedRules;
+  private final String result;
 
   public DecisionInstanceImpl(final DecisionInstanceResult item, final JsonMapper jsonMapper) {
     this(
@@ -69,7 +70,8 @@ public class DecisionInstanceImpl implements DecisionInstance {
         toDecisionDefinitionType(item.getDecisionDefinitionType()),
         item.getTenantId(),
         null,
-        null);
+        null,
+        item.getResult());
   }
 
   public DecisionInstanceImpl(
@@ -94,7 +96,8 @@ public class DecisionInstanceImpl implements DecisionInstance {
             .collect(Collectors.toList()),
         item.getMatchedRules().stream()
             .map(rule -> new MatchedDecisionRuleImpl(rule, jsonMapper))
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList()),
+        item.getResult());
   }
 
   public DecisionInstanceImpl(
@@ -113,7 +116,8 @@ public class DecisionInstanceImpl implements DecisionInstance {
       final DecisionDefinitionType decisionDefinitionType,
       final String tenantId,
       final List<EvaluatedDecisionInput> evaluatedInputs,
-      final List<MatchedDecisionRule> matchedRules) {
+      final List<MatchedDecisionRule> matchedRules,
+      final String result) {
     this.jsonMapper = jsonMapper;
     this.decisionInstanceKey = decisionInstanceKey;
     this.decisionInstanceId = decisionInstanceId;
@@ -130,6 +134,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
     this.tenantId = tenantId;
     this.evaluatedInputs = evaluatedInputs;
     this.matchedRules = matchedRules;
+    this.result = result;
   }
 
   private static DecisionDefinitionType toDecisionDefinitionType(
@@ -249,6 +254,11 @@ public class DecisionInstanceImpl implements DecisionInstance {
   @Override
   public List<MatchedDecisionRule> getMatchedRules() {
     return matchedRules;
+  }
+
+  @Override
+  public String getResult() {
+    return result;
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -17,6 +17,8 @@ package io.camunda.process.test.api;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
+import io.camunda.process.test.api.assertions.DecisionSelector;
 import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
@@ -24,6 +26,7 @@ import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.UserTaskAssert;
 import io.camunda.process.test.api.assertions.UserTaskSelector;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.assertions.DecisionInstanceAssertj;
 import io.camunda.process.test.impl.assertions.ProcessInstanceAssertj;
 import io.camunda.process.test.impl.assertions.UserTaskAssertj;
 import java.time.Duration;
@@ -177,6 +180,17 @@ public class CamundaAssert {
    */
   public static UserTaskAssert assertThat(final UserTaskSelector userTaskSelector) {
     return new UserTaskAssertj(getDataSource(), userTaskSelector);
+  }
+
+  /**
+   * To verify a decision instance (via business rule task).
+   *
+   * @param decisionSelector the selector of the decision instance to verify
+   * @return the assertion object
+   * @see io.camunda.process.test.api.assertions.DecisionSelectors
+   */
+  public static DecisionInstanceAssert assertThat(final DecisionSelector decisionSelector) {
+    return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
   }
 
   // ======== Internal ========

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+/** The assertion object to verify a decision. */
+public interface DecisionInstanceAssert {
+  /**
+   * Verifies that the decision is evaluated. The verification fails if the decision is not
+   * evaluated or if the evaluation fails.
+   *
+   * <p>The assertion waits until the decision is evaluated.
+   *
+   * @return the assertion object
+   */
+  DecisionInstanceAssert isEvaluated();
+
+  /**
+   * Verifies that the decision is evaluated with the expected output. The verification fails if the
+   * decision is not evaluated or the output does not match.
+   *
+   * @param expectedOutput the expected output value
+   * @return the assertion object
+   */
+  DecisionInstanceAssert hasOutput(final Object expectedOutput);
+
+  /**
+   * Verifies that the decision has matched the given rule indices.
+   *
+   * @param expectedMatchedRuleIndexes the rule indices that should have matched
+   * @return the assertion object
+   */
+  DecisionInstanceAssert hasMatchedRules(final int... expectedMatchedRuleIndexes);
+
+  /**
+   * Verifies that the decision has not matched the given rule indices.
+   *
+   * @param expectedUnmatchedRuleIndexes the rule indices that should not have matched
+   * @return the assertion object
+   */
+  DecisionInstanceAssert hasNotMatchedRules(final int... expectedUnmatchedRuleIndexes);
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
+import io.camunda.client.api.search.response.DecisionInstance;
+
+/** A selector for decisions. */
+@FunctionalInterface
+public interface DecisionSelector {
+  /**
+   * Checks if the decision instance matches the selector.
+   *
+   * @param instance the decision instance
+   * @return {@code true} if the decision matches, otherwise {@code false}
+   */
+  boolean test(DecisionInstance instance);
+
+  /**
+   * Returns a string representation of the selector. It is used to build the failure message of an
+   * assertion. Default: {@link Object#toString()}.
+   *
+   * @return the string representation
+   */
+  default String describe() {
+    return toString();
+  }
+
+  /**
+   * Applies the given filter to limit the search of decision instances that match the selector.
+   * Default: no filtering.
+   *
+   * @param filter the filter used to limit the decision instance search
+   */
+  default void applyFilter(final DecisionInstanceFilter filter) {}
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
+import io.camunda.client.api.search.response.DecisionInstance;
+
+/** A collection of predefined {@link DecisionSelector}s. */
+public class DecisionSelectors {
+
+  public static DecisionSelector byProcessInstanceKey(final long processInstanceKey) {
+    return new DecisionProcessInstanceKeySelector(processInstanceKey);
+  }
+
+  /**
+   * Select the decision instance by its name.
+   *
+   * @param decisionName the definition name of the decision.
+   * @return the selector
+   */
+  public static DecisionSelector byName(final String decisionName) {
+    return new DecisionNameSelector(decisionName);
+  }
+
+  /**
+   * Select the decision instance by its name.
+   *
+   * @param decisionName the definition name of the decision.
+   * @param processInstanceKey the associated process instance.
+   * @return the selector
+   */
+  public static DecisionSelector byName(final String decisionName, final long processInstanceKey) {
+    return new DecisionNameSelector(decisionName, processInstanceKey);
+  }
+
+  /**
+   * Select the decision instance by its ID.
+   *
+   * @param decisionId the definition ID of the decision instance.
+   * @return the selector
+   */
+  public static DecisionSelector byId(final String decisionId) {
+    return new DecisionIdSelector(decisionId);
+  }
+
+  /**
+   * Select the decision instance by its ID.
+   *
+   * @param decisionId the definition ID of the decision instance.
+   * @param processInstanceKey the associated process instance
+   * @return the selector
+   */
+  public static DecisionSelector byId(final String decisionId, final long processInstanceKey) {
+    return new DecisionIdSelector(decisionId, processInstanceKey);
+  }
+
+  private static final class DecisionProcessInstanceKeySelector implements DecisionSelector {
+
+    private final Long processInstanceKey;
+
+    private DecisionProcessInstanceKeySelector(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+    }
+
+    @Override
+    public boolean test(final DecisionInstance decisionInstance) {
+      return true; // We're assuming that this will be the correct decision instance.
+    }
+
+    @Override
+    public String describe() {
+      return String.format("%d", processInstanceKey);
+    }
+
+    @Override
+    public void applyFilter(final DecisionInstanceFilter filter) {
+      filter.processInstanceKey(processInstanceKey);
+    }
+  }
+
+  private static final class DecisionIdSelector implements DecisionSelector {
+
+    private final String decisionDefinitionId;
+    private final Long processInstanceKey;
+
+    private DecisionIdSelector(final String decisionDefinitionId) {
+      this(decisionDefinitionId, null);
+    }
+
+    private DecisionIdSelector(final String decisionDefinitionId, final Long processInstanceKey) {
+      this.decisionDefinitionId = decisionDefinitionId;
+      this.processInstanceKey = processInstanceKey;
+    }
+
+    @Override
+    public boolean test(final DecisionInstance decisionInstance) {
+      return decisionDefinitionId.equals(decisionInstance.getDecisionDefinitionId());
+    }
+
+    @Override
+    public String describe() {
+      if (processInstanceKey != null) {
+        return String.format(
+            "%s (processInstanceKey: %d)", decisionDefinitionId, processInstanceKey);
+      } else {
+        return decisionDefinitionId;
+      }
+    }
+
+    @Override
+    public void applyFilter(final DecisionInstanceFilter filter) {
+      filter.decisionDefinitionId(decisionDefinitionId);
+      if (processInstanceKey != null) {
+        filter.processInstanceKey(processInstanceKey);
+      }
+    }
+  }
+
+  private static final class DecisionNameSelector implements DecisionSelector {
+
+    private final String decisionDefinitionName;
+    private final Long processInstanceKey;
+
+    private DecisionNameSelector(final String decisionDefinitionName) {
+      this(decisionDefinitionName, null);
+    }
+
+    private DecisionNameSelector(
+        final String decisionDefinitionName, final Long processInstanceKey) {
+
+      this.decisionDefinitionName = decisionDefinitionName;
+      this.processInstanceKey = processInstanceKey;
+    }
+
+    @Override
+    public boolean test(final DecisionInstance userTask) {
+      return decisionDefinitionName.equals(userTask.getDecisionDefinitionName());
+    }
+
+    @Override
+    public String describe() {
+      if (processInstanceKey != null) {
+        return String.format(
+            "%s (processInstanceKey: %d)", decisionDefinitionName, processInstanceKey);
+      } else {
+        return decisionDefinitionName;
+      }
+    }
+
+    @Override
+    public void applyFilter(final DecisionInstanceFilter filter) {
+      filter.decisionDefinitionName(decisionDefinitionName);
+      if (processInstanceKey != null) {
+        filter.processInstanceKey(processInstanceKey);
+      }
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/UserTaskSelectors.java
@@ -85,7 +85,11 @@ public class UserTaskSelectors {
 
     @Override
     public String describe() {
-      return elementId;
+      if (processInstanceKey != null) {
+        return String.format("%s (processInstanceKey: %d)", elementId, processInstanceKey);
+      } else {
+        return elementId;
+      }
     }
 
     @Override
@@ -118,7 +122,11 @@ public class UserTaskSelectors {
 
     @Override
     public String describe() {
-      return taskName;
+      if (processInstanceKey != null) {
+        return String.format("%s (processInstanceKey: %d)", taskName, processInstanceKey);
+      } else {
+        return taskName;
+      }
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -16,12 +16,15 @@
 package io.camunda.process.test.impl.assertions;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -105,5 +108,18 @@ public class CamundaDataSource {
         .send()
         .join()
         .items();
+  }
+
+  public List<DecisionInstance> findDecisionInstances(
+      final Consumer<DecisionInstanceFilter> filter) {
+    return client.newDecisionInstanceSearchRequest().filter(filter).send().join().items();
+  }
+
+  public DecisionInstance getDecisionInstance(final String decisionInstanceId) {
+    return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
+  }
+
+  public JsonMapper getJsonMapper() {
+    return client.getConfiguration().getJsonMapper();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionInstanceAssertj.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.MatchedDecisionRule;
+import io.camunda.client.api.search.response.DecisionInstance;
+import io.camunda.client.api.search.response.DecisionInstanceState;
+import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
+import io.camunda.process.test.api.assertions.DecisionSelector;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractAssert;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+
+public class DecisionInstanceAssertj
+    extends AbstractAssert<DecisionInstanceAssertj, DecisionSelector>
+    implements DecisionInstanceAssert {
+
+  private final CamundaDataSource dataSource;
+
+  public DecisionInstanceAssertj(
+      final CamundaDataSource dataSource, final DecisionSelector decisionSelector) {
+
+    super(decisionSelector, DecisionInstanceAssert.class);
+    this.dataSource = dataSource;
+  }
+
+  @Override
+  public DecisionInstanceAssert isEvaluated() {
+    awaitDecisionInstance(
+        instance ->
+            assertThat(instance.getState())
+                .withFailMessage(
+                    "Expected [%s] to have been evaluated, but was %s",
+                    actual.describe(), formatState(instance.getState()))
+                .isEqualTo(DecisionInstanceState.EVALUATED));
+    return this;
+  }
+
+  @Override
+  public DecisionInstanceAssert hasOutput(final Object expectedOutput) {
+    awaitDecisionInstance(
+        instance -> {
+          try {
+            final Object result =
+                dataSource.getJsonMapper().fromJson(instance.getResult(), Object.class);
+
+            assertThat(result)
+                .withFailMessage(
+                    "Expected [%s] to have output '%s', but was '%s'",
+                    actual.describe(), expectedOutput, formatResult(instance.getResult()))
+                .isEqualTo(expectedOutput);
+          } catch (final ClientException | IllegalArgumentException e) {
+            // instance.getResult() could not be deserialized.
+            fail(
+                "Expected [%s] to have output '%s', but was '%s'",
+                actual.describe(), expectedOutput, formatResult(instance.getResult()));
+          }
+        });
+
+    return this;
+  }
+
+  @Override
+  public DecisionInstanceAssert hasMatchedRules(final int... expectedMatchedRuleIndexes) {
+    final List<Integer> expectedMatches =
+        Arrays.stream(expectedMatchedRuleIndexes).boxed().collect(Collectors.toList());
+
+    awaitDecisionInstance(
+        instance -> {
+          final List<Integer> actualMatchedRuleIndices =
+              instance.getMatchedRules().stream()
+                  .map(MatchedDecisionRule::getRuleIndex)
+                  .collect(Collectors.toList());
+
+          assertThat(actualMatchedRuleIndices)
+              .withFailMessage(
+                  "Expected [%s] to have matched rules %s, but did not. Matches:\n"
+                      + "\t- matched: %s\n"
+                      + "\t- missing: %s\n"
+                      + "\t- unexpected: %s",
+                  actual.describe(),
+                  Arrays.toString(expectedMatchedRuleIndexes),
+                  matchingRules(actualMatchedRuleIndices, expectedMatches),
+                  missingRules(actualMatchedRuleIndices, expectedMatches),
+                  unexpectedRules(actualMatchedRuleIndices, expectedMatches))
+              .containsAll(expectedMatches);
+        });
+
+    return this;
+  }
+
+  @Override
+  public DecisionInstanceAssert hasNotMatchedRules(final int... expectedUnmatchedRuleIndexes) {
+    final List<Integer> expectedUnmatchedRules =
+        Arrays.stream(expectedUnmatchedRuleIndexes).boxed().collect(Collectors.toList());
+
+    awaitDecisionInstance(
+        instance -> {
+          final List<Integer> actualMatchedRuleIndices =
+              instance.getMatchedRules().stream()
+                  .map(MatchedDecisionRule::getRuleIndex)
+                  .collect(Collectors.toList());
+
+          assertThat(actualMatchedRuleIndices)
+              .withFailMessage(
+                  "Expected [%s] to not have matched rules %s, but matched %s",
+                  actual.describe(),
+                  Arrays.toString(expectedUnmatchedRuleIndexes),
+                  matchingRules(actualMatchedRuleIndices, expectedUnmatchedRules))
+              .doesNotContainAnyElementsOf(expectedUnmatchedRules);
+        });
+
+    return this;
+  }
+
+  private <T> List<T> matchingRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return expectedMatches.stream().filter(actualMatches::contains).collect(Collectors.toList());
+  }
+
+  private <T> List<T> missingRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return expectedMatches.stream()
+        .filter(e -> actualMatches.stream().noneMatch(a -> Objects.equals(a, e)))
+        .collect(Collectors.toList());
+  }
+
+  private <T> List<T> unexpectedRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return actualMatches.stream()
+        .filter(e -> expectedMatches.stream().noneMatch(a -> Objects.equals(a, e)))
+        .collect(Collectors.toList());
+  }
+
+  private String formatState(final DecisionInstanceState state) {
+    if (state == null) {
+      return "not activated";
+    }
+
+    return state.name().toLowerCase();
+  }
+
+  private Object formatResult(final String result) {
+    return dataSource.getJsonMapper().fromJson(result, Object.class);
+  }
+
+  private void awaitDecisionInstance(final Consumer<DecisionInstance> assertion) {
+    final AtomicReference<String> failureMessage = new AtomicReference<>("?");
+
+    try {
+      Awaitility.await()
+          .ignoreException(ClientException.class)
+          .untilAsserted(
+              () -> dataSource.findDecisionInstances(actual::applyFilter),
+              decisionInstances -> {
+                final Optional<DecisionInstance> discoveredDecisionInstance =
+                    decisionInstances.stream().filter(actual::test).findFirst();
+
+                try {
+                  assertThat(discoveredDecisionInstance)
+                      .withFailMessage("No decision instance [%s] found.", actual.describe())
+                      .isPresent();
+                  // We need to use the getById endpoint because only that endpoint contains
+                  // the matchedRules() and evaluatedInput data.
+                  final DecisionInstance completeDecisionInstance =
+                      dataSource.getDecisionInstance(
+                          discoveredDecisionInstance.get().getDecisionInstanceId());
+
+                  assertion.accept(completeDecisionInstance);
+                } catch (final AssertionError e) {
+                  failureMessage.set(e.getMessage());
+                  throw e;
+                }
+              });
+    } catch (final ConditionTimeoutException ignore) {
+      fail(failureMessage.get());
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionInstanceAssertTest.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.MatchedDecisionRule;
+import io.camunda.client.api.search.response.DecisionDefinitionType;
+import io.camunda.client.api.search.response.DecisionInstance;
+import io.camunda.client.api.search.response.DecisionInstanceState;
+import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.impl.response.MatchedDecisionRuleImpl;
+import io.camunda.client.impl.search.response.DecisionInstanceImpl;
+import io.camunda.client.protocol.rest.DecisionInstanceResult;
+import io.camunda.client.protocol.rest.DecisionInstanceStateEnum;
+import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
+import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
+import io.camunda.process.test.api.assertions.DecisionSelectors;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DecisionInstanceAssertTest {
+
+  private static final String NAME = "name";
+  private static final String DECISION_INSTANCE_ID = "instanceId";
+  private static final String DECISION_INSTANCE_KEY = "1";
+  private static final String PROCESS_DEFINITION_KEY = "2";
+  private static final String PROCESS_INSTANCE_KEY = "3";
+  private static final String DECISION_DEFINITION_KEY = "4";
+  private static final int DECISION_DEFINITION_VERSION = 1;
+
+  @Mock private CamundaDataSource camundaDataSource;
+
+  @BeforeEach
+  void configureAssertions() {
+    CamundaAssert.initialize(camundaDataSource);
+    CamundaAssert.setAssertionInterval(Duration.ZERO);
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
+  }
+
+  @AfterEach
+  void resetAssertions() {
+    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+  }
+
+  private void mockDecisionInstanceSearch(final DecisionInstance mockedResult) {
+    mockDecisionInstanceSearch(Collections.singletonList(mockedResult), mockedResult);
+  }
+
+  private void mockDecisionInstanceSearch(
+      final List<DecisionInstance> mockedSearchResults,
+      final DecisionInstance mockedDecisionInstance) {
+
+    when(camundaDataSource.findDecisionInstances(any())).thenReturn(mockedSearchResults);
+    when(camundaDataSource.getDecisionInstance(DECISION_INSTANCE_ID))
+        .thenReturn(mockedDecisionInstance);
+  }
+
+  private DecisionInstance decisionInstance(
+      Function<DecisionInstanceResult, DecisionInstanceResult> resultBuilderFn) {
+    final DecisionInstanceResult basicResult =
+        new DecisionInstanceResult()
+            .decisionDefinitionName(NAME)
+            .decisionInstanceId(DECISION_INSTANCE_ID)
+            .decisionInstanceKey(DECISION_INSTANCE_KEY)
+            .processDefinitionKey(PROCESS_DEFINITION_KEY)
+            .processInstanceKey(PROCESS_INSTANCE_KEY)
+            .decisionDefinitionKey(DECISION_DEFINITION_KEY)
+            .decisionDefinitionVersion(DECISION_DEFINITION_VERSION);
+
+    return new DecisionInstanceImpl(resultBuilderFn.apply(basicResult), null);
+  }
+
+  private DecisionInstance decisionInstanceWithAnswers(
+      final String result, final MatchedDecisionRule... rules) {
+    final List<MatchedDecisionRule> rulesList = Arrays.stream(rules).collect(Collectors.toList());
+
+    return new DecisionInstanceImpl(
+        null,
+        Integer.parseInt(DECISION_INSTANCE_KEY),
+        DECISION_INSTANCE_ID,
+        DecisionInstanceState.EVALUATED,
+        null,
+        null,
+        Long.parseLong(PROCESS_DEFINITION_KEY),
+        Long.parseLong(PROCESS_INSTANCE_KEY),
+        Long.parseLong(DECISION_DEFINITION_KEY),
+        "decisionDefinitionId",
+        NAME,
+        1,
+        DecisionDefinitionType.DECISION_TABLE,
+        "tenantId",
+        Collections.emptyList(),
+        rulesList,
+        result);
+  }
+
+  private MatchedDecisionRule rule(MatchedDecisionRuleItem ruleItem) {
+    return new MatchedDecisionRuleImpl(ruleItem, null);
+  }
+
+  private MatchedDecisionRule singleRule() {
+    return rule(
+        new MatchedDecisionRuleItem()
+            .ruleId("ruleId")
+            .ruleIndex(1)
+            .addEvaluatedOutputsItem(
+                new EvaluatedDecisionOutputItem()
+                    .outputId("outputId")
+                    .outputName("outputName")
+                    .outputValue("outputValue")));
+  }
+
+  private MatchedDecisionRule[] multiRule() {
+    return new MatchedDecisionRule[] {
+      rule(
+          new MatchedDecisionRuleItem()
+              .ruleId("ruleId1")
+              .ruleIndex(1)
+              .addEvaluatedOutputsItem(
+                  new EvaluatedDecisionOutputItem()
+                      .outputId("outputId1")
+                      .outputName("outputName1")
+                      .outputValue("outputValue1"))),
+      rule(
+          new MatchedDecisionRuleItem()
+              .ruleId("ruleId2")
+              .ruleIndex(2)
+              .addEvaluatedOutputsItem(
+                  new EvaluatedDecisionOutputItem()
+                      .outputId("outputId2")
+                      .outputName("outputName2")
+                      .outputValue("outputValue2"))),
+      rule(
+          new MatchedDecisionRuleItem()
+              .ruleId("ruleId3")
+              .ruleIndex(3)
+              .addEvaluatedOutputsItem(
+                  new EvaluatedDecisionOutputItem()
+                      .outputId("outputId3")
+                      .outputName("outputName3")
+                      .outputValue("outputValue3")))
+    };
+  }
+
+  @Nested
+  public class IsEvaluated {
+
+    @Test
+    public void isEvaluated() {
+      // when
+      mockDecisionInstanceSearch(
+          decisionInstance(d -> d.state(DecisionInstanceStateEnum.EVALUATED)));
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).isEvaluated();
+    }
+
+    @Test
+    public void evaluationFailure() {
+      // when
+      mockDecisionInstanceSearch(decisionInstance(d -> d.state(DecisionInstanceStateEnum.FAILED)));
+
+      // then
+      Assertions.assertThatThrownBy(() -> assertThat(DecisionSelectors.byName(NAME)).isEvaluated())
+          .hasMessage("Expected [name] to have been evaluated, but was failed");
+    }
+  }
+
+  @Nested
+  public class HasOutput {
+
+    @Test
+    public void hasOutputWithStringMatch() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("\"outputValue\""));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).hasOutput("outputValue");
+    }
+
+    @Test
+    public void hasOutputWithSingleMapMatch() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("{\"a\":\"b\",\"v\":2}"));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      final Map<String, Object> expected = new HashMap<>();
+      expected.put("a", "b");
+      expected.put("v", 2);
+      assertThat(DecisionSelectors.byName(NAME)).hasOutput(expected);
+    }
+
+    @Test
+    public void hasOutputWithListMatch() {
+      // when
+      mockDecisionInstanceSearch(
+          decisionInstanceWithAnswers("[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]"));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      final Map<String, Object> firstMatch = new HashMap<>();
+      firstMatch.put("a", 1);
+      firstMatch.put("b", 2);
+      final Map<String, Object> secondMatch = new HashMap<>();
+      secondMatch.put("c", 3);
+      secondMatch.put("d", 4);
+
+      // All of these should match
+      assertThat(DecisionSelectors.byName(NAME)).hasOutput(Arrays.asList(firstMatch, secondMatch));
+    }
+
+    @Test
+    public void assertionFailureWithStringMatch() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("\"outputValue\""));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput("foo"))
+          .hasMessage("Expected [name] to have output 'foo', but was 'outputValue'");
+
+      final Map<String, Object> expected = new HashMap<>();
+      expected.put("a", "b");
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput(expected))
+          .hasMessage("Expected [name] to have output '{a=b}', but was 'outputValue'");
+    }
+
+    @Test
+    public void assertionFailureWithMapMatch() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("{\"a\":1,\"b\":2}"));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput("foo"))
+          .hasMessage("Expected [name] to have output 'foo', but was '{a=1, b=2}'");
+
+      final Map<String, Object> expected = new HashMap<>();
+      expected.put("a", "b");
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput(expected))
+          .hasMessage("Expected [name] to have output '{a=b}', but was '{a=1, b=2}'");
+    }
+
+    @Test
+    public void assertionFailureWithListMatch() {
+      // when
+      mockDecisionInstanceSearch(
+          decisionInstanceWithAnswers("[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]"));
+      when(camundaDataSource.getJsonMapper()).thenReturn(new CamundaObjectMapper());
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput("foo"))
+          .hasMessage("Expected [name] to have output 'foo', but was '[{a=1, b=2}, {c=3, d=4}]'");
+
+      final Map<String, Object> expected = new HashMap<>();
+      expected.put("a", "b");
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasOutput(expected))
+          .hasMessage("Expected [name] to have output '{a=b}', but was '[{a=1, b=2}, {c=3, d=4}]'");
+    }
+  }
+
+  @Nested
+  public class HasMatchedRulesIndices {
+    @Test
+    public void hasMatched() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).hasMatchedRules(1);
+    }
+
+    @Test
+    public void hasNotMatched() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasMatchedRules(2))
+          .hasMessage(
+              "Expected [name] to have matched rules [2], but did not. Matches:\n"
+                  + "\t- matched: []\n"
+                  + "\t- missing: [2]\n"
+                  + "\t- unexpected: [1]");
+    }
+
+    @Test
+    public void noMatchesExist() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue"));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasMatchedRules(2))
+          .hasMessage(
+              "Expected [name] to have matched rules [2], but did not. Matches:\n"
+                  + "\t- matched: []\n"
+                  + "\t- missing: [2]\n"
+                  + "\t- unexpected: []");
+    }
+
+    @Test
+    public void hasMatchedMultiple() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", multiRule()));
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).hasMatchedRules(1, 2, 3);
+    }
+
+    @Test
+    public void hasMatchedPartial() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", multiRule()));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasMatchedRules(1, 2, 4))
+          .hasMessage(
+              "Expected [name] to have matched rules [1, 2, 4], but did not. Matches:\n"
+                  + "\t- matched: [1, 2]\n"
+                  + "\t- missing: [4]\n"
+                  + "\t- unexpected: [3]");
+    }
+  }
+
+  @Nested
+  public class HasNotMatchedRulesIndices {
+    @Test
+    public void hasNotMatched() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).hasNotMatchedRules(2);
+    }
+
+    @Test
+    public void hasNotMatchedMultiple() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", multiRule()));
+
+      // then
+      assertThat(DecisionSelectors.byName(NAME)).hasNotMatchedRules(4, 5, 6);
+    }
+
+    @Test
+    public void hasMatched() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", singleRule()));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasNotMatchedRules(1))
+          .hasMessage("Expected [name] to not have matched rules [1], but matched [1]");
+    }
+
+    @Test
+    public void hasMatchedPartial() {
+      // when
+      mockDecisionInstanceSearch(decisionInstanceWithAnswers("outputValue", multiRule()));
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> assertThat(DecisionSelectors.byName(NAME)).hasNotMatchedRules(4, 1, 5))
+          .hasMessage("Expected [name] to not have matched rules [4, 1, 5], but matched [1]");
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/resources/dmn/decision-table-collect.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/decision-table-collect.dmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="jedi_or_sith_dmn" name="Jedi or Sith" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="b46fab0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_07h1nu7" hitPolicy="COLLECT">
+      <input id="Input_1" label="lightsaber_color">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaber_color</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="jedi_or_sith" name="jedi_or_sith" typeRef="string" />
+      <output id="OutputClause_1bzbl68" label="force_user" name="force_user" typeRef="string" />
+      <rule id="DecisionRule_0n6gbjm">
+        <inputEntry id="UnaryTests_1q1soz5">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0641l7f">
+          <text>"jedi"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ukiqrw">
+          <text>"Mace"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_15ce11f">
+        <inputEntry id="UnaryTests_0te6osg">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0seitk7">
+          <text>"jedi"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ygjqzh">
+          <text>"Anakin"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01sgj8o">
+        <inputEntry id="UnaryTests_1n1corz">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0kqonhr">
+          <text>"sith"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_145c3na">
+          <text>"Mace"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utrev9">
+        <inputEntry id="UnaryTests_0r0bxn4">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ugrkdt">
+          <text>"sith"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0lqhtsb">
+          <text>"Darth Maul"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/testing/camunda-process-test-java/src/test/resources/dmn/decision-table-unique.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/decision-table-unique.dmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="jedi_or_sith_dmn" name="Jedi or Sith" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="b46fab0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="jedi_or_sith" name="Jedi or Sith">
+    <decisionTable id="DecisionTable_07h1nu7" hitPolicy="UNIQUE">
+      <input id="Input_1" label="lightsaber_color">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>lightsaber_color</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="jedi_or_sith" name="jedi_or_sith" typeRef="string" />
+      <output id="OutputClause_1bzbl68" label="force_user" name="force_user" typeRef="string" />
+      <rule id="DecisionRule_0n6gbjm">
+        <inputEntry id="UnaryTests_1q1soz5">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0641l7f">
+          <text>"jedi"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ukiqrw">
+          <text>"Mace"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_15ce11f">
+        <inputEntry id="UnaryTests_0te6osg">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0seitk7">
+          <text>"jedi"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1ygjqzh">
+          <text>"Anakin"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_01sgj8o">
+        <inputEntry id="UnaryTests_1n1corz">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0kqonhr">
+          <text>"sith"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_145c3na">
+          <text>"Mace"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1utrev9">
+        <inputEntry id="UnaryTests_0r0bxn4">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ugrkdt">
+          <text>"sith"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0lqhtsb">
+          <text>"Darth Maul"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="jedi_or_sith">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/testing/camunda-process-test-java/src/test/resources/dmn/simple-decision-table-collect.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/simple-decision-table-collect.dmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0v4wfk6" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="b46fab0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="simple_decision" name="Simple Decision">
+    <decisionTable id="DecisionTable_1wz9myc" hitPolicy="COLLECT">
+      <input id="Input_1" label="yes_or_no">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>yes_or_no</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="result" name="result" typeRef="Any" />
+      <rule id="DecisionRule_0ikukos">
+        <inputEntry id="UnaryTests_1kvwstk">
+          <text>"yes"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05nw9v9">
+          <text>":)"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_02ysge9">
+        <inputEntry id="UnaryTests_0i50ybj">
+          <text>"no"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02z6d5t">
+          <text>":("</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1216938">
+        <inputEntry id="UnaryTests_1kozd3j">
+          <text>"yes"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0y4c35r">
+          <text>1</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="simple_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/testing/camunda-process-test-java/src/test/resources/dmn/simple-decision-table.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/simple-decision-table.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0v4wfk6" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="b46fab0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="simple_decision" name="Simple Decision">
+    <decisionTable id="DecisionTable_1wz9myc">
+      <input id="Input_1" label="yes_or_no">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>yes_or_no</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="result" name="result" typeRef="string" />
+      <rule id="DecisionRule_0ikukos">
+        <inputEntry id="UnaryTests_1kvwstk">
+          <text>"yes"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05nw9v9">
+          <text>":)"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_02ysge9">
+        <inputEntry id="UnaryTests_0i50ybj">
+          <text>"no"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_02z6d5t">
+          <text>":("</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="simple_decision">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

As a user, I want to verify the evaluations of DMN decisions with Camunda Process Test. This PR aims to implement several assertions for a DecisionInstance object via business rule tasks. A future PR will expand the assertion suite to include decisions evaluated via camunda client.

## Related issues

closes #31543
