### PR TITLE
feat: applications can be members of tenants

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -136,6 +136,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
       case USER -> true; // With simple mappings, any username can be assigned
+      case APPLICATION -> true; // With simple mappings, any application id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -245,6 +245,53 @@ public class TenantAppliersTest {
         .isFalse();
   }
 
+  @Test
+  void shouldAddEntityToTenantWithTypeApplication() {
+    // given
+    final var applicationId = "application-" + UUID.randomUUID();
+    final var tenantId = "tenantId";
+    final long tenantKey = 11L;
+    final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
+    tenantState.createTenant(tenantRecord);
+    tenantRecord.setEntityId(applicationId).setEntityType(EntityType.APPLICATION);
+
+    // when
+    tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
+
+    // then
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+        .isTrue();
+  }
+
+  @Test
+  void shouldRemoveEntityFromTenantWithTypeApplication() {
+    // given
+    final var applicationId = "application-" + UUID.randomUUID();
+    final var tenantId = "tenantId";
+    final long tenantKey = 11L;
+    final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
+    tenantState.createTenant(tenantRecord);
+    tenantRecord.setEntityId(applicationId).setEntityType(EntityType.APPLICATION);
+    tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
+
+    // Ensure the application is associated with the tenant before removal
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+        .isTrue();
+
+    // when
+    tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
+
+    // then
+    assertThat(
+            membershipState.hasRelation(
+                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+        .isFalse();
+  }
+
   private TenantRecord createTenant(final long tenantKey, final String tenantId) {
     final var tenantRecord =
         new TenantRecord()

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -563,7 +563,75 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserSearchResult"
-
+  /tenants/{tenantId}/applications/{applicationId}:
+    put:
+      tags:
+        - Tenant
+      operationId: assignApplicationToTenant
+      summary: Assign a user to a tenant
+      description: Assign a single user to a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The ID of the application to assign.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: The application was successfully assigned to the tenant.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The tenant was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - Tenant
+      operationId: removeApplicationFromTenant
+      summary: Remove an application from a tenant
+      description: Removes a single application from a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          required: true
+          description: The unique identifier of the application.
+          schema:
+            type: string
+      responses:
+        "204":
+          description: The application was successfully removed from the tenant.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The tenant does not exist or the application was not assigned to it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /tenants/{tenantId}/mappings/{mappingId}:
     put:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -112,6 +112,16 @@ public class TenantController {
             userQuery -> searchUsersInTenant(tenantId, userQuery));
   }
 
+  @CamundaPutMapping(path = "/{tenantId}/applications/{applicationId}")
+  public CompletableFuture<ResponseEntity<Object>> assignApplicationToTenant(
+      @PathVariable final String tenantId, @PathVariable final String applicationId) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .addMember(tenantId, EntityType.APPLICATION, applicationId));
+  }
+
   @CamundaPutMapping(path = "/{tenantId}/mappings/{mappingId}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingToTenant(
       @PathVariable final String tenantId, @PathVariable final String mappingId) {
@@ -150,6 +160,16 @@ public class TenantController {
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
                 .removeMember(tenantId, EntityType.USER, username));
+  }
+
+  @CamundaDeleteMapping(path = "/{tenantId}/applications/{applicationId}")
+  public CompletableFuture<ResponseEntity<Object>> removeApplicationFromTenant(
+      @PathVariable final String tenantId, @PathVariable final String applicationId) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .removeMember(tenantId, EntityType.APPLICATION, applicationId));
   }
 
   @CamundaPostMapping(path = "/{tenantId}/mappings/search")


### PR DESCRIPTION
Adds the API and adjust engine code so that applications can be added and removed from tenants. Camunda and RDBMS exporters already support any arbitrary entity type for tenant membership.

depends on #31565
closes #31378