### PR TITLE
[Backport stable/8.7] Use job key in migration error message

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -270,7 +270,7 @@ public class ProcessInstanceMigrationMigrateProcessor
                 Expected to migrate a job for process instance with key '%d', \
                 but could not find job with key '%d'. \
                 Please report this as a bug""",
-                processInstanceKey, elementInstance.getUserTaskKey()));
+                processInstanceKey, elementInstance.getJobKey()));
       }
       stateWriter.appendFollowUpEvent(
           elementInstance.getJobKey(),


### PR DESCRIPTION
# Description
Backport of #31552 to `stable/8.7`.

relates to #31541