### PR TITLE
`getRole` should use `roleId` instead of `roleKey`

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
+++ b/search/search-domain/src/main/java/io/camunda/search/exception/ErrorMessages.java
@@ -24,7 +24,7 @@ public class ErrorMessages {
   public static final String ERROR_NOT_FOUND_GROUP_BY_ID = "Group with ID %s not found";
   public static final String ERROR_NOT_FOUND_GROUP_BY_NAME = "Group with group name %s not found";
   public static final String ERROR_NOT_FOUND_MAPPING_BY_ID = "Mapping with mappingId %s not found";
-  public static final String ERROR_NOT_FOUND_ROLE_BY_KEY = "Role with roleKey %d not found";
+  public static final String ERROR_NOT_FOUND_ROLE_BY_ID = "Role with role ID %s not found";
   public static final String ERROR_NOT_FOUND_TENANT = "Tenant matching %s not found";
 
   public static final String ERROR_NOT_UNIQUE_ENTITY = "Found %s with key %s more than once";

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -21,7 +21,7 @@ public record RoleFilter(
     EntityType memberType)
     implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).name(name).memberIds(memberIds);
+    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -109,13 +109,6 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
         .findFirst();
   }
 
-  public Optional<RoleEntity> findRoleByName(final String name) {
-    return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.name(name)).build())
-        .items()
-        .stream()
-        .findFirst();
-  }
-
   public CompletableFuture<RoleRecord> deleteRole(final String roleId) {
     return sendBrokerRequest(new BrokerRoleDeleteRequest(roleId));
   }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -93,23 +93,23 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
             .setDescription(updateRoleRequest.description()));
   }
 
-  public RoleEntity getRole(final Long roleKey) {
-    return findRole(roleKey)
+  public RoleEntity getRole(final String roleId) {
+    return findRole(roleId)
         .orElseThrow(
             () ->
                 new CamundaSearchException(
-                    ErrorMessages.ERROR_NOT_FOUND_ROLE_BY_KEY.formatted(roleKey),
+                    ErrorMessages.ERROR_NOT_FOUND_ROLE_BY_ID.formatted(roleId),
                     CamundaSearchException.Reason.NOT_FOUND));
   }
 
-  public Optional<RoleEntity> findRole(final Long roleKey) {
-    return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.roleKey(roleKey)).build())
+  public Optional<RoleEntity> findRole(final String roleId) {
+    return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.roleId(roleId)).build())
         .items()
         .stream()
         .findFirst();
   }
 
