### PR TITLE
feat: check for application permissions

### DIFF
--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -126,8 +126,12 @@ public class AuthorizationChecker {
 
   private List<String> collectOwnerIds(final Authentication authentication) {
     final List<String> ownerIds = new ArrayList<>();
-    ownerIds.add(authentication.authenticatedUsername());
-    ownerIds.add(authentication.authenticationApplicationId());
+    if (authentication.authenticatedUsername() != null) {
+      ownerIds.add(authentication.authenticatedUsername());
+    }
+    if (authentication.authenticationApplicationId() != null) {
+      ownerIds.add(authentication.authenticationApplicationId());
+    }
     ownerIds.addAll(authentication.authenticatedMappingIds());
     ownerIds.addAll(
         // TODO remove this mapping when refactoring Groups to IDs

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -127,6 +127,7 @@ public class AuthorizationChecker {
   private List<String> collectOwnerIds(final Authentication authentication) {
     final List<String> ownerIds = new ArrayList<>();
     ownerIds.add(authentication.authenticatedUsername());
+    ownerIds.add(authentication.authenticationApplicationId());
     ownerIds.addAll(authentication.authenticatedMappingIds());
     ownerIds.addAll(
         // TODO remove this mapping when refactoring Groups to IDs

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -87,18 +87,15 @@ public final class AuthorizationCheckBehavior {
     }
 
     final var username = getUsername(request);
+    final var applicationId = getApplicationId(request);
 
-    // TODO: remove this check when username retrieval is supported in JWT modes
     if (username.isPresent()) {
       final var userAuthorized =
           isEntityAuthorized(request, EntityType.USER, Set.of(username.get()));
       if (userAuthorized.isRight()) {
         return userAuthorized;
       }
-    }
-
-    final var applicationId = getApplicationId(request);
-    if (applicationId.isPresent()) {
+    } else if (applicationId.isPresent()) {
       final var applicationAuthorized =
           isEntityAuthorized(request, EntityType.APPLICATION, Set.of(applicationId.get()));
       if (applicationAuthorized.isRight()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -91,13 +90,20 @@ public final class AuthorizationCheckBehavior {
 
     // TODO: remove this check when username retrieval is supported in JWT modes
     if (username.isPresent()) {
-      final var userAuthorized = isUserAuthorized(request, username.get());
+      final var userAuthorized =
+          isEntityAuthorized(request, EntityType.USER, Set.of(username.get()));
       if (userAuthorized.isRight()) {
         return userAuthorized;
       }
     }
 
-    final var mappingAuthorized = isMappingAuthorized(request);
+    final var mappingAuthorized =
+        isEntityAuthorized(
+            request,
+            EntityType.MAPPING,
+            getPersistedMappings(request.command)
+                .map(PersistedMapping::getMappingId)
+                .collect(Collectors.toSet()));
     if (mappingAuthorized.isLeft()) {
       return Either.left(mappingAuthorized.getLeft());
     }
@@ -110,52 +116,45 @@ public final class AuthorizationCheckBehavior {
    * access to the tenant and if the user has the required permissions for the resource.
    *
    * @param request the authorization request to check authorization for
-   * @param username the username of the user making this request
+   * @param entityType the type of the entity being accessed
+   * @param entityIds the username of the user making this request
    * @return an {@link Either} containing a {@link Rejection} or {@link Void}
    */
-  private Either<Rejection, Void> isUserAuthorized(
-      final AuthorizationRequest request, final String username) {
+  private Either<Rejection, Void> isEntityAuthorized(
+      final AuthorizationRequest request,
+      final EntityType entityType,
+      final Collection<String> entityIds) {
     if (multiTenancyEnabled) {
-      if (!isUserAuthorizedForTenant(request, username)) {
+      if (entityIds.stream()
+          .noneMatch(
+              entityId ->
+                  getAuthorizedTenantIds(entityType, entityId)
+                      .anyMatch(request.tenantId::equals))) {
         final var rejectionType =
             request.isNewResource() ? RejectionType.FORBIDDEN : RejectionType.NOT_FOUND;
         return Either.left(new Rejection(rejectionType, request.getTenantErrorMessage()));
       }
     }
 
-    if (authorizationsEnabled) {
-      final var authorizedResourceIdentifiers =
-          getUserAuthorizedResourceIdentifiers(
-              username, request.getResourceType(), request.getPermissionType());
-      return checkResourceIdentifiers(request, authorizedResourceIdentifiers);
-    }
-    return Either.right(null);
-  }
-
-  /**
-   * Verifies a mapping is authorized to perform this request. This method checks if the mapping has
-   * the required permissions for the resource.
-   *
-   * @param request the authorization request to check authorization for
-   * @return an {@link Either} containing a {@link Rejection} or {@link Void}
-   */
-  private Either<Rejection, Void> isMappingAuthorized(final AuthorizationRequest request) {
-    final var persistedMappings = getPersistedMappings(request.getCommand());
-
-    if (multiTenancyEnabled) {
-      if (!isMappingAuthorizedForTenant(request, persistedMappings)) {
-        final var rejectionType =
-            request.isNewResource() ? RejectionType.FORBIDDEN : RejectionType.NOT_FOUND;
-        return Either.left(new Rejection(rejectionType, request.getTenantErrorMessage()));
-      }
+    if (!authorizationsEnabled) {
+      return Either.right(null);
     }
 
-    if (authorizationsEnabled) {
-      final var authorizedResourceIdentifiers =
-          getMappingsAuthorizedResourceIdentifiers(request, persistedMappings);
-      return checkResourceIdentifiers(request, authorizedResourceIdentifiers);
+    final var authorizedResourceIdentifiers =
+        entityIds.stream()
+            .flatMap(
+                entityId ->
+                    getAuthorizedResourceIdentifiers(
+                        entityType,
+                        entityId,
+                        request.getResourceType(),
+                        request.getPermissionType()));
+    if (authorizedResourceIdentifiers.anyMatch(
+        resourceId -> request.getResourceIds().contains(resourceId))) {
+      return Either.right(null);
     }
-    return Either.right(null);
+
+    return Either.left(new Rejection(RejectionType.FORBIDDEN, request.getForbiddenErrorMessage()));
   }
 
   /**
@@ -183,113 +182,58 @@ public final class AuthorizationCheckBehavior {
         (String) command.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME));
   }
 
-  private boolean isUserAuthorizedForTenant(
-      final AuthorizationRequest request, final String username) {
-    final var tenantId = request.tenantId;
-    final var hasTenant =
-        membershipState.hasRelation(EntityType.USER, username, RelationType.TENANT, tenantId);
-    if (hasTenant) {
-      return true;
-    } else if (hasTenantIdThroughGroups(EntityType.USER, username, tenantId)) {
-      return true;
-    } else {
-      return hasTenantIdThroughRoles(EntityType.USER, username, tenantId);
-    }
-  }
-
-  private boolean isMappingAuthorizedForTenant(
-      final AuthorizationRequest request, final List<PersistedMapping> persistedMappings) {
-    final var tenantId = request.tenantId;
-
-    for (final var mapping : persistedMappings) {
-      final var hasTenant =
-          membershipState.hasRelation(
-              EntityType.MAPPING, mapping.getMappingId(), RelationType.TENANT, tenantId);
-      if (hasTenant) {
-        return true;
-      }
-    }
-
-    // Search for transitive tenant membership in a separate loop to optimize for the common case of
-    // a direct membership.
-    for (final var mapping : persistedMappings) {
-      if (hasTenantIdThroughGroups(EntityType.MAPPING, mapping.getMappingId(), tenantId)) {
-        return true;
-      } else if (hasTenantIdThroughRoles(EntityType.MAPPING, mapping.getMappingId(), tenantId)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private boolean hasTenantIdThroughGroups(
-      final EntityType entityType, final String entityId, final String tenantId) {
-    final var groupIds = membershipState.getMemberships(entityType, entityId, RelationType.GROUP);
-    final var hasTenantDirectly =
-        new HashSet<>(groupIds)
-            .stream()
-                .anyMatch(
+  private Stream<String> getAuthorizedTenantIds(
+      final EntityType entityType, final String entityId) {
+    return Stream.concat(
+        membershipState.getMemberships(entityType, entityId, RelationType.TENANT).stream(),
+        Stream.concat(
+            membershipState.getMemberships(entityType, entityId, RelationType.GROUP).stream()
+                .flatMap(
                     groupId ->
-                        membershipState.hasRelation(
-                            EntityType.GROUP, groupId, RelationType.TENANT, tenantId));
-
-    if (hasTenantDirectly) {
-      return true;
-    }
-
-    return groupIds.stream()
-        .anyMatch(groupId -> hasTenantIdThroughRoles(EntityType.GROUP, groupId, tenantId));
-  }
-
-  private boolean hasTenantIdThroughRoles(
-      final EntityType entityType, final String entityId, final String tenantId) {
-    final var roleIds = membershipState.getMemberships(entityType, entityId, RelationType.ROLE);
-    return roleIds.stream()
-        .anyMatch(
-            roleId ->
-                membershipState.hasRelation(
-                    EntityType.ROLE, roleId, RelationType.TENANT, tenantId));
-  }
-
-  private Set<String> getTenantIdsForGroups(final Collection<String> groupIds) {
-    final var tenantIds = new HashSet<String>();
-    for (final var groupId : groupIds) {
-      tenantIds.addAll(
-          membershipState.getMemberships(EntityType.GROUP, groupId, RelationType.TENANT));
-
-      final var roleIds =
-          new HashSet<>(
-              membershipState.getMemberships(EntityType.GROUP, groupId, RelationType.ROLE));
-      tenantIds.addAll(getTenantIdsForRoles(roleIds));
-    }
-    return tenantIds;
-  }
-
-  private Set<String> getTenantIdsForRoles(final Collection<String> roleIds) {
-    final var tenantIds = new HashSet<String>();
-    for (final var roleId : roleIds) {
-      tenantIds.addAll(
-          membershipState.getMemberships(EntityType.ROLE, roleId, RelationType.TENANT));
-    }
-    return tenantIds;
+                        Stream.concat(
+                            membershipState
+                                .getMemberships(EntityType.GROUP, groupId, RelationType.TENANT)
+                                .stream(),
+                            membershipState
+                                .getMemberships(EntityType.GROUP, groupId, RelationType.ROLE)
+                                .stream()
+                                .flatMap(
+                                    roleId ->
+                                        membershipState
+                                            .getMemberships(
+                                                EntityType.ROLE, roleId, RelationType.TENANT)
+                                            .stream()))),
+            membershipState.getMemberships(entityType, entityId, RelationType.ROLE).stream()
+                .flatMap(
+                    roleId ->
+                        membershipState
+                            .getMemberships(EntityType.ROLE, roleId, RelationType.TENANT)
+                            .stream())));
   }
 
   public Set<String> getAllAuthorizedResourceIdentifiers(final AuthorizationRequest request) {
-    if (!authorizationsEnabled) {
-      return Set.of(WILDCARD_PERMISSION);
-    }
-
-    if (isAuthorizedAnonymousUser(request.getCommand())) {
+    if (!authorizationsEnabled || isAuthorizedAnonymousUser(request.getCommand())) {
       return Set.of(WILDCARD_PERMISSION);
     }
 
     return getUsername(request)
         .map(
             username ->
-                getUserAuthorizedResourceIdentifiers(
-                    username, request.getResourceType(), request.getPermissionType()))
-        .orElseGet(() -> getMappingsAuthorizedResourceIdentifiers(request))
+                getAuthorizedResourceIdentifiers(
+                    EntityType.USER,
+                    username,
+                    request.getResourceType(),
+                    request.getPermissionType()))
+        .orElseGet(
+            () ->
+                getPersistedMappings(request.getCommand())
+                    .flatMap(
+                        mapping ->
+                            getAuthorizedResourceIdentifiers(
+                                EntityType.MAPPING,
+                                mapping.getMappingId(),
+                                request.getResourceType(),
+                                request.getPermissionType())))
         .collect(Collectors.toSet());
   }
 
@@ -307,119 +251,50 @@ public final class AuthorizationCheckBehavior {
         ownerType, ownerId, resourceType, permissionType);
   }
 
-  // TODO: refactor role and group keys to use groupNames and roleNames after
-  // https://github.com/camunda/camunda/issues/26981
-  private Stream<String> getUserAuthorizedResourceIdentifiers(
-      final String username,
+  private Stream<String> getAuthorizedResourceIdentifiers(
+      final EntityType ownerType,
+      final String ownerId,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
-    // Get resource identifiers for this user
-    final var userAuthorizedResourceIdentifiers =
-        authorizationState.getResourceIdentifiers(
-            AuthorizationOwnerType.USER, username, resourceType, permissionType);
-    // Get resource identifiers for the user's roles
-    final var roleIds =
-        membershipState.getMemberships(EntityType.USER, username, RelationType.ROLE);
-    final var roleAuthorizedResourceIdentifiers =
-        getAuthorizedResourceIdentifiersForOwners(
-            AuthorizationOwnerType.ROLE, roleIds, resourceType, permissionType);
-    // Get resource identifiers for the user's groups
-    final var groupsAuthorizedResourceIdentifiers =
-        getGroupsAuthorizedResourceIdentifiers(
-            EntityType.USER, username, resourceType, permissionType);
-    return Stream.concat(
-        userAuthorizedResourceIdentifiers.stream(),
-        Stream.concat(roleAuthorizedResourceIdentifiers, groupsAuthorizedResourceIdentifiers));
-  }
+    final var authorizationOwnerType =
+        switch (ownerType) {
+          case GROUP -> AuthorizationOwnerType.GROUP;
+          case ROLE -> AuthorizationOwnerType.ROLE;
+          case USER -> AuthorizationOwnerType.USER;
+          case MAPPING -> AuthorizationOwnerType.MAPPING;
+          case APPLICATION -> AuthorizationOwnerType.APPLICATION;
+          case UNSPECIFIED -> AuthorizationOwnerType.UNSPECIFIED;
+        };
 
-  private Stream<String> getMappingsAuthorizedResourceIdentifiers(
-      final AuthorizationRequest request) {
-    return getMappingsAuthorizedResourceIdentifiers(
-        request, getPersistedMappings(request.getCommand()));
-  }
-
-  private Stream<String> getGroupsAuthorizedResourceIdentifiers(
-      final EntityType entityType,
-      final String entityId,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType) {
-    final var groupIds = membershipState.getMemberships(entityType, entityId, RelationType.GROUP);
-    final var groupAuthorizedResourceIdentifiers =
-        getAuthorizedResourceIdentifiersForOwners(
-            AuthorizationOwnerType.GROUP, groupIds, resourceType, permissionType);
-    // Get resource identifiers for the groups' roles
-    final var roleAuthorizedResourceIdentifiers =
-        groupIds.stream()
+    final var direct =
+        getDirectAuthorizedResourceIdentifiers(
+            authorizationOwnerType, ownerId, resourceType, permissionType)
+            .stream();
+    final var viaRole =
+        membershipState.getMemberships(ownerType, ownerId, RelationType.ROLE).stream()
             .flatMap(
-                groupId -> {
-                  final var roleIds =
-                      membershipState.getMemberships(EntityType.GROUP, groupId, RelationType.ROLE);
-                  return getAuthorizedResourceIdentifiersForOwners(
-                      AuthorizationOwnerType.ROLE, roleIds, resourceType, permissionType);
+                roleId ->
+                    getDirectAuthorizedResourceIdentifiers(
+                        AuthorizationOwnerType.ROLE, roleId, resourceType, permissionType)
+                        .stream());
+    final var viaGroups =
+        membershipState.getMemberships(ownerType, ownerId, RelationType.GROUP).stream()
+            .<String>mapMulti(
+                (groupId, stream) -> {
+                  getDirectAuthorizedResourceIdentifiers(
+                          AuthorizationOwnerType.GROUP, groupId, resourceType, permissionType)
+                      .forEach(stream);
+                  membershipState
+                      .getMemberships(EntityType.GROUP, groupId, RelationType.ROLE)
+                      .stream()
+                      .flatMap(
+                          roleId ->
+                              getDirectAuthorizedResourceIdentifiers(
+                                  AuthorizationOwnerType.ROLE, roleId, resourceType, permissionType)
+                                  .stream())
+                      .forEach(stream);
                 });
-    return Stream.concat(groupAuthorizedResourceIdentifiers, roleAuthorizedResourceIdentifiers);
-  }
-
-  private Stream<String> getMappingsAuthorizedResourceIdentifiers(
-      final AuthorizationRequest request, final List<PersistedMapping> persistedMappings) {
-    return persistedMappings.stream()
-        .mapMulti(
-            (mapping, stream) -> {
-              getAuthorizedResourceIdentifiersForOwners(
-                      AuthorizationOwnerType.MAPPING,
-                      List.of(mapping.getMappingId()),
-                      request.getResourceType(),
-                      request.getPermissionType())
-                  .forEach(stream);
-              getGroupsAuthorizedResourceIdentifiers(
-                      EntityType.MAPPING,
-                      mapping.getMappingId(),
-                      request.getResourceType(),
-                      request.getPermissionType())
-                  .forEach(stream);
-              getAuthorizedResourceIdentifiersForOwners(
-                      AuthorizationOwnerType.ROLE,
-                      membershipState.getMemberships(
-                          EntityType.MAPPING, mapping.getMappingId(), RelationType.ROLE),
-                      request.getResourceType(),
-                      request.getPermissionType())
-                  .forEach(stream);
-            });
-  }
-
-  private Stream<String> getAuthorizedResourceIdentifiersForOwners(
-      final AuthorizationOwnerType ownerType,
-      final List<String> ownerIds,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType) {
-    return ownerIds.stream()
-        .flatMap(
-            ownerId ->
-                authorizationState
-                    .getResourceIdentifiers(ownerType, ownerId, resourceType, permissionType)
-                    .stream());
-  }
-
-  /**
-   * Checks the resource identifiers of the request against the authorized resource identifiers of
-   * the entity.
-   *
-   * @param request the authorization request to check authorization for
-   * @param authorizedResourceIdentifiers the authorized resource identifiers of the entity
-   * @return an {@link Either} containing a {@link Rejection} if there is no match or {@link Void}
-   *     if there is.
-   */
-  private Either<Rejection, Void> checkResourceIdentifiers(
-      final AuthorizationRequest request, final Stream<String> authorizedResourceIdentifiers) {
-    final var isAuthorized =
-        authorizedResourceIdentifiers.anyMatch(
-            resourceId -> request.getResourceIds().contains(resourceId));
-    if (isAuthorized) {
-      return Either.right(null);
-    } else {
-      return Either.left(
-          new Rejection(RejectionType.FORBIDDEN, request.getForbiddenErrorMessage()));
-    }
+    return Stream.concat(direct, Stream.concat(viaRole, viaGroups));
   }
 
   /**
@@ -452,18 +327,7 @@ public final class AuthorizationCheckBehavior {
 
     final var username = getUsername(command);
     if (username.isPresent()) {
-      final var tenantIds =
-          new HashSet<>(
-              membershipState.getMemberships(EntityType.USER, username.get(), RelationType.TENANT));
-
-      final var groupIds =
-          membershipState.getMemberships(EntityType.USER, username.get(), RelationType.GROUP);
-      tenantIds.addAll(getTenantIdsForGroups(groupIds));
-
-      final var roleIds =
-          membershipState.getMemberships(EntityType.USER, username.get(), RelationType.ROLE);
-      tenantIds.addAll(getTenantIdsForRoles(roleIds));
-
+      final var tenantIds = getAuthorizedTenantIds(EntityType.USER, username.get()).toList();
       if (tenantIds.isEmpty()) {
         return AuthorizedTenants.DEFAULT_TENANTS;
       } else {
@@ -472,26 +336,8 @@ public final class AuthorizationCheckBehavior {
     }
 
     final var tenantsOfMapping =
-        getPersistedMappings(command).stream()
-            .flatMap(
-                mapping -> {
-                  final var tenantIds =
-                      new HashSet<>(
-                          membershipState.getMemberships(
-                              EntityType.MAPPING, mapping.getMappingId(), RelationType.TENANT));
-
-                  final var groupIds =
-                      membershipState.getMemberships(
-                          EntityType.MAPPING, mapping.getMappingId(), RelationType.GROUP);
-                  tenantIds.addAll(getTenantIdsForGroups(groupIds));
-
-                  final var roleIds =
-                      membershipState.getMemberships(
-                          EntityType.MAPPING, mapping.getMappingId(), RelationType.ROLE);
-                  tenantIds.addAll(getTenantIdsForRoles(roleIds));
-
-                  return tenantIds.stream();
-                })
+        getPersistedMappings(command)
+            .flatMap(mapping -> getAuthorizedTenantIds(EntityType.MAPPING, mapping.getMappingId()))
             .collect(Collectors.toSet());
 
     return tenantsOfMapping.isEmpty()
@@ -499,7 +345,7 @@ public final class AuthorizationCheckBehavior {
         : new AuthenticatedAuthorizedTenants(tenantsOfMapping);
   }
 
-  private List<PersistedMapping> getPersistedMappings(final TypedRecord<?> command) {
+  private Stream<PersistedMapping> getPersistedMappings(final TypedRecord<?> command) {
     return command.getAuthorizations().entrySet().stream()
         .filter(entry -> entry.getKey().startsWith(Authorization.USER_TOKEN_CLAIM_PREFIX))
         .flatMap(
@@ -515,8 +361,7 @@ public final class AuthorizationCheckBehavior {
               }
             })
         .map((claim) -> mappingState.get(claim.claimName(), claim.claimValue()))
-        .<PersistedMapping>mapMulti(Optional::ifPresent)
-        .toList();
+        .mapMulti(Optional::ifPresent);
   }
 
   public static final class AuthorizationRequest {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -97,6 +97,15 @@ public final class AuthorizationCheckBehavior {
       }
     }
 
+    final var applicationId = getApplicationId(request);
+    if (applicationId.isPresent()) {
+      final var applicationAuthorized =
+          isEntityAuthorized(request, EntityType.APPLICATION, Set.of(applicationId.get()));
+      if (applicationAuthorized.isRight()) {
+        return applicationAuthorized;
+      }
+    }
+
     final var mappingAuthorized =
         isEntityAuthorized(
             request,
@@ -182,6 +191,15 @@ public final class AuthorizationCheckBehavior {
         (String) command.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME));
   }
 
+  private Optional<String> getApplicationId(final AuthorizationRequest request) {
+    return getApplicationId(request.getCommand());
+  }
+
+  private Optional<String> getApplicationId(final TypedRecord<?> command) {
+    return Optional.ofNullable(
+        (String) command.getAuthorizations().get(Authorization.AUTHORIZED_APPLICATION_ID));
+  }
+
   private Stream<String> getAuthorizedTenantIds(
       final EntityType entityType, final String entityId) {
     return Stream.concat(
@@ -224,6 +242,16 @@ public final class AuthorizationCheckBehavior {
                     username,
                     request.getResourceType(),
                     request.getPermissionType()))
+        .or(
+            () ->
+                getApplicationId(request)
+                    .map(
+                        applicationId ->
+                            getAuthorizedResourceIdentifiers(
+                                EntityType.APPLICATION,
+                                applicationId,
+                                request.getResourceType(),
+                                request.getPermissionType())))
         .orElseGet(
             () ->
                 getPersistedMappings(request.getCommand())
@@ -328,6 +356,17 @@ public final class AuthorizationCheckBehavior {
     final var username = getUsername(command);
     if (username.isPresent()) {
       final var tenantIds = getAuthorizedTenantIds(EntityType.USER, username.get()).toList();
+      if (tenantIds.isEmpty()) {
+        return AuthorizedTenants.DEFAULT_TENANTS;
+      } else {
+        return new AuthenticatedAuthorizedTenants(tenantIds);
+      }
+    }
+
+    final var applicationId = getApplicationId(command);
+    if (applicationId.isPresent()) {
+      final var tenantIds =
+          getAuthorizedTenantIds(EntityType.APPLICATION, applicationId.get()).toList();
       if (tenantIds.isEmpty()) {
         return AuthorizedTenants.DEFAULT_TENANTS;
       } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -103,18 +103,12 @@ public final class AuthorizationCheckBehavior {
       }
     }
 
-    final var mappingAuthorized =
-        isEntityAuthorized(
-            request,
-            EntityType.MAPPING,
-            getPersistedMappings(request)
-                .map(PersistedMapping::getMappingId)
-                .collect(Collectors.toSet()));
-    if (mappingAuthorized.isLeft()) {
-      return Either.left(mappingAuthorized.getLeft());
-    }
-
-    return Either.right(null);
+    return isEntityAuthorized(
+        request,
+        EntityType.MAPPING,
+        getPersistedMappings(request)
+            .map(PersistedMapping::getMappingId)
+            .collect(Collectors.toSet()));
   }
 
   /**


### PR DESCRIPTION
This first refactors and then extends the `AuthorizationCheckBehavior` to check application permissions during processing.
I've also included changes to `AuthorizationChecker` to check permissions during search requests.

closes #31379
closes #31380
