### PR TITLE
refactor: replace default user email with reserved domain

### DIFF
--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -148,7 +148,7 @@ services:
       KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8090
       KEYCLOAK_USERS_0_USERNAME: "demo"
       KEYCLOAK_USERS_0_PASSWORD: "demo"
-      KEYCLOAK_USERS_0_EMAIL: "demo@demo.com"
+      KEYCLOAK_USERS_0_EMAIL: "demo@example.com"
       KEYCLOAK_USERS_0_FIRST_NAME: "demo"
       KEYCLOAK_USERS_0_ROLES_0: "Optimize"
       KEYCLOAK_USERS_0_ROLES_1: "Identity"

--- a/c8run/internal/overrides/overrides.go
+++ b/c8run/internal/overrides/overrides.go
@@ -55,7 +55,7 @@ func AdjustJavaOpts(javaOpts string, settings types.C8RunSettings) string {
 		javaOpts = javaOpts + " -Dzeebe.broker.exporters.camundaExporter.args.createSchema=true"
 		javaOpts = javaOpts + " -Dzeebe.broker.exporters.camundaExporter.className=io.camunda.exporter.CamundaExporter"
 		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].name=Demo"
-		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].email=demo@demo.com"
+		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].email=demo@example.com"
 	}
 	if settings.Username != "" {
 		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].username=" + settings.Username

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -67,7 +67,7 @@ management.sanitize.keywords=user,pass,secret,accessKey,accountKey,token,\
 camunda.security.initialization.users[0].username=demo
 camunda.security.initialization.users[0].password=demo
 camunda.security.initialization.users[0].name=Demo
-camunda.security.initialization.users[0].email=demo@demo.com
+camunda.security.initialization.users[0].email=demo@example.com
 # Multipart file uploads
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB

--- a/identity/client/e2e/tests/users.spec.ts
+++ b/identity/client/e2e/tests/users.spec.ts
@@ -35,7 +35,7 @@ test.beforeEach(async ({ page, loginPage }) => {
 test.describe.serial("users CRUD", () => {
   test("creates a user", async ({ page, usersPage }) => {
     await expect(
-      usersPage.usersList.getByRole("cell", { name: "demo@demo.com" }),
+      usersPage.usersList.getByRole("cell", { name: "demo@example.com" }),
     ).toBeVisible();
     await expect(
       usersPage.usersList.getByRole("cell", { name: NEW_USER.email }),

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       KEYCLOAK_USERS_5_ROLES_0: 'Optimize'
       KEYCLOAK_USERS_6_USERNAME: 'demo'
       KEYCLOAK_USERS_6_PASSWORD: 'demo'
-      KEYCLOAK_USERS_6_EMAIL: 'demo@demo.com'
+      KEYCLOAK_USERS_6_EMAIL: 'demo@example.com'
       KEYCLOAK_USERS_6_FIRST_NAME: 'demo'
       KEYCLOAK_USERS_6_ROLES_0: 'Optimize'
       KEYCLOAK_USERS_6_ROLES_1: 'Identity'

--- a/optimize/client/e2e/sm-tests/Alerts.js
+++ b/optimize/client/e2e/sm-tests/Alerts.js
@@ -45,7 +45,7 @@ test('create, edit, copy and remove an alert', async (t) => {
   await t.click(Alert.newAlertButton);
 
   await t.typeText(Alert.inputWithLabel('Alert name'), 'Test Alert', {replace: true});
-  await t.typeText(Alert.inputWithLabel('Send email to'), 'demo@demo.com', {
+  await t.typeText(Alert.inputWithLabel('Send email to'), 'demo@example.com', {
     replace: true,
   });
 
@@ -61,7 +61,7 @@ test('create, edit, copy and remove an alert', async (t) => {
 
   await t.expect(Alert.list.textContent).contains('Test Alert');
   await t.expect(Alert.list.textContent).contains('Number Report');
-  await t.expect(Alert.list.textContent).contains('demo@demo.com');
+  await t.expect(Alert.list.textContent).contains('demo@example.com');
 
   await t
     .resizeWindow(1200, 500)

--- a/optimize/client/e2e/sm-tests/Dashboard.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.js
@@ -442,7 +442,7 @@ test('version selection', async (t) => {
   await t.typeText(Alert.inputWithLabel('Alert name'), 'Test alert', {replace: true});
   await t.click(Common.comboBox);
   await t.click(Common.carbonOption('Number report'));
-  await t.typeText(Alert.inputWithLabel('Send email to'), 'demo@demo.com ');
+  await t.typeText(Alert.inputWithLabel('Send email to'), 'demo@example.com ');
   await t.click(Common.modalConfirmButton);
   await t.click(Common.notificationCloseButton);
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -15,7 +15,7 @@ public class InitializationConfiguration {
   public static final String DEFAULT_USER_USERNAME = "demo";
   public static final String DEFAULT_USER_PASSWORD = "demo";
   public static final String DEFAULT_USER_NAME = "Demo";
-  public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
+  public static final String DEFAULT_USER_EMAIL = "demo@example.com";
 
   private List<ConfiguredUser> users = new ArrayList<>();
   private List<ConfiguredMapping> mappings = new ArrayList<>();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -227,7 +227,7 @@ final class IdentitySetupInitializerIT {
         authorizationsEnabled,
         partitionCount,
         cfg -> {
-          final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@demo.com");
+          final var user = new ConfiguredUser("demo", "demo", "Demo", "demo@example.com");
           cfg.getInitialization().getUsers().add(user);
         });
   }


### PR DESCRIPTION
## Description

Replace the default user email with a reserved domain to `demo@example.com`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31412
