### PR TITLE
refactor: batchoperation search api key to

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperation.java
@@ -20,7 +20,10 @@ import io.camunda.client.api.search.enums.BatchOperationType;
 
 public interface BatchOperation {
 
-  Long getBatchOperationKey();
+  // To be backwards compatible with legacy batch operations from Operate, we need a String ID
+  // Operate BatchOperation ID is a UUID
+  // Engine BatchOperation ID is a Long
+  String getBatchOperationId();
 
   BatchOperationState getStatus();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/BatchOperationItems.java
@@ -23,7 +23,7 @@ public interface BatchOperationItems {
   List<BatchOperationItem> items();
 
   interface BatchOperationItem {
-    Long getBatchOperationKey();
+    String getBatchOperationId();
 
     Long getItemKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -18,7 +18,6 @@ package io.camunda.client.impl.search.response;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.api.search.response.BatchOperation;
-import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.client.protocol.rest.BatchOperationResponse;
 import java.util.ArrayList;
@@ -26,7 +25,7 @@ import java.util.List;
 
 public class BatchOperationImpl implements BatchOperation {
 
-  private final Long batchOperationKey;
+  private final String batchOperationId;
   private final BatchOperationType type;
   private final BatchOperationState status;
   private final String startDate;
@@ -37,7 +36,7 @@ public class BatchOperationImpl implements BatchOperation {
   private final List<Long> keys = new ArrayList<>();
 
   public BatchOperationImpl(final BatchOperationCreatedResult item) {
-    batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+    batchOperationId = item.getBatchOperationKey();
     type =
         item.getBatchOperationType() != null
             ? BatchOperationType.valueOf(item.getBatchOperationType().name())
@@ -51,7 +50,7 @@ public class BatchOperationImpl implements BatchOperation {
   }
 
   public BatchOperationImpl(final BatchOperationResponse item) {
-    batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+    batchOperationId = item.getBatchOperationId();
     type =
         item.getBatchOperationType() != null
             ? BatchOperationType.valueOf(item.getBatchOperationType().name())
@@ -65,8 +64,8 @@ public class BatchOperationImpl implements BatchOperation {
   }
 
   @Override
-  public Long getBatchOperationKey() {
-    return batchOperationKey;
+  public String getBatchOperationId() {
+    return batchOperationId;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationItemsImpl.java
@@ -42,7 +42,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
 
   public static class BatchOperationItemImpl implements BatchOperationItem {
 
-    private final Long batchOperationKey;
+    private final String batchOperationId;
     private final Long itemKey;
     private final Long processInstanceKey;
     private final BatchOperationItemState status;
@@ -50,7 +50,7 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     private final String errorMessage;
 
     public BatchOperationItemImpl(final BatchOperationItemResponse item) {
-      batchOperationKey = ParseUtil.parseLongOrNull(item.getBatchOperationKey());
+      batchOperationId = item.getBatchOperationId();
       itemKey = ParseUtil.parseLongOrNull(item.getItemKey());
       processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
       status = EnumUtil.convert(item.getState(), BatchOperationItemState.class);
@@ -59,8 +59,8 @@ public class BatchOperationItemsImpl implements BatchOperationItems {
     }
 
     @Override
-    public Long getBatchOperationKey() {
-      return batchOperationKey;
+    public String getBatchOperationId() {
+      return batchOperationId;
     }
 
     @Override

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -482,7 +482,7 @@
 
   <changeSet id="create_batch_operation_table" author="pwunderlich">
     <createTable tableName="${prefix}BATCH_OPERATION">
-      <column name="BATCH_OPERATION_KEY" type="BIGINT">
+      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="STATE" type="VARCHAR(255)"/>
@@ -495,7 +495,7 @@
     </createTable>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ITEM">
-      <column name="BATCH_OPERATION_KEY" type="BIGINT">
+      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
         <constraints
           foreignKeyName="${prefix}FK_BATCH_OPERATION_ITEM_BATCH_OPERATION"
           referencedTableName="${prefix}BATCH_OPERATION"

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
@@ -14,7 +14,7 @@ public class BatchOperationEntityMapper {
 
   public static BatchOperationEntity toEntity(final BatchOperationDbModel dbModel) {
     return new BatchOperationEntity(
-        dbModel.batchOperationKey(),
+        dbModel.batchOperationKey().toString(),
         dbModel.state(),
         dbModel.operationType(),
         dbModel.startDate(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -31,18 +31,18 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
     this.batchOperationMapper = batchOperationMapper;
   }
 
-  public boolean exists(final Long batchOperationKey) {
+  public boolean exists(final String batchOperationKey) {
     final var query =
         new BatchOperationDbQuery.Builder()
-            .filter(b -> b.batchOperationIds(batchOperationKey.toString()))
+            .filter(b -> b.batchOperationIds(batchOperationKey))
             .build();
 
     return batchOperationMapper.count(query) == 1;
   }
 
-  public Optional<BatchOperationEntity> findOne(final Long batchOperationKey) {
+  public Optional<BatchOperationEntity> findOne(final String batchOperationKey) {
     final var result =
-        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationKey.toString()))));
+        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationKey))));
     return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
   }
 
@@ -61,7 +61,7 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
-  public List<BatchOperationItemEntity> getItems(final Long batchOperationKey) {
+  public List<BatchOperationItemEntity> getItems(final String batchOperationKey) {
 
     return batchOperationMapper.getItems(batchOperationKey).stream().toList();
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -34,15 +34,15 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
   public boolean exists(final Long batchOperationKey) {
     final var query =
         new BatchOperationDbQuery.Builder()
-            .filter(b -> b.batchOperationKeys(batchOperationKey))
+            .filter(b -> b.batchOperationIds(batchOperationKey.toString()))
             .build();
 
     return batchOperationMapper.count(query) == 1;
   }
 
-  public Optional<BatchOperationEntity> findOne(final long batchOperationKey) {
+  public Optional<BatchOperationEntity> findOne(final Long batchOperationKey) {
     final var result =
-        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey))));
+        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationKey.toString()))));
     return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -36,26 +36,26 @@ public interface BatchOperationMapper {
 
   List<BatchOperationDbModel> search(BatchOperationDbQuery query);
 
-  List<BatchOperationItemEntity> getItems(Long batchOperationKey);
+  List<BatchOperationItemEntity> getItems(String batchOperationKey);
 
   record BatchOperationUpdateDto(
-      long batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}
+      String batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}
 
-  record BatchOperationUpdateTotalCountDto(long batchOperationKey, int operationsTotalCount) {}
+  record BatchOperationUpdateTotalCountDto(String batchOperationKey, int operationsTotalCount) {}
 
-  record BatchOperationUpdateCountsDto(long batchOperationKey, long itemKey) {}
+  record BatchOperationUpdateCountsDto(String batchOperationKey, long itemKey) {}
 
-  record BatchOperationItemsDto(Long batchOperationKey, List<BatchOperationItemDbModel> items) {}
+  record BatchOperationItemsDto(String batchOperationKey, List<BatchOperationItemDbModel> items) {}
 
   record BatchOperationItemDto(
-      Long batchOperationKey,
+      String batchOperationKey,
       Long itemKey,
       BatchOperationEntity.BatchOperationItemState state,
       OffsetDateTime processedDate,
       String errorMessage) {}
 
   record BatchOperationItemStatusUpdateDto(
-      Long batchOperationKey,
+      String batchOperationKey,
       BatchOperationEntity.BatchOperationItemState oldState,
       BatchOperationEntity.BatchOperationItemState newState) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import java.util.function.Function;
 
 public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
-  BATCH_OPERATION_KEY("batchOperationKey", BatchOperationEntity::batchOperationKey);
+  BATCH_OPERATION_KEY("batchOperationKey", BatchOperationEntity::batchOperationId);
 
   private final String property;
   private final Function<BatchOperationEntity, Object> propertyReader;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import java.util.function.Function;
 
 public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
-  BATCH_OPERATION_KEY("batchOperationKey", BatchOperationEntity::batchOperationId);
+  BATCH_OPERATION_KEY("batchOperationId", BatchOperationEntity::batchOperationId);
 
   private final String property;
   private final Function<BatchOperationEntity, Object> propertyReader;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -12,7 +12,7 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 
 public record BatchOperationDbModel(
-    Long batchOperationKey,
+    String batchOperationKey,
     BatchOperationState state,
     String operationType,
     OffsetDateTime startDate,
@@ -24,7 +24,7 @@ public record BatchOperationDbModel(
   // Builder class
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
 
-    private Long batchOperationKey;
+    private String batchOperationKey;
     private BatchOperationState state;
     private String operationType;
     private OffsetDateTime startDate;
@@ -35,7 +35,7 @@ public record BatchOperationDbModel(
 
     public Builder() {}
 
-    public Builder batchOperationKey(final Long batchOperationKey) {
+    public Builder batchOperationKey(final String batchOperationKey) {
       this.batchOperationKey = batchOperationKey;
       return this;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -59,7 +59,7 @@ public class BatchOperationWriter {
   }
 
   public void updateBatchAndInsertItems(
-      final long batchOperationKey, final List<BatchOperationItemDbModel> items) {
+      final String batchOperationKey, final List<BatchOperationItemDbModel> items) {
     if (items != null && !items.isEmpty()) {
       executionQueue.executeInQueue(
           new QueueItem(
@@ -73,7 +73,7 @@ public class BatchOperationWriter {
   }
 
   public void updateItem(
-      final long batchOperationKey,
+      final String batchOperationKey,
       final long itemKey,
       final BatchOperationItemState state,
       final OffsetDateTime endDate,
@@ -107,13 +107,13 @@ public class BatchOperationWriter {
     }
   }
 
-  public void finish(final long batchOperationKey, final OffsetDateTime endDate) {
+  public void finish(final String batchOperationKey, final OffsetDateTime endDate) {
     updateCompleted(
         batchOperationKey,
         new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.COMPLETED, endDate));
   }
 
-  public void cancel(final long batchOperationKey, final OffsetDateTime endDate) {
+  public void cancel(final String batchOperationKey, final OffsetDateTime endDate) {
     updateCompleted(
         batchOperationKey,
         new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.CANCELED, endDate));
@@ -122,19 +122,19 @@ public class BatchOperationWriter {
         batchOperationKey, BatchOperationItemState.ACTIVE, BatchOperationItemState.CANCELED);
   }
 
-  public void pause(final long batchOperationKey) {
+  public void pause(final String batchOperationKey) {
     updateCompleted(
         batchOperationKey,
         new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.PAUSED, null));
   }
 
-  public void resume(final long batchOperationKey) {
+  public void resume(final String batchOperationKey) {
     updateCompleted(
         batchOperationKey,
         new BatchOperationUpdateDto(batchOperationKey, BatchOperationState.ACTIVE, null));
   }
 
-  private void updateCompleted(final long batchOperationKey, final BatchOperationUpdateDto dto) {
+  private void updateCompleted(final String batchOperationKey, final BatchOperationUpdateDto dto) {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.BATCH_OPERATION,
@@ -145,7 +145,7 @@ public class BatchOperationWriter {
   }
 
   private void updateItemsWithState(
-      final long batchOperationKey,
+      final String batchOperationKey,
       final BatchOperationItemState oldState,
       final BatchOperationItemState newState) {
     executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -23,7 +23,7 @@
   <resultMap id="BatchOperationItemResultMap"
     type="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemEntity">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
+      <idArg column="BATCH_OPERATION_ID" javaType="java.lang.String"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="STATE"
@@ -158,9 +158,9 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <!-- basic filters -->
-    <if test="filter.batchOperationKeys != null and !filter.batchOperationKeys.isEmpty()">
+    <if test="filter.batchOperationIds != null and !filter.batchOperationIds.isEmpty()">
       AND BATCH_OPERATION_KEY IN
-      <foreach collection="filter.batchOperationKeys" item="value" open="(" separator=", "
+      <foreach collection="filter.batchOperationIds" item="value" open="(" separator=", "
         close=")">#{value}
       </foreach>
     </if>

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -8,7 +8,7 @@
   <resultMap id="BatchOperationResultMap"
     type="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
+      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
       <arg column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationState"/>
       <arg column="OPERATION_TYPE" javaType="java.lang.String"/>
@@ -23,7 +23,7 @@
   <resultMap id="BatchOperationItemResultMap"
     type="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemEntity">
     <constructor>
-      <idArg column="BATCH_OPERATION_ID" javaType="java.lang.String"/>
+      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="STATE"
@@ -94,7 +94,8 @@
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
   </update>
 
-  <update id="incrementFailedOperationsCount" parameterType="java.lang.Long">
+  <update id="incrementFailedOperationsCount"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + 1
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
@@ -106,7 +107,8 @@
     )
   </update>
 
-  <update id="incrementCompletedOperationsCount" parameterType="java.lang.Long">
+  <update id="incrementCompletedOperationsCount"
+    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + 1
     WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
@@ -119,7 +121,7 @@
   </update>
 
   <select id="getItems"
-    parameterType="java.lang.Long"
+    parameterType="java.lang.String"
     resultMap="BatchOperationItemResultMap">
     SELECT BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE, PROCESSED_DATE, ERROR_MESSAGE
     FROM ${prefix}BATCH_OPERATION_ITEM

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -355,7 +355,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
-                        .batchOperationKeys(batchOperation.batchOperationKey())
+                        .batchOperationIds(batchOperation.batchOperationKey().toString())
                         .build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));
@@ -464,7 +464,7 @@ public class BatchOperationIT {
         .search(
             new BatchOperationQuery(
                 new BatchOperationFilter.Builder()
-                    .batchOperationKeys(batchOperation.batchOperationKey())
+                    .batchOperationIds(batchOperation.batchOperationKey().toString())
                     .build(),
                 BatchOperationSort.of(b -> b),
                 SearchQueryPage.of(b -> b)));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -13,6 +13,7 @@ import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSa
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.insertBatchOperationsItems;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
@@ -64,7 +65,7 @@ public class BatchOperationIT {
 
     createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b);
 
-    final var searchResult = rdbmsService.getBatchOperationReader().exists(nextKey());
+    final var searchResult = rdbmsService.getBatchOperationReader().exists(nextStringKey());
 
     assertThat(searchResult).isFalse();
   }
@@ -355,7 +356,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
-                        .batchOperationIds(batchOperation.batchOperationKey().toString())
+                        .batchOperationIds(batchOperation.batchOperationKey())
                         .build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));
@@ -449,8 +450,9 @@ public class BatchOperationIT {
     assertThat(instance).isNotNull();
     assertThat(instance)
         .usingRecursiveComparison()
-        .ignoringFields("startDate", "endDate")
+        .ignoringFields("batchOperationId", "startDate", "endDate")
         .isEqualTo(batchOperation);
+    assertThat(instance.batchOperationId()).isEqualTo(batchOperation.batchOperationKey());
     assertThat(instance.startDate())
         .isCloseTo(batchOperation.startDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(instance.endDate())
@@ -464,7 +466,7 @@ public class BatchOperationIT {
         .search(
             new BatchOperationQuery(
                 new BatchOperationFilter.Builder()
-                    .batchOperationIds(batchOperation.batchOperationKey().toString())
+                    .batchOperationIds(batchOperation.batchOperationKey())
                     .build(),
                 BatchOperationSort.of(b -> b),
                 SearchQueryPage.of(b -> b)));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationSortIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
+import io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.filter.BatchOperationFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.sort.BatchOperationSort;
+import java.util.Comparator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class BatchOperationSortIT {
+
+  @TestTemplate
+  public void shouldSortIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final BatchOperationReader batchOperationReader = rdbmsService.getBatchOperationReader();
+
+    BatchOperationFixtures.createAndSaveRandomBatchOperations(
+        rdbmsService.createWriter(1L), b -> b);
+
+    final var searchResult =
+        batchOperationReader.search(
+            BatchOperationQuery.of(
+                b ->
+                    b.filter(new BatchOperationFilter.Builder().build())
+                        .sort(BatchOperationSort.of(s -> s.batchOperationId().asc()))
+                        .page(SearchQueryPage.of(p -> p.from(0).size(10)))));
+
+    assertThat(searchResult.items())
+        .isSortedAccordingTo(Comparator.comparing(BatchOperationEntity::batchOperationId));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -29,7 +29,7 @@ public final class BatchOperationFixtures {
 
   public static BatchOperationDbModel createRandomized(
       final Function<Builder, Builder> builderFunction) {
-    final var key = CommonFixtures.nextKey();
+    final var key = CommonFixtures.nextStringKey();
     final var builder =
         new Builder()
             .batchOperationKey(key)
@@ -55,7 +55,7 @@ public final class BatchOperationFixtures {
   }
 
   public static List<Long> createAndSaveRandomBatchOperationItems(
-      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final int count) {
+      final RdbmsWriter rdbmsWriter, final String batchOperationKey, final int count) {
     final Set<Long> itemKeys =
         IntStream.range(0, count)
             .mapToObj(i -> CommonFixtures.nextKey())
@@ -80,7 +80,7 @@ public final class BatchOperationFixtures {
   }
 
   public static void insertBatchOperationsItems(
-      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final Set<Long> items) {
+      final RdbmsWriter rdbmsWriter, final String batchOperationKey, final Set<Long> items) {
     rdbmsWriter
         .getBatchOperationWriter()
         .updateBatchAndInsertItems(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
@@ -25,6 +25,10 @@ public class CommonFixtures {
     return ID_COUNTER.incrementAndGet();
   }
 
+  public static String nextStringKey() {
+    return nextKey().toString();
+  }
+
   public static String nextStringId() {
     return UUID.randomUUID().toString();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -84,7 +84,8 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationChunkRecord);
 
     // then
-    var batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
@@ -93,7 +94,8 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationExecutionCompletedRecord);
 
     // then it should be completed
-    batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.COMPLETED);
   }
 
@@ -111,7 +113,8 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationChunkRecord);
 
     // then
-    var batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
@@ -120,12 +123,13 @@ class RdbmsExporterBatchOperationsIT {
     exporter.export(batchOperationCanceledRecord);
 
     // then it should be canceled
-    batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.CANCELED);
 
     // and the items should be canceled
     final var batchOperationItems =
-        rdbmsService.getBatchOperationReader().getItems(batchOperationKey);
+        rdbmsService.getBatchOperationReader().getItems(String.valueOf(batchOperationKey));
     assertThat(batchOperationItems).hasSize(3);
     assertThat(
             batchOperationItems.stream()
@@ -150,7 +154,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then it should be canceled
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.PAUSED);
   }
 
@@ -174,7 +178,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then it should be canceled
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation.state()).isEqualTo(BatchOperationState.ACTIVE);
   }
 
@@ -195,7 +199,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -220,7 +224,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -245,7 +249,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -270,7 +274,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -295,7 +299,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -320,7 +324,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
@@ -345,7 +349,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
@@ -371,7 +375,7 @@ class RdbmsExporterBatchOperationsIT {
 
     // then
     final var batchOperation =
-        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+        rdbmsService.getBatchOperationReader().findOne(String.valueOf(batchOperationKey)).get();
     assertThat(batchOperation).isNotNull();
     assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
     assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -464,7 +464,7 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
-  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+  public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationId) {
     throw new UnsupportedOperationException("Not implemented yet");
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.rdbms;
 
+import static io.camunda.search.entities.BatchOperationEntity.getBatchOperationKey;
+
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AuthorizationEntity;
@@ -294,11 +296,11 @@ public class RdbmsSearchClient implements SearchClientsProxy {
   }
 
   @Override
-  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+  public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationId) {
     LOG.debug(
-        "[RDBMS Search Client] Search for batch operation items by batchOperationKey: {}",
-        batchOperationKey);
+        "[RDBMS Search Client] Search for batch operation items by batchOperationId: {}",
+        batchOperationId);
 
-    return rdbmsService.getBatchOperationReader().getItems(batchOperationKey);
+    return rdbmsService.getBatchOperationReader().getItems(getBatchOperationKey(batchOperationId));
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.search.rdbms;
 
-import static io.camunda.search.entities.BatchOperationEntity.getBatchOperationKey;
-
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AuthorizationEntity;
@@ -301,6 +299,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
         "[RDBMS Search Client] Search for batch operation items by batchOperationId: {}",
         batchOperationId);
 
-    return rdbmsService.getBatchOperationReader().getItems(getBatchOperationKey(batchOperationId));
+    return rdbmsService.getBatchOperationReader().getItems(batchOperationId);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
@@ -18,7 +18,7 @@ public interface BatchOperationSearchClient {
 
   SearchQueryResult<BatchOperationEntity> searchBatchOperations(BatchOperationQuery query);
 
-  List<BatchOperationItemEntity> getBatchOperationItems(Long batchOperationKey);
+  List<BatchOperationItemEntity> getBatchOperationItems(String batchOperationId);
 
   BatchOperationSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/BatchOperationEntity.java
@@ -12,7 +12,10 @@ import java.time.OffsetDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BatchOperationEntity(
-    Long batchOperationKey,
+    // To be backwards compatible with legacy batch operations from Operate, we need a String ID
+    // Operate BatchOperation ID is a UUID
+    // Engine BatchOperation ID is a Long
+    String batchOperationId,
     BatchOperationState state,
     String operationType,
     OffsetDateTime startDate,
@@ -21,8 +24,31 @@ public record BatchOperationEntity(
     Integer operationsFailedCount,
     Integer operationsCompletedCount) {
 
+  /**
+   * Because of backwards compatibility (Legacy Batches have a UUID as ID), batchOperationId is a
+   * String. However, the new batch engine uses a Long as ID (Key).
+   *
+   * @param batchOperationId throws IllegalArgumentException if the batchOperationId is not a valid
+   *     number (Legacy Batch Operation IDs are not supported)
+   * @return batchOperationKey
+   */
+  public static Long getBatchOperationKey(final String batchOperationId) {
+    try {
+      return Long.valueOf(batchOperationId);
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Batch operation id '%s' is not a valid number. Legacy Batch Operation IDs are not supported!",
+              batchOperationId),
+          e);
+    }
+  }
+
   public record BatchOperationItemEntity(
-      Long batchOperationKey,
+      // To be backwards compatible with legacy batch operations from Operate, we need a String ID
+      // Operate BatchOperation ID is a UUID
+      // Engine BatchOperation ID is a Long
+      String batchOperationId,
       Long itemKey,
       Long processInstanceKey,
       BatchOperationItemState state,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -16,21 +16,21 @@ import java.util.List;
 import java.util.Objects;
 
 public record BatchOperationFilter(
-    List<Long> batchOperationKeys, List<String> operationTypes, List<String> state)
+    List<String> batchOperationIds, List<String> operationTypes, List<String> state)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
 
-    private List<Long> batchOperationKeys;
+    private List<String> batchOperationIds;
     private List<String> operationTypes;
     private List<String> state;
 
-    public Builder batchOperationKeys(final Long value, final Long... values) {
-      return batchOperationKeys(collectValues(value, values));
+    public Builder batchOperationIds(final String value, final String... values) {
+      return batchOperationIds(collectValues(value, values));
     }
 
-    public Builder batchOperationKeys(final List<Long> values) {
-      batchOperationKeys = addValuesToList(batchOperationKeys, values);
+    public Builder batchOperationIds(final List<String> values) {
+      batchOperationIds = addValuesToList(batchOperationIds, values);
       return this;
     }
 
@@ -55,7 +55,7 @@ public record BatchOperationFilter(
     @Override
     public BatchOperationFilter build() {
       return new BatchOperationFilter(
-          Objects.requireNonNullElse(batchOperationKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(batchOperationIds, Collections.emptyList()),
           Objects.requireNonNullElse(operationTypes, Collections.emptyList()),
           Objects.requireNonNullElse(state, Collections.emptyList()));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationSort.java
@@ -26,8 +26,8 @@ public record BatchOperationSort(List<FieldSorting> orderings) implements SortOp
   public static final class Builder extends AbstractBuilder<BatchOperationSort.Builder>
       implements ObjectBuilder<BatchOperationSort> {
 
-    public Builder batchOperationKey() {
-      currentOrdering = new FieldSorting("batchOperationKey", null);
+    public Builder batchOperationId() {
+      currentOrdering = new FieldSorting("batchOperationId", null);
       return this;
     }
 

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import static io.camunda.search.entities.BatchOperationEntity.getBatchOperationKey;
 import static io.camunda.search.query.SearchQueryBuilders.batchOperationQuery;
 
 import io.camunda.search.clients.BatchOperationSearchClient;
@@ -60,39 +61,46 @@ public final class BatchOperationServices
         .searchBatchOperations(query);
   }
 
-  public BatchOperationEntity getByKey(final Long key) {
+  public BatchOperationEntity getById(final String batchOperationId) {
     final var result =
         batchOperationSearchClient.searchBatchOperations(
-            batchOperationQuery(q -> q.filter(f -> f.batchOperationKeys(key))));
-    return getSingleResultOrThrow(result, key, "BatchOperation");
+            batchOperationQuery(q -> q.filter(f -> f.batchOperationIds(batchOperationId))));
+    return getSingleResultOrThrow(result, batchOperationId, "BatchOperation");
   }
 
-  public List<BatchOperationItemEntity> getItemsByKey(final Long key) {
-    return batchOperationSearchClient.getBatchOperationItems(key);
+  public List<BatchOperationItemEntity> getItemsById(final String batchOperationId) {
+    return batchOperationSearchClient.getBatchOperationItems(batchOperationId);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementRecord> cancel(final long batchKey) {
-    LOGGER.debug("Cancelling batch operation with key '{}'", batchKey);
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> cancel(
+      final String batchOperationId) {
+    LOGGER.debug("Cancelling batch operation with id '{}'", batchOperationId);
 
     final var brokerRequest =
-        new BrokerCancelBatchOperationRequest().setBatchOperationKey(batchKey);
+        new BrokerCancelBatchOperationRequest()
+            .setBatchOperationKey(getBatchOperationKey(batchOperationId));
 
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementRecord> pause(final long batchKey) {
-    LOGGER.debug("Pausing batch operation with key '{}'", batchKey);
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> pause(
+      final String batchOperationId) {
+    LOGGER.debug("Pausing batch operation with id '{}'", batchOperationId);
 
-    final var brokerRequest = new BrokerPauseBatchOperationRequest().setBatchOperationKey(batchKey);
+    final var brokerRequest =
+        new BrokerPauseBatchOperationRequest()
+            .setBatchOperationKey(getBatchOperationKey(batchOperationId));
 
     return sendBrokerRequest(brokerRequest);
   }
 
-  public CompletableFuture<BatchOperationLifecycleManagementRecord> resume(final long batchKey) {
-    LOGGER.debug("Resuming batch operation with key '{}'", batchKey);
+  public CompletableFuture<BatchOperationLifecycleManagementRecord> resume(
+      final String batchOperationId) {
+    LOGGER.debug("Resuming batch operation with id '{}'", batchOperationId);
 
     final var brokerRequest =
-        new BrokerResumeBatchOperationRequest().setBatchOperationKey(batchKey);
+        new BrokerResumeBatchOperationRequest()
+            .setBatchOperationKey(getBatchOperationKey(batchOperationId));
 
     return sendBrokerRequest(brokerRequest);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
@@ -72,7 +72,7 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+  public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationId) {
     return List.of();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -18,15 +18,10 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
 import java.util.Collection;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Exports a batch operation chunk record, which contains all the item keys, to the database. */
 public class BatchOperationChunkExportHandler
     implements RdbmsExportHandler<BatchOperationChunkRecordValue> {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(BatchOperationChunkExportHandler.class);
 
   private final BatchOperationWriter batchOperationWriter;
 
@@ -44,7 +39,7 @@ public class BatchOperationChunkExportHandler
   public void export(final Record<BatchOperationChunkRecordValue> record) {
     final var value = record.getValue();
     batchOperationWriter.updateBatchAndInsertItems(
-        value.getBatchOperationKey(), mapItems(value.getItems()));
+        String.valueOf(value.getBatchOperationKey()), mapItems(value.getItems()));
   }
 
   private List<BatchOperationItemDbModel> mapItems(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCompletedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCompletedExportHandler.java
@@ -33,7 +33,7 @@ public class BatchOperationCompletedExportHandler
   @Override
   public void export(final Record<BatchOperationExecutionRecordValue> record) {
     final var value = record.getValue();
-    final var batchOperationKey = value.getBatchOperationKey();
+    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
     batchOperationWriter.finish(
         batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -43,8 +43,9 @@ public class BatchOperationCreatedExportHandler
 
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
     final var value = record.getValue();
+    final String batchOperationKey = String.valueOf(record.getKey());
     return new BatchOperationDbModel.Builder()
-        .batchOperationKey(record.getKey())
+        .batchOperationKey(batchOperationKey)
         .state(BatchOperationState.ACTIVE)
         .operationType(value.getBatchOperationType().name())
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationLifecycleManagementExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationLifecycleManagementExportHandler.java
@@ -40,7 +40,7 @@ public class BatchOperationLifecycleManagementExportHandler
   @Override
   public void export(final Record<BatchOperationLifecycleManagementRecordValue> record) {
     final var value = record.getValue();
-    final var batchOperationKey = value.getBatchOperationKey();
+    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
     if (record.getIntent().equals(BatchOperationIntent.CANCELED)) {
       batchOperationWriter.cancel(
           batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -36,14 +36,14 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
   public void export(final Record<T> record) {
     if (isCompleted(record)) {
       batchOperationWriter.updateItem(
-          record.getOperationReference(),
+          String.valueOf(record.getOperationReference()),
           getItemKey(record),
           BatchOperationItemState.COMPLETED,
           DateUtil.toOffsetDateTime(record.getTimestamp()),
           null);
     } else if (isFailed(record)) {
       batchOperationWriter.updateItem(
-          record.getOperationReference(),
+          String.valueOf(record.getOperationReference()),
           getItemKey(record),
           BatchOperationItemState.FAILED,
           DateUtil.toOffsetDateTime(record.getTimestamp()),

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4302,7 +4302,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /batch-operations/{batchOperationKey}:
+  /batch-operations/{batchOperationId}:
     get:
       tags:
         - Batch operation
@@ -4310,11 +4310,11 @@ paths:
       summary: Get batch operation
       description: Get batch operation by key.
       parameters:
-        - name: batchOperationKey
+        - name: batchOperationId
           in: path
           required: true
           description: |
-            The key of the batch operation.
+            The key (or operate legacy ID) of the batch operation.
           schema:
             type: string
       responses:
@@ -4339,7 +4339,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /batch-operations/{batchOperationKey}/items:
+  /batch-operations/{batchOperationId}/items:
     get:
       tags:
         - Batch operation
@@ -4347,11 +4347,11 @@ paths:
       summary: Get batch operation items
       description: Get items for a batch operation.
       parameters:
-        - name: batchOperationKey
+        - name: batchOperationId
           in: path
           required: true
           description: |
-            The key of the batch operation.
+            The key (or operate legacy ID) of the batch operation.
           schema:
             type: string
       responses:
@@ -4405,7 +4405,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /batch-operations/{batchOperationKey}/cancel:
+  /batch-operations/{batchOperationId}/cancel:
     put:
       tags:
         - Batch operation
@@ -4413,11 +4413,11 @@ paths:
       summary: Cancel Batch operation
       description: Cancels a running batch operation.
       parameters:
-        - name: batchOperationKey
+        - name: batchOperationId
           in: path
           required: true
           description: |
-            The key of the batch operation.
+            The key (or operate legacy ID) of the batch operation.
           schema:
             type: string
       requestBody:
@@ -4444,7 +4444,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /batch-operations/{batchOperationKey}/pause:
+  /batch-operations/{batchOperationId}/pause:
     put:
       tags:
         - Batch operation
@@ -4452,11 +4452,11 @@ paths:
       summary: Pause Batch operation
       description: Pauses a running batch operation.
       parameters:
-        - name: batchOperationKey
+        - name: batchOperationId
           in: path
           required: true
           description: |
-            The key of the batch operation.
+            The key (or operate legacy ID) of the batch operation.
           schema:
             type: string
       requestBody:
@@ -4483,7 +4483,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /batch-operations/{batchOperationKey}/resume:
+  /batch-operations/{batchOperationId}/resume:
     put:
       tags:
         - Batch operation
@@ -4491,11 +4491,11 @@ paths:
       summary: Resume Batch operation
       description: Resumes a paused batch operation.
       parameters:
-        - name: batchOperationKey
+        - name: batchOperationId
           in: path
           required: true
           description: |
-            The key of the batch operation.
+            The key (or operate legacy ID) of the batch operation.
           schema:
             type: string
       requestBody:
@@ -8594,7 +8594,6 @@ components:
           description: The field to sort by.
           type: string
           enum:
-            - batchOperationKey
             - operationType
             - state
             - startDate
@@ -8622,8 +8621,8 @@ components:
       description: Batch operation filter request.
       type: object
       properties:
-        batchOperationKey:
-          description: The batch operation key.
+        batchOperationId:
+          description: The key (or operate legacy ID) of the batch operation.
           type: string
         operationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"
@@ -8651,8 +8650,8 @@ components:
     BatchOperationResponse:
       type: object
       properties:
-        batchOperationKey:
-          description: Key of the batch operation.
+        batchOperationId:
+          description: Key or (Operate Legacy ID = UUID) of the batch operation.
           type: string
         state:
           description: The state of the batch operation.
@@ -8700,8 +8699,8 @@ components:
     BatchOperationItemResponse:
       type: object
       properties:
-        batchOperationKey:
-          description: Key of the batch operation.
+        batchOperationId:
+          description: The key (or operate legacy ID) of the batch operation.
           type: string
         itemKey:
           description: Key of the item, e.g. a process instance key.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -590,9 +590,7 @@ public final class SearchQueryRequestMapper {
     final var builder = FilterBuilders.batchOperation();
 
     if (filter != null) {
-      ofNullable(filter.getBatchOperationKey())
-          .map(KeyUtil::keyToLong)
-          .ifPresent(builder::batchOperationKeys);
+      ofNullable(filter.getBatchOperationId()).ifPresent(builder::batchOperationIds);
       ofNullable(filter.getState()).map(StateEnum::toString).ifPresent(builder::state);
       ofNullable(filter.getOperationType())
           .map(BatchOperationTypeEnum::toString)
@@ -610,7 +608,6 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case BATCH_OPERATION_KEY -> builder.batchOperationKey();
         case STATE -> builder.state();
         case OPERATION_TYPE -> builder.operationType();
         case START_DATE -> builder.startDate();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -352,7 +352,7 @@ public final class SearchQueryResponseMapper {
 
   public static BatchOperationResponse toBatchOperation(final BatchOperationEntity entity) {
     return new BatchOperationResponse()
-        .batchOperationKey(entity.batchOperationKey().toString())
+        .batchOperationId(entity.batchOperationId())
         .state(BatchOperationResponse.StateEnum.fromValue(entity.state().name()))
         .batchOperationType(BatchOperationTypeEnum.fromValue(entity.operationType()))
         .startDate(formatDate(entity.startDate()))
@@ -372,7 +372,7 @@ public final class SearchQueryResponseMapper {
   public static BatchOperationItemResponse toBatchOperationItem(
       final BatchOperationItemEntity entity) {
     return new BatchOperationItemResponse()
-        .batchOperationKey(entity.batchOperationKey().toString())
+        .batchOperationId(entity.batchOperationId())
         .itemKey(entity.itemKey().toString())
         .processInstanceKey(entity.processInstanceKey().toString())
         .processedDate(formatDate(entity.processedDate()))

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -37,31 +37,31 @@ public class BatchOperationController {
     this.batchOperationServices = batchOperationServices;
   }
 
-  @CamundaGetMapping(path = "/{batchOperationKey}")
-  public ResponseEntity<BatchOperationResponse> getByKey(
-      @PathVariable("batchOperationKey") final Long batchOperationKey) {
+  @CamundaGetMapping(path = "/{batchOperationId}")
+  public ResponseEntity<BatchOperationResponse> getById(
+      @PathVariable("batchOperationId") final String batchOperationId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toBatchOperation(
                   batchOperationServices
                       .withAuthentication(RequestMapper.getAuthentication())
-                      .getByKey(batchOperationKey)));
+                      .getById(batchOperationId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
   }
 
-  @CamundaGetMapping(path = "/{batchOperationKey}/items")
-  public ResponseEntity<BatchOperationItemSearchQueryResult> getItemsByKey(
-      @PathVariable("batchOperationKey") final Long batchOperationKey) {
+  @CamundaGetMapping(path = "/{batchOperationId}/items")
+  public ResponseEntity<BatchOperationItemSearchQueryResult> getItemsById(
+      @PathVariable("batchOperationId") final String batchOperationId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toBatchOperationItemSearchQueryResult(
                   batchOperationServices
                       .withAuthentication(RequestMapper.getAuthentication())
-                      .getItemsByKey(batchOperationKey)));
+                      .getItemsById(batchOperationId)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -74,33 +74,33 @@ public class BatchOperationController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @CamundaPutMapping(path = "/{key}/cancel")
-  public ResponseEntity<Object> cancelBatchOperation(@PathVariable final long key) {
+  @CamundaPutMapping(path = "/{batchOperationId}/cancel")
+  public ResponseEntity<Object> cancelBatchOperation(@PathVariable final String batchOperationId) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
             () ->
                 batchOperationServices
                     .withAuthentication(RequestMapper.getAuthentication())
-                    .cancel(key))
+                    .cancel(batchOperationId))
         .join();
   }
 
-  @CamundaPutMapping(path = "/{key}/pause")
-  public ResponseEntity<Object> pauseBatchOperation(@PathVariable final long key) {
+  @CamundaPutMapping(path = "/{batchOperationId}/pause")
+  public ResponseEntity<Object> pauseBatchOperation(@PathVariable final String batchOperationId) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
             () ->
                 batchOperationServices
                     .withAuthentication(RequestMapper.getAuthentication())
-                    .pause(key))
+                    .pause(batchOperationId))
         .join();
   }
 
-  @CamundaPutMapping(path = "/{key}/resume")
-  public ResponseEntity<Object> resumeBatchOperation(@PathVariable final long key) {
+  @CamundaPutMapping(path = "/{batchOperationId}/resume")
+  public ResponseEntity<Object> resumeBatchOperation(@PathVariable final String batchOperationId) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
             () ->
                 batchOperationServices
                     .withAuthentication(RequestMapper.getAuthentication())
-                    .resume(key))
+                    .resume(batchOperationId))
         .join();
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -43,14 +43,14 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @Test
   void shouldReturnBatchOperation() {
-    final var batchOperationKey = 1L;
-    final var batchOperationEntity = getBatchOperationEntity(batchOperationKey);
+    final var batchOperationId = "1";
+    final var batchOperationEntity = getBatchOperationEntity(batchOperationId);
 
-    when(batchOperationServices.getByKey(batchOperationKey)).thenReturn(batchOperationEntity);
+    when(batchOperationServices.getById(batchOperationId)).thenReturn(batchOperationEntity);
 
     webClient
         .get()
-        .uri("/v2/batch-operations/{batchOperationKey}", batchOperationKey)
+        .uri("/v2/batch-operations/{batchOperationKey}", batchOperationId)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -59,7 +59,7 @@ class BatchOperationControllerTest extends RestControllerTest {
         .json(
             """
           {
-              "batchOperationKey":"1",
+              "batchOperationId":"1",
               "state":"COMPLETED",
               "batchOperationType":"CANCEL_PROCESS_INSTANCE",
               "startDate":"2025-03-18T10:57:44.000+01:00",
@@ -73,7 +73,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   @Test
   void shouldSearchBatchOperations() {
     final var searchQueryResult = new BatchOperationSearchQueryResult();
-    final var entity = getBatchOperationEntity(1L);
+    final var entity = getBatchOperationEntity("1");
     when(batchOperationServices.search(any(BatchOperationQuery.class)))
         .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
 
@@ -94,7 +94,7 @@ class BatchOperationControllerTest extends RestControllerTest {
             """
           {"items":[
           {
-            "batchOperationKey":"1",
+            "batchOperationId":"1",
             "state":"COMPLETED",
             "batchOperationType":"CANCEL_PROCESS_INSTANCE",
             "startDate":"2025-03-18T10:57:44.000+01:00",
@@ -109,13 +109,13 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @Test
   void shouldCancelBatchOperation() {
-    final var batchOperationKey = 1L;
-    when(batchOperationServices.cancel(batchOperationKey))
+    final var batchOperationId = "1";
+    when(batchOperationServices.cancel(batchOperationId))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
         .put()
-        .uri("/v2/batch-operations/{key}/cancel", batchOperationKey)
+        .uri("/v2/batch-operations/{key}/cancel", batchOperationId)
         .exchange()
         .expectStatus()
         .isAccepted();
@@ -123,13 +123,13 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @Test
   void shouldPauseBatchOperation() {
-    final var batchOperationKey = 1L;
-    when(batchOperationServices.pause(batchOperationKey))
+    final var batchOperationId = "1";
+    when(batchOperationServices.pause(batchOperationId))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
         .put()
-        .uri("/v2/batch-operations/{key}/pause", batchOperationKey)
+        .uri("/v2/batch-operations/{key}/pause", batchOperationId)
         .exchange()
         .expectStatus()
         .isAccepted();
@@ -137,13 +137,13 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @Test
   void shouldResumeBatchOperation() {
-    final var batchOperationKey = 1L;
-    when(batchOperationServices.resume(batchOperationKey))
+    final var batchOperationId = "1";
+    when(batchOperationServices.resume(batchOperationId))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     webClient
         .put()
-        .uri("/v2/batch-operations/{key}/resume", batchOperationKey)
+        .uri("/v2/batch-operations/{key}/resume", batchOperationId)
         .exchange()
         .expectStatus()
         .isAccepted();
@@ -151,22 +151,22 @@ class BatchOperationControllerTest extends RestControllerTest {
 
   @Test
   void shouldReturnBatchOperationItems() {
-    final var batchOperationKey = 1L;
+    final var batchOperationId = "1";
 
     final var batchOperationItem =
         new BatchOperationEntity.BatchOperationItemEntity(
-            batchOperationKey,
+            batchOperationId,
             11L,
             12L,
             BatchOperationItemState.FAILED,
             OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
             "error");
-    when(batchOperationServices.getItemsByKey(batchOperationKey))
+    when(batchOperationServices.getItemsById(batchOperationId))
         .thenReturn(List.of(batchOperationItem));
 
     webClient
         .get()
-        .uri("/v2/batch-operations/{batchOperationKey}/items", batchOperationKey)
+        .uri("/v2/batch-operations/{batchOperationKey}/items", batchOperationId)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -176,7 +176,7 @@ class BatchOperationControllerTest extends RestControllerTest {
             """
                         {"items":[
                             {
-                                "batchOperationKey":"1",
+                                "batchOperationId":"1",
                                 "itemKey":"11",
                                 "processInstanceKey":"12",
                                 "state":"FAILED",
@@ -187,9 +187,9 @@ class BatchOperationControllerTest extends RestControllerTest {
                       """);
   }
 
-  private static BatchOperationEntity getBatchOperationEntity(final long batchOperationKey) {
+  private static BatchOperationEntity getBatchOperationEntity(final String batchOperationId) {
     return new BatchOperationEntity(
-        batchOperationKey,
+        batchOperationId,
         BatchOperationState.COMPLETED,
         "CANCEL_PROCESS_INSTANCE",
         OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),


### PR DESCRIPTION
## Description

To be backwards compatible with legacy batch operations from operate, which should still be readable longterm from ES and OS, we need to continue to use a String as ID Field. Because there we just have a UUID as PK. This means, that we also have to change the type in existing code. All places which has to be able to deal with both IDs:

* Rest API
* Search API
* Camunda Client
* RDBMS ... When we now do a query, the filter contains string ids (In order to be able to also query old batches from ES/OS). In Rdbms, up to now we used long for the batchOperationKey. Since on each RDBMS Type, casting Strings to Longs is different, we decided to change also there the batchOperationKey to String. To make life easier. 


## Related issues

closes #31589
