### PR TITLE
feat: applications can be members of groups

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.MembershipState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
-import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
@@ -35,7 +34,6 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
       "Expected to add entity with ID '%s' to group with ID '%s', but the entity is already assigned to this group.";
 
   private final GroupState groupState;
-  private final UserState userState;
   private final MappingState mappingState;
   private final MembershipState membershipState;
   private final AuthorizationCheckBehavior authCheckBehavior;
@@ -55,7 +53,6 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     this.keyGenerator = keyGenerator;
     this.authCheckBehavior = authCheckBehavior;
     groupState = processingState.getGroupState();
-    userState = processingState.getUserState();
     membershipState = processingState.getMembershipState();
     mappingState = processingState.getMappingState();
     stateWriter = writers.state();
@@ -136,7 +133,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case EntityType.USER -> true; // With simple mappings, any username can be assigned
+      case EntityType.USER, APPLICATION ->
+          true; // With simple mappings, any username or application id can be assigned
       case EntityType.MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -138,7 +138,8 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER -> true; // With simple mappings, any username can be assigned
+      case USER, APPLICATION ->
+          true; // With simple mappings, any username or application id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2992,6 +2992,89 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /groups/{groupId}/applications/{applicationId}:
+    put:
+      tags:
+        - Group
+      operationId: addApplicationToGroup
+      summary: Assign an application to a group (Work-in-Progress)
+      description: |
+        Assigns an application to a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The group ID.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The application ID.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The application was assigned successfully to the group.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The group with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: The application with the given ID is already assigned to the group.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - Group
+      operationId: unassignApplicationFromGroup
+      summary: Unassign an application from a group (Work-in-Progress)
+      description: |
+        Unassigns an appliction from a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The group ID.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The application ID.
+          schema:
+            type: string
+      responses:
+        "202":
+          description: The application was unassigned successfully from the group.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The group with the given ID was not found, or the application is not assigned to this group.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /groups/{groupId}/mapping-rules/{mappingId}:
     put:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -84,6 +84,15 @@ public class GroupController {
   }
 
   @CamundaPutMapping(
+      path = "/{groupId}/applications/{applicationId}",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> assignApplicationToGroup(
+      @PathVariable final String groupId, @PathVariable final String applicationId) {
+    return RequestMapper.toGroupMemberRequest(groupId, applicationId, EntityType.APPLICATION)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
+  }
+
+  @CamundaPutMapping(
       path = "/{groupId}/mapping-rules/{mappingId}",
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> assignMappingToGroup(
@@ -96,6 +105,13 @@ public class GroupController {
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromGroup(
       @PathVariable final String groupId, @PathVariable final String username) {
     return RequestMapper.toGroupMemberRequest(groupId, username, EntityType.USER)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
+  }
+
+  @CamundaDeleteMapping(path = "/{groupId}/applications/{applicationId}")
+  public CompletableFuture<ResponseEntity<Object>> unassignApplicationFromGroup(
+      @PathVariable final String groupId, @PathVariable final String applicationId) {
+    return RequestMapper.toGroupMemberRequest(groupId, applicationId, EntityType.APPLICATION)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 


### PR DESCRIPTION
Adds the API and adjust engine code so that applications can be added and removed from groups. Camunda and RDBMS exporters already support any arbitrary entity type for group membership.

depends on #31558
closes #31377