### PR TITLE
feat: Add support for `CREATING` and `CANCELING` listener event types in Operate

### DIFF
--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -185,5 +185,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
@@ -7,32 +7,53 @@
  */
 package io.camunda.operate.enties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.camunda.webapps.schema.entities.listener.ListenerEventType;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ListenerEventTypeTest {
 
-  @Test
-  public void convertStatesFromZeebeJobs() {
-    final ListenerEventType actual1 = ListenerEventType.fromZeebeListenerEventType("START");
-    assertEquals(actual1, ListenerEventType.START);
-    final ListenerEventType actual2 = ListenerEventType.fromZeebeListenerEventType("END");
-    assertEquals(actual2, ListenerEventType.END);
-    final ListenerEventType actual3 = ListenerEventType.fromZeebeListenerEventType("COMPLETING");
-    assertEquals(actual3, ListenerEventType.COMPLETING);
-    final ListenerEventType actual4 = ListenerEventType.fromZeebeListenerEventType("ASSIGNING");
-    assertEquals(actual4, ListenerEventType.ASSIGNING);
-    final ListenerEventType actual5 = ListenerEventType.fromZeebeListenerEventType("TEST");
-    assertEquals(actual5, ListenerEventType.UNKNOWN);
-    final ListenerEventType actual6 = ListenerEventType.fromZeebeListenerEventType(null);
-    assertEquals(actual6, ListenerEventType.UNSPECIFIED);
-    final ListenerEventType actual7 = ListenerEventType.fromZeebeListenerEventType("UPDATING");
-    assertEquals(actual7, ListenerEventType.UPDATING);
-    final ListenerEventType actual8 = ListenerEventType.fromZeebeListenerEventType("CREATING");
-    assertEquals(actual8, ListenerEventType.CREATING);
-    final ListenerEventType actual9 = ListenerEventType.fromZeebeListenerEventType("CANCELING");
-    assertEquals(actual9, ListenerEventType.CANCELING);
+  static Stream<Arguments> listenerEventTypeProvider() {
+    return Stream.of(
+        // Known Execution Listener event types
+        arguments("START", ListenerEventType.START),
+        arguments("END", ListenerEventType.END),
+
+        // Known User Task Listener event types
+        arguments("CREATING", ListenerEventType.CREATING),
+        arguments("ASSIGNING", ListenerEventType.ASSIGNING),
+        arguments("UPDATING", ListenerEventType.UPDATING),
+        arguments("COMPLETING", ListenerEventType.COMPLETING),
+        arguments("CANCELING", ListenerEventType.CANCELING),
+
+        // Unknown event types (invalid or unexpected input)
+        arguments("FOO", ListenerEventType.UNKNOWN),
+        arguments("", ListenerEventType.UNKNOWN),
+
+        // Lowercase variants (not supported, should map to 'UNKNOWN')
+        arguments("start", ListenerEventType.UNKNOWN),
+        arguments("end", ListenerEventType.UNKNOWN),
+        arguments("creating", ListenerEventType.UNKNOWN),
+        arguments("canceling", ListenerEventType.UNKNOWN),
+
+        // Explicit 'UNSPECIFIED' and 'null' input
+        arguments("UNSPECIFIED", ListenerEventType.UNSPECIFIED),
+        arguments(null, ListenerEventType.UNSPECIFIED));
+  }
+
+  @ParameterizedTest(name = "should map \"{0}\" to ListenerEventType.{1}")
+  @MethodSource("listenerEventTypeProvider")
+  void verifyMappingFromZeebeListenerEventTypeToEnumValue(
+      final String input, final ListenerEventType expected) {
+    // when
+    final var result = ListenerEventType.fromZeebeListenerEventType(input);
+
+    // then
+    assertThat(result).isEqualTo(expected);
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
@@ -30,5 +30,9 @@ public class ListenerEventTypeTest {
     assertEquals(actual6, ListenerEventType.UNSPECIFIED);
     final ListenerEventType actual7 = ListenerEventType.fromZeebeListenerEventType("UPDATING");
     assertEquals(actual7, ListenerEventType.UPDATING);
+    final ListenerEventType actual8 = ListenerEventType.fromZeebeListenerEventType("CREATING");
+    assertEquals(actual8, ListenerEventType.CREATING);
+    final ListenerEventType actual9 = ListenerEventType.fromZeebeListenerEventType("CANCELING");
+    assertEquals(actual9, ListenerEventType.CANCELING);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
@@ -16,6 +16,8 @@ public enum ListenerEventType {
   COMPLETING,
   ASSIGNING,
   UPDATING,
+  CREATING,
+  CANCELING,
   UNKNOWN,
   UNSPECIFIED;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
@@ -11,13 +11,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public enum ListenerEventType {
+  // Execution Listener event types
   START,
   END,
-  COMPLETING,
+
+  // User Task Listener event types
+  CREATING,
   ASSIGNING,
   UPDATING,
-  CREATING,
+  COMPLETING,
   CANCELING,
+
+  // Fallback event types
   UNKNOWN,
   UNSPECIFIED;
 


### PR DESCRIPTION
## Description

This PR adds support for the new listener event types `CREATING` and `CANCELING` introduced in Zeebe by #28565 issue.
These types are now declared in `io.camunda.webapps.schema.entities.listener.ListenerEventType` that allows a proper mapping from to avoid showing them as `UNKNOWN` in Operate's REST-API response.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31616
