### PR TITLE
feat: batch operation completed and lifecycle handlers for camunda exporter

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
@@ -89,7 +89,7 @@ public class TempESBatchOperationCancelProcessInstanceTest {
   }
 
   @Test
-  void shouldStartProcessInstancesWithBatch() throws InterruptedException {
+  void shouldCancelProcessInstancesWithBatch() throws InterruptedException {
     // when
     final var result =
         camundaClient
@@ -117,8 +117,8 @@ public class TempESBatchOperationCancelProcessInstanceTest {
               assertThat(batch.getBatchOperationId()).isEqualTo(String.valueOf(batchOperationKey));
               assertThat(batch.getStartDate()).isNotNull();
               assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
-              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.ACTIVE);
-              assertThat(batch.getEndDate()).isNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+              assertThat(batch.getEndDate()).isNotNull();
             });
 
     final var activeKeys =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -9,6 +9,8 @@ package io.camunda.exporter;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_EXECUTION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
@@ -422,7 +424,9 @@ processing records from previous version
             PROCESS,
             FORM,
             USER_TASK,
-            BATCH_OPERATION_CREATION);
+            BATCH_OPERATION_CREATION,
+            BATCH_OPERATION_EXECUTION,
+            BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -67,6 +67,7 @@ import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCompletedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCreatedHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationLifecycleManagementHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationStartedHandler;
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
@@ -282,6 +283,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new BatchOperationStartedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationCompletedHandler(
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+            new BatchOperationLifecycleManagementHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()));
 
     indicesWithCustomErrorHandlers =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -65,6 +65,7 @@ import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationCompletedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCreatedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationStartedHandler;
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
@@ -279,6 +280,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new BatchOperationCreatedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationStartedHandler(
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+            new BatchOperationCompletedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()));
 
     indicesWithCustomErrorHandlers =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchOperationCompletedHandler
