### PR TITLE
refactor: migrate tasklist e2e variables specs to core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/resources/usertask_with_variables.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_with_variables.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_with_variables" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_variables">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_without_variables.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_without_variables.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_without_variables" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_without_variables">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/usertask_with_variables.bpmn',
+    './resources/usertask_without_variables.bpmn',
+  ]);
+  await createInstances('usertask_without_variables', 1, 1);
+  await createInstances('usertask_with_variables', 1, 4, {
+    testData: 'something',
+  });
+});
+
+test.describe('variables page', () => {
+  test.beforeEach(async ({page, taskListLoginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await taskListLoginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('display info message when task has no variables', async ({
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await taskPanelPage.openTask('usertask_without_variables');
+    await expect(taskDetailsPage.emptyTaskMessage).toBeVisible();
+  });
+
+  test('display variables when task has variables', async ({
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPage.emptyTaskMessage).toBeHidden();
+    await expect(taskDetailsPage.nameColumnHeader).toBeVisible();
+    await expect(taskDetailsPage.valueColumnHeader).toBeVisible();
+    await expect(
+      taskDetailsPage.variablesTable.getByRole('cell', {name: 'testData'}),
+    ).toBeVisible();
+    await expect(
+      taskDetailsPage.variablesTable.getByText('something'),
+    ).toBeVisible();
+  });
+
+  test('edited variable is saved after refresh if task is completed', async ({
+    page,
+    taskDetailsPage,
+    taskPanelPage,
+  }) => {
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPage.assignee).toHaveText('Assigned to me');
+    await expect(
+      taskDetailsPage.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+    await taskDetailsPage.replaceExistingVariableValue({
+      name: 'testData value',
+      value: '"updatedValue"',
+    });
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+
+    await expect(taskDetailsPage.pickATaskHeader).toBeVisible();
+    await page.reload();
+
+    await taskPanelPage.filterBy('Completed');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(
+      taskDetailsPage.variablesTable.getByText('something'),
+    ).toBeHidden();
+    await expect(
+      taskDetailsPage.variablesTable.getByText('updatedValue'),
+    ).toBeVisible();
+  });
+
+  test('edited variable is not saved after refresh', async ({
+    page,
+    taskDetailsPage,
+    taskPanelPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPage.assignee).toHaveText('Assigned to me');
+    await expect(
+      taskDetailsPage.variablesTable.getByTitle('testData value'),
+    ).toBeVisible();
+    await expect(
+      taskDetailsPage.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+
+    await taskDetailsPage.replaceExistingVariableValue({
+      name: 'testData value',
+      value: '"updatedValue"',
+    });
+    await page.reload();
+    await expect(
+      taskDetailsPage.variablesTable.getByTitle('testData value'),
+    ).toHaveValue('"something"');
+    await expect(
+      taskDetailsPage.variablesTable.getByTitle('testData value'),
+    ).not.toHaveValue('"updatedValue"');
+  });
+
+  test('new variable disappears after refresh', async ({
+    page,
+    taskDetailsPage,
+    taskPanelPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPage.addVariableButton).toBeHidden();
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await taskDetailsPage.addVariable({
+      name: 'newVariableName',
+      value: '"newVariableValue"',
+    });
+
+    await page.reload();
+
+    await expect(
+      taskDetailsPage.variablesTable.getByText('newVariableName'),
+    ).toBeHidden();
+    await expect(
+      taskDetailsPage.variablesTable.getByText('newVariableValue'),
+    ).toBeHidden();
+  });
+
+  test('new variable still exists after refresh if task is completed', async ({
+    page,
+    taskDetailsPage,
+    taskPanelPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(taskDetailsPage.addVariableButton).toBeHidden();
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeDisabled();
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
+    await expect(taskDetailsPage.assignee).toHaveText('Assigned to me');
+
+    await taskDetailsPage.addVariable({
+      name: 'newVariableName',
+      value: '"newVariableValue"',
+    });
+
+    await taskDetailsPage.completeTaskButton.click();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+    await expect(taskDetailsPage.pickATaskHeader).toBeVisible();
+
+    await page.reload();
+
+    await taskPanelPage.filterBy('Completed');
+    await taskPanelPage.openTask('usertask_with_variables');
+
+    await expect(page.getByText('newVariableName')).toBeVisible();
+    await expect(page.getByText('newVariableValue')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR migrates `variables.spec` from tasklist to core application test suite

🧪 successful Test run can be found [here](https://github.com/camunda/camunda/actions/runs/14832658355)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to https://github.com/camunda/camunda/issues/30910

