### PR TITLE
ci: skip commitlint on release branches

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -22,7 +22,8 @@ outputs:
     value: >-
       ${{
         github.event_name == 'pull_request' &&
-        !contains(github.event.pull_request.labels.*.name, 'ci:ignore-commitlint')
+        !contains(github.event.pull_request.labels.*.name, 'ci:ignore-commitlint') &&
+        steps.filter-special-branch.outputs.release-branch != 'true'
       }}
   maven-spotless-linter:
     description: Output whether jobs depending on files relevant for Maven spotless should be run, related checks are based on GitHub events and file changes
@@ -160,7 +161,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' &&
-        steps.filter-stable-branch.outputs.stable-branch == 'true'
+        steps.filter-special-branch.outputs.stable-branch == 'true'
       }}
 
 runs:
@@ -280,11 +281,29 @@ runs:
           - optimize/c4/**
           - optimize/backend/src/main/resources/localization/**
 
-  - id: filter-stable-branch
+  # only works `on: push` and `on: pull_request` GitHub trigger events
+  - id: filter-special-branch
     shell: bash
     run: |
-      if [[ '${{ github.ref_name }}' =~ ^stable\/[0-9]+\.[0-9]+$ ]]; then
+      if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+        test_branch_name="$GITHUB_REF_NAME"
+      elif [[ $GITHUB_EVENT_NAME == 'pull_request' ]]; then
+        test_branch_name="$GITHUB_HEAD_REF"
+      fi
+      echo "Branch name: $test_branch_name"
+
+      if [[ $test_branch_name =~ ^stable\/[0-9]+\.[0-9]+$ ]]; then
+        echo "Stable branch: true"
         echo "stable-branch=true" >> "$GITHUB_OUTPUT"
       else
+        echo "Stable branch: false"
         echo "stable-branch=false" >> "$GITHUB_OUTPUT"
+      fi
+
+      if [[ $test_branch_name =~ ^release.*$ ]]; then
+        echo "Release branch: true"
+        echo "release-branch=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "Release branch: false"
+        echo "release-branch=false" >> "$GITHUB_OUTPUT"
       fi


### PR DESCRIPTION
## Description

Skip `commitlint` on `release/*` branches since Maven plugins don't obey our rules.

Sadly, automatically putting the GH label `ci:ignore-commitlint` [doesn't work seamlessly for PRs created via GH API](https://github.com/orgs/community/discussions/24724#discussioncomment-6883323) otherwise we could add that to the 

Demo from a test `release*` branch: https://github.com/camunda/camunda/pull/31668 -> `CI / commitlint` check should be skipped on both, push and pull_request, triggers as it is a PR from a `release*` branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Context from #30745 and current release