### PR TITLE
Handle exported roles using ids in RDBMS Exporter

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -206,7 +206,7 @@ public class CamundaOAuthPrincipalServiceTest {
                   new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
                   new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
-      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
+      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
       when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
           .thenReturn(List.of(roleR1));
       when(authorizationServices.getAuthorizedApplications(Set.of("test-id", "test-id-2", "8")))
@@ -242,7 +242,7 @@ public class CamundaOAuthPrincipalServiceTest {
       when(tenantServices.getTenantsByMemberIds(Set.of("map-1", "map-2")))
           .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
-      final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1");
+      final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
       when(roleServices.getRolesByMemberIds(Set.of("map-1", "map-2"))).thenReturn(List.of(roleR1));
 
       when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "10")))

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -58,7 +58,7 @@ public class CamundaOidcUserServiceTest {
             "role", "R1",
             "group", "G1");
 
-    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1");
+    final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
 
     when(camundaOAuthPrincipalService.loadOAuthContext(claims))
         .thenReturn(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -62,7 +62,7 @@ public class CamundaUserDetailsServiceTest {
     final var roleId = "admin";
     when(authorizationServices.getAuthorizedApplications(Set.of(roleId, TEST_USER_ID)))
         .thenReturn(List.of("operate", "identity"));
-    final RoleEntity adminRole = new RoleEntity(2L, roleId, "ADMIN");
+    final RoleEntity adminRole = new RoleEntity(2L, roleId, "ADMIN", "description");
     when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberId(TEST_USER_ID)))))
         .thenReturn(List.of(adminRole));
 

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -46,7 +46,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole")))
+                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole", "description")))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);
@@ -138,7 +138,7 @@ public class WebSessionMapperTest {
                 .withUsername("test")
                 .withPassword("admin")
                 .withUserKey(1L)
-                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole")))
+                .withRoles(List.of(new RoleEntity(1L, "testRole", "testRole", "description")))
                 .build(),
             null);
     securityContext.setAuthentication(authenticationToken);

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -450,7 +450,9 @@
       <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_TYPE" type="VARCHAR(255)" />
+      <column name="ENTITY_TYPE" type="VARCHAR(255)" >
+        <constraints primaryKey="true"/>
+      </column>
     </createTable>
   </changeSet>
 

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -401,7 +401,9 @@
       <column name="ENTITY_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_TYPE" type="VARCHAR(255)" />
+      <column name="ENTITY_TYPE" type="VARCHAR(255)" >
+        <constraints primaryKey="true"/>
+      </column>
     </createTable>
   </changeSet>
 

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -408,16 +408,18 @@
 
   <changeSet id="create_role_table" author="cthiel">
     <createTable tableName="${prefix}ROLES">
-      <column name="ROLE_KEY" type="BIGINT" >
+      <column name="ROLE_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="NAME" type="VARCHAR(255)"/>
+      <column name="ROLE_KEY" type="BIGINT" />
+      <column name="NAME" type="VARCHAR(255)" />
+      <column name="DESCRIPTION" type="VARCHAR(255)" />
     </createTable>
   </changeSet>
 
   <changeSet id="role_members_table" author="cthiel">
     <createTable tableName="${prefix}ROLE_MEMBER">
-      <column name="ROLE_KEY" type="BIGINT" >
+      <column name="ROLE_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_ID" type="VARCHAR(255)" >

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -31,13 +31,13 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     this.roleMapper = roleMapper;
   }
 
