### PR TITLE
refactor: remove spring dependency of UserStore on schema startup

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
@@ -31,13 +31,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Conditional(ElasticsearchCondition.class)
 @Component
-@DependsOn("searchEngineSchemaInitializer")
 @Profile(
     "!"
         + OperateProfileService.LDAP_AUTH_PROFILE

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
@@ -24,13 +24,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
 @Component
-@DependsOn("searchEngineSchemaInitializer")
 @Profile(
     "!"
         + OperateProfileService.LDAP_AUTH_PROFILE

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/AbstractSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/AbstractSpringDependenciesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.web.client.RestTemplate;
+
+abstract class AbstractSpringDependenciesTest {
+  private final Map<String, Set<String>> beansGraph = new HashMap<>();
+
+  void assertThatNoDependenciesBetween(final String from, final String to) {
+    assertBeanExists(from);
+    assertBeanExists(to);
+    assertThat(findAnyPath(from, to)).isNull();
+  }
+
+  void assertBeanExists(final String beanName) {
+    assertThat(beansGraph).containsKey(beanName);
+  }
+
+  private List<String> findAnyPath(final String start, final String target) {
+    final var queue = new LinkedList<List<String>>();
+    final var visited = new HashSet<String>();
+    queue.add(List.of(start));
+    while (!queue.isEmpty()) {
+      final var path = queue.poll();
+      final var last = path.get(path.size() - 1);
+
+      if (last.equals(target)) {
+        return path;
+      }
+
+      if (visited.contains(last)) {
+        continue;
+      }
+      visited.add(last);
+
+      for (final String neighbor : beansGraph.getOrDefault(last, Set.of())) {
+        final var newPath = new ArrayList<>(path);
+        newPath.add(neighbor);
+        queue.add(newPath);
+      }
+    }
+
+    return null;
+  }
+
+  void fetchBeansGraph(final URI actuatorBeansURI) {
+    final var response = new RestTemplate().getForEntity(actuatorBeansURI, JsonNode.class);
+    final JsonNode beans = response.getBody().get("contexts").elements().next().get("beans");
+    beans
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              final String beanName = entry.getKey();
+              final JsonNode deps = entry.getValue().get("dependencies");
+              if (deps != null && deps.isArray()) {
+                final Set<String> depSet = new HashSet<>();
+                deps.forEach(dep -> depSet.add(dep.asText()));
+                beansGraph.put(beanName, depSet);
+              }
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.spring;
+
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+final class CamundaApplicationSpringDependenciesTest extends AbstractSpringDependenciesTest {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA_APPLICATION =
+      new TestCamundaApplication()
+          .withProperty("management.endpoint.beans.access", "unrestricted")
+          .withCreateSchema(false);
+
+  @BeforeEach
+  void setUp() {
+    fetchBeansGraph(CAMUNDA_APPLICATION.actuatorAddress("beans"));
+  }
+
+  @Test
+  void shouldHaveNoDependenciesBetweenBrokerAndSearchEngineSchemaInitializer() {
+    assertThatNoDependenciesBetween("broker", "searchEngineSchemaInitializer");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/StandaloneBrokerSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/StandaloneBrokerSpringDependenciesTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.spring;
+
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+final class StandaloneBrokerSpringDependenciesTest extends AbstractSpringDependenciesTest {
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withProperty("management.endpoint.beans.access", "unrestricted");
+
+  @BeforeEach
+  void setUp() {
+    fetchBeansGraph(BROKER.actuatorAddress("beans"));
+  }
+
+  @Test
+  void shouldHaveNoDependenciesBetweenBrokerAndSearchEngineSchemaInitializer() {
+    assertThatNoDependenciesBetween("broker", "searchEngineSchemaInitializer");
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
@@ -42,13 +42,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE)
-@DependsOn("searchEngineSchemaInitializer")
 @Conditional(ElasticSearchCondition.class)
 public class UserStoreElasticSearch implements UserStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserStoreElasticSearch.class);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
@@ -34,13 +34,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE)
-@DependsOn("searchEngineSchemaInitializer")
 @Conditional(OpenSearchCondition.class)
 public class UserStoreOpenSearch implements UserStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserStoreOpenSearch.class);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -65,6 +65,11 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
     return uri(sslEnabled ? "https" : "http", TestZeebePort.REST, basePath);
   }
 
+  default URI actuatorAddress(final String path) {
+    final var basePath = property("server.servlet.context-path", String.class, "");
+    return uri("http", TestZeebePort.MONITORING, basePath, "actuator", path);
+  }
+
   /**
    * Returns the health actuator for this gateway. You can use this to check for liveness,
    * readiness, and startup.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Removing the explicit spring dependency to `searchEngineSchemaInitializer` that is declared in ES/OS UserStore of Operate and Tasklist.
This is coming from this [observation](https://github.com/camunda/camunda/issues/28896#issuecomment-2855196843) where the broker module was unnecessarily depending on `searchEngineSchemaInitializer` in single app mode (Spring dependency chain: `broker->``brokerModuleConfiguration` -> `getPasswordEncoder` -> `OperateUserDetailsService` -> `ElasticsearchUserStore` -> `searchEngineSchemaInitializer`)

The UserStore beans does not need to depend on `searchEngineSchemaInitializer`. The `save()` method invoked at startup is invoked by [StartupBean](https://github.com/camunda/camunda/blob/94d32e7299406d8b2458124b7af0e0cfc153bb7f/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java#L54) which already [declares explicit dependency](https://github.com/camunda/camunda/blob/94d32e7299406d8b2458124b7af0e0cfc153bb7f/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java#L27) to `searchEngineSchemaInitializer`.

This should break the dependency of `brokerModuleConfiguration` to `searchEngineSchemaInitializer` and should allow the broker to start without the need to wait for schema initialization in Single app mode.

This is not a major issue as it impacts only the default `auth` method which is meant to be removed.

I previously made another fix in https://github.com/camunda/camunda/pull/31757 for the same issue, by extracting `getPasswordEncoder` bean definition out of `OperateUserDetailsService`. But I think the current fix in this PR is enough.

**Tests**
I added a test to assert that there is no dependency between the broker and searchEngineSchemaInitializer for CamundaApp and Standalone Broker, this uses `/actuator/beans` to build the beans graph and assert that the dependencies do not exist. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/28896
