### PR TITLE
Remove default empty tenantId, roleId, mappingId and username

### DIFF
--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -87,9 +87,11 @@ final class TenantMappingRuleMigrationHandlerTest {
   void stopWhenNoMoreRecords() {
     // given
     givenMappingRules();
-    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "tenantId", "", null));
     when(mappingServices.createMapping(any()))
-        .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
+        .thenAnswer(
+            invocation ->
+                CompletableFuture.completedFuture(new MappingRecord().setMappingId("mappingId")));
     when(tenantServices.addMember(anyString(), any(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     // when
@@ -131,7 +133,9 @@ final class TenantMappingRuleMigrationHandlerTest {
     givenMappingRules();
     when(tenantServices.getById(any())).thenThrow(new RuntimeException());
     when(mappingServices.createMapping(any()))
-        .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
+        .thenAnswer(
+            invocation ->
+                CompletableFuture.completedFuture(new MappingRecord().setMappingId("mappingId")));
 
     // when
     migrationHandler.migrate();
@@ -154,9 +158,11 @@ final class TenantMappingRuleMigrationHandlerTest {
   void ignoreWhenMappingAlreadyAssigned() {
     // given
     givenMappingRules();
-    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "tenantId", "", null));
     when(mappingServices.createMapping(any()))
-        .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
+        .thenAnswer(
+            invocation ->
+                CompletableFuture.completedFuture(new MappingRecord().setMappingId("mappingId")));
     when(tenantServices.addMember(anyString(), any(), anyString()))
         .thenReturn(
             CompletableFuture.failedFuture(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -58,11 +58,12 @@ final class UserTenantsMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final TenantServices tenantServices,
       @Mock(answer = Answers.RETURNS_SELF) final MappingServices mappingServices) {
     when(tenantServices.createTenant(any()))
-        .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
+        .thenReturn(CompletableFuture.completedFuture(new TenantRecord().setTenantId("tenantId")));
     when(tenantServices.addMember(anyString(), any(), anyString()))
-        .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
+        .thenReturn(CompletableFuture.completedFuture(new TenantRecord().setTenantId("tenantId")));
     when(mappingServices.createMapping(any()))
-        .thenReturn(CompletableFuture.completedFuture(new MappingRecord()));
+        .thenReturn(
+            CompletableFuture.completedFuture(new MappingRecord().setMappingId("mappingId")));
 
     this.managementIdentityClient = managementIdentityClient;
     this.tenantServices = tenantServices;
@@ -94,11 +95,12 @@ final class UserTenantsMigrationHandlerTest {
     givenUserTenants();
     when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(tenantServices.createTenant(any()))
-        .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
+        .thenReturn(CompletableFuture.completedFuture(new TenantRecord().setTenantId("tenantId")));
     when(mappingServices.createMapping(any()))
-        .thenReturn(CompletableFuture.completedFuture(new MappingRecord()));
+        .thenReturn(
+            CompletableFuture.completedFuture(new MappingRecord().setMappingId("mappingId")));
     when(tenantServices.addMember(anyString(), any(), anyString()))
-        .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
+        .thenReturn(CompletableFuture.completedFuture(new TenantRecord().setTenantId("tenantId")));
 
     // when
     migrationHandler.migrate();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
@@ -41,7 +42,11 @@ public class IdentitySetupInitializeMultiPartitionTest {
   @Test
   public void shouldTestLifecycle() {
     // when
-    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var role =
+        new RoleRecord()
+            .setRoleId(Strings.newRandomValidIdentityId())
+            .setRoleKey(1)
+            .setName("roleName");
     final var user =
         new UserRecord()
             .setUserKey(2)
@@ -107,7 +112,11 @@ public class IdentitySetupInitializeMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var role =
+        new RoleRecord()
+            .setRoleId(Strings.newRandomValidIdentityId())
+            .setRoleKey(1)
+            .setName("roleName");
     final var user =
         new UserRecord()
             .setUserKey(2)
@@ -145,7 +154,11 @@ public class IdentitySetupInitializeMultiPartitionTest {
     engine.role().newRole("foo").create();
 
     // when
-    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var role =
+        new RoleRecord()
+            .setRoleId(Strings.newRandomValidIdentityId())
+            .setRoleKey(1)
+            .setName("roleName");
     final var user =
         new UserRecord()
             .setUserKey(2)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
@@ -184,8 +185,8 @@ public class IdentitySetupInitializeTest {
         engine
             .identitySetup()
             .initialize()
-            .withUser(new UserRecord().setUserKey(2))
-            .withRole(new RoleRecord().setRoleKey(3))
+            .withUser(new UserRecord().setUsername(Strings.newRandomValidUsername()))
+            .withRole(new RoleRecord().setRoleId(Strings.newRandomValidIdentityId()))
             .withTenant(tenant)
             .initialize();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.Strings;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,7 +125,7 @@ public class MappingAppliersTest {
 
   private MappingRecord createMapping() {
     final long mappingKey = 1L;
-    final String mappingId = String.valueOf(mappingKey);
+    final String mappingId = Strings.newRandomValidIdentityId();
     final String claimName = "foo";
     final String claimValue = "bar";
     final var mappingRecord =
@@ -136,16 +137,15 @@ public class MappingAppliersTest {
             .setName(claimName);
     mappingState.create(mappingRecord);
     // create role
-    final long roleKey = 2L;
     final var role =
         new RoleRecord()
-            .setRoleKey(roleKey)
+            .setRoleKey(2L)
+            .setRoleId(Strings.newRandomValidIdentityId())
             .setEntityKey(mappingKey)
             .setEntityType(EntityType.MAPPING);
     roleState.create(role);
-    // TODO: Use role id instead of key
     membershipState.insertRelation(
-        EntityType.MAPPING, mappingId, RelationType.ROLE, String.valueOf(roleKey));
+        EntityType.MAPPING, mappingId, RelationType.ROLE, role.getRoleId());
     // create tenant
     final long tenantKey = 3L;
     final var tenantId = "tenant";
@@ -158,17 +158,15 @@ public class MappingAppliersTest {
             .setEntityType(EntityType.MAPPING);
     tenantState.createTenant(tenant);
     // create group
-    final var groupId = "1";
-    final var groupKey = Long.parseLong(groupId);
-    membershipState.insertRelation(EntityType.MAPPING, mappingId, RelationType.GROUP, groupId);
     final var group =
         new GroupRecord()
-            .setGroupKey(groupKey)
-            .setGroupId(groupId)
-            // TODO: revisit
-            .setEntityId(String.valueOf(mappingKey))
+            .setGroupKey(4L)
+            .setGroupId(Strings.newRandomValidIdentityId())
+            .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     groupState.create(group);
+    membershipState.insertRelation(
+        EntityType.MAPPING, mappingId, RelationType.GROUP, group.getGroupId());
     // create authorization
     authorizationState.create(
         5L,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.function.Function;
 
@@ -47,11 +48,17 @@ public final class IdentitySetupClient {
 
     private final CommandWriter writer;
     private final IdentitySetupRecord record;
+    private final RoleRecord defaultRole =
+        new RoleRecord().setRoleId(Strings.newRandomValidIdentityId());
+    private final TenantRecord defaultTenant =
+        new TenantRecord().setTenantId(Strings.newRandomValidIdentityId());
     private Function<Long, Record<IdentitySetupRecordValue>> expectation = SUCCESS_SUPPLIER;
 
     public IdentitySetupInitializeClient(final CommandWriter writer) {
       this.writer = writer;
       record = new IdentitySetupRecord();
+      record.setDefaultRole(defaultRole);
+      record.setDefaultTenant(defaultTenant);
     }
 
     public IdentitySetupInitializeClient withRole(final RoleRecord role) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -59,7 +59,7 @@ public class RoleControllerTest extends RestControllerTest {
     when(roleServices.createRole(request))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new RoleRecord().setEntityKey(100L).setName(roleName)));
+                new RoleRecord().setRoleId(roleId).setName(roleName).setDescription(description)));
 
     // when
     webClient

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -16,18 +16,18 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public class MappingRecord extends UnifiedRecordValue implements MappingRecordValue {
 
   private final LongProperty mappingKeyProp = new LongProperty("mappingKey", -1L);
+  private final StringProperty mappingIdProp = new StringProperty("mappingId");
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
-  private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
 
   public MappingRecord() {
     super(5);
     declareProperty(mappingKeyProp)
+        .declareProperty(mappingIdProp)
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
-        .declareProperty(nameProp)
-        .declareProperty(mappingIdProp);
+        .declareProperty(nameProp);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -18,8 +18,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
 
   private final LongProperty roleKeyProp = new LongProperty("roleKey", -1L);
-  // TODO remove default empty string https://github.com/camunda/camunda/issues/30140
-  private final StringProperty roleIdProp = new StringProperty("roleId", "");
+  private final StringProperty roleIdProp = new StringProperty("roleId");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
   // TODO remove entityKeyProp https://github.com/camunda/camunda/issues/30111

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -21,7 +21,7 @@ import org.agrona.DirectBuffer;
 public final class TenantRecord extends UnifiedRecordValue implements TenantRecordValue {
   private static final long DEFAULT_KEY = -1;
   private final LongProperty tenantKeyProp = new LongProperty("tenantKey", DEFAULT_KEY);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final StringProperty tenantIdProp = new StringProperty("tenantId");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
   private final StringProperty entityIdProp = new StringProperty("entityId", "");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -18,7 +18,7 @@ import org.agrona.DirectBuffer;
 
 public final class UserRecord extends UnifiedRecordValue implements UserRecordValue {
   private final LongProperty userKeyProp = new LongProperty("userKey", -1L);
-  private final StringProperty usernameProp = new StringProperty("username", "");
+  private final StringProperty usernameProp = new StringProperty("username");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty emailProp = new StringProperty("email", "");
   private final StringProperty passwordProp = new StringProperty("password", "");

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2856,11 +2856,11 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty RoleRecord",
-        (Supplier<RoleRecord>) RoleRecord::new,
+        (Supplier<RoleRecord>) () -> new RoleRecord().setRoleId("roleId"),
         """
         {
           "roleKey": -1,
-          "roleId": "",
+          "roleId": "roleId",
           "name": "",
           "description": "",
           "entityKey": -1,
@@ -3153,12 +3153,13 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty IdentitySetupRecord",
-        (Supplier<IdentitySetupRecord>) IdentitySetupRecord::new,
+        (Supplier<IdentitySetupRecord>)
+            () -> new IdentitySetupRecord().setDefaultRole(new RoleRecord().setRoleId("roleId")),
         """
       {
           "defaultRole": {
               "roleKey": -1,
-              "roleId": "",
+              "roleId": "roleId",
               "name": "",
               "description": "",
               "entityKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3030,13 +3030,13 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty MappingRecord",
-        (Supplier<MappingRecord>) MappingRecord::new,
+        (Supplier<MappingRecord>) () -> new MappingRecord().setMappingId("mappingId"),
         """
       {
         "mappingKey": -1,
+        "mappingId": "mappingId",
         "claimName": "",
         "claimValue": "",
-        "mappingId": "",
         "name": ""
       }
       """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2900,11 +2900,11 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty TenantRecord",
-        (Supplier<UnifiedRecordValue>) TenantRecord::new,
+        (Supplier<UnifiedRecordValue>) () -> new TenantRecord().setTenantId("tenantId"),
         """
           {
             "tenantKey": -1,
-            "tenantId": "",
+            "tenantId": "tenantId",
             "name": "",
             "description": "",
             "entityId": "",
@@ -3154,7 +3154,10 @@ final class JsonSerializableToJsonTest {
       {
         "Empty IdentitySetupRecord",
         (Supplier<IdentitySetupRecord>)
-            () -> new IdentitySetupRecord().setDefaultRole(new RoleRecord().setRoleId("roleId")),
+            () ->
+                new IdentitySetupRecord()
+                    .setDefaultRole(new RoleRecord().setRoleId("roleId"))
+                    .setDefaultTenant(new TenantRecord().setTenantId("tenantId")),
         """
       {
           "defaultRole": {
@@ -3169,7 +3172,7 @@ final class JsonSerializableToJsonTest {
           "users": [],
           "defaultTenant": {
               "tenantKey": -1,
-              "tenantId": "",
+              "tenantId": "tenantId",
               "name": "",
               "description": "",
               "entityId": "",

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2700,20 +2700,14 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "UserRecord",
-        (Supplier<UserRecord>)
-            () ->
-                new UserRecord()
-                    .setUsername("foobar")
-                    .setName("Foo Bar")
-                    .setEmail("foo@bar")
-                    .setPassword("f00b4r"),
+        (Supplier<UserRecord>) () -> new UserRecord().setUsername("foobar"),
         """
         {
           "userKey": -1,
           "username": "foobar",
-          "name": "Foo Bar",
-          "email": "foo@bar",
-          "password": "f00b4r"
+          "name": "",
+          "email": "",
+          "password": ""
         }
         """
       },


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

These properties are the identifiers and shoudl be set for every request we receive. By removing the defaults we ensure we cannot forget to set this in the code somewhere.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30140
closes #30137 
