### PR TITLE
refactor: migrate tasklist public start form page tests to 8.7 core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/test-setup.ts
+++ b/qa/core-application-e2e-test-suite/test-setup.ts
@@ -9,14 +9,17 @@
 import {Page, TestInfo} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import axios from 'axios';
+import path from 'path';
 
 export async function captureScreenshot(page: Page, testInfo: TestInfo) {
-  const screenshotPath = `test-results/screenshots/screenshot-${randomUUID()}.png`;
+  const screenshotFileName = `screenshot-${randomUUID()}.png`;
+  const screenshotPath = path.resolve(testInfo.outputDir, screenshotFileName);
   await page.screenshot({
     path: screenshotPath,
     fullPage: true,
     timeout: 200000,
   });
+
   testInfo.annotations.push({
     type: 'testrail_attachment',
     description: screenshotPath,
@@ -25,7 +28,8 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo) {
 
 export async function captureFailureVideo(page: Page, testInfo: TestInfo) {
   if (testInfo.status === 'failed') {
-    const videoPath = `test-results/videos/video-${testInfo.title}-chromium.webm`;
+    const videoFileName = `video-${randomUUID()}.webm`;
+    const videoPath = path.resolve(testInfo.outputDir, videoFileName);
     const video = page.video();
     if (video) {
       await video.saveAs(videoPath);

--- a/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -128,6 +128,7 @@ test.describe('process page', () => {
     tasklistProcessesPage,
     taskPanelPage,
   }) => {
+    test.slow();
     await tasklistHeader.clickProcessesTab();
     await expect(page).toHaveURL('/tasklist/processes');
     await tasklistProcessesPage.continueButton.click();

--- a/qa/core-application-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/v1/public-start-form.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.describe('public start process', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('should submit form', async ({makeAxeBuilder, publicFormsPage}) => {
+    await deploy([
+      './resources/subscribeFormProcess.bpmn',
+      './resources/subscribeForm.form',
+    ]);
+    await publicFormsPage.goToPublicForm('subscribeFormProcess');
+
+    await expect(publicFormsPage.nameInput).toBeVisible({timeout: 60000});
+
+    const results = await makeAxeBuilder().analyze();
+
+    expect(results.violations).toHaveLength(0);
+    expect(results.passes.length).toBeGreaterThan(0);
+
+    await publicFormsPage.nameInput.fill('Joe Doe');
+    await publicFormsPage.emailInput.fill('joe@doe.com');
+    await publicFormsPage.submitButton.click();
+
+    await expect(publicFormsPage.successMessage).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR migrates `public-start-from.spec` to `8.7` core application test suite and also includes fixing uploading screenshots to testRail

🧪 Successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/14966515865/job/42037582382)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues


related to https://github.com/camunda/camunda/issues/30910