### PR TITLE
feat: validate mapping exists for ownerId in authorization

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -408,10 +408,6 @@ public final class AuthorizationCheckBehavior {
         .mapMulti(Optional::ifPresent);
   }
 
-  public boolean mappingExists(final String mappingId) {
-    return mappingState.get(mappingId).isPresent();
-  }
-
   public static final class AuthorizationRequest {
     private final TypedRecord<?> command;
     private final AuthorizationResourceType resourceType;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -408,6 +408,10 @@ public final class AuthorizationCheckBehavior {
         .mapMulti(Optional::ifPresent);
   }
 
+  public boolean mappingExists(final String mappingId) {
+    return mappingState.get(mappingId).isPresent();
+  }
+
   public static final class AuthorizationRequest {
     private final TypedRecord<?> command;
     private final AuthorizationResourceType resourceType;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -59,6 +59,7 @@ public class AuthorizationCreateProcessor
                     record.getPermissionTypes(),
                     record.getResourceType(),
                     "Expected to create authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
+        .flatMap(permissionsBehavior::mappingExists)
         .flatMap(permissionsBehavior::permissionsAlreadyExist)
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, command.getValue()),
@@ -71,7 +72,8 @@ public class AuthorizationCreateProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
     permissionsBehavior
-        .permissionsAlreadyExist(command.getValue())
+        .mappingExists(command.getValue())
+        .flatMap(permissionsBehavior::permissionsAlreadyExist)
         .ifRightOrLeft(
             ignored ->
                 stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -34,10 +35,12 @@ public class PermissionsBehavior {
 
   private final AuthorizationState authorizationState;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final MappingState mappingState;
 
   public PermissionsBehavior(
       final ProcessingState processingState, final AuthorizationCheckBehavior authCheckBehavior) {
     authorizationState = processingState.getAuthorizationState();
+    mappingState = processingState.getMappingState();
     this.authCheckBehavior = authCheckBehavior;
   }
 
@@ -107,7 +110,7 @@ public class PermissionsBehavior {
       return Either.right(record);
     }
 
-    if (!authCheckBehavior.mappingExists(record.getOwnerId())) {
+    if (mappingState.get(record.getOwnerId()).isEmpty()) {
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -133,4 +133,30 @@ public class CreateAuthorizationTest {
                     resourceType,
                     resourceType.getSupportedPermissionTypes()));
   }
+
+  @Test
+  public void shouldRejectCreateWhenMappingDoesNotExist() {
+    // given
+    final var nonexistentMappingId = "nonexistent-mapping-id";
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withOwnerId(nonexistentMappingId)
+            .withOwnerType(AuthorizationOwnerType.MAPPING)
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withPermissions(PermissionType.CREATE)
+            .expectRejection()
+            .create();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to create or update authorization with ownerId '%s', but a mapping with this ID does not exist."
+                .formatted(nonexistentMappingId));
+  }
 }


### PR DESCRIPTION
## Description

This PR ensures that when creating or updating an authorization with ownerType = MAPPING, the system validates the existence of the mapping with the provided ownerId. If the mapping does not exist, a 404 Not Found error is returned. This prevents orphan authorizations and aligns the behavior with other entity validations.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29845
