### PR TITLE
feat: use partition id in filters for batch operation

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
@@ -101,7 +101,6 @@ public class BatchOperationCancelProcessInstanceTest {
 
     // then
     assertThat(result).isNotNull();
-    //    assertThat(result.getBatchOperationKey()).isNotNull();
 
     // and
     Awaitility.await("should complete batch operation")
@@ -112,10 +111,7 @@ public class BatchOperationCancelProcessInstanceTest {
             () -> {
               // and
               final var batch =
-                  camundaClient
-                      .newBatchOperationGetRequest(result.getBatchOperationKey())
-                      .send()
-                      .join();
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
               assertThat(batch).isNotNull();
               assertThat(batch.getEndDate()).isNotNull();
               assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
@@ -127,8 +123,7 @@ public class BatchOperationCancelProcessInstanceTest {
       waitForProcessInstanceToBeTerminated(camundaClient, key);
     }
 
-    final var batch =
-        camundaClient.newBatchOperationGetRequest(result.getBatchOperationKey()).send().join();
+    final var batch = camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
     assertThat(batch).isNotNull();
     assertThat(batch.getEndDate()).isNotNull();
     assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.cluster;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "es")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ClusterMultiplePartitionsBatchOperationIT {
+
+  private static CamundaClient camundaClient;
+
+  @MultiDbTestApplication
+  private static final TestStandaloneApplication<?> APPLICATION =
+      new TestStandaloneBroker()
+          .withUnauthenticatedAccess()
+          .withBrokerConfig(
+              b -> {
+                final var cluster = b.getCluster();
+                cluster.setPartitionsCount(3);
+                b.setCluster(cluster);
+              });
+
+  private static Process deployedProcess;
+  private static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
+
+  @BeforeAll
+  public static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+
+    // Deploy process definitions
+    deployedProcess =
+        deployResource(camundaClient, "process/service_tasks_v1.bpmn").getProcesses().getFirst();
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    // Start process instances
+    IntStream.range(0, 10)
+        .forEach(
+            i ->
+                ACTIVE_PROCESS_INSTANCES.add(
+                    startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"bar\"}")));
+
+    // Wait for process instances to start
+    waitForProcessInstancesToStart(camundaClient, ACTIVE_PROCESS_INSTANCES.size());
+    waitForElementInstances(camundaClient, ACTIVE_PROCESS_INSTANCES.size() * 2);
+  }
+
+  @AfterEach
+  void afterAll() {
+    deployedProcess = null;
+    ACTIVE_PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldCancelProcessInstancesOnSeveralPartitionsWithBatch() {
+    // when
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(new ProcessInstanceFilterImpl())
+            .send()
+            .join();
+    final var batchOperationKey = result.getBatchOperationKey();
+
+    // then
+    assertThat(result).isNotNull();
+
+    // and
+    Awaitility.await("should complete batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getEndDate()).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+              assertThat(batch.getOperationsTotalCount())
+                  .isEqualTo(ACTIVE_PROCESS_INSTANCES.size());
+              assertThat(batch.getOperationsCompletedCount())
+                  .isEqualTo(ACTIVE_PROCESS_INSTANCES.size());
+              assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+            });
+
+    // Now wait until all process instances are terminated
+    final var activeKeys =
+        ACTIVE_PROCESS_INSTANCES.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
+    for (final Long key : activeKeys) {
+      waitForProcessInstanceToBeTerminated(camundaClient, key);
+    }
+
+    // and
+    final var itemsObj =
+        camundaClient.newBatchOperationItemsGetRequest(batchOperationKey).send().join();
+    final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
+
+    assertThat(itemsObj.items()).hasSize(ACTIVE_PROCESS_INSTANCES.size());
+    assertThat(itemsObj.items().stream().map(BatchOperationItem::getStatus).distinct().toList())
+        .containsExactly(BatchOperationItemState.COMPLETED);
+    assertThat(itemKeys).containsExactlyInAnyOrder(activeKeys.toArray(Long[]::new));
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -314,7 +314,7 @@ public class CamundaMultiDBExtension
     final var application = applicationUnderTest.application;
     closeables.add(application);
     application.start();
-    application.awaitCompleteTopology();
+    application.awaitCompleteTopology(application.brokerConfig());
 
     Awaitility.await("Await exporter readiness")
         .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -180,10 +180,14 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
     return switch (batchOperation.getBatchOperationType()) {
       case CANCEL_PROCESS_INSTANCE, MIGRATE_PROCESS_INSTANCE, MODIFY_PROCESS_INSTANCE ->
           entityKeyProvider.fetchProcessInstanceItems(
-              batchOperation.getEntityFilter(ProcessInstanceFilter.class), abortCondition);
+              partitionId,
+              batchOperation.getEntityFilter(ProcessInstanceFilter.class),
+              abortCondition);
       case RESOLVE_INCIDENT ->
           entityKeyProvider.fetchIncidentItems(
-              batchOperation.getEntityFilter(ProcessInstanceFilter.class), abortCondition);
+              partitionId,
+              batchOperation.getEntityFilter(ProcessInstanceFilter.class),
+              abortCondition);
       default ->
           throw new IllegalArgumentException(
               "Unexpected batch operation type: " + batchOperation.getBatchOperationType());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -43,6 +43,7 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   private final BatchOperationState batchOperationState;
   private ReadonlyStreamProcessorContext processingContext;
   private final BatchOperationItemProvider entityKeyProvider;
+  private final int partitionId;
 
   /** Marks if this scheduler is currently executing or not. */
   private final AtomicBoolean executing = new AtomicBoolean(false);
@@ -50,10 +51,12 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
   public BatchOperationExecutionScheduler(
       final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
       final BatchOperationItemProvider entityKeyProvider,
-      final EngineConfiguration engineConfiguration) {
+      final EngineConfiguration engineConfiguration,
+      final int partitionId) {
     batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
     this.entityKeyProvider = entityKeyProvider;
     pollingInterval = engineConfiguration.getBatchOperationSchedulerInterval();
+    this.partitionId = partitionId;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -50,17 +50,21 @@ public class BatchOperationItemProvider {
   }
 
   /**
-   * Fetches the process instance items based on the provided filter. The items are fetched
-   * sequentially in pages. Depending on the overall size of the result this can cause multiple
-   * queries to the secondary database.
+   * Fetches the process instance items for the given partitionId based on the provided filter. The
+   * items are fetched sequentially in pages. Depending on the overall size of the result, this can
+   * cause multiple queries to the secondary database.
    *
    * @param filter the filter to use
    * @param shouldAbort if the process should be aborted
    * @return a set of all found process instance items
    */
   public Set<Item> fetchProcessInstanceItems(
-      final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
-    return fetchEntityItems(new ProcessInstancePageFetcher(), filter, shouldAbort);
+      final int partitionId,
+      final ProcessInstanceFilter filter,
+      final Supplier<Boolean> shouldAbort) {
+    final var processInstanceFilter = filter.toBuilder().partitionId(partitionId).build();
+
+    return fetchEntityItems(new ProcessInstancePageFetcher(), processInstanceFilter, shouldAbort);
   }
 
   /**
@@ -78,20 +82,22 @@ public class BatchOperationItemProvider {
   }
 
   /**
-   * Fetches the incident items based on the provided process instance filter. This will return
-   * <b>ALL</b> incidents of the matching processInstances. The items are fetched sequentially in
-   * pages. Depending on the overall size of the result this can cause multiple queries to the
-   * secondary database.
+   * Fetches the incident items based on the provided process instance filter for the given
+   * partitonId. This will return <b>ALL</b> incidents of the matching processInstances. The items
+   * are fetched sequentially in pages. Depending on the overall size of the result, this can cause
+   * multiple queries to the secondary database.
    *
    * @param filter the filter to use
    * @param shouldAbort if the process should be aborted
    * @return a set of all found incident items
    */
   public Set<Item> fetchIncidentItems(
-      final ProcessInstanceFilter filter, final Supplier<Boolean> shouldAbort) {
+      final int partitionId,
+      final ProcessInstanceFilter filter,
+      final Supplier<Boolean> shouldAbort) {
     // first fetch all matching processInstances
     final var processInstanceKeys =
-        fetchProcessInstanceItems(filter, shouldAbort).stream()
+        fetchProcessInstanceItems(partitionId, filter, shouldAbort).stream()
             .map(Item::processInstanceKey)
             .toList();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -109,6 +109,7 @@ public final class BatchOperationSetupProcessors {
             new BatchOperationExecutionScheduler(
                 scheduledTaskStateFactory,
                 new BatchOperationItemProvider(searchClientsProxy),
-                engineConfiguration));
+                engineConfiguration,
+                partitionId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -51,6 +51,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BatchOperationExecutionSchedulerTest {
 
+  private static final int PARTITION_ID = 1;
+
   @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
   @Mock private BatchOperationItemProvider entityKeyProvider;
   @Mock private TaskResultBuilder taskResultBuilder;
@@ -88,7 +90,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, entityKeyProvider, engineConfiguration, 1);
+            scheduledTaskStateFactory, entityKeyProvider, engineConfiguration, PARTITION_ID);
   }
 
   @Test
@@ -120,7 +122,8 @@ public class BatchOperationExecutionSchedulerTest {
     final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
 
     // given
-    when(entityKeyProvider.fetchProcessInstanceItems(queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchProcessInstanceItems(
+            eq(PARTITION_ID), queryCaptor.capture(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -144,7 +147,7 @@ public class BatchOperationExecutionSchedulerTest {
     when(batchOperation.getBatchOperationType()).thenReturn(RESOLVE_INCIDENT);
 
     // given
-    when(entityKeyProvider.fetchIncidentItems(queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchIncidentItems(eq(PARTITION_ID), queryCaptor.capture(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -168,7 +171,8 @@ public class BatchOperationExecutionSchedulerTest {
     when(batchOperation.getBatchOperationType()).thenReturn(MIGRATE_PROCESS_INSTANCE);
 
     // given
-    when(entityKeyProvider.fetchProcessInstanceItems(queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchProcessInstanceItems(
+            eq(PARTITION_ID), queryCaptor.capture(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -192,7 +196,8 @@ public class BatchOperationExecutionSchedulerTest {
 
     // given
     final var queryItems = createItems(LongStream.range(0, CHUNK_SIZE_IN_RECORD * 2).toArray());
-    when(entityKeyProvider.fetchProcessInstanceItems(queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchProcessInstanceItems(
+            eq(PARTITION_ID), queryCaptor.capture(), any()))
         .thenReturn(new HashSet<>(queryItems));
 
     // when our scheduler fires
@@ -224,7 +229,8 @@ public class BatchOperationExecutionSchedulerTest {
     final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceFilter.class);
 
     // given
-    when(entityKeyProvider.fetchProcessInstanceItems(queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchProcessInstanceItems(
+            eq(PARTITION_ID), queryCaptor.capture(), any()))
         .thenReturn(new HashSet<>(createItems(1L)));
 
     // when our scheduler fires

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -88,7 +88,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     scheduler =
         new BatchOperationExecutionScheduler(
-            scheduledTaskStateFactory, entityKeyProvider, engineConfiguration);
+            scheduledTaskStateFactory, entityKeyProvider, engineConfiguration, 1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
@@ -26,6 +26,8 @@ import org.mockito.ArgumentCaptor;
 
 class BatchOperationItemProviderTest {
 
+  private static final int PARTITION_ID = 1;
+
   private final SearchClientsProxy searchClientsProxy = mock(SearchClientsProxy.class);
 
   private final BatchOperationItemProvider provider =
@@ -49,10 +51,14 @@ class BatchOperationItemProviderTest {
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
-    final var resultKeys = provider.fetchProcessInstanceItems(filter, () -> false);
+    final var resultKeys = provider.fetchProcessInstanceItems(PARTITION_ID, filter, () -> false);
 
     // then
     assertThat(resultKeys).containsExactly(new Item(1L, 1L), new Item(2L, 2L), new Item(3L, 3L));
+
+    // and partitionId is set in filter
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().partitionId()).isEqualTo(PARTITION_ID);
   }
 
   @Test
@@ -84,7 +90,7 @@ class BatchOperationItemProviderTest {
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
-    final var resultKeys = provider.fetchProcessInstanceItems(filter, () -> false);
+    final var resultKeys = provider.fetchProcessInstanceItems(PARTITION_ID, filter, () -> false);
 
     // then
     assertThat(resultKeys)
@@ -95,6 +101,10 @@ class BatchOperationItemProviderTest {
             new Item(4L, 4L),
             new Item(5L, 5L),
             new Item(6L, 6L));
+
+    // and partitionId is set in filter
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().partitionId()).isEqualTo(PARTITION_ID);
   }
 
   @Test
@@ -119,10 +129,14 @@ class BatchOperationItemProviderTest {
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
-    final var resultKeys = provider.fetchProcessInstanceItems(filter, () -> false);
+    final var resultKeys = provider.fetchProcessInstanceItems(PARTITION_ID, filter, () -> false);
 
     // then
     assertThat(resultKeys).containsExactly(new Item(1L, 1L), new Item(2L, 2L), new Item(3L, 3L));
+
+    // and partitionId is set in filter
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().partitionId()).isEqualTo(PARTITION_ID);
   }
 
   @Test
@@ -159,14 +173,21 @@ class BatchOperationItemProviderTest {
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
-    final var resultItems = provider.fetchProcessInstanceItems(filter, shouldAbort::get);
+    final var resultItems =
+        provider.fetchProcessInstanceItems(PARTITION_ID, filter, shouldAbort::get);
 
     // then
     assertThat(resultItems).isEmpty();
+
+    // and partitionId is set in filter
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().partitionId()).isEqualTo(PARTITION_ID);
   }
 
   @Test
   public void shouldFetchIncidentItems() {
+    final var queryCaptor = ArgumentCaptor.forClass(ProcessInstanceQuery.class);
+
     // given
     final var processInstanceResult =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
@@ -177,7 +198,8 @@ class BatchOperationItemProviderTest {
                     mockProcessInstanceEntity(3L)))
             .total(3)
             .build();
-    when(searchClientsProxy.searchProcessInstances(any())).thenReturn(processInstanceResult);
+    when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
+        .thenReturn(processInstanceResult);
 
     // given
     final var incidentResult =
@@ -193,10 +215,14 @@ class BatchOperationItemProviderTest {
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
-    final var resultKeys = provider.fetchIncidentItems(filter, () -> false);
+    final var resultKeys = provider.fetchIncidentItems(PARTITION_ID, filter, () -> false);
 
     // then
     assertThat(resultKeys).containsExactly(new Item(11L, 1L), new Item(12L, 2L), new Item(13L, 3L));
+
+    // and partitionId is set in process instance filter
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().partitionId()).isEqualTo(PARTITION_ID);
   }
 
   private ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
+import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -138,5 +139,19 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    */
   default T awaitCompleteTopology() {
     return awaitCompleteTopology(1, 1, 1, Duration.ofSeconds(30));
+  }
+
+  /**
+   * Method to await the complete topology of a cluster with the given configuration.
+   *
+   * @return itself for chaining
+   */
+  default T awaitCompleteTopology(BrokerBasedProperties brokerBasedProperties) {
+    final var clusterCfg = brokerBasedProperties.getCluster();
+    return awaitCompleteTopology(
+        clusterCfg.getClusterSize(),
+        clusterCfg.getPartitionsCount(),
+        clusterCfg.getReplicationFactor(),
+        Duration.ofSeconds(30));
   }
 }


### PR DESCRIPTION
## Description

* Batch Operation Scheduler now uses the partitionID when doing process instance queries against Secondary Storage
* Extends MultiDbTest in order to make it possible to run against multiple partitions
* Added a new cluster test that uses multiple partitions to ensure batch operations work correctly in this setup

## Related issues

closes #31012 