-  public Optional<RoleEntity> findRole(final String name) {
+  public Optional<RoleEntity> findRoleByName(final String name) {
     return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.name(name)).build())
         .items()
         .stream()

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -109,20 +109,20 @@ public class RoleServicesTest {
     when(client.searchRoles(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findRole(1L);
+    final var searchQueryResult = services.findRole(entity.roleId());
 
     // then
     assertThat(searchQueryResult).contains(entity);
   }
 
   @Test
-  public void shouldThrownExceptionIfNotFoundByKey() {
+  public void shouldThrownExceptionIfNotFoundById() {
     // given
-    final var key = 100L;
+    final var roleId = "roleId";
     when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
-    assertThat(services.findRole(key)).isEmpty();
+    assertThat(services.findRole(roleId)).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -52,12 +52,6 @@ public class DbRoleState implements MutableRoleState {
     roleColumnFamily.deleteExisting(roleId);
   }
 
-  // TODO remove this method after the key > id refactoring
-  @Override
-  public Optional<PersistedRole> getRole(final long roleKey) {
-    return getRole(String.valueOf(roleKey));
-  }
-
   @Override
   public Optional<PersistedRole> getRole(final String roleId) {
     this.roleId.wrapString(roleId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoleState.java
@@ -12,7 +12,5 @@ import java.util.Optional;
 
 public interface RoleState {
 
-  Optional<PersistedRole> getRole(long roleKey);
-
   Optional<PersistedRole> getRole(String roleId);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
@@ -33,7 +33,7 @@ public class RoleStateTest {
   void shouldCreateRole() {
     // given
     final var roleKey = 1L;
-    final var roleId = "1";
+    final var roleId = Strings.newRandomValidIdentityId();
     final var roleName = "foo";
     final var roleDescription = "bar";
     final var roleRecord =
@@ -57,7 +57,7 @@ public class RoleStateTest {
   @Test
   void shouldReturnNullIfRoleDoesNotExist() {
     // when
-    final var role = roleState.getRole(1L);
+    final var role = roleState.getRole(Strings.newRandomValidIdentityId());
 
     // then
     assertThat(role).isEmpty();
@@ -67,7 +67,7 @@ public class RoleStateTest {
   void shouldUpdateRole() {
     // given
     final var roleKey = 123L;
-    final var roleId = "123";
+    final var roleId = Strings.newRandomValidIdentityId();
     final var roleRecord =
         new RoleRecord().setRoleKey(roleKey).setRoleId(roleId).setName("foo").setDescription("bar");
     roleState.create(roleRecord);
@@ -79,7 +79,7 @@ public class RoleStateTest {
     roleState.update(updatedRecord);
 
     // then
-    final var persistedRole = roleState.getRole(roleKey).get();
+    final var persistedRole = roleState.getRole(roleId).get();
     assertThat(persistedRole.getRoleKey()).isEqualTo(roleKey);
     assertThat(persistedRole.getName()).isEqualTo(updatedName);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -27,11 +27,6 @@ public class RoleClient {
     return new RoleCreateClient(writer, id);
   }
 
-  // TODO remove this method and use the one with role Id
-  public RoleUpdateClient updateRole(final long roleKey) {
-    return updateRole(String.valueOf(roleKey));
-  }
-
   public RoleUpdateClient updateRole(final String roleId) {
     return new RoleUpdateClient(writer, roleId);
   }
@@ -43,11 +38,6 @@ public class RoleClient {
 
   public RoleAddEntityClient addEntity(final String roleId) {
     return new RoleAddEntityClient(writer, roleId);
-  }
-
-  // TODO remove this method and use the one with role Id
-  public RoleRemoveEntityClient removeEntity(final long key) {
-    return new RoleRemoveEntityClient(writer, key);
   }
 
   public RoleRemoveEntityClient removeEntity(final String roleId) {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6701,6 +6701,9 @@ components:
         roleKey:
           type: string
           description: The role key.
+        roleId:
+          type: string
+          description: The role id.
         assignedMemberKeys:
           type: array
           description: The set of keys of members assigned to the role.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6704,6 +6704,9 @@ components:
         roleId:
           type: string
           description: The role id.
+        description:
+          type: string
+          description: The description of the role.
         assignedMemberKeys:
           type: array
           description: The set of keys of members assigned to the role.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -388,7 +388,8 @@ public final class SearchQueryResponseMapper {
     return new RoleResult()
         .roleKey(KeyUtil.keyToString(roleEntity.roleKey()))
         .roleId(roleEntity.roleId())
-        .name(roleEntity.name());
+        .name(roleEntity.name())
+        .description(roleEntity.description());
   }
 
   private static List<GroupResult> toGroups(final List<GroupEntity> groups) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -387,6 +387,7 @@ public final class SearchQueryResponseMapper {
   public static RoleResult toRole(final RoleEntity roleEntity) {
     return new RoleResult()
         .roleKey(KeyUtil.keyToString(roleEntity.roleKey()))
+        .roleId(roleEntity.roleId())
         .name(roleEntity.name());
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -83,15 +83,15 @@ public class RoleController {
             roleServices.withAuthentication(RequestMapper.getAuthentication()).deleteRole(roleId));
   }
 
-  @CamundaGetMapping(path = "/{roleKey}")
-  public ResponseEntity<Object> getRole(@PathVariable final long roleKey) {
+  @CamundaGetMapping(path = "/{roleId}")
+  public ResponseEntity<Object> getRole(@PathVariable final String roleId) {
     try {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toRole(
                   roleServices
                       .withAuthentication(RequestMapper.getAuthentication())
-                      .getRole(roleKey)));
+                      .getRole(roleId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -59,7 +59,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
             """
             {
               "name": "Role Name",
-              "roleKey": "100"
+              "roleKey": "100",
+              "roleId": "roleId"
             }""");
 
     // then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -86,7 +86,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
         .isNotFound()
         .expectBody()
         .json(
-                """
+            """
             {
               "type": "about:blank",
               "title": "NOT_FOUND",

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.search.sort.RoleSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.RoleServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,12 +44,12 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void getRoleShouldReturnOk() {
     // given
     final var role = new RoleEntity(100L, "roleId", "Role Name", "description");
-    when(roleServices.getRole(role.roleKey())).thenReturn(role);
+    when(roleServices.getRole(role.roleId())).thenReturn(role);
 
     // when
     webClient
         .get()
-        .uri("%s/%s".formatted(ROLE_BASE_URL, role.roleKey()))
+        .uri("%s/%s".formatted(ROLE_BASE_URL, role.roleId()))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -62,15 +63,15 @@ public class RoleQueryControllerTest extends RestControllerTest {
             }""");
 
     // then
-    verify(roleServices, times(1)).getRole(role.roleKey());
+    verify(roleServices, times(1)).getRole(role.roleId());
   }
 
   @Test
   void getNonExistingRoleShouldReturnNotFound() {
     // given
-    final var roleKey = 100L;
-    final var path = "%s/%s".formatted(ROLE_BASE_URL, roleKey);
-    when(roleServices.getRole(roleKey))
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var path = "%s/%s".formatted(ROLE_BASE_URL, roleId);
+    when(roleServices.getRole(roleId))
         .thenThrow(
             new CamundaSearchException("role not found", CamundaSearchException.Reason.NOT_FOUND));
 
@@ -84,7 +85,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
         .isNotFound()
         .expectBody()
         .json(
-            """
+                """
             {
               "type": "about:blank",
               "title": "NOT_FOUND",
@@ -95,7 +96,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
                 .formatted(path));
 
     // then
-    verify(roleServices, times(1)).getRole(roleKey);
+    verify(roleServices, times(1)).getRole(roleId);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -60,7 +60,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
             {
               "name": "Role Name",
               "roleKey": "100",
-              "roleId": "roleId"
+              "roleId": "roleId",
+              "description": "description"
             }""");
 
     // then


### PR DESCRIPTION
## Description

Refactor the role get and search endpoint to work with a role id instead of a key.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30016
