### PR TITLE
[Backport release-8.8.0-alpha4] ci: fetch depth of 0 for qa testbench

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+          fetch-depth: 0
       - name: Authenticate for zeebe image registry
         uses: google-github-actions/auth@v2
         id: auth-zeebe


### PR DESCRIPTION
# Description
Backport of #31566 to `release-8.8.0-alpha4`.

relates to yarnpkg/berry#4014