### PR TITLE
feat: populate application id in grpc context

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -504,6 +504,12 @@ public final class EndpointManager {
       claims.put(Authorization.AUTHORIZED_USERNAME, username);
     }
 
+    // retrieve the application id from the context and add it to the authorization if present
+    final String applicationId = Context.current().call(AuthenticationHandler.APPLICATION_ID::get);
+    if (applicationId != null) {
+      claims.put(Authorization.AUTHORIZED_APPLICATION_ID, applicationId);
+    }
+
     brokerRequest.setAuthorization(claims);
 
     return brokerRequest;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -116,24 +116,6 @@ public sealed interface AuthenticationHandler {
                       oidcAuthenticationConfiguration.getUsernameClaim(),
                       oidcAuthenticationConfiguration.getApplicationIdClaim())));
     }
-
-    private Either<Status, String> getApplicationIdClaim(final Map<String, Object> claims) {
-      final var applicationIdClaim =
-          claims.get(oidcAuthenticationConfiguration.getApplicationIdClaim());
-
-      if (applicationIdClaim == null) {
-        return null;
-      }
-
-      if (applicationIdClaim instanceof String) {
-        return Either.right(applicationIdClaim.toString());
-      }
-
-      return Either.left(
-          Status.UNAUTHENTICATED.augmentDescription(
-              CONFIGURED_CLAIM_NOT_A_STRING.formatted(
-                  "application id", oidcAuthenticationConfiguration.getApplicationIdClaim())));
-    }
   }
 
   final class BasicAuth implements AuthenticationHandler {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

This PR adds in the support for the GRPC side of the requests to add application ID to the requests (which is then set in the EndpointManager class).

The logic is:

-  Firstly:
    - Look for the username and application ID on the token:
        - If no username or application ID is found -> REJECT 
- If username is not found:
    - if application id is not a string -> REJECT
    - return application ID in context
- if username is found:
    - If the value is not a string -> REJECT
    - return username in context

closes [#30333](https://github.com/camunda/camunda/issues/30333), closes [#31607](https://github.com/camunda/camunda/issues/31607)