### PR TITLE
Implement API visibility monitoring via Operate REST polling for benchmarks

### DIFF
--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -24,6 +24,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+    <docker.image.tag>SNAPSHOT</docker.image.tag>
 
     <!-- java version -->
     <version.java>21</version.java>
@@ -175,10 +176,10 @@
             <version>${plugin.version.jib}</version>
             <configuration>
               <from>
-                <image>eclipse-temurin:21</image>
+                <image>eclipse-temurin:21-jre-noble</image>
               </from>
               <to>
-                <image>gcr.io/zeebe-io/starter:SNAPSHOT</image>
+                <image>gcr.io/zeebe-io/starter:${docker.image.tag}</image>
               </to>
               <container>
                 <mainClass>io.camunda.zeebe.Starter</mainClass>
@@ -198,10 +199,10 @@
             <version>${plugin.version.jib}</version>
             <configuration>
               <from>
-                <image>eclipse-temurin:21</image>
+                <image>eclipse-temurin:21-jre-noble</image>
               </from>
               <to>
-                <image>gcr.io/zeebe-io/worker:SNAPSHOT</image>
+                <image>gcr.io/zeebe-io/worker:${docker.image.tag}</image>
               </to>
               <container>
                 <mainClass>io.camunda.zeebe.Worker</mainClass>

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ApiVisibilityMonitor.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ApiVisibilityMonitor.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe;
 

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ApiVisibilityMonitor.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ApiVisibilityMonitor.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+@FunctionalInterface
+public interface ApiVisibilityMonitor extends AutoCloseable {
+  void monitor(long processInstanceKey);
+
+  @Override
+  default void close() {}
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/OperateClient.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/OperateClient.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe;
 

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/OperateClient.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/OperateClient.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.util.CloseableSilently;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.agrona.CloseHelper;
+
+final class OperateClient implements CloseableSilently {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final HttpClient client;
+
+  private final URI baseUri;
+
+  OperateClient(final URI baseUri, final Executor executor) {
+    this.baseUri = baseUri;
+
+    client =
+        HttpClient.newBuilder()
+            .authenticator(
+                new Authenticator() {
+                  @Override
+                  protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication("demo", "demo".toCharArray());
+                  }
+                })
+            .executor(executor)
+            .connectTimeout(Duration.ofSeconds(1))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .version(Version.HTTP_1_1)
+            .build();
+  }
+
+  @Override
+  public void close() {
+    CloseHelper.quietClose(client);
+  }
+
+  public CompletableFuture<ProcessInstance> getProcessInstance(final long processInstanceKey) {
+    final var result = new CompletableFuture<ProcessInstance>();
+    final var requestUri = baseUri.resolve("/v1/process-instances/" + processInstanceKey);
+    final var request =
+        HttpRequest.newBuilder().GET().uri(requestUri).timeout(Duration.ofSeconds(1)).build();
+    client
+        .sendAsync(request, BodyHandlers.ofByteArray())
+        .whenCompleteAsync(
+            (response, error) -> {
+              if (error != null) {
+                result.completeExceptionally(
+                    new RuntimeException(
+                        "Failed to poll [%s] for PI visibility".formatted(requestUri), error));
+                return;
+              }
+
+              mapProcessInstanceResponse(requestUri, response, result);
+            });
+
+    return result;
+  }
+
+  private void mapProcessInstanceResponse(
+      final URI requestUri,
+      HttpResponse<byte[]> response,
+      CompletableFuture<ProcessInstance> result) {
+    if (response.statusCode() < 200 || response.statusCode() > 299) {
+      result.completeExceptionally(new HttpResponseException(requestUri, response.statusCode()));
+      return;
+    }
+
+    try {
+      result.complete(MAPPER.readValue(response.body(), ProcessInstance.class));
+    } catch (final IOException e) {
+      result.completeExceptionally(new HttpResponseException(requestUri, response.statusCode(), e));
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ProcessInstance(long key) {}
+
+  static final class HttpResponseException extends RuntimeException {
+    private final int code;
+
+    public HttpResponseException(final URI requestUri, final int code) {
+      super("Failed to execute request " + requestUri + ", received non-success code " + code);
+      this.code = code;
+    }
+
+    public HttpResponseException(final URI requestUri, final int code, final Throwable cause) {
+      super(
+          "Failed to execute request %s, received non-success code %d".formatted(requestUri, code),
+          cause);
+      this.code = code;
+    }
+
+    int code() {
+      return code;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceMonitor.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceMonitor.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe;
 
@@ -16,7 +24,6 @@ import static io.camunda.zeebe.ProcessInstanceMonitor.MetricsDoc.LATENCY;
 import static io.camunda.zeebe.ProcessInstanceMonitor.MetricsDoc.MONITORING;
 
 import io.camunda.zeebe.OperateClient.HttpResponseException;
-import io.camunda.zeebe.OperateClient.ProcessInstance;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Counter;

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceMonitor.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/ProcessInstanceMonitor.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import static io.camunda.zeebe.ProcessInstanceMonitor.LoggingKeys.MONITORING_COUNT;
+import static io.camunda.zeebe.ProcessInstanceMonitor.LoggingKeys.PROCESS_INSTANCE_KEY;
+import static io.camunda.zeebe.ProcessInstanceMonitor.LoggingKeys.REQUEST_COUNT;
+import static io.camunda.zeebe.ProcessInstanceMonitor.LoggingKeys.START_TIME;
+import static io.camunda.zeebe.ProcessInstanceMonitor.MetricsDoc.ERRORS;
+import static io.camunda.zeebe.ProcessInstanceMonitor.MetricsDoc.LATENCY;
+import static io.camunda.zeebe.ProcessInstanceMonitor.MetricsDoc.MONITORING;
+
+import io.camunda.zeebe.OperateClient.HttpResponseException;
+import io.camunda.zeebe.OperateClient.ProcessInstance;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.SleepingIdleStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LoggingEventBuilder;
+
+final class ProcessInstanceMonitor implements ApiVisibilityMonitor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceMonitor.class);
+
+  private static final Duration BACKOFF_DELAY = Duration.ofMillis(100);
+  private static final int MAX_MONITORING_COUNT = 500;
+
+  private final AtomicInteger monitoringCount = new AtomicInteger();
+
+  private final OperateClient client;
+  private final Executor executor;
+  private final Timer latency;
+  private final Counter errors;
+
+  private volatile boolean isClosed = false;
+
+  ProcessInstanceMonitor(
+      final OperateClient client, final Executor executor, final MeterRegistry meterRegistry) {
+    this.client = client;
+    this.executor = executor;
+
+    latency =
+        Timer.builder(LATENCY.getName())
+            .description(LATENCY.getDescription())
+            .tag(MetricKeyName.ENTITY.asString(), EntityKeys.PROCESS_INSTANCE.asTag())
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    errors =
+        Counter.builder(ERRORS.getName())
+            .description(ERRORS.getDescription())
+            .tag(MetricKeyName.ENTITY.asString(), EntityKeys.PROCESS_INSTANCE.asTag())
+            .register(meterRegistry);
+    Gauge.builder(MONITORING.getName(), monitoringCount, AtomicInteger::get)
+        .description(MONITORING.getDescription())
+        .tag(MetricKeyName.ENTITY.asString(), EntityKeys.PROCESS_INSTANCE.asTag())
+        .register(meterRegistry);
+  }
+
+  @Override
+  public void monitor(final long processInstanceKey) {
+    final var count = monitoringCount.incrementAndGet();
+    if (count > MAX_MONITORING_COUNT) {
+      monitoringCount.decrementAndGet();
+      LOGGER
+          .atTrace()
+          .addKeyValue(PROCESS_INSTANCE_KEY.key(), processInstanceKey)
+          .addKeyValue(MONITORING_COUNT.key(), count)
+          .log("Exceeded maximum monitoring count, will skip this process instance");
+      return;
+    }
+
+    final var task =
+        new ProcessInstanceMonitorTask(
+            processInstanceKey, Instant.now(), new SleepingIdleStrategy(BACKOFF_DELAY.toNanos()));
+    executor.execute(task);
+  }
+
+  @Override
+  public void close() {
+    isClosed = true;
+    CloseHelper.quietClose(client);
+  }
+
+  private final class ProcessInstanceMonitorTask implements Runnable {
+    private static final Duration MONITOR_TIMEOUT = Duration.ofSeconds(60);
+
+    private final long processInstanceKey;
+    private final Instant startTime;
+    private final IdleStrategy idleStrategy;
+
+    private int requestCount;
+
+    private ProcessInstanceMonitorTask(
+        final long processInstanceKey, final Instant startTime, final IdleStrategy idleStrategy) {
+      this.processInstanceKey = processInstanceKey;
+      this.startTime = startTime;
+      this.idleStrategy = idleStrategy;
+    }
+
+    @Override
+    public void run() {
+      if (isClosed) {
+        LOGGER.atTrace().log("Process instance monitor is already closed, stopping task");
+        return;
+      }
+
+      if (Duration.between(startTime, Instant.now()).compareTo(MONITOR_TIMEOUT) > 0) {
+        withContext(LOGGER.atDebug())
+            .addArgument(MONITOR_TIMEOUT)
+            .log("Failed to observe process instance after {} seconds");
+        latency.record(MONITOR_TIMEOUT);
+        return;
+      }
+
+      final var requestTime = Instant.now();
+      client
+          .getProcessInstance(processInstanceKey)
+          .whenCompleteAsync((r, e) -> onProcessInstanceResponse(requestTime, e), executor);
+    }
+
+    private void onProcessInstanceResponse(final Instant requestTime, final Throwable error) {
+      final TaskState taskState = error != null ? handleError(error) : handleSuccess(requestTime);
+
+      if (taskState == TaskState.STOP) {
+        monitoringCount.decrementAndGet();
+        return;
+      }
+
+      idleStrategy.idle(0);
+      requestCount++;
+      withContext(LOGGER.atTrace()).log("Retrying process instance monitoring...");
+      executor.execute(this);
+    }
+
+    private TaskState handleSuccess(final Instant requestTime) {
+      // subtract at least one backoff delay to account for a possible error margin of having waited
+      // up to BACKOFF_DELAY too long in the last cycle
+      final var piLatency = Duration.between(startTime, requestTime).minus(BACKOFF_DELAY);
+      latency.record(piLatency);
+      withContext(LOGGER.atDebug())
+          .addArgument(piLatency)
+          .log("Process instance was visible after {}");
+
+      return TaskState.STOP;
+    }
+
+    private TaskState handleError(final Throwable error) {
+      withContext(LOGGER.atTrace())
+          .setCause(error)
+          .log("Failed to search process instances to measure visibility latency");
+
+      // we expect 404 (not found) until it is; however, for other errors, we will likely have
+      // skewed measurements, so we should stop monitoring that PI
+      if (error instanceof HttpResponseException problem && problem.code() == 404) {
+        return TaskState.RETRY;
+      }
+
+      withContext(LOGGER.atDebug())
+          .setCause(error)
+          .log("Unexpected error while monitoring PI, will ignore to avoid skewed measurements");
+      errors.increment();
+      return TaskState.STOP;
+    }
+
+    private LoggingEventBuilder withContext(final LoggingEventBuilder builder) {
+      return builder
+          .addKeyValue(PROCESS_INSTANCE_KEY.key(), processInstanceKey)
+          .addKeyValue(START_TIME.key(), startTime)
+          .addKeyValue(REQUEST_COUNT.key(), requestCount)
+          .addKeyValue(MONITORING_COUNT.key(), monitoringCount.get());
+    }
+
+    private enum TaskState {
+      STOP,
+      RETRY;
+    }
+  }
+
+  enum LoggingKeys {
+    REQUEST_COUNT("requestCount"),
+    PROCESS_INSTANCE_KEY("processInstanceKey"),
+    START_TIME("startTime"),
+    MONITORING_COUNT("monitoringCount");
+
+    private final String key;
+
+    LoggingKeys(final String key) {
+      this.key = key.intern();
+    }
+
+    String key() {
+      return key;
+    }
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public enum MetricsDoc implements ExtendedMeterDocumentation {
+    /** The latency between an entity being created and initially visible by the same client. */
+    LATENCY {
+      @Override
+      public String getDescription() {
+        return "The latency between an entity being created and initially visible by the same client";
+      }
+
+      @Override
+      public String getName() {
+        return "camunda.benchmark.api.latency";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.TIMER;
+      }
+    },
+
+    /** The number of unexpected errors detected while monitoring for visibility latency */
+    ERRORS {
+      @Override
+      public String getDescription() {
+        return "The number of unexpected errors detected while monitoring for visibility latency";
+      }
+
+      @Override
+      public String getName() {
+        return "camunda.benchmark.api.latency.errors";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.COUNTER;
+      }
+    },
+
+    /** The number of PI keys currently being monitored for visibility latency. */
+    MONITORING {
+      @Override
+      public String getDescription() {
+        return "The number of PI keys currently being monitored for visibility latency";
+      }
+
+      @Override
+      public String getName() {
+        return "camunda.benchmark.api.latency.monitoring";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.GAUGE;
+      }
+    }
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public enum MetricKeyName implements KeyName {
+    ENTITY {
+      @Override
+      public String asString() {
+        return "entity";
+      }
+    }
+  }
+
+  public enum EntityKeys {
+    PROCESS_INSTANCE("process-instance");
+
+    private final String tag;
+
+    EntityKeys(final String tag) {
+      this.tag = tag.intern();
+    }
+
+    public String asTag() {
+      return tag;
+    }
+  }
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -111,10 +111,15 @@ public class Starter extends App {
             TimeUnit.NANOSECONDS);
 
     if (starterCfg.isMonitorApiVisibility()) {
-      final var operateClient =
-          new OperateClient(
-              URI.create((appCfg.isTls() ? "https://" : "http://") + appCfg.getOperateUrl()),
-              virtualExecutor);
+      final var operateUri =
+          URI.create((appCfg.isTls() ? "https://" : "http://") + appCfg.getOperateUrl());
+      LOG.atInfo()
+          .addKeyValue("operateUrl", operateUri)
+          .log(
+              """
+              Starting API visibility monitor, polling for newly created process instances; make \
+              sure Operate is deployed and accessible as configured""");
+      final var operateClient = new OperateClient(operateUri, virtualExecutor);
       apiVisibilityMonitor = new ProcessInstanceMonitor(operateClient, virtualExecutor, registry);
     }
 

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -18,10 +18,19 @@ package io.camunda.zeebe.config;
 public class AppCfg {
 
   private String brokerUrl;
+  private String operateUrl;
   private boolean tls;
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
+
+  public String getOperateUrl() {
+    return operateUrl;
+  }
+
+  public void setOperateUrl(String operateUrl) {
+    this.operateUrl = operateUrl;
+  }
 
   public String getBrokerUrl() {
     return brokerUrl;

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
@@ -40,6 +40,16 @@ public class StarterCfg {
   private boolean startViaMessage;
   private String msgName;
 
+  private boolean monitorApiVisibility;
+
+  public boolean isMonitorApiVisibility() {
+    return monitorApiVisibility;
+  }
+
+  public void setMonitorApiVisibility(final boolean monitorApiVisibility) {
+    this.monitorApiVisibility = monitorApiVisibility;
+  }
+
   public boolean isStartViaMessage() {
     return startViaMessage;
   }

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -8,7 +8,7 @@ app {
 
   starter {
     processId = "benchmark"
-    rate = 1
+    rate = 300
     threads = 2
     bpmnXmlPath = "bpmn/one_task.bpmn"
     extraBpmnModels = []

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -1,12 +1,14 @@
 app {
   brokerUrl = "localhost:26500"
   brokerUrl = ${?ZEEBE_ADDRESS}
+  operateUrl = "localhost:8080"
+  operateUrl = ${?OPERATE_ADDRESS}
   tls = false
   monitoringPort = 9600
 
   starter {
     processId = "benchmark"
-    rate = 300
+    rate = 1
     threads = 2
     bpmnXmlPath = "bpmn/one_task.bpmn"
     extraBpmnModels = []
@@ -17,6 +19,8 @@ app {
     durationLimit = 0
     msgName = "msg"
     startViaMessage = false
+    # requires Operate to be deployed if enabled
+    monitorApiVisibility = false
   }
 
   worker {

--- a/zeebe/benchmarks/project/src/main/resources/log4j2.xml
+++ b/zeebe/benchmarks/project/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %notEmpty{[%X] }%-5level%n\t%logger{36} - %msg%n" />
     </Console>
   </Appenders>
   <Loggers>

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -1,6 +1,8 @@
 app {
   brokerUrl = "localhost:26500"
   brokerUrl = ${?ZEEBE_ADDRESS}
+  operateUrl = "localhost:8080"
+  operateUrl = ${?OPERATE_ADDRESS}
   tls = false
   monitoringPort = 9600
 
@@ -17,6 +19,8 @@ app {
     durationLimit = 0
     msgName = "msg"
     startViaMessage = false
+    # requires Operate to be deployed if enabled
+    monitorApiVisibility = false
   }
 
   worker {


### PR DESCRIPTION
## Description

This PR adds some basic API visibility monitoring for the benchmark starter. The idea is to visualize how fast a new process instance is visible via the REST API after it has been created, thus measuring how soon something processed becomes visible from the secondary storage.

Note that for <8.7, this relies on Operate being deployed. As such, visibility monitoring is off by default.
