### PR TITLE
Improve medics benchmark workflow

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -1,6 +1,12 @@
 name: Zeebe Weekly medic benchmark
 on:
-  workflow_dispatch: { }
+  workflow_dispatch:
+     inputs:
+      reuse-tag:
+        description: 'Docker image tag, that should be reused for the medic benchmarks. Allows to skip the docker image build step, can be used for recreating previous weekly benchmarks.'
+        type: string
+        default: ""
+        required: false
   schedule:
     # Runs at 1am every monday https://crontab.guru/#0_1_*_*_1
     - cron: 0 1 * * 1
@@ -51,8 +57,23 @@ jobs:
       - name: Collect benchmark data
         id: data
         run: |
+          var=${{ inputs.reuse-tag || '' }}
+          # ${#var} will return the length of the string
+          if [[ ${#var} -eq 0 ]]; then
+            echo "Creating new weekly benchmark"
+            echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
+          else 
+            # Example:
+            # $ echo ${var%?}
+            # medic-y-2025-cw-18-b1bd4006-benchmark-b1bd400
+            # $ echo ${var%-*}
+            # medic-y-2025-cw-18-b1bd4006-benchmark
+            tag=${{ inputs.reuse-tag }}
+            var=${tag%-*}
+            echo "Re-creating weekly benchmark, with name: $var and tag: $tag"
+            echo "benchmark=$var" >> $GITHUB_OUTPUT
+          fi
           echo "full-ref"=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
-          echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
 
   setup-normal-benchmark:
     name: Normal Benchmark
@@ -66,6 +87,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark
@@ -79,6 +101,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       benchmark-load: >
         -f https://raw.githubusercontent.com/camunda/zeebe-benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
   setup-latency-benchmark:
@@ -93,6 +116,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      reuse-tag: ${{ inputs.reuse-tag || '' }}
       benchmark-load: >
         --set starter.rate=1
         --set workers.benchmark.replicas=1

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -23,13 +23,22 @@ jobs:
       - name: Collect benchmark data
         id: data
         run: |
+          # Count normal weekly namespaces
+          echo "count=$(kubectl get ns -o name | grep -E namespace/medic-y-[0-9]+-cw-[0-9]+-[a-z0-9]+-benchmark$ | wc -l)" >> $GITHUB_OUTPUT
           # Get all namespaces, filter for medic benchmarks and select the oldest one
           echo "normal=$(kubectl get ns -o name | grep -E namespace/medic-y-[0-9]+-cw-[0-9]+-[a-z0-9]+-benchmark$ | sort -V | head -n1)" >> $GITHUB_OUTPUT
       - name: Delete benchmarks
         run: |
-          kubectl delete ${{ steps.data.outputs.normal }}
-          kubectl delete ${{ steps.data.outputs.normal }}-mixed
-          kubectl delete ${{ steps.data.outputs.normal }}-latency
+          if [[  ${{ steps.data.outputs.count }} -ge 4 ]];
+          then
+            # We want to have always at least 4 benchmarks running
+            echo "Delete namespaces for ${{ steps.data.outputs.normal }}"
+            # kubectl delete ${{ steps.data.outputs.normal }}
+            # kubectl delete ${{ steps.data.outputs.normal }}-mixed
+            # kubectl delete ${{ steps.data.outputs.normal }}-latency
+          else 
+            echo "Detected only ${{ steps.data.outputs.count }} benchmarks. Do not delete the oldest."
+          fi
   benchmark-data:
     name: Collect benchmark data
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Improve our medics benchmark workflow, such that:

  * we are no longer delete benchmarks if we have less then four weeks running
  * We can now recreate medic benchmarks with the given tag - this will reuse the image and create latency, normal and mixed benchmark


I used this extension now to recreate our benchmarks, now we have finally again four weeks of running benchmarks

![2025-05-05_14-31](https://github.com/user-attachments/assets/f07291a1-6ff3-427e-9248-a7f963e0d1c8)


## Related issues

closes https://github.com/camunda/camunda/issues/30848
