### PR TITLE
Streamline variable search V2 REST API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
@@ -25,9 +25,6 @@ public interface Variable {
   /* The value of the variable */
   String getValue();
 
-  /* The full value of the variable */
-  String getFullValue();
-
   /* The scope key of the variable */
   Long getScopeKey();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
@@ -18,27 +18,36 @@ package io.camunda.client.impl.search.response;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.VariableResult;
+import io.camunda.client.protocol.rest.VariableSearchResult;
 
 public class VariableImpl implements Variable {
 
   private final Long variableKey;
   private final String name;
   private final String value;
-  private final String fullValue;
   private final Long scopeKey;
   private final Long processInstanceKey;
   private final String tenantId;
   private final Boolean isTruncated;
 
-  public VariableImpl(final VariableResult item) {
+  public VariableImpl(final VariableSearchResult item) {
     variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
     name = item.getName();
     value = item.getValue();
-    fullValue = item.getFullValue();
     scopeKey = ParseUtil.parseLongOrNull(item.getScopeKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     tenantId = item.getTenantId();
     isTruncated = item.getIsTruncated();
+  }
+
+  public VariableImpl(final VariableResult item) {
+    variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
+    name = item.getName();
+    value = item.getValue();
+    scopeKey = ParseUtil.parseLongOrNull(item.getScopeKey());
+    processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
+    tenantId = item.getTenantId();
+    isTruncated = false;
   }
 
   @Override
@@ -54,11 +63,6 @@ public class VariableImpl implements Variable {
   @Override
   public String getValue() {
     return value;
-  }
-
-  @Override
-  public String getFullValue() {
-    return fullValue;
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
@@ -22,7 +22,6 @@ public class VariableBuilder implements Variable {
   private Long variableKey;
   private String name;
   private String value;
-  private String fullValue;
   private Long scopeKey;
   private Long processInstanceKey;
   private String tenantId;
@@ -93,11 +92,6 @@ public class VariableBuilder implements Variable {
     return this;
   }
 
-  public VariableBuilder setFullValue(final String fullValue) {
-    this.fullValue = fullValue;
-    return this;
-  }
-
   public VariableBuilder setTruncated(final Boolean truncated) {
     isTruncated = truncated;
     return this;
@@ -108,10 +102,6 @@ public class VariableBuilder implements Variable {
   }
 
   public static VariableBuilder newVariable(final String name, final String value) {
-    return new VariableBuilder()
-        .setName(name)
-        .setValue(value)
-        .setFullValue(value)
-        .setTruncated(false);
+    return new VariableBuilder().setName(name).setValue(value).setTruncated(false);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/VariableBuilder.java
@@ -44,11 +44,6 @@ public class VariableBuilder implements Variable {
   }
 
   @Override
-  public String getFullValue() {
-    return fullValue;
-  }
-
-  @Override
   public Long getScopeKey() {
     return scopeKey;
   }
@@ -83,11 +78,6 @@ public class VariableBuilder implements Variable {
     return this;
   }
 
-  public VariableBuilder setFullValue(final String fullValue) {
-    this.fullValue = fullValue;
-    return this;
-  }
-
   public VariableBuilder setValue(final String value) {
     this.value = value;
     return this;
@@ -100,6 +90,11 @@ public class VariableBuilder implements Variable {
 
   public VariableBuilder setVariableKey(final Long variableKey) {
     this.variableKey = variableKey;
+    return this;
+  }
+
+  public VariableBuilder setFullValue(final String fullValue) {
+    this.fullValue = fullValue;
     return this;
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4980,33 +4980,38 @@ components:
           description: The matching variables.
           type: array
           items:
-            $ref: "#/components/schemas/VariableResult"
-    VariableResult:
+            $ref: "#/components/schemas/VariableSearchResult"
+    VariableSearchResult:
       description: Variable search response item.
+      type: object
+      allOf:
+        - "$ref": "#/components/schemas/VariableResultBase"
+      properties:
+        value:
+          description: Value of this variable. Can be truncated.
+          type: string
+        isTruncated:
+          description: Whether the value is truncated or not.
+          type: boolean
+    VariableResult:
+        description: Variable search response item.
+        type: object
+        allOf:
+          - "$ref": "#/components/schemas/VariableResultBase"
+        properties:
+          value:
+            description: Full value of this variable.
+            type: string
+    VariableResultBase:
+      description: Variable response item.
       type: object
       properties:
         name:
           description: Name of this variable.
           type: string
-        value:
-          description: |
-            Value of this variable. If `isTruncated` is `true`, this value is truncated. Use
-            `fullValue` to get the full value instead.
-          type: string
-        fullValue:
-          description: |
-            Full value of this variable. If `isTruncated` is `true`, this value resembles the full
-            variable value. Otherwise, this is empty and `value` contains the full value.
-          type: string
         tenantId:
           description: Tenant ID of this variable.
           type: string
-        isTruncated:
-          description: |
-            Whether the value is truncated or not. If this is `true`, the `fullValue` contains the
-            full variable value and `value` is a truncated view. Otherwise, `value` contains the
-            full value.
-          type: boolean
         variableKey:
           description: The key for this variable.
           type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -90,6 +90,7 @@ import io.camunda.zeebe.gateway.protocol.rest.UserTaskResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableResult;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.VariableSearchResult;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCacheItem;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -707,19 +708,29 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
-  private static List<VariableResult> toVariables(final List<VariableEntity> variableEntities) {
+  private static List<VariableSearchResult> toVariables(
+      final List<VariableEntity> variableEntities) {
     return variableEntities.stream().map(SearchQueryResponseMapper::toVariable).toList();
   }
 
-  public static VariableResult toVariable(final VariableEntity variableEntity) {
-    return new VariableResult()
+  private static VariableSearchResult toVariable(final VariableEntity variableEntity) {
+    return new VariableSearchResult()
         .variableKey(KeyUtil.keyToString(variableEntity.variableKey()))
         .name(variableEntity.name())
         .value(variableEntity.value())
-        .fullValue(variableEntity.fullValue())
         .processInstanceKey(KeyUtil.keyToString(variableEntity.processInstanceKey()))
         .tenantId(variableEntity.tenantId())
         .isTruncated(variableEntity.isPreview())
+        .scopeKey(KeyUtil.keyToString(variableEntity.scopeKey()));
+  }
+
+  public static VariableResult toVariableItem(final VariableEntity variableEntity) {
+    return new VariableResult()
+        .variableKey(KeyUtil.keyToString(variableEntity.variableKey()))
+        .name(variableEntity.name())
+        .value(variableEntity.isPreview() ? variableEntity.fullValue() : variableEntity.value())
+        .processInstanceKey(KeyUtil.keyToString(variableEntity.processInstanceKey()))
+        .tenantId(variableEntity.tenantId())
         .scopeKey(KeyUtil.keyToString(variableEntity.scopeKey()));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -56,7 +56,7 @@ public class VariableController {
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok()
           .body(
-              SearchQueryResponseMapper.toVariable(
+              SearchQueryResponseMapper.toVariableItem(
                   variableServices
                       .withAuthentication(RequestMapper.getAuthentication())
                       .getByKey(variableKey)));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -100,19 +100,25 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "variableKey":"0",
               "name":"name",
               "value":"value",
-              "fullValue":"test",
               "scopeKey":"1",
               "processInstanceKey":"2",
               "tenantId":"<default>",
               "isTruncated":false
+          },
+          {
+              "variableKey":"1",
+              "name":"name2",
+              "value":"value",
+              "scopeKey":"1",
+              "processInstanceKey":"2",
+              "tenantId":"<default>",
+              "isTruncated":true
           }
         ],
         "page": {
-          "totalItems": 1,
-          "firstSortValues": ["f"],
-          "lastSortValues": [
-            "v"
-          ]
+          "totalItems": 2,
+          "firstSortValues": ["0"],
+          "lastSortValues": ["1"]
         }
       }
       """;
@@ -190,13 +196,14 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
   private static final SearchQueryResult<VariableEntity> SEARCH_VAR_QUERY_RESULT =
       new Builder<VariableEntity>()
-          .total(1L)
+          .total(2L)
           .items(
               List.of(
+                  new VariableEntity(0L, "name", "value", null, false, 1L, 2L, "bpid", "<default>"),
                   new VariableEntity(
-                      0L, "name", "value", "test", false, 1L, 2L, "bpid", "<default>")))
-          .firstSortValues(new Object[] {"f"})
-          .lastSortValues(new Object[] {"v"})
+                      1L, "name2", "value", "valueLong", true, 1L, 2L, "bpid", "<default>")))
+          .firstSortValues(new Object[] {"0"})
+          .lastSortValues(new Object[] {"1"})
           .build();
 
   @MockBean UserTaskServices userTaskServices;


### PR DESCRIPTION
## Description

The variable search V2 REST API has the following outline:
* All variable API (get and search) uses a `value` attribute only, no `fullValue`
* Search requests yield potentially truncated values, indicated by `isTruncated`
* Get by key requests yield full values, no `isTruncated` flag

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31636 
