### PR TITLE
Feat/31047 create batch operation chunk handler camunda exporter

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
@@ -126,5 +126,10 @@ public class TempESBatchOperationCancelProcessInstanceTest {
     for (final Long key : activeKeys) {
       waitForProcessInstanceToBeTerminated(camundaClient, key);
     }
+
+    final var items =
+        camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
+
+    assertThat(items.items()).hasSize(ACTIVE_PROCESS_INSTANCES.size());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -46,6 +46,7 @@ import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -60,6 +61,7 @@ import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
+import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UsageMetricsQuery;
@@ -510,6 +512,17 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
 
   @Override
   public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationId) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    // TODO must be refactored to always use paged filter #31777
+    return searchBatchOperationItems(
+            SearchQueryBuilders.batchOperationItemQuery()
+                .filter(f -> f.batchOperationIds(batchOperationId))
+                .build())
+        .items();
+  }
+
+  public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final BatchOperationItemQuery query) {
+    return getSearchExecutor()
+        .search(query, io.camunda.webapps.schema.entities.operation.OperationEntity.class);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -25,6 +25,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.entity.AuthorizationEntityTransformer;
 import io.camunda.search.clients.transformers.entity.BatchOperationEntityTransformer;
+import io.camunda.search.clients.transformers.entity.BatchOperationItemEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionRequirementsEntityTransformer;
@@ -46,6 +47,7 @@ import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.BatchOperationFilterTransformer;
+import io.camunda.search.clients.transformers.filter.BatchOperationItemFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DateValueFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionInstanceFilterTransformer;
@@ -73,6 +75,7 @@ import io.camunda.search.clients.transformers.result.DecisionRequirementsResultC
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.sort.AuthorizationFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.BatchOperationFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.BatchOperationItemFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionRequirementsFieldSortingTransformer;
@@ -92,6 +95,7 @@ import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransform
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
+import io.camunda.search.filter.BatchOperationItemFilter;
 import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
@@ -114,6 +118,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -138,6 +143,7 @@ import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
 import io.camunda.search.sort.AuthorizationSort;
+import io.camunda.search.sort.BatchOperationItemSort;
 import io.camunda.search.sort.BatchOperationSort;
 import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
@@ -174,6 +180,7 @@ import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.ProcessEntity;
@@ -187,6 +194,7 @@ import io.camunda.webapps.schema.entities.form.FormEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -263,6 +271,7 @@ public final class ServiceTransformers {
     Stream.of(
             AuthorizationQuery.class,
             BatchOperationQuery.class,
+            BatchOperationItemQuery.class,
             DecisionDefinitionQuery.class,
             DecisionInstanceQuery.class,
             DecisionRequirementsQuery.class,
@@ -305,6 +314,7 @@ public final class ServiceTransformers {
     mappers.put(MappingEntity.class, new MappingEntityTransformer());
     mappers.put(UsageMetricsEntity.class, new UsageMetricsEntityTransformer());
     mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
+    mappers.put(OperationEntity.class, new BatchOperationItemEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
@@ -326,6 +336,7 @@ public final class ServiceTransformers {
     mappers.put(MappingSort.class, new MappingFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
     mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
+    mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -391,6 +402,9 @@ public final class ServiceTransformers {
     mappers.put(
         BatchOperationFilter.class,
         new BatchOperationFilterTransformer(indexDescriptors.get(BatchOperationTemplate.class)));
+    mappers.put(
+        BatchOperationItemFilter.class,
+        new BatchOperationItemFilterTransformer(indexDescriptors.get(OperationTemplate.class)));
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public class BatchOperationItemEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.operation.OperationEntity, BatchOperationItemEntity> {
+
+  @Override
+  public BatchOperationItemEntity apply(
+      final io.camunda.webapps.schema.entities.operation.OperationEntity source) {
+    if (source == null) {
+      return null;
+    }
+
+    return isLegacy(source) ? mapLegacyBatchOperation(source) : mapBatchOperation(source);
+  }
+
+  /**
+   * Checks if the batch operation is legacy or not. This is done be checking if the ID is NOT
+   * numeric. New batch operations use a Long value, old ones use a UUID
+   *
+   * @param source the batch operation entity
+   * @return true if the batch operation is legacy, false otherwise
+   */
+  private static boolean isLegacy(
+      final io.camunda.webapps.schema.entities.operation.OperationEntity source) {
+    return !StringUtils.isNumeric(source.getBatchOperationId());
+  }
+
+  private BatchOperationItemEntity mapBatchOperation(
+      final io.camunda.webapps.schema.entities.operation.OperationEntity source) {
+    return new BatchOperationItemEntity(
+        source.getBatchOperationId(),
+        source.getItemKey(),
+        source.getProcessInstanceKey(),
+        map(source.getState()),
+        source.getCompletedDate(),
+        source.getErrorMessage());
+  }
+
+  private BatchOperationItemEntity mapLegacyBatchOperation(
+      final io.camunda.webapps.schema.entities.operation.OperationEntity source) {
+    return new BatchOperationItemEntity(
+        source.getBatchOperationId(),
+        // in legacy items only one of the following is set (processInstanceKey as default)
+        ObjectUtils.firstNonNull(source.getIncidentKey(), source.getProcessInstanceKey()),
+        source.getProcessInstanceKey(),
+        map(source.getState()),
+        source.getCompletedDate(),
+        source.getErrorMessage());
+  }
+
+  private BatchOperationItemState map(final OperationState state) {
+    if (state == null) {
+      return null;
+    }
+    return switch (state) {
+      case SCHEDULED, LOCKED, SENT -> BatchOperationItemState.ACTIVE;
+      case COMPLETED -> BatchOperationItemState.COMPLETED;
+      case FAILED -> BatchOperationItemState.FAILED;
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.*;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.*;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.BatchOperationItemFilter;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+import java.util.Optional;
+
+public final class BatchOperationItemFilterTransformer
+    extends IndexFilterTransformer<BatchOperationItemFilter> {
+
+  public BatchOperationItemFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final BatchOperationItemFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+
+    Optional.ofNullable(stringTerms(BATCH_OPERATION_ID, filter.batchOperationIds()))
+        .ifPresent(queries::add);
+    Optional.ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
+    Optional.ofNullable(longTerms(ITEM_KEY, filter.itemKeys())).ifPresent(queries::add);
+    Optional.ofNullable(longTerms(PROCESS_INSTANCE_KEY, filter.processInstanceKeys()))
+        .ifPresent(queries::add);
+
+    return and(queries);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.BATCH_OPERATION_ID;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.ID;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.ITEM_KEY;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.OperationTemplate.STATE;
+
+public class BatchOperationItemFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "batchOperationId" -> BATCH_OPERATION_ID;
+      case "state" -> STATE;
+      case "itemKey" -> ITEM_KEY;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return ID;
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationItemEntityTransformerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationItemEntityTransformerTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  private final BatchOperationItemEntityTransformer transformer =
+      new BatchOperationItemEntityTransformer();
+
+  @Test
+  void shouldTransformEntityToSearchEntity() {
+    // given
+    final OperationEntity entity = new OperationEntity();
+    entity.setBatchOperationId("1");
+    entity.setState(OperationState.SCHEDULED);
+    entity.setItemKey(123L);
+    entity.setProcessInstanceKey(456L);
+    entity.setCompletedDate(NOW);
+    entity.setErrorMessage("error");
+
+    // when
+    final var searchEntity = transformer.apply(entity);
+    assertThat(searchEntity).isNotNull();
+    assertThat(searchEntity.batchOperationId()).isEqualTo("1");
+    assertThat(searchEntity.state()).isEqualTo(BatchOperationItemState.ACTIVE);
+    assertThat(searchEntity.itemKey()).isEqualTo(123L);
+    assertThat(searchEntity.processInstanceKey()).isEqualTo(456L);
+    assertThat(searchEntity.processedDate()).isEqualTo(NOW);
+    assertThat(searchEntity.errorMessage()).isEqualTo("error");
+  }
+
+  @Test
+  void shouldTransformLegacyEntityToSearchEntity() {
+    final var uuid = UUID.randomUUID().toString();
+
+    final OperationEntity entity = new OperationEntity();
+    entity.setBatchOperationId(uuid);
+    entity.setState(OperationState.SCHEDULED);
+    entity.setIncidentKey(123L);
+    entity.setProcessInstanceKey(456L);
+    entity.setCompletedDate(NOW);
+    entity.setErrorMessage("error");
+
+    // when
+    final var searchEntity = transformer.apply(entity);
+    assertThat(searchEntity).isNotNull();
+    assertThat(searchEntity.batchOperationId()).isEqualTo(uuid);
+    assertThat(searchEntity.state()).isEqualTo(BatchOperationItemState.ACTIVE);
+    assertThat(searchEntity.itemKey()).isEqualTo(123L);
+    assertThat(searchEntity.processInstanceKey()).isEqualTo(456L);
+    assertThat(searchEntity.processedDate()).isEqualTo(NOW);
+    assertThat(searchEntity.errorMessage()).isEqualTo("error");
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  void shouldQueryByBatchOperationId() {
+    // given
+    final var filter = FilterBuilders.batchOperationItem(f -> f.batchOperationIds("123"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("batchOperationId");
+              assertThat(t.value().stringValue()).isEqualTo("123");
+            });
+  }
+
+  @Test
+  void shouldQueryLegacyByBatchOperationId() {
+    // given
+    final var batchIdUuid = UUID.randomUUID().toString();
+    final var filter = FilterBuilders.batchOperationItem(f -> f.batchOperationIds(batchIdUuid));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("batchOperationId");
+              assertThat(t.value().stringValue()).isEqualTo(batchIdUuid);
+            });
+  }
+
+  @Test
+  void shouldQueryItemKey() {
+    // given
+    final var filter = FilterBuilders.batchOperationItem(f -> f.itemKeys(123L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("itemKey");
+              assertThat(t.value().longValue()).isEqualTo(123L);
+            });
+  }
+
+  @Test
+  void shouldQueryByProcessInstanceKey() {
+    // given
+    final var filter = FilterBuilders.batchOperationItem(f -> f.processInstanceKeys(456L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(456L);
+            });
+  }
+
+  @Test
+  void shouldQueryByState() {
+    // given
+    final var filter = FilterBuilders.batchOperationItem(f -> f.state("ACTIVE"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("state");
+              assertThat(t.value().stringValue()).isEqualTo("ACTIVE");
+            });
+  }
+
+  @Test
+  void shouldQueryByAllFields() {
+    // given
+    final var filter =
+        FilterBuilders.batchOperationItem(
+            f ->
+                f.batchOperationIds("123")
+                    .state("ACTIVE")
+                    .itemKeys(123L)
+                    .processInstanceKeys(456L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(4);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("batchOperationId");
+              assertThat(t.value().stringValue()).isEqualTo("123");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("state");
+              assertThat(t.value().stringValue()).isEqualTo("ACTIVE");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(2).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("itemKey");
+              assertThat(t.value().longValue()).isEqualTo(123L);
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(3).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(456L);
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/BatchOperationItemFieldSortingTransformerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.BatchOperationItemSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BatchOperationItemFieldSortingTransformerTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("batchOperationId", SortOrder.ASC, s -> s.batchOperationId().asc()),
+        new TestArguments("state", SortOrder.DESC, s -> s.state().desc()),
+        new TestArguments("itemKey", SortOrder.DESC, s -> s.itemKey().desc()),
+        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<BatchOperationItemSort.Builder, ObjectBuilder<BatchOperationItemSort>> fn) {
+    // when
+    final var request = SearchQueryBuilders.batchOperationItemQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(field);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("id");
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<BatchOperationItemSort.Builder, ObjectBuilder<BatchOperationItemSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record BatchOperationItemFilter(
+    List<String> batchOperationIds,
+    List<Long> itemKeys,
+    List<Long> processInstanceKeys,
+    List<String> state)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<BatchOperationItemFilter> {
+
+    private List<String> batchOperationIds;
+    private List<Long> itemKeys;
+    private List<Long> processInstanceKeys;
+    private List<String> state;
+
+    public Builder batchOperationIds(final String value, final String... values) {
+      return batchOperationIds(collectValues(value, values));
+    }
+
+    public Builder batchOperationIds(final List<String> values) {
+      batchOperationIds = addValuesToList(batchOperationIds, values);
+      return this;
+    }
+
+    public Builder itemKeys(final Long value, final Long... values) {
+      return itemKeys(collectValues(value, values));
+    }
+
+    public Builder itemKeys(final List<Long> values) {
+      itemKeys = addValuesToList(itemKeys, values);
+      return this;
+    }
+
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeys(collectValues(value, values));
+    }
+
+    public Builder processInstanceKeys(final List<Long> values) {
+      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+      return this;
+    }
+
+    public Builder state(final String value, final String... values) {
+      return state(collectValues(value, values));
+    }
+
+    public Builder state(final List<String> values) {
+      state = addValuesToList(state, values);
+      return this;
+    }
+
+    @Override
+    public BatchOperationItemFilter build() {
+      return new BatchOperationItemFilter(
+          Objects.requireNonNullElse(batchOperationIds, Collections.emptyList()),
+          Objects.requireNonNullElse(itemKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(state, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -199,6 +199,16 @@ public final class FilterBuilders {
     return fn.apply(batchOperation()).build();
   }
 
+  public static BatchOperationItemFilter.Builder batchOperationItem() {
+    return new BatchOperationItemFilter.Builder();
+  }
+
+  public static BatchOperationItemFilter batchOperationItem(
+      final Function<BatchOperationItemFilter.Builder, ObjectBuilder<BatchOperationItemFilter>>
+          fn) {
+    return fn.apply(batchOperationItem()).build();
+  }
+
   public static FormFilter.Builder form() {
     return new FormFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/BatchOperationItemQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/BatchOperationItemQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.BatchOperationItemFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.BatchOperationItemSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record BatchOperationItemQuery(
+    BatchOperationItemFilter filter, BatchOperationItemSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<BatchOperationItemFilter, BatchOperationItemSort> {
+
+  public static BatchOperationItemQuery of(
+      final Function<Builder, ObjectBuilder<BatchOperationItemQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          BatchOperationItemQuery,
+          BatchOperationItemQuery.Builder,
+          BatchOperationItemFilter,
+          BatchOperationItemSort> {
+
+    private static final BatchOperationItemFilter EMPTY_FILTER =
+        FilterBuilders.batchOperationItem().build();
+    private static final BatchOperationItemSort EMPTY_SORT =
+        SortOptionBuilders.batchOperationItem().build();
+
+    private BatchOperationItemFilter filter;
+    private BatchOperationItemSort sort;
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder filter(final BatchOperationItemFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final BatchOperationItemSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<BatchOperationItemFilter.Builder, ObjectBuilder<BatchOperationItemFilter>>
+            fn) {
+      return filter(FilterBuilders.batchOperationItem(fn));
+    }
+
+    public Builder sort(
+        final Function<BatchOperationItemSort.Builder, ObjectBuilder<BatchOperationItemSort>> fn) {
+      return sort(SortOptionBuilders.batchOperationItem(fn));
+    }
+
+    @Override
+    public BatchOperationItemQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new BatchOperationItemQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -176,4 +176,13 @@ public final class SearchQueryBuilders {
       final Function<BatchOperationQuery.Builder, ObjectBuilder<BatchOperationQuery>> fn) {
     return fn.apply(batchOperationQuery()).build();
   }
+
+  public static BatchOperationItemQuery.Builder batchOperationItemQuery() {
+    return new BatchOperationItemQuery.Builder();
+  }
+
+  public static BatchOperationItemQuery batchOperationItemQuery(
+      final Function<BatchOperationItemQuery.Builder, ObjectBuilder<BatchOperationItemQuery>> fn) {
+    return fn.apply(batchOperationItemQuery()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationItemSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/BatchOperationItemSort.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record BatchOperationItemSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static BatchOperationItemSort of(
+      final Function<Builder, ObjectBuilder<BatchOperationItemSort>> fn) {
+    return SortOptionBuilders.batchOperationItem(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<BatchOperationItemSort.Builder>
+      implements ObjectBuilder<BatchOperationItemSort> {
+
+    public Builder batchOperationId() {
+      currentOrdering = new FieldSorting("batchOperationId", null);
+      return this;
+    }
+
+    public Builder state() {
+      currentOrdering = new FieldSorting("state", null);
+      return this;
+    }
+
+    public Builder itemKey() {
+      currentOrdering = new FieldSorting("itemKey", null);
+      return this;
+    }
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public BatchOperationItemSort build() {
+      return new BatchOperationItemSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -168,6 +168,15 @@ public final class SortOptionBuilders {
     return fn.apply(batchOperation()).build();
   }
 
+  public static BatchOperationItemSort.Builder batchOperationItem() {
+    return new BatchOperationItemSort.Builder();
+  }
+
+  public static BatchOperationItemSort batchOperationItem(
+      final Function<BatchOperationItemSort.Builder, ObjectBuilder<BatchOperationItemSort>> fn) {
+    return fn.apply(batchOperationItem()).build();
+  }
+
   public static AuthorizationSort authorization(
       final Function<AuthorizationSort.Builder, ObjectBuilder<AuthorizationSort>> fn) {
     return fn.apply(authorization()).build();

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -126,6 +126,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CHUNK;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_EXECUTION;
 import static io.camunda.zeebe.protocol.record.ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT;
@@ -426,7 +427,8 @@ processing records from previous version
             USER_TASK,
             BATCH_OPERATION_CREATION,
             BATCH_OPERATION_EXECUTION,
-            BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
+            BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            BATCH_OPERATION_CHUNK);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -65,6 +65,7 @@ import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCompletedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCreatedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationLifecycleManagementHandler;
@@ -285,7 +286,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new BatchOperationCompletedHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationLifecycleManagementHandler(
-                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()));
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
+            new BatchOperationChunkCreatedItemHandler(
+                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()));
 
     indicesWithCustomErrorHandlers =
         Map.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import com.google.common.base.Splitter;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchOperationChunkCreatedItemHandler
+    implements ExportHandler<OperationEntity, BatchOperationChunkRecordValue> {
+  protected static final String ID_PATTERN = "%s_%s";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BatchOperationChunkCreatedItemHandler.class);
+
+  private final String indexName;
+
+  public BatchOperationChunkCreatedItemHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_CHUNK;
+  }
+
+  @Override
+  public Class<OperationEntity> getEntityType() {
+    return OperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getIntent().equals(BatchOperationChunkIntent.CREATED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getValue().getItems().stream()
+        .map(item -> generateId(record.getValue().getBatchOperationKey(), item.getItemKey()))
+        .toList();
+  }
+
+  @Override
+  public OperationEntity createNewEntity(final String id) {
+    return new OperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationChunkRecordValue> record, final OperationEntity entity) {
+    final BatchOperationChunkRecordValue value = record.getValue();
+
+    final var item =
+        value.getItems().stream()
+            .filter(i -> i.getItemKey() == extractItemKey(entity.getId()))
+            .findFirst()
+            .orElseThrow();
+
+    LOG.trace(
+        "Updating entity {} with processInstanceKey {} to index {}",
+        item.getItemKey(),
+        item.getProcessInstanceKey(),
+        indexName);
+
+    entity
+        .setBatchOperationId(String.valueOf(value.getBatchOperationKey()))
+        .setState(OperationState.SCHEDULED)
+        .setProcessInstanceKey(item.getProcessInstanceKey())
+        .setItemKey(item.getItemKey());
+  }
+
+  @Override
+  public void flush(final OperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private String generateId(final long batchOperationId, final long itemKey) {
+    return String.format(ID_PATTERN, batchOperationId, itemKey);
+  }
+
+  private Long extractItemKey(final String id) {
+    return Splitter.on("_").splitToStream(id).skip(1).findFirst().map(Long::parseLong).orElse(null);
+  }
+}


### PR DESCRIPTION
## Description

Implements the BatchOperationChunkHandler to store batch operation items.

To implement a proper test, I also implemented the batch operation item search client for ES/OS.

## Related issues

closes #31060 #31047 
