### PR TITLE
fix: predefine access rule id

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityHighRequestCountIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityHighRequestCountIT.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -335,22 +336,21 @@ public class MultiTenancyOverIdentityHighRequestCountIT {
       final List<String> tenantIds, final String clientId) throws Exception {
 
     try (final PostgresHelper postgres = new PostgresHelper()) {
-      final String accessRuleId;
+      final String accessRuleId = UUID.randomUUID().toString();
       // Create access rule for service account
       try (final var resultSet =
           postgres.executeQuery(
               """
                   INSERT INTO access_rules \
-                    (member_id, member_type, global) \
-                  VALUES ('%s', 'APPLICATION', false) \
+                    (id, member_id, member_type, global) \
+                  VALUES ('%s','%s', 'APPLICATION', false) \
                   ON CONFLICT DO NOTHING \
                   RETURNING id"""
-                  .formatted(clientId))) {
+                  .formatted(accessRuleId, clientId))) {
         if (!resultSet.next()) {
           throw new IllegalStateException(
               "Expected to find access rule associated to service account.");
         }
-        accessRuleId = resultSet.getString(1);
       }
 
       // Create tenant(s) if not already existing,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -56,6 +56,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
@@ -1664,22 +1665,21 @@ public class MultiTenancyOverIdentityIT {
       final List<String> tenantIds, final String clientId) throws Exception {
 
     try (final PostgresHelper postgres = new PostgresHelper()) {
-      final String accessRuleId;
+      final String accessRuleId = UUID.randomUUID().toString();
       // Create access rule for service account
       try (final var resultSet =
           postgres.executeQuery(
               """
                   INSERT INTO access_rules \
-                    (member_id, member_type, global) \
-                  VALUES ('%s', 'APPLICATION', false) \
+                    (id, member_id, member_type, global) \
+                  VALUES ('%s','%s', 'APPLICATION', false) \
                   ON CONFLICT DO NOTHING \
                   RETURNING id"""
-                  .formatted(clientId))) {
+                  .formatted(accessRuleId, clientId))) {
         if (!resultSet.next()) {
           throw new IllegalStateException(
               "Expected to find access rule associated to service account.");
         }
-        accessRuleId = resultSet.getString(1);
       }
 
       // Create tenant(s) if not already existing,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
With the removal of PostgreSQL specific queries used in Identity, specifically 
```
@Column(columnDefinition = "UUID default gen_random_uuid()")
```

The statically typed inserts for Identity's `AccessRules` have to provide a predetermined ID.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
