### PR TITLE
Add endpoint to search roles by groupId

### DIFF
--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -13,7 +13,7 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}ROLES r
-    <if test="filter.groupId != null">
+    <if test="filter.memberIds != null">
       JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
     </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
@@ -44,7 +44,7 @@
     <if test="filter.roleKey != null">AND r.ROLE_KEY = #{filter.roleKey}</if>
     <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
     <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
-    <if test="filter.groupId != null">AND rm.ENTITY_ID = #{filter.groupId} AND rm.ENTITY_TYPE = #{filter.memberType}</if>
+    <if test="filter.memberIds != null">AND rm.ENTITY_ID IN <foreach item="id" collection="filter.memberIds" open="(" separator="," close=")">#{id}</foreach> AND rm.ENTITY_TYPE = #{filter.memberType}</if>
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -13,6 +13,9 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.RoleDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}ROLES r
+    <if test="filter.groupId != null">
+      JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
+    </if>
     <include refid="io.camunda.db.rdbms.sql.RoleMapper.searchFilter"/>
   </select>
 
@@ -41,6 +44,7 @@
     <if test="filter.roleKey != null">AND r.ROLE_KEY = #{filter.roleKey}</if>
     <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
     <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
+    <if test="filter.groupId != null">AND rm.ENTITY_ID = #{filter.groupId}</if>
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -44,7 +44,7 @@
     <if test="filter.roleKey != null">AND r.ROLE_KEY = #{filter.roleKey}</if>
     <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
     <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
-    <if test="filter.groupId != null">AND rm.ENTITY_ID = #{filter.groupId}</if>
+    <if test="filter.groupId != null">AND rm.ENTITY_ID = #{filter.groupId} AND rm.ENTITY_TYPE = #{filter.memberType}</if>
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.role;
 
+import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,15 +16,19 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.RoleReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
+import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.sort.RoleSort;
+import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,6 +55,31 @@ public class RoleSpecificFilterIT {
     rdbmsWriter = rdbmsService.createWriter(0L);
   }
 
