### PR TITLE
ci: increase timeout for OS and H2 integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     name: "[IT] OpenSearch"
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
     env:
@@ -454,6 +454,7 @@ jobs:
       # -D test.integration.camunda.database.type=os
       #
       - name: Run integration test with externalized OS
+        timeout-minutes: 10
         run: >
           ./mvnw -B -T 1 --no-snapshot-updates
           -D forkCount=4
@@ -493,7 +494,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     name: "[IT] RDBMS - H2"
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     env:
@@ -519,6 +520,7 @@ jobs:
       # -Dcamunda.it.database.type=rdbms
       #
       - name: Run integration test with InMemory H2
+        timeout-minutes: 10
         run: >
           ./mvnw -B -T 2 --no-snapshot-updates
           -D forkCount=3


### PR DESCRIPTION
Both jobs used a strict 10 minute timeout which is problematic when building takes longer than usual, for example when the cache is not usable.

For those two jobs, we now allow for an additional 5 minutes but restrict the test step to the original 10 minutes.

I've reviewed other jobs in the CI workflow but those timeouts seemed more reasonable and I didn't want to touch everything at once.