### PR TITLE
Migrate `RoleDeletedHandler` to work with `roleId`

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
@@ -44,7 +44,7 @@ public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordV
 
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getRoleId());
   }
 
   @Override
@@ -55,7 +55,11 @@ public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordV
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     final RoleRecordValue value = record.getValue();
-    entity.setKey(value.getRoleKey()).setName(value.getName());
+    entity
+        .setKey(value.getRoleKey())
+        .setRoleId(value.getRoleId())
+        .setName(value.getName())
+        .setDescription(value.getDescription());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
@@ -57,7 +57,7 @@ public class RoleDeletedHandlerTest {
     final var idList = underTest.generateIds(roleRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(roleRecord.getKey()));
+    assertThat(idList).containsExactly(String.valueOf(roleRecord.getValue().getRoleId()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Migrate `RoleDeletedHandler` to work with `roleId`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31349
