### PR TITLE
feat: applications can be members of roles

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -135,7 +135,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER -> true; // With simple mappings, any username can be assigned
+      case USER, APPLICATION ->
+          true; // With simple mappings, any username and application id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -140,7 +140,8 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER -> true; // With simple mappings, any username can be assigned
+      case USER, APPLICATION ->
+          true; // With simple mappings, any username or application id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2559,6 +2559,89 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /roles/{roleId}/applications/{applicationId}:
+    put:
+      tags:
+        - Role
+      operationId: addApplicationToRole
+      summary: Assign an application to a role (Work-in-Progress)
+      description: |
+        Assigns an application to a role.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: roleId
+          in: path
+          required: true
+          description: The role ID.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The application ID.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The application was assigned successfully to the role.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: The application with the given ID is already assigned to the role.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - Role
+      operationId: removeApplicationFromRole
+      summary: Unassign an application from a role (Work-in-Progress)
+      description: |
+        Unassigns an application from a role.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: roleId
+          in: path
+          required: true
+          description: The role ID.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The application ID.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The application was unassigned successfully from the role.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role or application with the given ID or username was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /roles/search:
     post:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -124,6 +124,15 @@ public class RoleController {
   }
 
   @CamundaPutMapping(
+      path = "/{roleId}/applications/{applicationId}",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> addApplicationToRole(
+      @PathVariable final String roleId, @PathVariable final String applicationId) {
+    return RequestMapper.toRoleMemberRequest(roleId, applicationId, EntityType.APPLICATION)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
+  }
+
+  @CamundaPutMapping(
       path = "/{roleId}/groups/{groupId}",
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> addGroupToRole(
@@ -143,6 +152,13 @@ public class RoleController {
   public CompletableFuture<ResponseEntity<Object>> removeUserFromRole(
       @PathVariable final String roleId, @PathVariable final String username) {
     return RequestMapper.toRoleMemberRequest(roleId, username, EntityType.USER)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
+  }
+
+  @CamundaDeleteMapping(path = "/{roleId}/applications/{applicationId}")
+  public CompletableFuture<ResponseEntity<Object>> removeApplicationFromRole(
+      @PathVariable final String roleId, @PathVariable final String applicationId) {
+    return RequestMapper.toRoleMemberRequest(roleId, applicationId, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 


### PR DESCRIPTION
Adds the API and adjust engine code so that applications can be added and removed from roles. Camunda and RDBMS exporters already support any arbitrary entity type for role membership.

depends on #31510
closes #31376
