### PR TITLE
fix: split parallel and batched paths in IncidentUpdate

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -176,8 +176,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
               return r.hits().hits().stream()
                   .map(h -> h.source().get(OperationTemplate.PROCESS_INSTANCE_KEY))
-                  .map(Object::toString)
-                  .map(Long::valueOf)
+                  .map(v -> ((Number) v).longValue())
                   .collect(Collectors.toSet());
             },
             executor);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -13,10 +13,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -82,14 +82,13 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       List<String> processInstanceIds);
 
   /**
-   * Returns whether the process instances were explicitly deleted, meaning a user executed an
+   * Returns the process instances that were explicitly deleted, meaning a user executed an
    * operation to explicitly delete them from the historic data.
    *
    * @param processInstanceKeys list of process instance keys
-   * @return a map of process instance keys to whether they were deleted
+   * @return a set of process instance keys that were deleted
    */
-  CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-      final List<Long> processInstanceKeys);
+  CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys);
 
   /**
    * Executes the given bulk update against the underlying document store, waiting until the
@@ -206,10 +205,8 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-        final List<Long> processInstanceKeys) {
-      return CompletableFuture.completedFuture(
-          processInstanceKeys.stream().collect(Collectors.toMap(key -> key, key -> false)));
+    public CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys) {
+      return CompletableFuture.completedFuture(Set.of());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -81,13 +82,14 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       List<String> processInstanceIds);
 
   /**
-   * Returns whether the process instance was explicitly deleted, meaning a user executed an
-   * operation to explicitly delete it from the historic data.
+   * Returns whether the process instances were explicitly deleted, meaning a user executed an
+   * operation to explicitly delete them from the historic data.
    *
-   * @param processInstanceKey the key of the process instance
-   * @return true if it was deleted, false otherwise
+   * @param processInstanceKeys list of process instance keys
+   * @return a map of process instance keys to whether they were deleted
    */
-  CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey);
+  CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+      final List<Long> processInstanceKeys);
 
   /**
    * Executes the given bulk update against the underlying document store, waiting until the
@@ -204,8 +206,10 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
-      return CompletableFuture.completedFuture(false);
+    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+        final List<Long> processInstanceKeys) {
+      return CompletableFuture.completedFuture(
+          processInstanceKeys.stream().collect(Collectors.toMap(key -> key, key -> false)));
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -240,7 +240,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
       throw new ExporterException(
           """
         "%d process instances are not yet imported for incident post processing; operation will \
-        be retried..."""
+        be retried...
+        """
               .formatted(countMissingInstance));
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -35,7 +36,6 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -165,18 +165,41 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   @Override
-  public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
-    final var query = createProcessInstanceDeletedQuery(processInstanceKey);
+  public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+      final List<Long> processInstanceKeys) {
+    final var query = createProcessInstanceDeletedQuery(processInstanceKeys);
     final var request =
-        new CountRequest.Builder()
+        new SearchRequest.Builder()
             .index(operationAlias)
             .query(query)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
+            .size(0)
+            .aggregations(
+                "keys",
+                a ->
+                    a.terms(
+                        t ->
+                            t.field(OperationTemplate.PROCESS_INSTANCE_KEY)
+                                .size(processInstanceKeys.size())))
             .build();
 
     try {
-      return client.count(request).thenApplyAsync(r -> r.count() > 0, executor);
+      return client
+          .search(request, Void.class)
+          .thenApplyAsync(
+              r -> {
+                final var buckets = r.aggregations().get("keys").lterms().buckets().array();
+                final Map<Long, Boolean> matchedPIs = new HashMap<>();
+                for (final var key : processInstanceKeys) {
+                  matchedPIs.put(
+                      key,
+                      buckets.stream()
+                          .anyMatch(bucket -> bucket.key().equals(String.valueOf(key))));
+                }
+                return matchedPIs;
+              },
+              executor);
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
@@ -255,11 +278,16 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
   }
 
-  private Query createProcessInstanceDeletedQuery(final long processInstanceKey) {
+  private Query createProcessInstanceDeletedQuery(final List<Long> processInstanceKeys) {
     final var piKeyQ =
-        QueryBuilders.term()
+        QueryBuilders.terms()
             .field(OperationTemplate.PROCESS_INSTANCE_KEY)
-            .value(v -> v.longValue(processInstanceKey))
+            .terms(
+                t ->
+                    t.value(
+                        processInstanceKeys.stream()
+                            .map(FieldValue::of)
+                            .collect(Collectors.toList())))
             .build()
             .toQuery();
     final var typeQ =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -189,8 +189,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
 
                 return r.hits().hits().stream()
                     .map(h -> h.source().get(OperationTemplate.PROCESS_INSTANCE_KEY))
-                    .map(Object::toString)
-                    .map(Long::valueOf)
+                    .map(v -> ((Number) v).longValue())
                     .collect(Collectors.toSet());
               },
               executor);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
@@ -671,11 +672,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @Test
@@ -692,10 +692,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @ParameterizedTest
@@ -717,11 +717,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of());
 
       // then
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @ParameterizedTest
@@ -742,11 +741,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, true));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of(1L));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -671,10 +671,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
     }
 
     @Test
@@ -691,10 +692,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
     }
 
     @ParameterizedTest
@@ -716,10 +717,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
     }
 
     @ParameterizedTest
@@ -740,10 +742,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, true));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,10 +139,14 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
+    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+        final List<Long> processInstanceKeys) {
       return wasProcessInstanceDeleted != null
-          ? wasProcessInstanceDeleted
-          : super.wasProcessInstanceDeleted(processInstanceKey);
+          ? CompletableFuture.completedFuture(
+              processInstanceKeys.stream()
+                  .collect(
+                      Collectors.toMap(key -> key, key -> wasProcessInstanceDeleted.getNow(false))))
+          : super.wereProcessInstancesDeleted(processInstanceKeys);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -30,10 +30,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,14 +139,10 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-        final List<Long> processInstanceKeys) {
+    public CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys) {
       return wasProcessInstanceDeleted != null
-          ? CompletableFuture.completedFuture(
-              processInstanceKeys.stream()
-                  .collect(
-                      Collectors.toMap(key -> key, key -> wasProcessInstanceDeleted.getNow(false))))
-          : super.wereProcessInstancesDeleted(processInstanceKeys);
+          ? CompletableFuture.completedFuture(processInstanceKeys)
+          : super.deletedProcessInstances(processInstanceKeys);
     }
 
     @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Split paths of parallel execution and plain sequential one in the incident update pipeline
- Peform batch request to retrieve only deleted process instances during incident update

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