+    implements ExportHandler<BatchOperationEntity, BatchOperationExecutionRecordValue> {
+
+  private final String indexName;
+
+  public BatchOperationCompletedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_EXECUTION;
+  }
+
+  @Override
+  public Class<BatchOperationEntity> getEntityType() {
+    return BatchOperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationExecutionRecordValue> record) {
+    return record.getIntent().equals(BatchOperationExecutionIntent.COMPLETED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationExecutionRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Override
+  public BatchOperationEntity createNewEntity(final String id) {
+    return new BatchOperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationExecutionRecordValue> record, final BatchOperationEntity entity) {
+    entity
+        .setEndDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .setState(BatchOperationState.COMPLETED);
+  }
+
+  @Override
+  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
+    updateFields.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
+    batchRequest.update(indexName, entity.getId(), updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class BatchOperationLifecycleManagementHandler
+    implements ExportHandler<BatchOperationEntity, BatchOperationLifecycleManagementRecordValue> {
+
+  private static final Set<Intent> EXPORTABLE_INTENTS =
+      Set.of(
+          BatchOperationIntent.CANCELED, BatchOperationIntent.PAUSED, BatchOperationIntent.RESUMED);
+  private final String indexName;
+
+  public BatchOperationLifecycleManagementHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
+  }
+
+  @Override
+  public Class<BatchOperationEntity> getEntityType() {
+    return BatchOperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationLifecycleManagementRecordValue> record) {
+    return EXPORTABLE_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(
+      final Record<BatchOperationLifecycleManagementRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Override
+  public BatchOperationEntity createNewEntity(final String id) {
+    return new BatchOperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationLifecycleManagementRecordValue> record,
+      final BatchOperationEntity entity) {
+    final var value = record.getValue();
+    if (record.getIntent().equals(BatchOperationIntent.CANCELED)) {
+      entity
+          .setEndDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+          .setState(BatchOperationState.CANCELED);
+    } else if (record.getIntent().equals(BatchOperationIntent.PAUSED)) {
+      entity.setEndDate(null).setState(BatchOperationState.PAUSED);
+    } else if (record.getIntent().equals(BatchOperationIntent.RESUMED)) {
+      entity.setEndDate(null).setState(BatchOperationState.ACTIVE);
+    }
+  }
+
+  @Override
+  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.STATE, entity.getState());
+    updateFields.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
+    batchRequest.update(indexName, entity.getId(), updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandlerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BatchOperationCompletedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-index";
+  private final BatchOperationCompletedHandler handler =
+      new BatchOperationCompletedHandler(indexName);
+
+  @Test
+  void shouldHandleCompletedIntent() {
+    // given
+    final Record<BatchOperationExecutionRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.COMPLETED);
+
+    // when
+    final boolean result = handler.handlesRecord(record);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleOtherIntent() {
+    // given
+    final Record<BatchOperationExecutionRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.EXECUTE);
+
+    // when
+    final boolean result = handler.handlesRecord(record);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<BatchOperationExecutionRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionIntent.COMPLETED);
+
+    // when
+    final List<String> idList = handler.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // given
+    final String id = "12345";
+
+    // when
+    final BatchOperationEntity entity = handler.createNewEntity(id);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(id);
+  }
+
+  @Test
+  void shouldUpdateEntity() {
+    // given
+    final Record<BatchOperationExecutionRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_EXECUTION,
+            r -> r.withIntent(BatchOperationExecutionIntent.COMPLETED));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    handler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getState()).isEqualTo(BatchOperationState.COMPLETED);
+    assertThat(entity.getEndDate()).isEqualTo(DateUtil.toOffsetDateTime(record.getTimestamp()));
+  }
+
+  @Test
+  void shouldFlushEntity() throws Exception {
+    // given
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+    final BatchOperationEntity entity =
+        new BatchOperationEntity()
+            .setId("12345")
+            .setState(BatchOperationState.COMPLETED)
+            .setEndDate(DateUtil.toOffsetDateTime(Instant.now().toEpochMilli()));
+
+    // when
+    handler.flush(entity, batchRequest);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(batchRequest).update(eq(indexName), eq("12345"), argumentCaptor.capture());
+    final Map<String, Object> updateFields = argumentCaptor.getValue();
+    assertThat(updateFields).containsEntry("state", BatchOperationState.COMPLETED);
+    assertThat(updateFields).containsEntry("endDate", entity.getEndDate());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class BatchOperationLifecycleManagementHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-index";
+  private final BatchOperationLifecycleManagementHandler handler =
+      new BatchOperationLifecycleManagementHandler(indexName);
+
+  @Test
+  void shouldHandleExportableIntents() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> canceledRecord =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.CANCELED);
+    final Record<BatchOperationLifecycleManagementRecordValue> pausedRecord =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.PAUSED);
+    final Record<BatchOperationLifecycleManagementRecordValue> resumedRecord =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.RESUMED);
+
+    // when
+    final boolean handlesCanceled = handler.handlesRecord(canceledRecord);
+    final boolean handlesPaused = handler.handlesRecord(pausedRecord);
+    final boolean handlesResumed = handler.handlesRecord(resumedRecord);
+
+    // then
+    assertThat(handlesCanceled).isTrue();
+    assertThat(handlesPaused).isTrue();
+    assertThat(handlesResumed).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleNonExportableIntent() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.UNKNOWN);
+
+    // when
+    final boolean result = handler.handlesRecord(record);
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.CANCELED);
+
+    // when
+    final List<String> idList = handler.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // given
+    final String id = "12345";
+
+    // when
+    final BatchOperationEntity entity = handler.createNewEntity(id);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(id);
+  }
+
+  @Test
+  void shouldUpdateEntityForCanceledIntent() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            r -> r.withIntent(BatchOperationIntent.CANCELED));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    handler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getState()).isEqualTo(BatchOperationState.CANCELED);
+    assertThat(entity.getEndDate()).isEqualTo(DateUtil.toOffsetDateTime(record.getTimestamp()));
+  }
+
+  @Test
+  void shouldUpdateEntityForPausedIntent() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            r -> r.withIntent(BatchOperationIntent.PAUSED));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    handler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getState()).isEqualTo(BatchOperationState.PAUSED);
+    assertThat(entity.getEndDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityForResumedIntent() {
+    // given
+    final Record<BatchOperationLifecycleManagementRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            r -> r.withIntent(BatchOperationIntent.RESUMED));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    handler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getState()).isEqualTo(BatchOperationState.ACTIVE);
+    assertThat(entity.getEndDate()).isNull();
+  }
+
+  @Test
+  void shouldFlushEntity() throws Exception {
+    // given
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+    final BatchOperationEntity entity =
+        new BatchOperationEntity()
+            .setId("12345")
+            .setState(BatchOperationState.CANCELED)
+            .setEndDate(DateUtil.toOffsetDateTime(Instant.now().toEpochMilli()));
+
+    // when
+    handler.flush(entity, batchRequest);
+
+    // then
+    final var argumentCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(batchRequest).update(eq(indexName), eq("12345"), argumentCaptor.capture());
+    final Map<String, Object> updateFields = argumentCaptor.getValue();
+    assertThat(updateFields).containsEntry("state", BatchOperationState.CANCELED);
+    assertThat(updateFields).containsEntry("endDate", entity.getEndDate());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds camunda exporter handler for completed and all lifecycle events (canceled, paused, resumded) for batch operation. 

## Related issues

closes #31053 #31054
