### PR TITLE
fix: add v2 apis to startup message

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -9,7 +9,7 @@ Identity:                 http://localhost:{{.IdentityPort}}/identity
 
 Camunda 8 API:            http://localhost:{{.CamundaPort}}/v2/
 Inbound Connectors API:   http://localhost:8085/
-Zeebe API (grpc):         http://localhost:26500/
+Zeebe API (gRPC):         http://localhost:26500/
 
 Camunda metrics endpoint: http://localhost:9600/actuator/prometheus
 

--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,13 +1,17 @@
 -------------------------------------------
-Access each component at the following urls:
+Access each component at the following urls with these credentials:
+- username: demo
+- password: demo
 
-Operate:                     http://localhost:{{.OperatePort}}/operate
-Tasklist:                    http://localhost:{{.TasklistPort}}/tasklist
-Identity:                    http://localhost:{{.IdentityPort}}/identity
-Zeebe Cluster Endpoint:      http://localhost:26500
-Inbound Connectors Endpoint: http://localhost:8085
+Operate:                  http://localhost:{{.OperatePort}}/operate
+Tasklist:                 http://localhost:{{.TasklistPort}}/tasklist
+Identity:                 http://localhost:{{.IdentityPort}}/identity
 
-Camunda metrics endpoint:    http://localhost:9600/actuator/prometheus
+Camunda 8 API:            http://localhost:{{.CamundaPort}}/v2/
+Inbound Connectors API:   http://localhost:8085/
+Zeebe API (grpc):         http://localhost:26500/
+
+Camunda metrics endpoint: http://localhost:9600/actuator/prometheus
 
 When using the Desktop Modeler, Authentication may be set to None.
 

--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,5 +1,5 @@
 -------------------------------------------
-Access each component at the following urls with these credentials:
+Access each component at the following urls with these default credentials:
 - username: demo
 - password: demo
 

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -74,7 +74,7 @@ func PrintStatus(settings types.C8RunSettings) error {
 		operatePort = 8081
 		tasklistPort = 8082
 		identityPort = 8084
-		camundaPort = 8085
+		camundaPort = 8088
 	}
 
 	endpoints, _ := os.ReadFile("endpoints.txt")

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -26,6 +26,7 @@ type Ports struct {
 	OperatePort  int
 	TasklistPort int
 	IdentityPort int
+	CamundaPort  int
 }
 
 func QueryCamunda(c8 opener, name string, settings types.C8RunSettings) error {
@@ -66,13 +67,14 @@ func isRunning(name, url string, retries int, delay time.Duration) bool {
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	operatePort, tasklistPort, identityPort := 8080, 8080, 8080
+	operatePort, tasklistPort, identityPort, camundaPort := 8080, 8080, 8080, 8080
 
 	// Overwrite ports if Docker is enabled
 	if settings.Docker {
 		operatePort = 8081
 		tasklistPort = 8082
 		identityPort = 8084
+		camundaPort = 8085
 	}
 
 	endpoints, _ := os.ReadFile("endpoints.txt")
@@ -85,6 +87,7 @@ func PrintStatus(settings types.C8RunSettings) error {
 		OperatePort:  operatePort,
 		TasklistPort: tasklistPort,
 		IdentityPort: identityPort,
+		CamundaPort:  camundaPort,
 	}
 
 	err = t.Execute(os.Stdout, data)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

related to https://github.com/camunda/camunda/issues/31390

for 8.8

How the message will look like (_edit: grpc --> gRPC_):
![Screenshot 2025-05-02 at 14 36 11](https://github.com/user-attachments/assets/324e4b75-a020-4506-a2d1-5fd9ad85ff48)


Example for working v2 camunda api:
![image](https://github.com/user-attachments/assets/814a2da1-1b80-46b2-ac58-9483aca6be43)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
