### PR TITLE
[Backport release-8.8.0-alpha4] fix: add operate, tasklist alpine libraries required for secure commu…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,6 +613,8 @@ jobs:
             docker-file: camunda.Dockerfile
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+      OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
+      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
       CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
     services:
@@ -637,6 +639,22 @@ jobs:
           repository: ${{ matrix.docker-repository }}
           version: ${{ env.DOCKER_IMAGE_TAG }}
           dockerfile: ${{ matrix.docker-file }}
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - uses: ./.github/actions/build-platform-docker
+        if: ${{ matrix.group == 'root' }}
+        with:
+          repository: localhost:5000/camunda/operate
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: operate.Dockerfile
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - uses: ./.github/actions/build-platform-docker
+        if: ${{ matrix.group == 'root' }}
+        with:
+          repository: localhost:5000/camunda/tasklist
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: tasklist.Dockerfile
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Create build output log file

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -60,7 +60,7 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 EXPOSE 8080
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata
+RUN apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
 
 ENV OPE_HOME=/usr/local/operate
 

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -457,6 +457,21 @@
       <artifactId>process-migration</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -16,12 +16,10 @@ import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
-import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebePort;
-import io.zeebe.containers.util.RemoteDebugger;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -33,7 +31,6 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -42,7 +39,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 @Testcontainers
-final class SecureClusteredMessagingIT {
+final class SecuredClusteredMessagingIT {
   private static final SelfSignedCertificate CERTIFICATE = newCertificate();
   private static final DockerImageName OPERATE =
       DockerImageName.parse("camunda/operate").withTag("current-test");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -25,6 +25,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AutoClose;
@@ -41,10 +42,16 @@ import org.testcontainers.utility.MountableFile;
 @Testcontainers
 final class SecuredClusteredMessagingIT {
   private static final SelfSignedCertificate CERTIFICATE = newCertificate();
-  private static final DockerImageName OPERATE =
-      DockerImageName.parse("camunda/operate").withTag("current-test");
-  private static final DockerImageName TASKLIST =
-      DockerImageName.parse("camunda/tasklist").withTag("current-test");
+
+  private static final String OPERATE_IMAGE_NAME =
+      Optional.ofNullable(System.getenv("OPERATE_TEST_DOCKER_IMAGE"))
+          .orElse("camunda/operate:current-test");
+  private static final String TASKLIST_IMAGE_NAME =
+      Optional.ofNullable(System.getenv("TASKLIST_TEST_DOCKER_IMAGE"))
+          .orElse("camunda/tasklist:current-test");
+
+  private static final DockerImageName OPERATE = DockerImageName.parse(OPERATE_IMAGE_NAME);
+  private static final DockerImageName TASKLIST = DockerImageName.parse(TASKLIST_IMAGE_NAME);
 
   @AutoClose private static final Network NETWORK = Network.newNetwork();
 
@@ -53,7 +60,8 @@ final class SecuredClusteredMessagingIT {
   private static final ElasticsearchContainer ELASTIC =
       TestSearchContainers.createDefeaultElasticsearchContainer()
           .withNetwork(NETWORK)
-          .withNetworkAliases("elastic");
+          .withNetworkAliases("elastic")
+          .withStartupTimeout(Duration.ofMinutes(5));
 
   private final String testPrefix = UUID.randomUUID().toString();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/network/SecuredClusterMessagingIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.network;
+
+import static io.camunda.zeebe.test.util.asserts.TopologyAssert.assertThat;
+
+import io.atomix.utils.net.Address;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Topology;
+import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.asserts.SslAssert;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebePort;
+import io.zeebe.containers.util.RemoteDebugger;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.security.cert.CertificateException;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@Testcontainers
+final class SecureClusteredMessagingIT {
+  private static final SelfSignedCertificate CERTIFICATE = newCertificate();
+  private static final DockerImageName OPERATE =
+      DockerImageName.parse("camunda/operate").withTag("current-test");
+  private static final DockerImageName TASKLIST =
+      DockerImageName.parse("camunda/tasklist").withTag("current-test");
+
+  @AutoClose private static final Network NETWORK = Network.newNetwork();
+
+  @SuppressWarnings("unused")
+  @Container
+  private static final ElasticsearchContainer ELASTIC =
+      TestSearchContainers.createDefeaultElasticsearchContainer()
+          .withNetwork(NETWORK)
+          .withNetworkAliases("elastic");
+
+  private final String testPrefix = UUID.randomUUID().toString();
+
+  @Container
+  private final ZeebeContainer zeebe =
+      new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+          .withNetwork(NETWORK)
+          .withNetworkAliases("zeebe")
+          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
+          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
+          .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
+              "/tmp/certificate.pem")
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
+          .withEnv("CAMUNDA_DATABASE_TYPE", "elasticsearch")
+          .withEnv("CAMUNDA_DATABASE_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
+          .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", "zeebe")
+          .withEnv(
+              "ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME", "io.camunda.exporter.CamundaExporter")
+          .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDA_ARGS_CONNECT_URL", "http://elastic:9200")
+          .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDA_ARGS_CONNECT_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_LOG_LEVEL", "DEBUG")
+          .withAdditionalExposedPort(8080)
+          .withAdditionalExposedPort(ZeebePort.INTERNAL.getPort());
+
+  @Container
+  private final GenericContainer<?> operate =
+      new GenericContainer<>(OPERATE)
+          .withNetworkAliases("operate")
+          .withNetwork(NETWORK)
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", "zeebe:26502")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "operate")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", "operate")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
+              "/tmp/certificate.pem")
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
+          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_DATABASE_TYPE", "elasticsearch")
+          .withEnv("CAMUNDA_DATABASE_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
+          .withEnv("CAMUNDA_LOG_LEVEL", "DEBUG")
+          .withExposedPorts(8080, 9600, 26502)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/actuator/health/readiness")
+                  .forPort(9600)
+                  .withStartupTimeout(Duration.ofSeconds(60)))
+          .dependsOn(zeebe);
+
+  @Container
+  private final GenericContainer<?> tasklist =
+      new GenericContainer<>(TASKLIST)
+          .withNetworkAliases("tasklist")
+          .withNetwork(NETWORK)
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", "zeebe:26502")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "tasklist")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", "tasklist")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_ENABLED", "true")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_CERTIFICATECHAINPATH", "/tmp/certificate.pem")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_SECURITY_PRIVATEKEYPATH", "/tmp/key.pem")
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.certificate().toPath(), 0777),
+              "/tmp/certificate.pem")
+          .withCopyToContainer(
+              MountableFile.forHostPath(CERTIFICATE.privateKey().toPath(), 0777), "/tmp/key.pem")
+          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_DATABASE_TYPE", "elasticsearch")
+          .withEnv("CAMUNDA_DATABASE_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_INDEXPREFIX", testPrefix)
+          .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", "http://elastic:9200")
+          .withEnv("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebe.getInternalGatewayAddress())
+          .withEnv(
+              "CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS", "http://" + zeebe.getInternalHost() + ":8080")
+          .withEnv("CAMUNDA_LOG_LEVEL", "DEBUG")
+          .withExposedPorts(8080, 9600, 26502)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPath("/actuator/health/readiness")
+                  .forPort(9600)
+                  .withStartupTimeout(Duration.ofSeconds(60)))
+          .dependsOn(zeebe);
+
+  @Test
+  void shouldFormAClusterWithTlsWithCertChain() {
+    // given - a cluster with Zeebe, Operate, and Tasklist
+
+    // when - note the client is using plaintext since we only care about inter-cluster TLS
+    final Topology topology;
+    try (final var client =
+        CamundaClient.newClientBuilder()
+            .usePlaintext()
+            .restAddress(
+                URI.create("http://" + zeebe.getExternalHost() + ":" + zeebe.getMappedPort(8080)))
+            .grpcAddress(
+                URI.create("http://" + zeebe.getExternalHost() + ":" + zeebe.getMappedPort(26500)))
+            .build()) {
+      topology = client.newTopologyRequest().send().join(15, TimeUnit.SECONDS);
+    }
+
+    // then
+    assertThat(topology).isComplete(1, 1, 1);
+    assertInternalPortIsSecured(zeebe);
+    assertInternalPortIsSecured(operate);
+    assertInternalPortIsSecured(tasklist);
+  }
+
+  /** Verifies that both the command and internal APIs of the broker are correctly secured. */
+  private void assertInternalPortIsSecured(final GenericContainer<?> container) {
+    final var internalApiAddress =
+        new InetSocketAddress(
+            container.getContainerIpAddress(),
+            container.getMappedPort(ZeebePort.INTERNAL.getPort()));
+
+    assertAddressIsSecured(container.getNetworkAliases(), internalApiAddress);
+  }
+
+  private InetSocketAddress getGatewayAddress(final TestCluster cluster) {
+    final ClusterCfg clusterConfig = cluster.availableGateway().gatewayConfig().getCluster();
+    final var address =
+        Address.from(clusterConfig.getAdvertisedHost(), clusterConfig.getAdvertisedPort());
+    return address.socketAddress();
+  }
+
+  private void assertAddressIsSecured(final Object nodeId, final SocketAddress address) {
+    SslAssert.assertThat(address)
+        .as("node %s is not secured correctly at address %s", nodeId, address)
+        .isSecuredBy(CERTIFICATE);
+  }
+
+  private static SelfSignedCertificate newCertificate() {
+    try {
+      return new SelfSignedCertificate();
+    } catch (final CertificateException e) {
+      throw new IllegalStateException("Failed to create self-signed certificate", e);
+    }
+  }
+}

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -57,7 +57,7 @@ LABEL io.k8s.description="Tasklist is a ready-to-use application to rapidly impl
 EXPOSE 8080
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash openjdk21-jre tzdata
+    apk add --no-cache bash openjdk21-jre tzdata gcompat libgcc libc6-compat
 
 ENV TASKLIST_HOME=/usr/local/tasklist
 


### PR DESCRIPTION
# Description
Backport of #31499 to `release-8.8.0-alpha4`.

relates to camunda/camunda#31472