### PR TITLE
Use lowercase when checking which properties to sanitise

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/ConfigSanitizingFunction.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ConfigSanitizingFunction.java
@@ -35,7 +35,10 @@ public final class ConfigSanitizingFunction implements SanitizingFunction {
     }
 
     for (final var keyword : properties.keywords()) {
-      if (key.contains(keyword)) {
+      // at times the cases are changed by Spring, e.g. when it tries to sanitize the input via a
+      // qualified key; it might be upper case, lower case, etc., so anything with camel case, for
+      // example, would not be matched. instead, we match all cases.
+      if (key.toLowerCase().contains(keyword.toLowerCase())) {
         return data.withSanitizedValue();
       }
     }

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -61,7 +61,8 @@ management.endpoint.rebalance.access=unrestricted
 management.endpoint.usage-metrics.access=unrestricted
 # Define keywords to sanitize in applicable endpoints; this will be applied to the configprops,
 # beans, and if enabled, the environment endpoint as well
-management.sanitize.keywords=user,pass,secret,accessKey,accountKey,connectionString
+management.sanitize.keywords=user,pass,secret,accessKey,accountKey,token,\
+  connectionString
 # Default user configuration
 camunda.security.initialization.users[0].username=demo
 camunda.security.initialization.users[0].password=demo


### PR DESCRIPTION
This Pr makes both the key and the keywords lowercase when comparing both.

The issue arose due to the key words were being converted to lower case when compared to the words that needed to be sanitized. This caused for some credentials in the "inputs" section in the config props to be exposed.
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
