### PR TITLE
Remove `entityKey` from `RoleRecord`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -101,7 +101,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
     if (!isEntityAssigned(record)) {
       final var errorMessage =
-          ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityKey(), record.getRoleKey());
+          ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -141,7 +141,7 @@ public class MappingAppliersTest {
         new RoleRecord()
             .setRoleKey(2L)
             .setRoleId(Strings.newRandomValidIdentityId())
-            .setEntityKey(mappingKey)
+            .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     roleState.create(role);
     membershipState.insertRelation(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -188,12 +188,6 @@ public class RoleClient {
       roleRecord.setRoleId(id);
     }
 
-    // TODO remove this method, use id instead
-    public RoleAddEntityClient withEntityKey(final long entityKey) {
-      roleRecord.setEntityKey(entityKey);
-      return this;
-    }
-
     public RoleAddEntityClient withEntityId(final String entityId) {
       roleRecord.setEntityId(entityId);
       return this;
@@ -243,11 +237,6 @@ public class RoleClient {
       this.writer = writer;
       roleRecord = new RoleRecord();
       roleRecord.setRoleId(id);
-    }
-
-    public RoleRemoveEntityClient withEntityKey(final long entityKey) {
-      roleRecord.setEntityKey(entityKey);
-      return this;
     }
 
     public RoleRemoveEntityClient withEntityId(final String entityId) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -21,19 +21,16 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   private final StringProperty roleIdProp = new StringProperty("roleId");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
-  // TODO remove entityKeyProp https://github.com/camunda/camunda/issues/30111
-  private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public RoleRecord() {
-    super(7);
+    super(6);
     declareProperty(roleKeyProp)
         .declareProperty(roleIdProp)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
-        .declareProperty(entityKeyProp)
         .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
@@ -79,11 +76,6 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   }
 
   @Override
-  public long getEntityKey() {
-    return entityKeyProp.getValue();
-  }
-
-  @Override
   public String getEntityId() {
     return BufferUtil.bufferAsString(entityIdProp.getValue());
   }
@@ -100,11 +92,6 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
 
   public RoleRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
-    return this;
-  }
-
-  public RoleRecord setEntityKey(final long entityKey) {
-    entityKeyProp.setValue(entityKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2830,7 +2830,6 @@ final class JsonSerializableToJsonTest {
                     .setRoleId("id")
                     .setName("role")
                     .setDescription("description")
-                    .setEntityKey(2L)
                     .setEntityId("entityId")
                     .setEntityType(EntityType.USER),
         """
@@ -2839,7 +2838,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "id",
           "name": "role",
           "description": "description",
-          "entityKey": 2,
           "entityId": "entityId",
           "entityType": "USER"
         }
@@ -2857,7 +2855,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "roleId",
           "name": "",
           "description": "",
-          "entityKey": -1,
           "entityId": "",
           "entityType": "UNSPECIFIED"
         }
@@ -3055,7 +3052,6 @@ final class JsonSerializableToJsonTest {
                             .setRoleId("id")
                             .setName("roleName")
                             .setDescription("description")
-                            .setEntityKey(2)
                             .setEntityId("entityId")
                             .setEntityType(EntityType.USER))
                     .addUser(
@@ -3095,7 +3091,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "id",
           "name": "roleName",
           "description": "description",
-          "entityKey": 2,
           "entityId": "entityId",
           "entityType": "USER"
         },
@@ -3159,7 +3154,6 @@ final class JsonSerializableToJsonTest {
               "roleId": "roleId",
               "name": "",
               "description": "",
-              "entityKey": -1,
               "entityId": "",
               "entityType": "UNSPECIFIED"
           },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
@@ -35,9 +35,6 @@ public interface RoleRecordValue extends RecordValue {
   /** The description of the role. */
   String getDescription();
 
-  /** The key of a user/mapping to assign/remove from a role. */
-  long getEntityKey();
-
   /** The id of an entity to assign/remove from a role. */
   String getEntityId();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1016,8 +1016,10 @@ public class CompactRecordLogger {
         .append(formatId(value.getRoleId()))
         .append(", Name=")
         .append(formatId(value.getName()))
-        .append(", EntityKey=")
-        .append(shortenKey(value.getEntityKey()))
+        .append(", Description=")
+        .append(value.getDescription())
+        .append(", EntityId=")
+        .append(formatId(value.getEntityId()))
         .append("]");
 
     return builder.toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RoleRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RoleRecordStream.java
@@ -35,10 +35,6 @@ public class RoleRecordStream extends ExporterRecordStream<RoleRecordValue, Role
     return valueFilter(v -> v.getName().equals(name));
   }
 
-  public RoleRecordStream withEntityKey(final long entityKey) {
-    return valueFilter(v -> v.getEntityKey() == entityKey);
-  }
-
   public RoleRecordStream withEntityId(final String entityId) {
     return valueFilter(v -> v.getEntityId().equals(entityId));
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We can safely remove this as the `RoleRecord` cannot be written pre-8.8. The `entityKey` is removed in favor of an `entityId`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30111
