### PR TITLE
Add commands to search groups

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -75,6 +75,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetRequest;
 import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
+import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
@@ -1846,4 +1847,19 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand(String groupId);
+
+  /**
+   * Request to get a group by group ID.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newGroupGetRequest(groupId)
+   *  .send();
+   * </pre>
+   *
+   * @param groupId the ID of the group
+   * @return a builder for the request to get a group
+   */
+  GroupGetRequest newGroupGetRequest(String groupId);
 }

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -76,6 +76,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
+import io.camunda.client.api.fetch.GroupsSearchRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
@@ -1862,4 +1863,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a group
    */
   GroupGetRequest newGroupGetRequest(String groupId);
+
+  /**
+   * Executes a search request to query groups.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newGroupsSearchRequest()
+   *  .filter((f) -> f.name(name))
+   *  .sort((s) -> s.name().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the groups search request
+   */
+  GroupsSearchRequest newGroupsSearchRequest();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/GroupGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/GroupGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.Group;
+
+public interface GroupGetRequest extends FinalCommandStep<Group> {}

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/GroupsSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/GroupsSearchRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.TypedSearchRequest;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.sort.GroupSort;
+
+public interface GroupsSearchRequest
+    extends TypedSearchRequest<GroupFilter, GroupSort, GroupsSearchRequest>,
+        FinalSearchRequestStep<Group> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
@@ -15,10 +15,17 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
 
 public interface GroupFilter extends SearchRequestFilter {
+
+  /**
+   * Filters groups by the specified groupId.
+   *
+   * @param groupId the ID of the group
+   * @return the updated filter
+   */
+  GroupFilter groupId(final String groupId);
 
   /**
    * Filters groups by the specified name.
@@ -27,12 +34,4 @@ public interface GroupFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   GroupFilter name(final String name);
-
-  /**
-   * Filters groups by the specified name using {@link StringProperty} consumer.
-   *
-   * @param fn the name {@link StringProperty} consumer of the group
-   * @return the updated filter
-   */
-  GroupFilter name(final java.util.function.Consumer<String> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+
+public interface GroupFilter extends SearchRequestFilter {
+
+  /**
+   * Filters groups by the specified name.
+   *
+   * @param name the name of the group
+   * @return the updated filter
+   */
+  GroupFilter name(final String name);
+
+  /**
+   * Filters groups by the specified name using {@link StringProperty} consumer.
+   *
+   * @param fn the name {@link StringProperty} consumer of the group
+   * @return the updated filter
+   */
+  GroupFilter name(final java.util.function.Consumer<StringProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
@@ -34,5 +34,5 @@ public interface GroupFilter extends SearchRequestFilter {
    * @param fn the name {@link StringProperty} consumer of the group
    * @return the updated filter
    */
-  GroupFilter name(final java.util.function.Consumer<StringProperty> fn);
+  GroupFilter name(final java.util.function.Consumer<String> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
@@ -31,6 +32,7 @@ import io.camunda.client.api.search.sort.DecisionDefinitionSort;
 import io.camunda.client.api.search.sort.DecisionInstanceSort;
 import io.camunda.client.api.search.sort.DecisionRequirementsSort;
 import io.camunda.client.api.search.sort.ElementInstanceSort;
+import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.IncidentSort;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
@@ -42,6 +44,7 @@ import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.client.impl.search.filter.ElementInstanceFilterImpl;
+import io.camunda.client.impl.search.filter.GroupFilterImpl;
 import io.camunda.client.impl.search.filter.IncidentFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
@@ -54,6 +57,7 @@ import io.camunda.client.impl.search.sort.DecisionDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
 import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
 import io.camunda.client.impl.search.sort.ElementInstanceSortImpl;
+import io.camunda.client.impl.search.sort.GroupSortImpl;
 import io.camunda.client.impl.search.sort.IncidentSortImpl;
 import io.camunda.client.impl.search.sort.ProcessDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.ProcessInstanceSortImpl;
@@ -214,5 +218,17 @@ public final class SearchRequestBuilders {
     final ProcessDefinitionStatisticsFilter filter = new ProcessDefinitionStatisticsFilterImpl();
     fn.accept(filter);
     return filter;
+  }
+
+  public static GroupFilter groupFilter(final Consumer<GroupFilter> fn) {
+    final GroupFilter filter = new GroupFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static GroupSort groupSort(final Consumer<GroupSort> fn) {
+    final GroupSort sort = new GroupSortImpl();
+    fn.accept(sort);
+    return sort;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Group.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Group.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+public interface Group {
+
+  Long getGroupKey();
+
+  String getGroupId();
+
+  String getName();
+
+  String getDescription();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupSort.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+
+public interface GroupSort extends SearchRequestSort<GroupSort> {
+
+  GroupSort name();
+
+  GroupSort groupId();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -87,6 +87,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
+import io.camunda.client.api.fetch.GroupsSearchRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
@@ -188,6 +189,7 @@ import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
+import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessInstanceSearchRequestImpl;
@@ -996,6 +998,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public GroupGetRequest newGroupGetRequest(final String groupId) {
     return new GroupGetRequestImpl(httpClient, groupId);
+  }
+
+  @Override
+  public GroupsSearchRequest newGroupsSearchRequest() {
+    return new GroupSearchRequestImpl(httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -86,6 +86,7 @@ import io.camunda.client.api.fetch.DecisionRequirementsGetRequest;
 import io.camunda.client.api.fetch.DecisionRequirementsGetXmlRequest;
 import io.camunda.client.api.fetch.DocumentContentGetRequest;
 import io.camunda.client.api.fetch.ElementInstanceGetRequest;
+import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
@@ -171,6 +172,7 @@ import io.camunda.client.impl.fetch.DecisionRequirementsGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionRequirementsGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.DocumentContentGetRequestImpl;
 import io.camunda.client.impl.fetch.ElementInstanceGetRequestImpl;
+import io.camunda.client.impl.fetch.GroupGetRequestImpl;
 import io.camunda.client.impl.fetch.IncidentGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetFormRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
@@ -989,6 +991,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand(final String groupId) {
     return new UnassignMappingFromGroupCommandImpl(httpClient, groupId);
+  }
+
+  @Override
+  public GroupGetRequest newGroupGetRequest(final String groupId) {
+    return new GroupGetRequestImpl(httpClient, groupId);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/GroupGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/GroupGetRequestImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.GroupGetRequest;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GroupResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GroupGetRequestImpl implements GroupGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String groupId;
+
+  public GroupGetRequestImpl(HttpClient httpClient, String groupId) {
+    this.httpClient = httpClient;
+    this.httpRequestConfig = httpClient.newRequestConfig();
+    this.groupId = groupId;
+  }
+
+  @Override
+  public FinalCommandStep<Group> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Group> send() {
+    final HttpCamundaFuture<Group> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/groups/%s", groupId),
+        httpRequestConfig.build(),
+        GroupResult.class,
+        SearchResponseMapper::toGroupResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -18,7 +18,6 @@ package io.camunda.client.impl.search.filter;
 import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.GroupFilterRequest;
-import java.util.function.Consumer;
 
 public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFilterRequest>
     implements GroupFilter {
@@ -30,16 +29,14 @@ public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFil
   }
 
   @Override
-  public GroupFilter name(final String name) {
-    filter.setName(name);
+  public GroupFilter groupId(final String groupId) {
+    filter.setGroupId(groupId);
     return this;
   }
 
   @Override
-  public GroupFilter name(final Consumer<String> fn) {
-    final String property = "";
-    fn.accept(property);
-    filter.setName(provideSearchRequestProperty(property));
+  public GroupFilter name(final String name) {
+    filter.setName(name);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.GroupFilterRequest;
+import java.util.function.Consumer;
+
+public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFilterRequest>
+    implements GroupFilter {
+
+  private final GroupFilterRequest filter;
+
+  public GroupFilterImpl() {
+    filter = new GroupFilterRequest();
+  }
+
+  @Override
+  public GroupFilter name(final String name) {
+    name(b -> b.eq(name));
+    return this;
+  }
+
+  @Override
+  public GroupFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  protected GroupFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -16,8 +16,6 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.GroupFilter;
-import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.GroupFilterRequest;
 import java.util.function.Consumer;
@@ -33,13 +31,13 @@ public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFil
 
   @Override
   public GroupFilter name(final String name) {
-    name(b -> b.eq(name));
+    filter.setName(name);
     return this;
   }
 
   @Override
-  public GroupFilter name(final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
+  public GroupFilter name(final Consumer<String> fn) {
+    final String property = "";
     fn.accept(property);
     filter.setName(provideSearchRequestProperty(property));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupSearchRequestImpl.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.fetch.GroupsSearchRequest;
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GroupSearchQueryRequest;
+import io.camunda.client.protocol.rest.GroupSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GroupSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<GroupSearchQueryRequest>
+    implements GroupsSearchRequest {
+
+  private final GroupSearchQueryRequest request;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final JsonMapper jsonMapper;
+
+  public GroupSearchRequestImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new GroupSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Group> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Group>> send() {
+    final HttpCamundaFuture<SearchResponse<Group>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/groups/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GroupSearchQueryResult.class,
+        SearchResponseMapper::toGroupsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  protected GroupSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public GroupsSearchRequest filter(final GroupFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GroupsSearchRequest filter(final Consumer<GroupFilter> fn) {
+    return filter(groupFilter(fn));
+  }
+
+  @Override
+  public GroupsSearchRequest sort(final GroupSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toGroupSearchQuerySortRequest(provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public GroupsSearchRequest sort(final Consumer<GroupSort> fn) {
+    return sort(groupSort(fn));
+  }
+
+  @Override
+  public GroupsSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GroupsSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.Group;
+
+public class GroupImpl implements Group {
+
+  private final long groupKey;
+  private final String groupId;
+  private final String name;
+  private final String description;
+
+  public GroupImpl(
+      final Long groupKey, final String groupId, final String name, final String description) {
+    this.groupKey = groupKey;
+    this.groupId = groupId;
+    this.name = name;
+    this.description = description;
+  }
+
+  @Override
+  public Long getGroupKey() {
+    return groupKey;
+  }
+
+  @Override
+  public String getGroupId() {
+    return groupId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -29,6 +30,7 @@ import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.SearchResponsePage;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
 import java.util.Collections;
 import java.util.List;
@@ -147,6 +149,14 @@ public final class SearchResponseMapper {
   public static BatchOperationItems toBatchOperationItemsGetResponse(
       final BatchOperationItemSearchQueryResult response) {
     return new BatchOperationItemsImpl(response);
+  }
+
+  public static Group toGroupResponse(final GroupResult response) {
+    return new GroupImpl(
+        ParseUtil.parseLongOrNull(response.getGroupKey()),
+        response.getGroupId(),
+        response.getName(),
+        response.getDescription());
   }
 
   private static <T, R> List<R> toSearchResponseInstances(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -159,6 +159,13 @@ public final class SearchResponseMapper {
         response.getDescription());
   }
 
+  public static SearchResponse<Group> toGroupsResponse(final GroupSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<Group> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toGroupResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
   private static <T, R> List<R> toSearchResponseInstances(
       final List<T> items, final Function<T, R> mapper) {
     return Optional.ofNullable(items)

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/GroupSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/GroupSortImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class GroupSortImpl extends SearchRequestSortBase<GroupSort> implements GroupSort {
+
+  @Override
+  public GroupSort name() {
+    return field("name");
+  }
+
+  @Override
+  public GroupSort groupId() {
+    return field("groupId");
+  }
+
+  @Override
+  protected GroupSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -34,5 +35,22 @@ public class GroupSearchTest extends ClientRestTest {
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/groups/" + groupId);
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  public void testGroupsSearch() {
+    // when
+    client
+        .newGroupsSearchRequest()
+        .filter(fn -> fn.name("groupName"))
+        .sort(GroupSort::name)
+        .page(fn -> fn.limit(5))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/groups/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class GroupSearchTest extends ClientRestTest {
+
+  @Test
+  public void testGroupSearch() {
+    // when
+    final String groupId = "groupId";
+    client.newGroupGetRequest(groupId).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/groups/" + groupId);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -11,10 +11,11 @@ import static io.camunda.client.api.search.enums.PermissionType.*;
 import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
 import static io.camunda.client.api.search.enums.ResourceType.GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.Group;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
@@ -23,40 +24,30 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
-@Disabled("Enable with https://github.com/camunda/camunda/issues/29925")
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-class GroupSearchingAuthorizationIT {
+class GroupAuthorizationIT {
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
 
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
+  private static final String GROUP_ID_1 = Strings.newRandomValidIdentityId();
+  private static final String GROUP_ID_2 = Strings.newRandomValidIdentityId();
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";
   private static final String RESTRICTED_WITH_READ = "restricteUser2";
   private static final String DEFAULT_PASSWORD = "password";
-  private static final String GROUP_SEARCH_ENDPOINT = "v2/groups/search";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);
 
   @UserDefinition
@@ -84,75 +75,59 @@ class GroupSearchingAuthorizationIT {
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createGroup(adminClient, "group1");
-    createGroup(adminClient, "group2");
-    final int expectedCount = 2;
-    waitForGroupsToBeCreated(
-        adminClient.getConfiguration().getRestAddress().toString(), ADMIN, expectedCount);
-  }
-
-  private static GroupSearchResponse searchGroups(final String restAddress, final String username)
-      throws URISyntaxException, IOException, InterruptedException {
-    final var encodedCredentials =
-        Base64.getEncoder()
-            .encodeToString("%s:%s".formatted(username, DEFAULT_PASSWORD).getBytes());
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s".formatted(restAddress, GROUP_SEARCH_ENDPOINT)))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .header("Authorization", "Basic %s".formatted(encodedCredentials))
-            .build();
-
-    final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-
-    return OBJECT_MAPPER.readValue(response.body(), GroupSearchResponse.class);
+    createGroup(adminClient, GROUP_ID_1);
+    createGroup(adminClient, GROUP_ID_2);
+    waitForGroupsToBeCreated(adminClient, 2);
   }
 
   @Test
   void searchShouldReturnAuthorizedGroups(
-      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) throws Exception {
-    final var groupSearchResponse =
-        searchGroups(
-            camundaClient.getConfiguration().getRestAddress().toString(), RESTRICTED_WITH_READ);
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
+    final var groupSearchResponse = camundaClient.newGroupsSearchRequest().send().join();
 
     assertThat(groupSearchResponse.items())
         .hasSize(2)
-        .map(GroupResponse::name)
-        .containsExactlyInAnyOrder("group1", "group2");
+        .map(Group::getGroupId)
+        .containsExactlyInAnyOrder(GROUP_ID_1, GROUP_ID_2);
   }
 
   @Test
   void searchShouldReturnEmptyListWhenUnauthorized(
-      @Authenticated(RESTRICTED) final CamundaClient camundaClient) throws Exception {
-    final var groupSearchResponse =
-        searchGroups(camundaClient.getConfiguration().getRestAddress().toString(), RESTRICTED);
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    final var groupSearchResponse = camundaClient.newGroupsSearchRequest().send().join();
 
-    assertThat(groupSearchResponse.items()).hasSize(0).map(GroupResponse::name).isEmpty();
+    assertThat(groupSearchResponse.items()).hasSize(0).map(Group::getName).isEmpty();
   }
 
-  private static void createGroup(final CamundaClient adminClient, final String groupName) {
-    adminClient
-        .newCreateGroupCommand()
-        .groupId(Strings.newRandomValidIdentityId())
-        .name(groupName)
-        .send()
-        .join();
+  @Test
+  void getGroupByIdShouldReturnGroupIfAuthorized(
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
+    final var group = camundaClient.newGroupGetRequest(GROUP_ID_1).send().join();
+
+    assertThat(group.getGroupId()).isEqualTo(GROUP_ID_1);
+  }
+
+  @Test
+  void getGroupByIdShouldReturnNotFoundIfUnauthorized(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    assertThatThrownBy(() -> camundaClient.newGroupGetRequest(GROUP_ID_1).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("404: 'Not Found'");
+  }
+
+  private static void createGroup(final CamundaClient adminClient, final String groupId) {
+    adminClient.newCreateGroupCommand().groupId(groupId).name("groupName").send().join();
   }
 
   private static void waitForGroupsToBeCreated(
-      final String restAddress, final String username, final int expectedCount) {
+      final CamundaClient client, final int expectedCount) {
     Awaitility.await("should create groups and import in ES")
         .atMost(AWAIT_TIMEOUT)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              final var groupSearchResponse = searchGroups(restAddress, username);
+              final var groupSearchResponse = client.newGroupsSearchRequest().send().join();
               assertThat(groupSearchResponse.items()).hasSize(expectedCount);
             });
   }
-
-  private record GroupSearchResponse(List<GroupResponse> items) {}
-
-  private record GroupResponse(String name) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -106,6 +106,18 @@ class GroupAuthorizationIT {
   }
 
   @Test
+  void searchShouldReturnGroupFilteredByGroupId(
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
+    final var groupSearchResponse =
+        camundaClient.newGroupsSearchRequest().filter(fn -> fn.groupId(GROUP_ID_1)).send().join();
+
+    assertThat(groupSearchResponse.items())
+        .hasSize(1)
+        .map(Group::getGroupId)
+        .containsExactly(GROUP_ID_1);
+  }
+
+  @Test
   void searchShouldReturnGroupsFilteredByName(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     final var groupSearchResponse =

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6575,8 +6575,7 @@ components:
       properties:
         name:
           description: The group name search filters.
-          allOf:
-            - $ref: "#/components/schemas/StringFilterProperty"
+          type: string
     GroupSearchQueryResult:
       description: Group search response.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6574,8 +6574,9 @@ components:
       type: object
       properties:
         name:
-          type: string
-          description: The name of the group.
+          description: The group name search filters.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
     GroupSearchQueryResult:
       description: Group search response.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6573,6 +6573,9 @@ components:
       description: Group filter request
       type: object
       properties:
+        groupId:
+          description: The group ID search filters.
+          type: string
         name:
           description: The group name search filters.
           type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -755,6 +755,7 @@ public final class SearchQueryRequestMapper {
   private static GroupFilter toGroupFilter(final GroupFilterRequest filter) {
     final var builder = FilterBuilders.group();
     if (filter != null) {
+      ofNullable(filter.getGroupId()).ifPresent(builder::groupId);
       ofNullable(filter.getName()).ifPresent(builder::name);
     }
     return builder.build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -281,7 +281,8 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper.fromGroupSearchQuerySortRequest(request.getSort()),
             SortOptionBuilders::group,
             SearchQueryRequestMapper::applyGroupSortField);
-    return buildSearchQuery(sort, page, SearchQueryBuilders::groupSearchQuery);
+    final var filter = toGroupFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::groupSearchQuery);
   }
 
   public static Either<ProblemDetail, TenantQuery> toTenantQuery(
@@ -746,6 +747,14 @@ public final class SearchQueryRequestMapper {
     final var builder = FilterBuilders.tenant();
     if (filter != null) {
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantId);
+      ofNullable(filter.getName()).ifPresent(builder::name);
+    }
+    return builder.build();
+  }
+
+  private static GroupFilter toGroupFilter(final GroupFilterRequest filter) {
+    final var builder = FilterBuilders.group();
+    if (filter != null) {
       ofNullable(filter.getName()).ifPresent(builder::name);
     }
     return builder.build();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PRs adds 2 new commands:
- `newGroupGetRequest(groupId)` -> get a group by ID
- `newGroupsSearchRequest` -> fetch the groups from the second storage, you can add filter sort and page parameter to the request

## Related issues

closes #31503 
closes #31497 
