### PR TITLE
[Backport stable/8.4] Use lowercase when checking which properties to sanitise

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/ConfigSanitizingFunction.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/ConfigSanitizingFunction.java
@@ -35,7 +35,10 @@ public final class ConfigSanitizingFunction implements SanitizingFunction {
     }
 
     for (final var keyword : properties.keywords()) {
-      if (key.contains(keyword)) {
+      // at times the cases are changed by Spring, e.g. when it tries to sanitize the input via a
+      // qualified key; it might be upper case, lower case, etc., so anything with camel case, for
+      // example, would not be matched. instead, we match all cases.
+      if (key.toLowerCase().contains(keyword.toLowerCase())) {
         return data.withSanitizedValue();
       }
     }

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -41,7 +41,8 @@ management.endpoint.configprops.show-values=always
 management.endpoint.info.enabled=true
 # Define keywords to sanitize in applicable endpoints; this will be applied to the configprops,
 # beans, and if enabled, the environment endpoint as well
-management.sanitize.keywords=user,pass,secret,accessKey,accountKey,connectionString
+management.sanitize.keywords=user,pass,secret,accessKey,accountKey,token,\
+  connectionString
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)
 spring.autoconfigure.exclude=\


### PR DESCRIPTION
# Description
Backport of #31588 to `stable/8.4`.

relates to 