-  public Optional<RoleEntity> findOne(final long roleKey) {
-    final var result = search(RoleQuery.of(b -> b.filter(f -> f.roleKey(roleKey))));
+  public Optional<RoleEntity> findOne(final String roleId) {
+    final var result = search(RoleQuery.of(b -> b.filter(f -> f.roleId(roleId))));
     return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
   }
 
   public SearchQueryResult<RoleEntity> search(final RoleQuery query) {
-    final var dbSort = convertSort(query.sort(), RoleSearchColumn.ROLE_KEY);
+    final var dbSort = convertSort(query.sort(), RoleSearchColumn.ROLE_ID);
     final var dbQuery =
         RoleDbQuery.of(
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -51,9 +51,9 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
   private RoleEntity map(final RoleDbModel model) {
     return new RoleEntity(
         model.roleKey(),
-        // TODO use id instead of key https://github.com/camunda/camunda/issues/30127
-        String.valueOf(model.roleKey()),
+        model.roleId(),
         model.name(),
+        model.description(),
         model.members().stream().map(RoleMemberDbModel::entityId).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/RoleSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/RoleSearchColumn.java
@@ -12,7 +12,9 @@ import java.util.function.Function;
 
 public enum RoleSearchColumn implements SearchColumn<RoleEntity> {
   ROLE_KEY("roleKey", RoleEntity::roleKey),
-  NAME("name", RoleEntity::name);
+  ROLE_ID("roleId", RoleEntity::roleId),
+  NAME("name", RoleEntity::name),
+  DESCRIPTION("description", RoleEntity::description);
 
   private final String property;
   private final Function<RoleEntity, Object> propertyReader;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -14,7 +14,9 @@ import java.util.function.Function;
 public class RoleDbModel implements DbModel<RoleDbModel> {
 
   private Long roleKey;
+  private String roleId;
   private String name;
+  private String description;
   private List<RoleMemberDbModel> members;
 
   public Long roleKey() {
@@ -25,12 +27,28 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
     this.roleKey = roleKey;
   }
 
+  public String roleId() {
+    return roleId;
+  }
+
+  public void roleId(final String roleId) {
+    this.roleId = roleId;
+  }
+
   public String name() {
     return name;
   }
 
   public void name(final String name) {
     this.name = name;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public void description(final String description) {
+    this.description = description;
   }
 
   public List<RoleMemberDbModel> members() {
@@ -52,8 +70,12 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
     return "RoleDbModel{"
         + "roleKey="
         + roleKey
+        + ", roleId='"
+        + roleId
         + ", name='"
         + name
+        + ", description='"
+        + description
         + '\''
         + ", members="
         + members
@@ -63,7 +85,9 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
   public static class Builder implements ObjectBuilder<RoleDbModel> {
 
     private Long roleKey;
+    private String roleId;
     private String name;
+    private String description;
     private List<RoleMemberDbModel> members;
 
     public Builder() {}
@@ -73,8 +97,18 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
       return this;
     }
 
+    public Builder roleId(final String roleId) {
+      this.roleId = roleId;
+      return this;
+    }
+
     public Builder name(final String name) {
       this.name = name;
+      return this;
+    }
+
+    public Builder description(final String description) {
+      this.description = description;
       return this;
     }
 
@@ -87,7 +121,9 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
     public RoleDbModel build() {
       final RoleDbModel model = new RoleDbModel();
       model.roleKey(roleKey);
+      model.roleId(roleId);
       model.name(name);
+      model.description(description);
       model.members(members);
       return model;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
@@ -9,17 +9,17 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record RoleMemberDbModel(Long roleKey, String entityId, String entityType) {
+public record RoleMemberDbModel(String roleId, String entityId, String entityType) {
 
   // create builder implementing ObjectBuilder
   public static class Builder implements ObjectBuilder<RoleMemberDbModel> {
 
-    private Long roleKey;
+    private String roleId;
     private String entityId;
     private String entityType;
 
-    public Builder roleKey(final Long roleKey) {
-      this.roleKey = roleKey;
+    public Builder roleId(final String roleId) {
+      this.roleId = roleId;
       return this;
     }
 
@@ -35,7 +35,7 @@ public record RoleMemberDbModel(Long roleKey, String entityId, String entityType
 
     @Override
     public RoleMemberDbModel build() {
-      return new RoleMemberDbModel(roleKey, entityId, entityType);
+      return new RoleMemberDbModel(roleId, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GroupWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GroupWriter.java
@@ -79,13 +79,6 @@ public class GroupWriter {
             groupId,
             "io.camunda.db.rdbms.sql.GroupMapper.delete",
             groupId));
-    executionQueue.executeInQueue(
-        new QueueItem(
-            ContextType.GROUP,
-            WriteStatementType.DELETE,
-            groupId,
-            "io.camunda.db.rdbms.sql.GroupMapper.deleteAllMembers",
-            groupId));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -71,21 +71,14 @@ public class RoleWriter {
             member));
   }
 
-  public void delete(final long roleKey) {
+  public void delete(final String roleId) {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.ROLE,
             WriteStatementType.DELETE,
-            roleKey,
+            roleId,
             "io.camunda.db.rdbms.sql.RoleMapper.delete",
-            roleKey));
-    executionQueue.executeInQueue(
-        new QueueItem(
-            ContextType.ROLE,
-            WriteStatementType.DELETE,
-            roleKey,
-            "io.camunda.db.rdbms.sql.RoleMapper.deleteAllMembers",
-            roleKey));
+            roleId));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -29,7 +29,7 @@ public class RoleWriter {
         new QueueItem(
             ContextType.ROLE,
             WriteStatementType.INSERT,
-            role.roleKey(),
+            role.roleId(),
             "io.camunda.db.rdbms.sql.RoleMapper.insert",
             role));
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -66,7 +66,7 @@ public class RoleWriter {
         new QueueItem(
             ContextType.ROLE,
             WriteStatementType.DELETE,
-            member.roleKey(),
+            member.roleId(),
             "io.camunda.db.rdbms.sql.RoleMapper.deleteMember",
             member));
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -35,14 +35,17 @@ public class RoleWriter {
   }
 
   public void update(final RoleDbModel role) {
-    final boolean wasMerged = mergeToQueue(role.roleKey(), b -> b.name(role.name()));
+    final boolean wasMerged =
+        mergeToQueue(
+            role.roleId(),
+            b -> b.roleId(role.roleId()).name(role.name()).description(role.description()));
 
     if (!wasMerged) {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.ROLE,
               WriteStatementType.UPDATE,
-              role.roleKey(),
+              role.roleId(),
               "io.camunda.db.rdbms.sql.RoleMapper.update",
               role));
     }
@@ -86,8 +89,8 @@ public class RoleWriter {
   }
 
   private boolean mergeToQueue(
-      final long key, final Function<RoleDbModel.Builder, RoleDbModel.Builder> mergeFunction) {
+      final String roleId, final Function<RoleDbModel.Builder, RoleDbModel.Builder> mergeFunction) {
     return executionQueue.tryMergeWithExistingQueueItem(
-        new UpsertMerger<>(ContextType.ROLE, key, RoleDbModel.class, mergeFunction));
+        new UpsertMerger<>(ContextType.ROLE, roleId, RoleDbModel.class, mergeFunction));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -56,7 +56,7 @@ public class RoleWriter {
         new QueueItem(
             ContextType.ROLE,
             WriteStatementType.INSERT,
-            member.roleKey(),
+            member.roleId(),
             "io.camunda.db.rdbms.sql.RoleMapper.insertMember",
             member));
   }

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -101,13 +101,4 @@
       AND ENTITY_TYPE = #{entityType}
   </delete>
 
-  <delete
-    id="deleteAllMembers"
-    parameterType="java.lang.String"
-    flushCache="true">
-    DELETE
-    FROM ${prefix}GROUP_MEMBER
-    WHERE GROUP_ID = #{groupId}
-  </delete>
-
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -66,8 +66,9 @@
     parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel"
     flushCache="true">
     UPDATE ${prefix}ROLES
-    SET NAME = #{name}
-    WHERE ROLE_KEY = #{roleKey}
+    SET NAME = #{name},
+        DESCRIPTION = #{description}
+    WHERE ROLE_ID = #{roleId}
   </update>
 
   <delete id="delete" parameterType="java.lang.Long" flushCache="true">

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -81,8 +81,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_KEY, ENTITY_ID, ENTITY_TYPE)
-    VALUES (#{roleKey}, #{entityId}, #{entityType})
+    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_ID, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{roleId}, #{entityId}, #{entityType})
   </insert>
 
   <delete

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -91,7 +91,7 @@
     flushCache="true">
     DELETE
     FROM ${prefix}ROLE_MEMBER
-    WHERE ROLE_KEY = #{roleKey}
+    WHERE ROLE_ID = #{roleId}
       AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -20,13 +20,15 @@
     resultMap="io.camunda.db.rdbms.sql.RoleMapper.roleResultMap">
     SELECT * FROM (
     SELECT
+    r.ROLE_ID,
     r.ROLE_KEY,
     r.NAME,
-    rm.ROLE_KEY AS MEMBER_ROLE_KEY,
+    r.DESCRIPTION,
+    rm.ROLE_ID AS MEMBER_ROLE_ID,
     rm.ENTITY_ID AS MEMBER_ENTITY_ID,
     rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}ROLES r
-    LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_KEY = rm.ROLE_KEY
+    LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -37,16 +39,19 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <if test="filter.roleKey != null">AND r.ROLE_KEY = #{filter.roleKey}</if>
+    <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
     <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">
-    <id column="ROLE_KEY" property="roleKey" />
+    <id column="ROLE_ID" property="roleId" />
+    <result column="ROLE_KEY" property="roleKey" />
     <result column="NAME" property="name"/>
+    <result column="DESCRIPTION" property="description"/>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
       javaType="java.util.List">
       <constructor>
-        <idArg column="MEMBER_ROLE_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_ROLE_ID" javaType="java.lang.String"/>
         <idArg column="MEMBER_ENTITY_ID" javaType="java.lang.String"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -57,8 +57,8 @@
     id="insert"
     parameterType="io.camunda.db.rdbms.write.domain.RoleDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}ROLES (ROLE_KEY, NAME)
-    VALUES (#{roleKey}, #{name})
+    INSERT INTO ${prefix}ROLES (ROLE_KEY, ROLE_ID, NAME, DESCRIPTION)
+    VALUES (#{roleKey}, #{roleId}, #{name}, #{description})
   </insert>
 
   <update

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -71,10 +71,10 @@
     WHERE ROLE_ID = #{roleId}
   </update>
 
-  <delete id="delete" parameterType="java.lang.Long" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String" flushCache="true">
     DELETE
     FROM ${prefix}ROLES
-    WHERE ROLE_KEY = #{roleKey}
+    WHERE ROLE_ID = #{roleId}
   </delete>
 
   <insert
@@ -94,15 +94,6 @@
     WHERE ROLE_KEY = #{roleKey}
       AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
-  </delete>
-
-  <delete
-    id="deleteAllMembers"
-    parameterType="java.lang.Long"
-    flushCache="true">
-    DELETE
-    FROM ${prefix}ROLE_MEMBER
-    WHERE ROLE_KEY = #{roleKey}
   </delete>
 
 </mapper>

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/permission/PermissionsServiceTest.java
@@ -61,7 +61,7 @@ public class PermissionsServiceTest {
         .thenReturn(
             new AuthenticationContext.AuthenticationContextBuilder()
                 .withUsername("test")
-                .withRoles(List.of(new RoleEntity(roleKey, roleId, "roleName")))
+                .withRoles(List.of(new RoleEntity(roleKey, roleId, "roleName", "description")))
                 .withTenants(List.of(new TenantDTO(123L, tenantId, "tenantName", "")))
                 .build());
     when(mockAuthentication.getPrincipal()).thenReturn(camundaUser);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/RoleFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/RoleFixtures.java
@@ -18,8 +18,14 @@ public final class RoleFixtures extends CommonFixtures {
   private RoleFixtures() {}
 
   public static RoleDbModel createRandomized(final Function<Builder, Builder> builderFunction) {
-    final var userKey = nextKey();
-    final var builder = new Builder().roleKey(userKey).name("Role " + userKey);
+    final var roleKey = nextKey();
+    final var roleId = nextStringId();
+    final var builder =
+        new Builder()
+            .roleKey(roleKey)
+            .roleId(roleId)
+            .name("Role " + roleId)
+            .description("Description " + roleId);
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -44,7 +44,7 @@ public class RoleIT {
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriter, role);
 
-    final var instance = roleReader.findOne(role.roleKey()).orElse(null);
+    final var instance = roleReader.findOne(role.roleId()).orElse(null);
 
     compareRoles(instance, role);
   }
@@ -62,7 +62,7 @@ public class RoleIT {
     rdbmsWriter.getRoleWriter().update(roleUpdate);
     rdbmsWriter.flush();
 
-    final var instance = roleReader.findOne(role.roleKey()).orElse(null);
+    final var instance = roleReader.findOne(role.roleId()).orElse(null);
 
     compareRoles(instance, roleUpdate);
   }
@@ -75,13 +75,13 @@ public class RoleIT {
 
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriter, role);
-    final var instance = roleReader.findOne(role.roleKey()).orElse(null);
+    final var instance = roleReader.findOne(role.roleId()).orElse(null);
     compareRoles(instance, role);
 
     rdbmsWriter.getRoleWriter().delete(role.roleId());
     rdbmsWriter.flush();
 
-    final var deletedInstance = roleReader.findOne(role.roleKey()).orElse(null);
+    final var deletedInstance = roleReader.findOne(role.roleId()).orElse(null);
     assertThat(deletedInstance).isNull();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -24,14 +24,12 @@ import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.sort.RoleSort;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
-@Disabled("https://github.com/camunda/camunda/issues/30127")
 public class RoleIT {
 
   public static final Long PARTITION_ID = 0L;
@@ -80,7 +78,7 @@ public class RoleIT {
     final var instance = roleReader.findOne(role.roleKey()).orElse(null);
     compareRoles(instance, role);
 
-    rdbmsWriter.getRoleWriter().delete(role.roleKey());
+    rdbmsWriter.getRoleWriter().delete(role.roleId());
     rdbmsWriter.flush();
 
     final var deletedInstance = roleReader.findOne(role.roleKey()).orElse(null);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -58,7 +58,8 @@ public class RoleIT {
     final var role = RoleFixtures.createRandomized(b -> b);
     createAndSaveRole(rdbmsWriter, role);
 
-    final var roleUpdate = RoleFixtures.createRandomized(b -> b.roleKey(role.roleKey()));
+    final var roleUpdate =
+        RoleFixtures.createRandomized(b -> b.roleId(role.roleId()).roleKey(role.roleKey()));
     rdbmsWriter.getRoleWriter().update(roleUpdate);
     rdbmsWriter.flush();
 
@@ -179,7 +180,9 @@ public class RoleIT {
                                 p.size(5)
                                     .searchAfter(
                                         new Object[] {
-                                          instanceAfter.name(), instanceAfter.roleKey()
+                                          instanceAfter.name(),
+                                          instanceAfter.roleId(),
+                                          instanceAfter.roleKey()
                                         }))));
 
     assertThat(nextPage.total()).isEqualTo(20);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -386,16 +386,16 @@ class RdbmsExporterIT {
   public void shouldExportUpdateAndDeleteRole() {
     // given
     final var roleRecord = getRoleRecord(42L, RoleIntent.CREATED);
-    final var roleRecordValue = ((RoleRecordValue) roleRecord.getValue());
+    final var recordValue = (RoleRecordValue) roleRecord.getValue();
 
     // when
     exporter.export(roleRecord);
 
     // then
-    final var role = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
+    final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
-    assertThat(role.get().roleKey()).isEqualTo(roleRecordValue.getRoleKey());
-    assertThat(role.get().name()).isEqualTo(roleRecordValue.getName());
+    assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
+    assertThat(role.get().name()).isEqualTo(recordValue.getName());
 
     // given
     final var updateRoleRecord = getRoleRecord(42L, RoleIntent.UPDATED);
@@ -405,7 +405,7 @@ class RdbmsExporterIT {
     exporter.export(updateRoleRecord);
 
     // then
-    final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
+    final var updatedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(updatedRole).isNotEmpty();
     assertThat(updatedRole.get().roleKey()).isEqualTo(updateRoleRecordValue.getRoleKey());
     assertThat(updatedRole.get().name()).isEqualTo(updateRoleRecordValue.getName());
@@ -414,7 +414,7 @@ class RdbmsExporterIT {
     exporter.export(getRoleRecord(42L, RoleIntent.DELETED));
 
     // then
-    final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
+    final var deletedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(deletedRole).isEmpty();
   }
 
@@ -422,29 +422,31 @@ class RdbmsExporterIT {
   public void shouldExportRoleAndAddAndDeleteMember() {
     // given
     final var roleRecord = getRoleRecord(42L, RoleIntent.CREATED);
-    final var roleRecordValue = ((RoleRecordValue) roleRecord.getValue());
+    final var recordValue = (RoleRecordValue) roleRecord.getValue();
 
     // when
     exporter.export(roleRecord);
 
     // then
-    final var role = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
+    final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
-    assertThat(role.get().roleKey()).isEqualTo(roleRecordValue.getRoleKey());
-    assertThat(role.get().name()).isEqualTo(roleRecordValue.getName());
+    assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
+    assertThat(role.get().name()).isEqualTo(recordValue.getName());
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_ADDED, 1337L));
 
     // then
-    final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
+    final var updatedRole =
+        rdbmsService.getRoleReader().findOne(recordValue.getRoleId()).orElseThrow();
     assertThat(updatedRole.assignedMemberIds()).containsExactly("1337");
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, 1337L));
 
     // then
-    final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
+    final var deletedRole =
+        rdbmsService.getRoleReader().findOne(recordValue.getRoleId()).orElseThrow();
     assertThat(deletedRole.assignedMemberIds()).isEmpty();
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -385,7 +385,8 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportUpdateAndDeleteRole() {
     // given
-    final var roleRecord = getRoleRecord(42L, RoleIntent.CREATED);
+    final var roleId = "roleId";
+    final var roleRecord = getRoleRecord(roleId, RoleIntent.CREATED);
     final var recordValue = (RoleRecordValue) roleRecord.getValue();
 
     // when
@@ -395,10 +396,12 @@ class RdbmsExporterIT {
     final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
     assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
+    assertThat(role.get().roleId()).isEqualTo(recordValue.getRoleId());
     assertThat(role.get().name()).isEqualTo(recordValue.getName());
+    assertThat(role.get().description()).isEqualTo(recordValue.getDescription());
 
     // given
-    final var updateRoleRecord = getRoleRecord(42L, RoleIntent.UPDATED);
+    final var updateRoleRecord = getRoleRecord(roleId, RoleIntent.UPDATED);
     final var updateRoleRecordValue = ((RoleRecordValue) updateRoleRecord.getValue());
 
     // when
@@ -408,10 +411,12 @@ class RdbmsExporterIT {
     final var updatedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(updatedRole).isNotEmpty();
     assertThat(updatedRole.get().roleKey()).isEqualTo(updateRoleRecordValue.getRoleKey());
+    assertThat(updatedRole.get().roleId()).isEqualTo(updateRoleRecordValue.getRoleId());
     assertThat(updatedRole.get().name()).isEqualTo(updateRoleRecordValue.getName());
+    assertThat(updatedRole.get().description()).isEqualTo(updateRoleRecordValue.getDescription());
 
     // when
-    exporter.export(getRoleRecord(42L, RoleIntent.DELETED));
+    exporter.export(getRoleRecord(roleId, RoleIntent.DELETED));
 
     // then
     final var deletedRole = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
@@ -421,7 +426,8 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportRoleAndAddAndDeleteMember() {
     // given
-    final var roleRecord = getRoleRecord(42L, RoleIntent.CREATED);
+    final var roleId = "roleId";
+    final var roleRecord = getRoleRecord(roleId, RoleIntent.CREATED);
     final var recordValue = (RoleRecordValue) roleRecord.getValue();
 
     // when
@@ -431,18 +437,21 @@ class RdbmsExporterIT {
     final var role = rdbmsService.getRoleReader().findOne(recordValue.getRoleId());
     assertThat(role).isNotEmpty();
     assertThat(role.get().roleKey()).isEqualTo(recordValue.getRoleKey());
+    assertThat(role.get().roleId()).isEqualTo(recordValue.getRoleId());
     assertThat(role.get().name()).isEqualTo(recordValue.getName());
+    assertThat(role.get().description()).isEqualTo(recordValue.getDescription());
 
     // when
-    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_ADDED, 1337L));
+    final var entityId = "entityId";
+    exporter.export(getRoleRecord(roleId, RoleIntent.ENTITY_ADDED, entityId));
 
     // then
     final var updatedRole =
         rdbmsService.getRoleReader().findOne(recordValue.getRoleId()).orElseThrow();
-    assertThat(updatedRole.assignedMemberIds()).containsExactly("1337");
+    assertThat(updatedRole.assignedMemberIds()).containsExactly(entityId);
 
     // when
-    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, 1337L));
+    exporter.export(getRoleRecord(roleId, RoleIntent.ENTITY_REMOVED, entityId));
 
     // then
     final var deletedRole =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -332,13 +332,14 @@ public class RecordFixtures {
   }
 
   protected static ImmutableRecord<RecordValue> getRoleRecord(
-      final Long roleKey, final RoleIntent intent) {
-    return getRoleRecord(roleKey, intent, null);
+      final String roleId, final RoleIntent intent) {
+    return getRoleRecord(roleId, intent, null);
   }
 
   protected static ImmutableRecord<RecordValue> getRoleRecord(
-      final Long roleKey, final RoleIntent intent, final Long entityKey) {
+      final String roleId, final RoleIntent intent, final String entityId) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.ROLE);
+    final long roleKey = 1L;
     return ImmutableRecord.builder()
         .from(recordValueRecord)
         .withIntent(intent)
@@ -349,8 +350,9 @@ public class RecordFixtures {
             ImmutableRoleRecordValue.builder()
                 .from((RoleRecordValue) recordValueRecord.getValue())
                 .withRoleKey(roleKey)
-                .withEntityKey(entityKey != null ? entityKey : 0)
-                .withEntityType(entityKey != null ? EntityType.USER : null)
+                .withRoleId(roleId)
+                .withEntityId(entityId)
+                .withEntityType(entityId != null ? EntityType.USER : null)
                 .build())
         .build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/RoleEntityTransformer.java
@@ -17,6 +17,7 @@ public class RoleEntityTransformer
   @Override
   public RoleEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.RoleEntity value) {
-    return new RoleEntity(value.getKey(), value.getRoleId(), value.getName());
+    return new RoleEntity(
+        value.getKey(), value.getRoleId(), value.getName(), value.getDescription());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -12,9 +12,11 @@ import java.io.Serializable;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String roleId, String name, Set<String> assignedMemberIds)
+public record RoleEntity(
+    Long roleKey, String roleId, String name, String description, Set<String> assignedMemberIds)
     implements Serializable {
-  public RoleEntity(final Long roleKey, final String roleId, final String name) {
-    this(roleKey, roleId, name, Set.of());
+  public RoleEntity(
+      final Long roleKey, final String roleId, final String name, final String description) {
+    this(roleKey, roleId, name, description, Set.of());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -7,26 +7,48 @@
  */
 package io.camunda.search.filter;
 
+import io.camunda.search.filter.GroupFilter.Builder;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 
-public record RoleFilter(Long roleKey, String name, Set<String> memberIds) implements FilterBase {
+public record RoleFilter(
+    Long roleKey,
+    String roleId,
+    String name,
+    String description,
+    Set<String> memberIds,
+    EntityType memberType)
+    implements FilterBase {
   public Builder toBuilder() {
     return new Builder().roleKey(roleKey).name(name).memberIds(memberIds);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
     private Long roleKey;
+    private String roleId;
     private String name;
+    private String description;
     private Set<String> memberIds;
+    private EntityType memberType;
 
     public Builder roleKey(final Long value) {
       roleKey = value;
       return this;
     }
 
+    public Builder roleId(final String value) {
+      roleId = value;
+      return this;
+    }
+
     public Builder name(final String value) {
       name = value;
+      return this;
+    }
+
+    public Builder description(final String value) {
+      description = value;
       return this;
     }
 
@@ -39,9 +61,14 @@ public record RoleFilter(Long roleKey, String name, Set<String> memberIds) imple
       return memberIds(Set.of(values));
     }
 
+    public Builder memberType(final EntityType value) {
+      memberType = value;
+      return this;
+    }
+
     @Override
     public RoleFilter build() {
-      return new RoleFilter(roleKey, name, memberIds);
+      return new RoleFilter(roleKey, roleId, name, description, memberIds, memberType);
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -53,9 +53,8 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
       case RoleIntent.ENTITY_ADDED ->
           roleWriter.addMember(
               new RoleMemberDbModel.Builder()
-                  .roleKey(value.getRoleKey())
-                  // todo,remove parse in https://github.com/camunda/camunda/issues/30111
-                  .entityId(String.valueOf(value.getEntityKey()))
+                  .roleId(value.getRoleId())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       case RoleIntent.ENTITY_REMOVED ->

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -60,9 +60,8 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
       case RoleIntent.ENTITY_REMOVED ->
           roleWriter.removeMember(
               new RoleMemberDbModel.Builder()
-                  .roleKey(value.getRoleKey())
-                  // todo,remove parse in https://github.com/camunda/camunda/issues/30111
-                  .entityId(String.valueOf(value.getEntityKey()))
+                  .roleId(value.getRoleId())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for role record", record.getIntent());

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -49,7 +49,7 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
     switch (record.getIntent()) {
       case RoleIntent.CREATED -> roleWriter.create(map(value));
       case RoleIntent.UPDATED -> roleWriter.update(map(value));
-      case RoleIntent.DELETED -> roleWriter.delete(value.getRoleKey());
+      case RoleIntent.DELETED -> roleWriter.delete(value.getRoleId());
       case RoleIntent.ENTITY_ADDED ->
           roleWriter.addMember(
               new RoleMemberDbModel.Builder()

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -70,10 +70,12 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
     }
   }
 
-  private RoleDbModel map(final RoleRecordValue decision) {
+  private RoleDbModel map(final RoleRecordValue role) {
     return new RoleDbModel.Builder()
-        .roleKey(decision.getRoleKey())
-        .name(decision.getName())
+        .roleKey(role.getRoleKey())
+        .roleId(role.getRoleId())
+        .name(role.getName())
+        .description(role.getDescription())
         .build();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -42,7 +42,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
   @Test
   void getRoleShouldReturnOk() {
     // given
-    final var role = new RoleEntity(100L, "roleId", "Role Name");
+    final var role = new RoleEntity(100L, "roleId", "Role Name", "description");
     when(roleServices.getRole(role.roleKey())).thenReturn(role);
 
     // when
@@ -109,9 +109,9 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
-                        new RoleEntity(100L, "role1", "Role 1"),
-                        new RoleEntity(200L, "role2", "Role 2"),
-                        new RoleEntity(300L, "role12", "Role 12")))
+                        new RoleEntity(100L, "role1", "Role 1", "description 1"),
+                        new RoleEntity(200L, "role2", "Role 2", "description 2"),
+                        new RoleEntity(300L, "role12", "Role 12", "description 12")))
                 .build());
 
     // when / then
@@ -163,9 +163,9 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 .total(3)
                 .items(
                     List.of(
-                        new RoleEntity(100L, "role1", "Role 1"),
-                        new RoleEntity(300L, "role12", "Role 12"),
-                        new RoleEntity(200L, "role2", "Role 2")))
+                        new RoleEntity(100L, "role1", "Role 1", "description 1"),
+                        new RoleEntity(300L, "role12", "Role 12", "description 12"),
+                        new RoleEntity(200L, "role2", "Role 2", "description 2")))
                 .build());
 
     // when / then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR refactord the RDBMS Exporter to handle Role related events with the role id as identifier.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30127 