+  @Test
+  public void shouldFilterRolesForGroup() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var anotherRoleId = Strings.newRandomValidIdentityId();
+    final var group = GroupFixtures.createRandomized(b -> b);
+    createAndSaveGroup(rdbmsWriter, group);
+    createAndSaveRole(
+        rdbmsWriter, RoleFixtures.createRandomized(b -> b.roleId(roleId).name("Role 1337")));
+    createAndSaveRole(
+        rdbmsWriter,
+        RoleFixtures.createRandomized(b -> b.roleId(anotherRoleId).name("Another Role 1337")));
+
+    addGroupToRole(roleId, group.groupId());
+    addGroupToRole(anotherRoleId, group.groupId());
+
+    final var roles =
+        roleReader.search(
+            new RoleQuery(
+                new RoleFilter.Builder().groupId(group.groupId()).build(),
+                RoleSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(roles.total()).isEqualTo(2);
+  }
+
   @ParameterizedTest
   @MethodSource("shouldFindWithSpecificFilterParameters")
   public void shouldFindWithSpecificFilter(final RoleFilter filter) {
@@ -70,5 +100,10 @@ public class RoleSpecificFilterIT {
     return List.of(
         new RoleFilter.Builder().roleKey(1337L).build(),
         new RoleFilter.Builder().name("Role 1337").build());
+  }
+
+  private void addGroupToRole(final String roleId, final String entityId) {
+    rdbmsWriter.getRoleWriter().addMember(new RoleMemberDbModel(roleId, entityId, "GROUP"));
+    rdbmsWriter.flush();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.rdbms.db.role;
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
 import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
+import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
@@ -19,11 +20,13 @@ import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
+import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.sort.RoleSort;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +63,11 @@ public class RoleSpecificFilterIT {
     final var roleId = Strings.newRandomValidIdentityId();
     final var anotherRoleId = Strings.newRandomValidIdentityId();
     final var group = GroupFixtures.createRandomized(b -> b);
+    final var userId = Strings.newRandomValidIdentityId();
+    createAndSaveUser(
+        rdbmsWriter,
+        UserFixtures.createRandomized(
+            b -> b.username(userId).name("User 1337").password("password")));
     createAndSaveGroup(rdbmsWriter, group);
     createAndSaveRole(
         rdbmsWriter, RoleFixtures.createRandomized(b -> b.roleId(roleId).name("Role 1337")));
@@ -67,13 +75,17 @@ public class RoleSpecificFilterIT {
         rdbmsWriter,
         RoleFixtures.createRandomized(b -> b.roleId(anotherRoleId).name("Another Role 1337")));
 
+    addUserToRole(roleId, userId);
     addGroupToRole(roleId, group.groupId());
     addGroupToRole(anotherRoleId, group.groupId());
 
     final var roles =
         roleReader.search(
             new RoleQuery(
-                new RoleFilter.Builder().groupId(group.groupId()).build(),
+                new RoleFilter.Builder()
+                    .groupId(group.groupId())
+                    .memberType(EntityType.GROUP)
+                    .build(),
                 RoleSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
@@ -104,6 +116,11 @@ public class RoleSpecificFilterIT {
 
   private void addGroupToRole(final String roleId, final String entityId) {
     rdbmsWriter.getRoleWriter().addMember(new RoleMemberDbModel(roleId, entityId, "GROUP"));
+    rdbmsWriter.flush();
+  }
+
+  private void addUserToRole(final String roleId, final String entityId) {
+    rdbmsWriter.getRoleWriter().addMember(new RoleMemberDbModel(roleId, entityId, "USER"));
     rdbmsWriter.flush();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -83,7 +83,7 @@ public class RoleSpecificFilterIT {
         roleReader.search(
             new RoleQuery(
                 new RoleFilter.Builder()
-                    .groupId(group.groupId())
+                    .memberId(group.groupId())
                     .memberType(EntityType.GROUP)
                     .build(),
                 RoleSort.of(b -> b),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -297,8 +297,7 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
-  public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery roleQuery) {
-    final var query = applyFilters(roleQuery);
+  public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery query) {
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.usermanagement.RoleEntity.class);
   }
@@ -426,13 +425,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     return userQuery;
   }
 
-  private RoleQuery applyFilters(final RoleQuery roleQuery) {
-    if (roleQuery.filter().groupId() != null) {
-      return expandGroupFilterForRole(roleQuery);
-    }
-    return roleQuery;
-  }
-
   private UserQuery expandTenantFilter(final UserQuery userQuery) {
     final List<TenantMemberEntity> tenantMembers =
         getSearchExecutor()
@@ -462,12 +454,6 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
 
     return userQuery.toBuilder()
         .filter(userQuery.filter().toBuilder().usernames(usernames).build())
-        .build();
-  }
-
-  private RoleQuery expandGroupFilterForRole(final RoleQuery roleQuery) {
-    return roleQuery.toBuilder()
-        .filter(roleQuery.filter().toBuilder().memberId(roleQuery.filter().groupId()).build())
         .build();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -36,6 +36,11 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    stringTerms(RoleIndex.MEMBER_ID, filter.memberIds())));
+                    stringTerms(RoleIndex.MEMBER_ID, filter.memberIds())),
+        filter.roleIds() == null
+            ? null
+            : filter.roleIds().isEmpty()
+                ? matchNone()
+                : stringTerms(RoleIndex.ROLE_ID, filter.roleIds()));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -18,11 +18,10 @@ public record RoleFilter(
     String description,
     Set<String> memberIds,
     EntityType memberType,
-    String groupId,
     Set<String> roleIds)
     implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds).groupId(groupId);
+    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
@@ -32,7 +31,6 @@ public record RoleFilter(
     private String description;
     private Set<String> memberIds;
     private EntityType memberType;
-    private String groupId;
     private Set<String> roleIds;
 
     public Builder roleKey(final Long value) {
@@ -69,11 +67,6 @@ public record RoleFilter(
       return this;
     }
 
-    public Builder groupId(final String value) {
-      groupId = value;
-      return this;
-    }
-
     public Builder roleIds(final Set<String> value) {
       roleIds = value == null ? Set.of() : value;
       return this;
@@ -81,8 +74,7 @@ public record RoleFilter(
 
     @Override
     public RoleFilter build() {
-      return new RoleFilter(
-          roleKey, roleId, name, description, memberIds, memberType, groupId, roleIds);
+      return new RoleFilter(roleKey, roleId, name, description, memberIds, memberType, roleIds);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.filter;
 
-import io.camunda.search.filter.GroupFilter.Builder;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
@@ -18,10 +17,12 @@ public record RoleFilter(
     String name,
     String description,
     Set<String> memberIds,
-    EntityType memberType)
+    EntityType memberType,
+    String groupId,
+    Set<String> roleIds)
     implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds);
+    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds).groupId(groupId);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
@@ -31,6 +32,8 @@ public record RoleFilter(
     private String description;
     private Set<String> memberIds;
     private EntityType memberType;
+    private String groupId;
+    private Set<String> roleIds;
 
     public Builder roleKey(final Long value) {
       roleKey = value;
@@ -66,9 +69,20 @@ public record RoleFilter(
       return this;
     }
 
+    public Builder groupId(final String value) {
+      groupId = value;
+      return this;
+    }
+
+    public Builder roleIds(final Set<String> value) {
+      roleIds = value == null ? Set.of() : value;
+      return this;
+    }
+
     @Override
     public RoleFilter build() {
-      return new RoleFilter(roleKey, roleId, name, description, memberIds, memberType);
+      return new RoleFilter(
+          roleKey, roleId, name, description, memberIds, memberType, groupId, roleIds);
     }
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -18,6 +18,7 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String INDEX_VERSION = "8.8.0";
 
   public static final String KEY = "key";
+  public static final String ROLE_ID = "roleId";
   public static final String NAME = "name";
   public static final String MEMBER_ID = "memberId";
   public static final String JOIN = "join";

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3206,6 +3206,51 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /groups/{groupId}/roles/search:
+    post:
+      tags:
+        - Group
+      operationId: searchRolesForGroup
+      summary: Search group roles (Work-in-Progress)
+      description: |
+        Search roles assigned to a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes until
+        its release with an upcoming minor release.
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          description: The group ID.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleSearchQueryRequest"
+      responses:
+        "200":
+          description: The roles assigned to the group.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoleSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /groups/{groupId}/users/{username}:
     put:
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3244,7 +3244,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The role with the given ID was not found.
+          description: The group with the given ID was not found.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -390,8 +390,8 @@ public final class SearchQueryResponseMapper {
     return new RoleResult()
         .roleKey(KeyUtil.keyToString(roleEntity.roleKey()))
         .roleId(roleEntity.roleId())
-        .name(roleEntity.name())
-        .description(roleEntity.description());
+        .description(roleEntity.description())
+        .name(roleEntity.name());
   }
 
   private static List<GroupResult> toGroups(final List<GroupEntity> groups) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
 
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.RoleQuery;
@@ -228,13 +229,13 @@ public class GroupController {
   }
 
   private ResponseEntity<RoleSearchQueryResult> searchRolesInGroup(
-      final String groupId, final RoleQuery userQuery) {
+      final String groupId, final RoleQuery roleQuery) {
     try {
-      final var composedUserQuery = buildRoleQuery(groupId, userQuery);
+      final var composedRoleQuery = buildRoleQuery(groupId, roleQuery);
       final var result =
           roleServices
               .withAuthentication(RequestMapper.getAuthentication())
-              .search(composedUserQuery);
+              .search(composedRoleQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -249,7 +250,12 @@ public class GroupController {
 
   private RoleQuery buildRoleQuery(final String groupId, final RoleQuery roleQuery) {
     return roleQuery.toBuilder()
-        .filter(roleQuery.filter().toBuilder().groupId(groupId).build())
+        .filter(
+            roleQuery.filter().toBuilder()
+                .groupId(groupId)
+                .memberId(groupId)
+                .memberType(GROUP)
+                .build())
         .build();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -250,12 +250,7 @@ public class GroupController {
 
   private RoleQuery buildRoleQuery(final String groupId, final RoleQuery roleQuery) {
     return roleQuery.toBuilder()
-        .filter(
-            roleQuery.filter().toBuilder()
-                .groupId(groupId)
-                .memberId(groupId)
-                .memberType(GROUP)
-                .build())
+        .filter(roleQuery.filter().toBuilder().memberId(groupId).memberType(GROUP).build())
         .build();
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
+import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -45,6 +46,7 @@ public class GroupControllerTest extends RestControllerTest {
 
   @MockBean private GroupServices groupServices;
   @MockBean private UserServices userServices;
+  @MockBean private RoleServices roleServices;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -136,15 +136,21 @@ public class RoleQueryControllerTest extends RestControllerTest {
              "items": [
                {
                  "roleKey": "100",
-                 "name": "Role 1"
+                 "name": "Role 1",
+                 "roleId": "role1",
+                 "description": "description 1"
                },
                {
                  "roleKey": "200",
-                 "name": "Role 2"
+                 "name": "Role 2",
+                 "roleId": "role2",
+                 "description": "description 2"
                },
                {
                  "roleKey": "300",
-                 "name": "Role 12"
+                 "name": "Role 12",
+                 "roleId": "role12",
+                 "description": "description 12"
                }
              ],
              "page": {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the endpoint to search for roles by groupId. It also fix a minor issue with the search role response adding the `roleId` and `description` as fields

## Related issues

closes #31744 
