### PR TITLE
refactor: c8run printStatus function

### DIFF
--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -14,11 +14,18 @@ import (
 	"os"
 	"text/template"
 	"time"
-        "github.com/camunda/camunda/c8run/internal/types"
+
+	"github.com/camunda/camunda/c8run/internal/types"
 )
 
 type opener interface {
 	OpenBrowser(protocol string, port int) error
+}
+
+type Ports struct {
+	OperatePort  int
+	TasklistPort int
+	IdentityPort int
 }
 
 func QueryCamunda(c8 opener, name string, settings types.C8RunSettings) error {
@@ -59,30 +66,25 @@ func isRunning(name, url string, retries int, delay time.Duration) bool {
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-        var operatePort, tasklistPort, identityPort int
-        if settings.Docker {
-                operatePort = 8081
-                tasklistPort = 8082
-                identityPort = 8084
-        } else {
-                operatePort = 8080
-                tasklistPort = 8080
-                identityPort = 8080
-        }
+	operatePort, tasklistPort, identityPort := 8080, 8080, 8080
+
+	// Overwrite ports if Docker is enabled
+	if settings.Docker {
+		operatePort = 8081
+		tasklistPort = 8082
+		identityPort = 8084
+	}
+
 	endpoints, _ := os.ReadFile("endpoints.txt")
 	t, err := template.New("endpoints").Parse(string(endpoints))
 	if err != nil {
 		return fmt.Errorf("Error: failed to parse endpoints template: %s", err.Error())
 	}
 
-	data := struct {
-		OperatePort int
-                TasklistPort int
-                IdentityPort int
-	}{
-		OperatePort: operatePort,
-                TasklistPort: tasklistPort,
-                IdentityPort: identityPort,
+	data := Ports{
+		OperatePort:  operatePort,
+		TasklistPort: tasklistPort,
+		IdentityPort: identityPort,
 	}
 
 	err = t.Execute(os.Stdout, data)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

related to https://github.com/camunda/camunda/issues/31390

Refactor the `printStatus function`: 
* Create the Port struct explicitly.
* assign port `8080` to all apps as default and only override if docker option used.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
