### PR TITLE
[CPT] fix: Print only global process instance variables

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.request.SearchRequestPage;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
@@ -56,9 +57,13 @@ public class CamundaDataSource {
   }
 
   public List<Variable> findVariablesByProcessInstanceKey(final long processInstanceKey) {
+    return findVariables(filter -> filter.processInstanceKey(processInstanceKey));
+  }
+
+  public List<Variable> findVariables(final Consumer<VariableFilter> filter) {
     return client
         .newVariableSearchRequest()
-        .filter(filter -> filter.processInstanceKey(processInstanceKey))
+        .filter(filter)
         .page(DEFAULT_PAGE_REQUEST)
         .send()
         .join()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -61,7 +61,11 @@ public class CamundaProcessTestResultCollector {
   }
 
   private Map<String, String> collectVariables(final long processInstanceKey) {
-    return dataSource.findVariablesByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource
+        // Collect global process instance variables (i.e. no local variables)
+        .findVariables(
+            filter -> filter.processInstanceKey(processInstanceKey).scopeKey(processInstanceKey))
+        .stream()
         // We're deliberately switching from the Collectors.toMap collector to a custom
         // implementation because it's allowed to have Camunda Variables with null values
         // However, the toMap collector does not allow null values and would throw an exception.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -54,7 +54,7 @@ public class CamundaProcessTestResultCollector {
 
     result.setProcessInstance(processInstance);
     result.setVariables(collectVariables(processInstanceKey));
-    result.setOpenIncidents(collectOpenIncidents(processInstanceKey));
+    result.setActiveIncidents(collectActiveIncidents(processInstanceKey));
     result.setActiveElementInstances(collectActiveElementInstances(processInstanceKey));
 
     return result;
@@ -73,7 +73,7 @@ public class CamundaProcessTestResultCollector {
         .collect(HashMap::new, (m, v) -> m.put(v.getName(), v.getValue()), HashMap::putAll);
   }
 
-  private List<Incident> collectOpenIncidents(final long processInstanceKey) {
+  private List<Incident> collectActiveIncidents(final long processInstanceKey) {
     return dataSource.findIncidents(
         filter -> filter.processInstanceKey(processInstanceKey).state(IncidentState.ACTIVE));
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -74,8 +74,8 @@ public class CamundaProcessTestResultPrinter {
         + "Variables:\n"
         + formatVariables(result.getVariables())
         + "\n\n"
-        + "Open incidents:\n"
-        + formatIncidents(result.getOpenIncidents());
+        + "Active incidents:\n"
+        + formatIncidents(result.getActiveIncidents());
   }
 
   private static String formatVariables(final Map<String, String> variables) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
@@ -29,7 +29,7 @@ public class ProcessInstanceResult {
 
   private Map<String, String> variables = new HashMap<>();
 
-  private List<Incident> openIncidents = new ArrayList<>();
+  private List<Incident> activeIncidents = new ArrayList<>();
 
   private List<ElementInstance> activeElementInstances = new ArrayList<>();
 
@@ -49,12 +49,12 @@ public class ProcessInstanceResult {
     this.variables = variables;
   }
 
-  public List<Incident> getOpenIncidents() {
-    return openIncidents;
+  public List<Incident> getActiveIncidents() {
+    return activeIncidents;
   }
 
-  public void setOpenIncidents(final List<Incident> openIncidents) {
-    this.openIncidents = openIncidents;
+  public void setActiveIncidents(final List<Incident> activeIncidents) {
+    this.activeIncidents = activeIncidents;
   }
 
   public List<ElementInstance> getActiveElementInstances() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -101,7 +101,7 @@ public class CamundaProcessResultCollectorTest {
 
     assertThat(result.getProcessInstanceTestResults())
         .allMatch(processInstanceResult -> processInstanceResult.getVariables().isEmpty())
-        .allMatch(processInstanceResult -> processInstanceResult.getOpenIncidents().isEmpty());
+        .allMatch(processInstanceResult -> processInstanceResult.getActiveIncidents().isEmpty());
   }
 
   @Test
@@ -158,7 +158,7 @@ public class CamundaProcessResultCollectorTest {
   }
 
   @Test
-  void shouldReturnOpenIncidents() {
+  void shouldReturnActiveIncidents() {
     // given
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Arrays.asList(PROCESS_INSTANCE_1, PROCESS_INSTANCE_2));
@@ -218,14 +218,14 @@ public class CamundaProcessResultCollectorTest {
     // then
     assertThat(result.getProcessInstanceTestResults()).hasSize(2);
 
-    assertThat(result.getProcessInstanceTestResults().get(0).getOpenIncidents())
+    assertThat(result.getProcessInstanceTestResults().get(0).getActiveIncidents())
         .hasSize(2)
         .extracting(Incident::getErrorType, Incident::getErrorMessage, Incident::getElementId)
         .contains(
             tuple(IncidentErrorType.JOB_NO_RETRIES, "No retries left.", "A"),
             tuple(IncidentErrorType.EXTRACT_VALUE_ERROR, "Failed to evaluate expression.", "B"));
 
-    assertThat(result.getProcessInstanceTestResults().get(1).getOpenIncidents())
+    assertThat(result.getProcessInstanceTestResults().get(1).getActiveIncidents())
         .hasSize(1)
         .extracting(Incident::getErrorType, Incident::getErrorMessage, Incident::getElementId)
         .contains(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -18,9 +18,11 @@ package io.camunda.process.test.impl.testresult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.search.enums.IncidentErrorType;
+import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -31,9 +33,13 @@ import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import io.camunda.process.test.utils.VariableBuilder;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,6 +57,11 @@ public class CamundaProcessResultCollectorTest {
           .build();
 
   @Mock private CamundaDataSource camundaDataSource;
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private VariableFilter variableFilter;
+
+  @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
 
   private CamundaProcessTestResultCollector resultCollector;
 
@@ -97,33 +108,29 @@ public class CamundaProcessResultCollectorTest {
   void shouldReturnProcessInstanceVariables() {
     // given
     when(camundaDataSource.findProcessInstances())
-        .thenReturn(Arrays.asList(PROCESS_INSTANCE_1, PROCESS_INSTANCE_2));
+        .thenReturn(Collections.singletonList(PROCESS_INSTANCE_1));
 
-    when(camundaDataSource.findVariablesByProcessInstanceKey(
-            PROCESS_INSTANCE_1.getProcessInstanceKey()))
+    when(camundaDataSource.findVariables(variableFilterCaptor.capture()))
         .thenReturn(
             Arrays.asList(
                 VariableBuilder.newVariable("var-1", "1").build(),
                 VariableBuilder.newVariable("var-2", "2").build()));
 
-    when(camundaDataSource.findVariablesByProcessInstanceKey(
-            PROCESS_INSTANCE_2.getProcessInstanceKey()))
-        .thenReturn(Collections.singletonList(VariableBuilder.newVariable("var-3", "3").build()));
-
     // when
     final ProcessTestResult result = resultCollector.collect();
 
     // then
-    assertThat(result.getProcessInstanceTestResults()).hasSize(2);
+    assertThat(result.getProcessInstanceTestResults()).hasSize(1);
 
     assertThat(result.getProcessInstanceTestResults().get(0).getVariables())
         .hasSize(2)
         .containsEntry("var-1", "1")
         .containsEntry("var-2", "2");
 
-    assertThat(result.getProcessInstanceTestResults().get(1).getVariables())
-        .hasSize(1)
-        .containsEntry("var-3", "3");
+    // assert that it collects only global variables
+    variableFilterCaptor.getValue().accept(variableFilter);
+    verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_1.getProcessInstanceKey());
+    verify(variableFilter).scopeKey(PROCESS_INSTANCE_1.getProcessInstanceKey());
   }
 
   @Test
@@ -132,8 +139,7 @@ public class CamundaProcessResultCollectorTest {
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Collections.singletonList(PROCESS_INSTANCE_1));
 
-    when(camundaDataSource.findVariablesByProcessInstanceKey(
-            PROCESS_INSTANCE_1.getProcessInstanceKey()))
+    when(camundaDataSource.findVariables(any()))
         .thenReturn(
             Arrays.asList(
                 VariableBuilder.newVariable("var-1", "1").build(),

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
@@ -93,7 +93,7 @@ public class CamundaProcessResultPrinterTest {
                 + "Variables:\n"
                 + "<None>\n"
                 + "\n"
-                + "Open incidents:\n"
+                + "Active incidents:\n"
                 + "<None>\n"
                 + "---------------------\n"
                 + "\n"
@@ -105,7 +105,7 @@ public class CamundaProcessResultPrinterTest {
                 + "Variables:\n"
                 + "<None>\n"
                 + "\n"
-                + "Open incidents:\n"
+                + "Active incidents:\n"
                 + "<None>\n"
                 + "=====================\n");
   }
@@ -147,12 +147,12 @@ public class CamundaProcessResultPrinterTest {
   }
 
   @Test
-  void shouldPrintOpenIncidents() {
+  void shouldPrintActiveIncidents() {
     // given
     final ProcessTestResult processTestResult = new ProcessTestResult();
 
     final ProcessInstanceResult processInstance1 = newProcessInstance(1L, "process-a");
-    processInstance1.setOpenIncidents(
+    processInstance1.setActiveIncidents(
         Arrays.asList(
             IncidentBuilder.newActiveIncident(IncidentErrorType.JOB_NO_RETRIES, "No retries left.")
                 .setElementId("task-a")
@@ -163,7 +163,7 @@ public class CamundaProcessResultPrinterTest {
                 .build()));
 
     final ProcessInstanceResult processInstance2 = newProcessInstance(2L, "process-b");
-    processInstance2.setOpenIncidents(
+    processInstance2.setActiveIncidents(
         Collections.singletonList(
             IncidentBuilder.newActiveIncident(
                     IncidentErrorType.UNHANDLED_ERROR_EVENT, "No error catch event found.")
@@ -184,11 +184,11 @@ public class CamundaProcessResultPrinterTest {
     assertThat(outputBuilder.toString())
         .containsSubsequence(
             "Process instance: 1 [process-id: 'process-a', state: active]\n",
-            "Open incidents:\n",
+            "Active incidents:\n",
             "- 'task-a' [type: JOB_NO_RETRIES] \"No retries left.\"\n",
             "- 'task-b' [type: EXTRACT_VALUE_ERROR] \"Failed to evaluate expression.\"\n",
             "Process instance: 2 [process-id: 'process-b', state: active]\n",
-            "Open incidents:\n",
+            "Active incidents:\n",
             "- 'task-c' [type: UNHANDLED_ERROR_EVENT] \"No error catch event found.\"\n");
   }
 
@@ -266,7 +266,7 @@ public class CamundaProcessResultPrinterTest {
 
     final String bigIncidentMessage = StringUtils.repeat("x", 1000);
 
-    processInstance.setOpenIncidents(
+    processInstance.setActiveIncidents(
         Collections.singletonList(
             IncidentBuilder.newActiveIncident(IncidentErrorType.JOB_NO_RETRIES, bigIncidentMessage)
                 .setElementId("task-a")));
@@ -283,7 +283,8 @@ public class CamundaProcessResultPrinterTest {
     final String expectedIncidentMessage = StringUtils.abbreviate(bigIncidentMessage, 500);
     assertThat(outputBuilder.toString())
         .containsSequence(
-            "Open incidents:\n", "- 'task-a' [type: JOB_NO_RETRIES] \"" + expectedIncidentMessage);
+            "Active incidents:\n",
+            "- 'task-a' [type: JOB_NO_RETRIES] \"" + expectedIncidentMessage);
   }
 
   private static ProcessInstanceResult newProcessInstance(


### PR DESCRIPTION
## Description

This PR adjusts the result output if a test case fails. Instead of printing all process instance variables, it only prints the global variables and ignores the local ones. 

Minor change: rename "Open incidents" to "Active incidents" in the result output to align with the incident state name and the incident assertions. 

## Related issues

closes #31641 
