### PR TITLE
feat: update batch operation counts in camunda exporter 

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/TempESBatchOperationCancelProcessInstanceTest.java
@@ -118,6 +118,8 @@ public class TempESBatchOperationCancelProcessInstanceTest {
               assertThat(batch.getStartDate()).isNotNull();
               assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
               assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+              assertThat(batch.getOperationsTotalCount())
+                  .isEqualTo(ACTIVE_PROCESS_INSTANCES.size());
               assertThat(batch.getEndDate()).isNotNull();
             });
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
-import io.camunda.zeebe.util.DateUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,9 +58,7 @@ public class BatchOperationCompletedHandler
   @Override
   public void updateEntity(
       final Record<BatchOperationExecutionRecordValue> record, final BatchOperationEntity entity) {
-    entity
-        .setEndDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
-        .setState(BatchOperationState.COMPLETED);
+    entity.setState(BatchOperationState.COMPLETED);
   }
 
   @Override
@@ -69,7 +66,6 @@ public class BatchOperationCompletedHandler
       throws PersistenceException {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(BatchOperationTemplate.STATE, entity.getState());
-    updateFields.put(BatchOperationTemplate.END_DATE, entity.getEndDate());
     batchRequest.update(indexName, entity.getId(), updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandlerTest.java
@@ -18,8 +18,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import io.camunda.zeebe.util.DateUtil;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -101,7 +99,6 @@ class BatchOperationCompletedHandlerTest {
 
     // then
     assertThat(entity.getState()).isEqualTo(BatchOperationState.COMPLETED);
-    assertThat(entity.getEndDate()).isEqualTo(DateUtil.toOffsetDateTime(record.getTimestamp()));
   }
 
   @Test
@@ -109,10 +106,7 @@ class BatchOperationCompletedHandlerTest {
     // given
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final BatchOperationEntity entity =
-        new BatchOperationEntity()
-            .setId("12345")
-            .setState(BatchOperationState.COMPLETED)
-            .setEndDate(DateUtil.toOffsetDateTime(Instant.now().toEpochMilli()));
+        new BatchOperationEntity().setId("12345").setState(BatchOperationState.COMPLETED);
 
     // when
     handler.flush(entity, batchRequest);
@@ -122,6 +116,5 @@ class BatchOperationCompletedHandlerTest {
     verify(batchRequest).update(eq(indexName), eq("12345"), argumentCaptor.capture());
     final Map<String, Object> updateFields = argumentCaptor.getValue();
     assertThat(updateFields).containsEntry("state", BatchOperationState.COMPLETED);
-    assertThat(updateFields).containsEntry("endDate", entity.getEndDate());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class BatchOperationUpdateRepositoryTest {
+
+  @Test
+  void shouldReturnCorrectOperationCounts() {
+    // given
+    final OperationsAggData data =
+        new OperationsAggData(
+            "1", Map.of("SCHEDULED", 4L, "COMPLETED", 3L, "FAILED", 2L, "LOCKED", 1L));
+
+    // then
+    assertThat(data.getFinishedOperationsCount()).isEqualTo(5L);
+    assertThat(data.getCompletedOperationsCount()).isEqualTo(3L);
+    assertThat(data.getFailedOperationsCount()).isEqualTo(2L);
+    assertThat(data.getTotalOperationsCount()).isEqualTo(10L);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -61,8 +62,8 @@ public class BatchOperationUpdateTaskTest {
     repository.batchOperationIds.add("1");
     repository.batchOperationIds.add("2");
     repository.batchOperationIds.add("3");
-    repository.finishedOperationsCount.add(new OperationsAggData("1", 5));
-    repository.finishedOperationsCount.add(new OperationsAggData("2", 6));
+    repository.finishedOperationsCount.add(new OperationsAggData("1", Map.of("COMPLETED", 5L)));
+    repository.finishedOperationsCount.add(new OperationsAggData("2", Map.of("COMPLETED", 6L)));
     final var result = task.execute();
 
     // then
@@ -72,7 +73,7 @@ public class BatchOperationUpdateTaskTest {
         .isEqualTo(2);
     assertThat(repository.documentUpdates).hasSize(2);
     assertThat(repository.documentUpdates)
-        .contains(new DocumentUpdate("1", 5L), new DocumentUpdate("2", 6L));
+        .contains(new DocumentUpdate("1", 5L, 0L, 5L, 5L), new DocumentUpdate("2", 6L, 0L, 6L, 6L));
   }
 
   private static final class TestRepository implements BatchOperationUpdateRepository {
@@ -86,7 +87,7 @@ public class BatchOperationUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
+    public CompletionStage<List<OperationsAggData>> getOperationsCount(
         final Collection<String> batchOperationIds) {
       return CompletableFuture.completedFuture(finishedOperationsCount);
     }


### PR DESCRIPTION
## Description

Extend the BatchOperationUpdateTask and ES/OS repositories to not only update the finished items but also the completed and total counts.

Notes:
- The endDate is not set in the CompletedHandler anymore but in the BatchOperationUpdateTask after the final update of the counts.

closes #31776 
