### PR TITLE
ci: fetch depth of 0 for qa testbench

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+          fetch-depth: 0
       - name: Authenticate for zeebe image registry
         uses: google-github-actions/auth@v2
         id: auth-zeebe


### PR DESCRIPTION
## Description

Workaround for https://github.com/yarnpkg/berry/issues/4014 .

[INFO] Usage Error: No ancestor could be found between any of HEAD and master, origin/master, upstream/master, main, origin/main, upstream/main
