### PR TITLE
deps: update identity and operate versions

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.5.6-SNAPSHOT",
+  "version": "8.5.14-SNAPSHOT",
   "private": true,
   "dependencies": {
     "@axe-core/playwright": "4.8.5",

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -92,7 +92,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -57,7 +57,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.15
+    image: camunda/identity:8.5.16
     ports:
       - "8080:8080"
     volumes:
@@ -106,7 +106,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -58,7 +58,7 @@ services:
       keycloak:
         condition: service_healthy
     container_name: identity
-    image: camunda/identity:8.5.15
+    image: camunda/identity:8.5.16
     ports:
       - "8080:8080"
     volumes:
@@ -123,7 +123,7 @@ services:
       - 9600:9600
     restart: always
   operate:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -67,7 +67,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.15
+    image: camunda/identity:8.5.16
     ports:
       - "8080:8080"
     volumes:
@@ -131,7 +131,7 @@ services:
       - "9600:9600"
     restart: always
   operate:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -110,7 +110,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -37,7 +37,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -58,7 +58,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.15
+    image: camunda/identity:8.5.16
     ports:
       - "8080:8080"
     volumes:
@@ -123,7 +123,7 @@ services:
       - "8000:8000"
     restart: always
   operate:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/docker-compose.opensearch.yml
+++ b/operate/docker-compose.opensearch.yml
@@ -26,7 +26,7 @@ services:
       - ./os-snapshots:/usr/local/os-snapshots
   zeebe-opensearch:
     container_name: zeebe-opensearch
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/docker-compose.opensearch.yml
+++ b/operate/docker-compose.opensearch.yml
@@ -41,7 +41,7 @@ services:
       - 8000:8000
     restart: always
   operate-opensearch:
-    image: camunda/operate:8.5.13
+    image: camunda/operate:8.5.14
     container_name: operate-opensearch
     environment:
       - SERVER_PORT=8080

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -47,7 +47,7 @@ services:
 
   zeebe-e2e:
     container_name: zeebe-e2e
-    image: camunda/zeebe:8.5.17
+    image: camunda/zeebe:8.5.18
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}


### PR DESCRIPTION
## Description

Updates versions of dependencies (Zeebe and Identity) and Operate for release of version 8.5.14.

Correct versions can be checked in the [release train thread](https://camunda.slack.com/archives/C03NFMH4KC6/p1746425668658279) for the specific version.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
