### PR TITLE
Support role `create` and `get` in the camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -83,6 +83,7 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.UsersByGroupSearchRequest;
@@ -1131,6 +1132,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CreateRoleCommandStep1 newCreateRoleCommand();
+
+  /**
+   * Request to get a role by role ID.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newRoleGetRequest(roleId)
+   *  .send();
+   * </pre>
+   *
+   * @param roleId the ID of the role
+   * @return a builder for the request to get a role
+   */
+  RoleGetRequest newRoleGetRequest(String roleId);
 
   /**
    * Command to create a group.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateRoleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateRoleCommandStep1.java
@@ -19,11 +19,28 @@ import io.camunda.client.api.response.CreateRoleResponse;
 
 public interface CreateRoleCommandStep1 extends FinalCommandStep<CreateRoleResponse> {
   /**
-   * Set the name to create role with.
+   * Set the ID to create role with.
    *
-   * @param name the name value
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @param roleId the role ID
+   * @return the builder for this command.
    */
-  CreateRoleCommandStep1 name(String name);
+  CreateRoleCommandStep2 roleId(String roleId);
+
+  interface CreateRoleCommandStep2 extends FinalCommandStep<CreateRoleResponse> {
+    /**
+     * Set the name for the role to be created.
+     *
+     * @param name the role name
+     * @return the builder for this command
+     */
+    CreateRoleCommandStep2 name(String name);
+
+    /**
+     * Set the description for the role to be created.
+     *
+     * @param description the role description
+     * @return the builder for this command
+     */
+    CreateRoleCommandStep2 description(String description);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateRoleCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateRoleCommandStep1.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateRoleResponse;
 
-public interface CreateRoleCommandStep1 extends FinalCommandStep<CreateRoleResponse> {
+public interface CreateRoleCommandStep1 {
   /**
    * Set the ID to create role with.
    *

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/RoleGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/RoleGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.Role;
+
+public interface RoleGetRequest extends FinalCommandStep<Role> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateRoleResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateRoleResponse.java
@@ -23,4 +23,25 @@ public interface CreateRoleResponse {
    * @return the key of the created role.
    */
   long getRoleKey();
+
+  /**
+   * Returns the ID of the created role.
+   *
+   * @return the ID of the created role.
+   */
+  String getRoleId();
+
+  /**
+   * Returns the name of the created role.
+   *
+   * @return the name of the created role.
+   */
+  String getName();
+
+  /**
+   * Returns the description of the created role.
+   *
+   * @return the description of the created role.
+   */
+  String getDescription();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import java.util.Set;
+
+public interface Role {
+
+  Long getRoleKey();
+
+  String getRoleId();
+
+  String getName();
+
+  String getDescription();
+
+  Set<String> getAssignedMemberIds();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.client.api.search.response;
 
-import java.util.Set;
-
 public interface Role {
 
   Long getRoleKey();
@@ -26,6 +24,4 @@ public interface Role {
   String getName();
 
   String getDescription();
-
-  Set<String> getAssignedMemberIds();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -94,6 +94,7 @@ import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetCallHierarchyRequest;
 import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
+import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.UsersByGroupSearchRequest;
@@ -182,6 +183,7 @@ import io.camunda.client.impl.fetch.ProcessDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetCallHierarchyRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetRequestImpl;
+import io.camunda.client.impl.fetch.RoleGetRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetFormRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
@@ -785,6 +787,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateRoleCommandStep1 newCreateRoleCommand() {
     return new CreateRoleCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public RoleGetRequest newRoleGetRequest(final String roleId) {
+    return new RoleGetRequestImpl(httpClient, roleId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
@@ -69,8 +69,8 @@ public final class CreateRoleCommandImpl implements CreateRoleCommandStep1, Crea
 
   @Override
   public CamundaFuture<CreateRoleResponse> send() {
-    ArgumentUtil.ensureNotNull("roleId", request.getRoleId());
-    ArgumentUtil.ensureNotNull("name", request.getName());
+    ArgumentUtil.ensureNotNullNorEmpty("roleId", request.getRoleId());
+    ArgumentUtil.ensureNotNullNorEmpty("name", request.getName());
     final HttpCamundaFuture<CreateRoleResponse> result = new HttpCamundaFuture<>();
     final CreateRoleResponseImpl response = new CreateRoleResponseImpl();
     httpClient.post(

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CreateRoleCommandStep1;
+import io.camunda.client.api.command.CreateRoleCommandStep1.CreateRoleCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.CreateRoleResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -29,7 +30,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class CreateRoleCommandImpl implements CreateRoleCommandStep1 {
+public final class CreateRoleCommandImpl implements CreateRoleCommandStep1, CreateRoleCommandStep2 {
   private final RoleCreateRequest request;
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
@@ -43,9 +44,20 @@ public final class CreateRoleCommandImpl implements CreateRoleCommandStep1 {
   }
 
   @Override
-  public CreateRoleCommandStep1 name(final String name) {
-    ArgumentUtil.ensureNotNull("name", name);
-    request.setName(name);
+  public CreateRoleCommandStep2 roleId(final String roleId) {
+    request.setRoleId(roleId);
+    return this;
+  }
+
+  @Override
+  public CreateRoleCommandStep2 name(final String name) {
+    request.name(name);
+    return this;
+  }
+
+  @Override
+  public CreateRoleCommandStep2 description(final String description) {
+    request.description(description);
     return this;
   }
 
@@ -57,6 +69,7 @@ public final class CreateRoleCommandImpl implements CreateRoleCommandStep1 {
 
   @Override
   public CamundaFuture<CreateRoleResponse> send() {
+    ArgumentUtil.ensureNotNull("roleId", request.getRoleId());
     ArgumentUtil.ensureNotNull("name", request.getName());
     final HttpCamundaFuture<CreateRoleResponse> result = new HttpCamundaFuture<>();
     final CreateRoleResponseImpl response = new CreateRoleResponseImpl();

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.RoleGetRequest;
+import io.camunda.client.api.search.response.Role;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.RoleResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class RoleGetRequestImpl implements RoleGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String roleId;
+
+  public RoleGetRequestImpl(final HttpClient httpClient, final String roleId) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.roleId = roleId;
+  }
+
+  @Override
+  public FinalCommandStep<Role> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Role> send() {
+    final HttpCamundaFuture<Role> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/roles/%s", roleId),
+        httpRequestConfig.build(),
+        RoleResult.class,
+        SearchResponseMapper::toRoleResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.search.response.Role;
+import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
@@ -47,6 +48,7 @@ public class RoleGetRequestImpl implements RoleGetRequest {
 
   @Override
   public CamundaFuture<Role> send() {
+    ArgumentUtil.ensureNotNull("roleId", roleId);
     final HttpCamundaFuture<Role> result = new HttpCamundaFuture<>();
     httpClient.get(
         String.format("/roles/%s", roleId),

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/RoleGetRequestImpl.java
@@ -48,7 +48,7 @@ public class RoleGetRequestImpl implements RoleGetRequest {
 
   @Override
   public CamundaFuture<Role> send() {
-    ArgumentUtil.ensureNotNull("roleId", roleId);
+    ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
     final HttpCamundaFuture<Role> result = new HttpCamundaFuture<>();
     httpClient.get(
         String.format("/roles/%s", roleId),

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
@@ -20,14 +20,35 @@ import io.camunda.client.protocol.rest.RoleCreateResult;
 
 public class CreateRoleResponseImpl implements CreateRoleResponse {
   private long roleKey;
+  private String roleId;
+  private String name;
+  private String description;
 
   @Override
   public long getRoleKey() {
     return roleKey;
   }
 
+  @Override
+  public String getRoleId() {
+    return roleId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
   public CreateRoleResponseImpl setResponse(final RoleCreateResult response) {
     roleKey = Long.parseLong(response.getRoleKey());
+    roleId = response.getRoleId();
+    name = response.getName();
+    description = response.getDescription();
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
@@ -16,7 +16,6 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.Role;
-import java.util.Set;
 
 public class RoleImpl implements Role {
 
@@ -24,19 +23,13 @@ public class RoleImpl implements Role {
   private final String roleId;
   private final String name;
   private final String description;
-  private final Set<String> assignedMemberIds;
 
   public RoleImpl(
-      final long roleKey,
-      final String roleId,
-      final String name,
-      final String description,
-      final Set<String> assignedMemberIds) {
+      final long roleKey, final String roleId, final String name, final String description) {
     this.roleKey = roleKey;
     this.roleId = roleId;
     this.name = name;
     this.description = description;
-    this.assignedMemberIds = assignedMemberIds;
   }
 
   @Override
@@ -57,10 +50,5 @@ public class RoleImpl implements Role {
   @Override
   public String getDescription() {
     return description;
-  }
-
-  @Override
-  public Set<String> getAssignedMemberIds() {
-    return assignedMemberIds;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.Role;
+import java.util.Set;
+
+public class RoleImpl implements Role {
+
+  private final long roleKey;
+  private final String roleId;
+  private final String name;
+  private final String description;
+  private final Set<String> assignedMemberIds;
+
+  public RoleImpl(
+      final long roleKey,
+      final String roleId,
+      final String name,
+      final String description,
+      final Set<String> assignedMemberIds) {
+    this.roleKey = roleKey;
+    this.roleId = roleId;
+    this.name = name;
+    this.description = description;
+    this.assignedMemberIds = assignedMemberIds;
+  }
+
+  @Override
+  public Long getRoleKey() {
+    return roleKey;
+  }
+
+  @Override
+  public String getRoleId() {
+    return roleId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public Set<String> getAssignedMemberIds() {
+    return assignedMemberIds;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -37,10 +37,8 @@ import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -162,8 +160,7 @@ public final class SearchResponseMapper {
         ParseUtil.parseLongOrNull(response.getRoleKey()),
         response.getRoleId(),
         response.getName(),
-        response.getDescription(),
-        convertListToSet(response.getAssignedMemberKeys()));
+        response.getDescription());
   }
 
   public static Group toGroupResponse(final GroupResult response) {
@@ -208,13 +205,5 @@ public final class SearchResponseMapper {
     return Optional.ofNullable(items)
         .map(i -> i.stream().map(mapper).collect(Collectors.toList()))
         .orElse(Collections.emptyList());
-  }
-
-  private static Set<String> convertListToSet(final List<String> values) {
-    if (values == null || values.isEmpty()) {
-      return Collections.emptySet();
-    }
-
-    return new HashSet<>(values);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -27,6 +27,7 @@ import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
+import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.SearchResponsePage;
 import io.camunda.client.api.search.response.User;
@@ -36,8 +37,10 @@ import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -154,6 +157,15 @@ public final class SearchResponseMapper {
     return new BatchOperationItemsImpl(response);
   }
 
+  public static Role toRoleResponse(final RoleResult response) {
+    return new RoleImpl(
+        ParseUtil.parseLongOrNull(response.getRoleKey()),
+        response.getRoleId(),
+        response.getName(),
+        response.getDescription(),
+        convertListToSet(response.getAssignedMemberKeys()));
+  }
+
   public static Group toGroupResponse(final GroupResult response) {
     return new GroupImpl(
         ParseUtil.parseLongOrNull(response.getGroupKey()),
@@ -196,5 +208,13 @@ public final class SearchResponseMapper {
     return Optional.ofNullable(items)
         .map(i -> i.stream().map(mapper).collect(Collectors.toList()))
         .orElse(Collections.emptyList());
+  }
+
+  private static Set<String> convertListToSet(final List<String> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    return new HashSet<>(values);
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
@@ -27,16 +27,32 @@ import org.junit.jupiter.api.Test;
 
 public class CreateRoleTest extends ClientRestTest {
 
-  public static final String NAME = "Role Name";
+  public static final String ROLE_ID = "roleId";
+  public static final String NAME = "roleName";
+  public static final String DESCRIPTION = "roleDescription";
 
   @Test
   void shouldCreateRole() {
     // when
-    client.newCreateRoleCommand().name(NAME).send().join();
+    client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).description(DESCRIPTION).send().join();
 
     // then
     final RoleCreateRequest request = gatewayService.getLastRequest(RoleCreateRequest.class);
+    assertThat(request.getRoleId()).isEqualTo(ROLE_ID);
     assertThat(request.getName()).isEqualTo(NAME);
+    assertThat(request.getDescription()).isEqualTo(DESCRIPTION);
+  }
+
+  @Test
+  void shouldCreateRoleWithoutDescription() {
+    // when
+    client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join();
+
+    // then
+    final RoleCreateRequest request = gatewayService.getLastRequest(RoleCreateRequest.class);
+    assertThat(request.getRoleId()).isEqualTo(ROLE_ID);
+    assertThat(request.getName()).isEqualTo(NAME);
+    assertThat(request.getDescription()).isNull();
   }
 
   @Test
@@ -46,29 +62,37 @@ public class CreateRoleTest extends ClientRestTest {
         REST_API_PATH + "/roles", () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newCreateRoleCommand().name(NAME).send().join())
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 
   @Test
-  void shouldRaiseExceptionOnNullName() {
+  void shouldRaiseExceptionOnNullRoleId() {
     // when / then
     assertThatThrownBy(() -> client.newCreateRoleCommand().send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullName() {
+    // when / then
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("name must not be null");
   }
 
   @Test
-  void shouldRaiseExceptionIfRoleNameAlreadyExists() {
+  void shouldRaiseExceptionIfRoleAlreadyExists() {
     // given
-    client.newCreateRoleCommand().name(NAME).send().join();
+    client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join();
 
     gatewayService.errorOnRequest(
         REST_API_PATH + "/roles", () -> new ProblemDetail().title("Conflict").status(409));
 
     // when / then
-    assertThatThrownBy(() -> client.newCreateRoleCommand().name(NAME).send().join())
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'");
   }
@@ -80,7 +104,7 @@ public class CreateRoleTest extends ClientRestTest {
         REST_API_PATH + "/roles", () -> new ProblemDetail().title("Bad Request").status(400));
 
     // when / then
-    assertThatThrownBy(() -> client.newCreateRoleCommand().name(NAME).send().join())
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(ROLE_ID).name(NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }

--- a/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/CreateRoleTest.java
@@ -70,7 +70,7 @@ public class CreateRoleTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullRoleId() {
     // when / then
-    assertThatThrownBy(() -> client.newCreateRoleCommand().send().join())
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
   }

--- a/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/SearchRoleTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class SearchRoleTest extends ClientRestTest {
+
+  public static final String ROLE_ID = "roleId";
+
+  @Test
+  public void shouldSearchRoleByRoleId() {
+    // when
+    client.newRoleGetRequest(ROLE_ID).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/roles/" + ROLE_ID);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -202,6 +202,7 @@ class RoleAuthorizationIT {
             });
   }
 
+  // TODO replace with role search when implemented in Camunda Client #31716
   private static RoleSearchResponse searchRoles(final String restAddress, final String username)
       throws URISyntaxException, IOException, InterruptedException {
     final var encodedCredentials =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class RoleIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  private static final String ROLE_ID_1 = Strings.newRandomValidIdentityId();
+  private static final String ROLE_ID_2 = Strings.newRandomValidIdentityId();
+  private static final String ROLE_NAME_1 = "ARoleName";
+  private static final String ROLE_NAME_2 = "BRoleName";
+  private static final String DESCRIPTION = "description";
+
+  @Test
+  void shouldCreateAndGetRoleById() {
+    // when
+    camundaClient
+        .newCreateRoleCommand()
+        .roleId(ROLE_ID_1)
+        .name(ROLE_NAME_1)
+        .description(DESCRIPTION)
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("Role is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var role = camundaClient.newRoleGetRequest(ROLE_ID_1).send().join();
+              assertThat(role).isNotNull();
+              assertThat(role.getRoleId()).isEqualTo(ROLE_ID_1);
+              assertThat(role.getName()).isEqualTo(ROLE_NAME_1);
+              assertThat(role.getDescription()).isEqualTo(DESCRIPTION);
+              assertThat(role.getRoleKey()).isPositive();
+            });
+  }
+
+  @Test
+  void shouldRejectCreationIfRoleIdAlreadyExists() {
+    // given
+    camundaClient
+        .newCreateRoleCommand()
+        .roleId(ROLE_ID_2)
+        .name(ROLE_NAME_2)
+        .description(DESCRIPTION)
+        .send()
+        .join();
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newCreateRoleCommand()
+                    .roleId(ROLE_ID_2)
+                    .name(ROLE_NAME_2)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 409: 'Conflict'")
+        .hasMessageContaining("a role with this ID already exists");
+  }
+
+  @Test
+  void shouldRejectCreationIfMissingRoleId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newRoleGetRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be null");
+  }
+
+  @Test
+  void shouldRejectCreationIfEmptyRoleId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newRoleGetRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be empty");
+  }
+
+  @Test
+  void shouldRejectCreationIfMissingRoleName() {
+    // when / then
+    assertThatThrownBy(
+            () -> camundaClient.newCreateRoleCommand().roleId("someRoleId").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldReturnNotFoundIfRoleDoesNotExist() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newRoleGetRequest("someRoleId").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining("Role with role ID someRoleId not found");
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -71,6 +71,11 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   }
 
   public RoleRecord setDescription(final String description) {
+    if (description == null) {
+      descriptionProp.reset();
+      return this;
+    }
+
     descriptionProp.setValue(description);
     return this;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateRoleTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateRoleTest.java
@@ -83,7 +83,7 @@ class CreateRoleTest {
   @Test
   void shouldRejectIfMissingRoleId() {
     // when / then
-    assertThatThrownBy(() -> client.newCreateRoleCommand().send().join())
+    assertThatThrownBy(() -> client.newCreateRoleCommand().roleId(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
   }


### PR DESCRIPTION
## Description

This PR covers:

- Support Role `get` in the `CamundaClient`
- Support Role `create` in the `CamundaClient`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31713
closes #31707
