### PR TITLE
fix: enable separateMinorPatch for maintenance branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,14 @@
   },
   "packageRules": [
     {
+      "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
+      "separateMinorPatch": true,
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/",
+        "stable/operate-8.5"
+      ]
+    },
+    {
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
         "/^stable\\/8\\..*/",


### PR DESCRIPTION
## Description

In case a package has a newer minor version, otherwise its patch will be ignored for maintenance branches.
`packageRules` cannot combine both `matchUpdateTypes` and `separateMinorPatch`, so it needs to be 2 separate rules.

Linting workflow expected to fail until https://github.com/camunda/camunda/issues/28665 is done.

Renovate config documentation: https://docs.renovatebot.com/configuration-options/#separateminorpatch

Example:
- current package version: `1.2.3`
- latest version available: `1.3.4`
- latest `1.2.x` version (patch) available: `1.2.5`

Without `separateMinorPatch`, `1.2.5` will be ignored and `1.3.4` won't be applied because we explicitly turn the non-patch upgrades off in the maintenance branches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
