### PR TITLE
fix: log at warn when a leader steps down and include the original exception

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -773,7 +773,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             }
             appendListener.onCommitError(index, commitError);
             // replicating the entry will be retried on the next append request
-            log.error("Failed to replicate entry: {}", commitIndex, commitError);
+            log.warn("Failed to replicate entry: {}", commitIndex, commitError);
           }
         },
         raft.getThreadContext());


### PR DESCRIPTION
## Description
The original log line is at the wrong error level, so it's downgraded to WARNING.

## Related issues
relates #31436
