### PR TITLE
fix: prevent ActivateJobsCommand timeout before the server

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -146,10 +146,16 @@ public interface CamundaClientBuilder {
   CamundaClientBuilder defaultRequestTimeout(Duration requestTimeout);
 
   /**
-   * The {@link io.camunda.client.impl.command.ActivateJobsCommandImpl}'s response timeout offset.
-   * Default is 1 second.
+   * The request timeout client offset is used in commands where the {@link
+   * #defaultRequestTimeout(Duration)} is also passed to the server. This ensures that the client
+   * timeout does not occur before the server timeout.
+   *
+   * <p>The client-side timeout for these commands is calculated as the sum of {@code
+   * defaultRequestTimeout} and {@code defaultRequestTimeoutOffset}.
+   *
+   * <p>Default is 1 second.
    */
-  CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(Duration responseTimeoutOffset);
+  CamundaClientBuilder defaultRequestTimeoutOffset(Duration requestTimeoutOffset);
 
   /** Use a plaintext connection between the client and the gateway. */
   CamundaClientBuilder usePlaintext();

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -145,6 +145,12 @@ public interface CamundaClientBuilder {
   /** The request timeout used if not overridden by the command. Default is 10 seconds. */
   CamundaClientBuilder defaultRequestTimeout(Duration requestTimeout);
 
+  /**
+   * The {@link io.camunda.client.impl.command.ActivateJobsCommandImpl}'s response timeout offset.
+   * Default is 1 second.
+   */
+  CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(Duration responseTimeoutOffset);
+
   /** Use a plaintext connection between the client and the gateway. */
   CamundaClientBuilder usePlaintext();
 

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -90,6 +90,11 @@ public interface CamundaClientConfiguration {
   Duration getDefaultRequestTimeout();
 
   /**
+   * @see CamundaClientBuilder#defaultActivateJobsResponseTimeoutOffset(Duration)
+   */
+  Duration getDefaultActivateJobsResponseTimeoutOffset();
+
+  /**
    * @see CamundaClientBuilder#usePlaintext()
    */
   boolean isPlaintextConnectionEnabled();

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientConfiguration.java
@@ -90,9 +90,9 @@ public interface CamundaClientConfiguration {
   Duration getDefaultRequestTimeout();
 
   /**
-   * @see CamundaClientBuilder#defaultActivateJobsResponseTimeoutOffset(Duration)
+   * @see CamundaClientBuilder#defaultRequestTimeoutOffset(Duration)
    */
-  Duration getDefaultActivateJobsResponseTimeoutOffset();
+  Duration getDefaultRequestTimeoutOffset();
 
   /**
    * @see CamundaClientBuilder#usePlaintext()

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -93,6 +93,12 @@ public final class ClientProperties {
   public static final String DEFAULT_REQUEST_TIMEOUT = "camunda.client.requestTimeout";
 
   /**
+   * @see CamundaClientBuilder#defaultActivateJobsResponseTimeoutOffset(Duration)
+   */
+  public static final String DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET =
+      "camunda.client.activateJobsResponseTimeoutOffset";
+
+  /**
    * @see CamundaClientBuilder#usePlaintext()
    */
   public static final String USE_PLAINTEXT_CONNECTION = "camunda.client.security.plaintext";

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -93,10 +93,9 @@ public final class ClientProperties {
   public static final String DEFAULT_REQUEST_TIMEOUT = "camunda.client.requestTimeout";
 
   /**
-   * @see CamundaClientBuilder#defaultActivateJobsResponseTimeoutOffset(Duration)
+   * @see CamundaClientBuilder#defaultRequestTimeoutOffset(Duration)
    */
-  public static final String DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET =
-      "camunda.client.activateJobsResponseTimeoutOffset";
+  public static final String DEFAULT_REQUEST_TIMEOUT_OFFSET = "camunda.client.requestTimeoutOffset";
 
   /**
    * @see CamundaClientBuilder#usePlaintext()

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.command;
 
+import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.api.response.ActivateJobsResponse;
 import java.time.Duration;
 import java.util.List;
@@ -103,9 +104,12 @@ public interface ActivateJobsCommandStep1
     ActivateJobsCommandStep3 fetchVariables(String... fetchVariables);
 
     /**
-     * Sets the request timeout for the command and adjusts the HTTP response timeout to be 100ms
-     * longer than the specified value, ensuring that the client timeout does not occur before the
-     * server timeout.
+     * Sets the request timeout for the command.
+     *
+     * <p>Additionally, it sets the HTTP response timeout to the specified value, incremented by the
+     * offset defined in {@link
+     * CamundaClientConfiguration#getDefaultActivateJobsResponseTimeoutOffset()} (default 1 second),
+     * ensuring that the client timeout does not occur before the server timeout.
      *
      * @see FinalCommandStep#requestTimeout(Duration)
      * @param requestTimeout the request timeout

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
@@ -101,5 +101,17 @@ public interface ActivateJobsCommandStep1
      *     it to the broker.
      */
     ActivateJobsCommandStep3 fetchVariables(String... fetchVariables);
+
+    /**
+     * Sets the request timeout for the command and adjusts the HTTP response timeout to be 100ms
+     * longer than the specified value, ensuring that the client timeout does not occur before the
+     * server timeout.
+     *
+     * @see FinalCommandStep#requestTimeout(Duration)
+     * @param requestTimeout the request timeout
+     * @return the configured command
+     */
+    @Override
+    FinalCommandStep<ActivateJobsResponse> requestTimeout(Duration requestTimeout);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
@@ -107,9 +107,9 @@ public interface ActivateJobsCommandStep1
      * Sets the request timeout for the command.
      *
      * <p>Additionally, it sets the HTTP response timeout to the specified value, incremented by the
-     * offset defined in {@link
-     * CamundaClientConfiguration#getDefaultActivateJobsResponseTimeoutOffset()} (default 1 second),
-     * ensuring that the client timeout does not occur before the server timeout.
+     * offset defined in {@link CamundaClientConfiguration#getDefaultRequestTimeoutOffset()}
+     * (default 1 second), ensuring that the client timeout does not occur before the server
+     * timeout.
      *
      * @see FinalCommandStep#requestTimeout(Duration)
      * @param requestTimeout the request timeout

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl;
 
 import static io.camunda.client.ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES;
 import static io.camunda.client.ClientProperties.CA_CERTIFICATE_PATH;
+import static io.camunda.client.ClientProperties.DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_POLL_INTERVAL;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_TIMEOUT;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_NAME;
@@ -105,6 +106,7 @@ public final class CamundaClientBuilderImpl
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
+  private Duration defaultActivateJobsResponseTimeoutOffset = Duration.ofSeconds(1);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
   private CredentialsProvider credentialsProvider;
@@ -177,6 +179,11 @@ public final class CamundaClientBuilderImpl
   @Override
   public Duration getDefaultRequestTimeout() {
     return defaultRequestTimeout;
+  }
+
+  @Override
+  public Duration getDefaultActivateJobsResponseTimeoutOffset() {
+    return defaultActivateJobsResponseTimeoutOffset;
   }
 
   @Override
@@ -336,6 +343,11 @@ public final class CamundaClientBuilderImpl
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultActivateJobsResponseTimeoutOffset(Duration.ofMillis(Long.parseLong(value))),
+        DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
         value -> {
           /**
            * The following condition is phrased in this particular way in order to be backwards
@@ -482,6 +494,13 @@ public final class CamundaClientBuilderImpl
   @Override
   public CamundaClientBuilder defaultRequestTimeout(final Duration requestTimeout) {
     defaultRequestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(
+      final Duration responseTimeoutOffset) {
+    defaultActivateJobsResponseTimeoutOffset = responseTimeoutOffset;
     return this;
   }
 
@@ -652,6 +671,8 @@ public final class CamundaClientBuilderImpl
     BuilderUtils.appendProperty(sb, "defaultJobPollInterval", defaultJobPollInterval);
     BuilderUtils.appendProperty(sb, "defaultMessageTimeToLive", defaultMessageTimeToLive);
     BuilderUtils.appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
+    BuilderUtils.appendProperty(
+        sb, "defaultActivateJobsResponseTimeoutOffset", defaultActivateJobsResponseTimeoutOffset);
     BuilderUtils.appendProperty(sb, "overrideAuthority", overrideAuthority);
     BuilderUtils.appendProperty(sb, "maxMessageSize", maxMessageSize);
     BuilderUtils.appendProperty(sb, "maxMetadataSize", maxMetadataSize);

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -17,13 +17,13 @@ package io.camunda.client.impl;
 
 import static io.camunda.client.ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES;
 import static io.camunda.client.ClientProperties.CA_CERTIFICATE_PATH;
-import static io.camunda.client.ClientProperties.DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_POLL_INTERVAL;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_TIMEOUT;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_NAME;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.client.ClientProperties.GRPC_ADDRESS;
 import static io.camunda.client.ClientProperties.JOB_WORKER_EXECUTION_THREADS;
@@ -106,7 +106,7 @@ public final class CamundaClientBuilderImpl
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
-  private Duration defaultActivateJobsResponseTimeoutOffset = Duration.ofSeconds(1);
+  private Duration defaultRequestTimeoutOffset = Duration.ofSeconds(1);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
   private CredentialsProvider credentialsProvider;
@@ -182,8 +182,8 @@ public final class CamundaClientBuilderImpl
   }
 
   @Override
-  public Duration getDefaultActivateJobsResponseTimeoutOffset() {
-    return defaultActivateJobsResponseTimeoutOffset;
+  public Duration getDefaultRequestTimeoutOffset() {
+    return defaultRequestTimeoutOffset;
   }
 
   @Override
@@ -343,8 +343,8 @@ public final class CamundaClientBuilderImpl
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
-        value -> defaultActivateJobsResponseTimeoutOffset(Duration.ofMillis(Long.parseLong(value))),
-        DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET);
+        value -> defaultRequestTimeoutOffset(Duration.ofMillis(Long.parseLong(value))),
+        DEFAULT_REQUEST_TIMEOUT_OFFSET);
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
@@ -498,9 +498,8 @@ public final class CamundaClientBuilderImpl
   }
 
   @Override
-  public CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(
-      final Duration responseTimeoutOffset) {
-    defaultActivateJobsResponseTimeoutOffset = responseTimeoutOffset;
+  public CamundaClientBuilder defaultRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    defaultRequestTimeoutOffset = requestTimeoutOffset;
     return this;
   }
 
@@ -671,8 +670,7 @@ public final class CamundaClientBuilderImpl
     BuilderUtils.appendProperty(sb, "defaultJobPollInterval", defaultJobPollInterval);
     BuilderUtils.appendProperty(sb, "defaultMessageTimeToLive", defaultMessageTimeToLive);
     BuilderUtils.appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
-    BuilderUtils.appendProperty(
-        sb, "defaultActivateJobsResponseTimeoutOffset", defaultActivateJobsResponseTimeoutOffset);
+    BuilderUtils.appendProperty(sb, "defaultRequestTimeoutOffset", defaultRequestTimeoutOffset);
     BuilderUtils.appendProperty(sb, "overrideAuthority", overrideAuthority);
     BuilderUtils.appendProperty(sb, "maxMessageSize", maxMessageSize);
     BuilderUtils.appendProperty(sb, "maxMetadataSize", maxMetadataSize);

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -217,9 +217,8 @@ public class CamundaClientCloudBuilderImpl
   }
 
   @Override
-  public CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(
-      final Duration responseTimeoutOffset) {
-    innerBuilder.defaultActivateJobsResponseTimeoutOffset(responseTimeoutOffset);
+  public CamundaClientBuilder defaultRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    innerBuilder.defaultRequestTimeoutOffset(requestTimeoutOffset);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -217,6 +217,13 @@ public class CamundaClientCloudBuilderImpl
   }
 
   @Override
+  public CamundaClientBuilder defaultActivateJobsResponseTimeoutOffset(
+      final Duration responseTimeoutOffset) {
+    innerBuilder.defaultActivateJobsResponseTimeoutOffset(responseTimeoutOffset);
+    return this;
+  }
+
+  @Override
   public CamundaClientBuilder usePlaintext() {
     innerBuilder.usePlaintext();
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
@@ -145,7 +145,7 @@ public final class ActivateJobsCommandImpl
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     this.requestTimeout = requestTimeout;
     // increment response timeout so client doesn't time out before the server
-    final long offsetMillis = config.getDefaultActivateJobsResponseTimeoutOffset().toMillis();
+    final long offsetMillis = config.getDefaultRequestTimeoutOffset().toMillis();
     httpRequestConfig.setResponseTimeout(
         requestTimeout.toMillis() + offsetMillis, TimeUnit.MILLISECONDS);
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
@@ -61,6 +61,7 @@ public final class ActivateJobsCommandImpl
 
   private final Set<String> defaultTenantIds;
   private final Set<String> customTenantIds;
+  private final CamundaClientConfiguration config;
 
   public ActivateJobsCommandImpl(
       final GatewayStub asyncStub,
@@ -68,6 +69,7 @@ public final class ActivateJobsCommandImpl
       final CamundaClientConfiguration config,
       final JsonMapper jsonMapper,
       final Predicate<StatusCode> retryPredicate) {
+    this.config = config;
     this.asyncStub = asyncStub;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -143,7 +145,9 @@ public final class ActivateJobsCommandImpl
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     this.requestTimeout = requestTimeout;
     // increment response timeout so client doesn't time out before the server
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis() + 100, TimeUnit.MILLISECONDS);
+    final long offsetMillis = config.getDefaultActivateJobsResponseTimeoutOffset().toMillis();
+    httpRequestConfig.setResponseTimeout(
+        requestTimeout.toMillis() + offsetMillis, TimeUnit.MILLISECONDS);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
@@ -142,7 +142,8 @@ public final class ActivateJobsCommandImpl
     grpcRequestObjectBuilder.setRequestTimeout(requestTimeout.toMillis());
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     this.requestTimeout = requestTimeout;
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    // increment response timeout so client doesn't time out before the server
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis() + 100, TimeUnit.MILLISECONDS);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -16,9 +16,9 @@
 package io.camunda.client;
 
 import static io.camunda.client.ClientProperties.CLOUD_REGION;
-import static io.camunda.client.ClientProperties.DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.client.ClientProperties.GRPC_ADDRESS;
 import static io.camunda.client.ClientProperties.MAX_MESSAGE_SIZE;
@@ -106,8 +106,7 @@ public final class CamundaClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(configuration.getDefaultActivateJobsResponseTimeoutOffset())
-          .isEqualTo(Duration.ofSeconds(1));
+      assertThat(configuration.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofSeconds(1));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
@@ -1182,8 +1181,8 @@ public final class CamundaClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET})
-  public void shouldSetActivateJobsResponseTimeoutOffset(final String propertyName) {
+  @ValueSource(strings = {DEFAULT_REQUEST_TIMEOUT_OFFSET})
+  public void shouldSetRequestTimeoutOffset(final String propertyName) {
     // given
     final Properties properties = new Properties();
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
@@ -1194,7 +1193,6 @@ public final class CamundaClientTest {
     builder.build();
 
     // then
-    assertThat(builder.getDefaultActivateJobsResponseTimeoutOffset())
-        .isEqualTo(Duration.ofMillis(100));
+    assertThat(builder.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofMillis(100));
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -16,6 +16,7 @@
 package io.camunda.client;
 
 import static io.camunda.client.ClientProperties.CLOUD_REGION;
+import static io.camunda.client.ClientProperties.DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET;
 import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.client.ClientProperties.DEFAULT_TENANT_ID;
@@ -105,6 +106,8 @@ public final class CamundaClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
+      assertThat(configuration.getDefaultActivateJobsResponseTimeoutOffset())
+          .isEqualTo(Duration.ofSeconds(1));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
@@ -1176,5 +1179,22 @@ public final class CamundaClientTest {
 
     // then
     assertThat(builder.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {DEFAULT_ACTIVATE_JOBS_RESPONSE_TIMEOUT_OFFSET})
+  public void shouldSetActivateJobsResponseTimeoutOffset(final String propertyName) {
+    // given
+    final Properties properties = new Properties();
+    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
+    properties.setProperty(propertyName, "100");
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getDefaultActivateJobsResponseTimeoutOffset())
+        .isEqualTo(Duration.ofMillis(100));
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -146,6 +146,13 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
   }
 
   @Override
+  public Duration getDefaultActivateJobsResponseTimeoutOffset() {
+    return propertyOrDefault(
+        camundaClientProperties.getActivateJobsResponseTimeoutOffset(),
+        DEFAULT.getDefaultActivateJobsResponseTimeoutOffset());
+  }
+
+  @Override
   public boolean isPlaintextConnectionEnabled() {
     return plaintext;
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -146,10 +146,10 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
   }
 
   @Override
-  public Duration getDefaultActivateJobsResponseTimeoutOffset() {
+  public Duration getDefaultRequestTimeoutOffset() {
     return propertyOrDefault(
-        camundaClientProperties.getActivateJobsResponseTimeoutOffset(),
-        DEFAULT.getDefaultActivateJobsResponseTimeoutOffset());
+        camundaClientProperties.getRequestTimeoutOffset(),
+        DEFAULT.getDefaultRequestTimeoutOffset());
   }
 
   @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
@@ -75,6 +75,7 @@ public class CamundaClientProperties {
 
   private String tenantId;
   private Duration requestTimeout;
+  private Duration activateJobsResponseTimeoutOffset;
 
   public CamundaClientCloudProperties getCloud() {
     return cloud;
@@ -90,6 +91,15 @@ public class CamundaClientProperties {
 
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+  }
+
+  public Duration getActivateJobsResponseTimeoutOffset() {
+    return activateJobsResponseTimeoutOffset;
+  }
+
+  public void setActivateJobsResponseTimeoutOffset(
+      final Duration activateJobsResponseTimeoutOffset) {
+    this.activateJobsResponseTimeoutOffset = activateJobsResponseTimeoutOffset;
   }
 
   public String getTenantId() {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
@@ -75,7 +75,7 @@ public class CamundaClientProperties {
 
   private String tenantId;
   private Duration requestTimeout;
-  private Duration activateJobsResponseTimeoutOffset;
+  private Duration requestTimeoutOffset;
 
   public CamundaClientCloudProperties getCloud() {
     return cloud;
@@ -93,13 +93,12 @@ public class CamundaClientProperties {
     this.requestTimeout = requestTimeout;
   }
 
-  public Duration getActivateJobsResponseTimeoutOffset() {
-    return activateJobsResponseTimeoutOffset;
+  public Duration getRequestTimeoutOffset() {
+    return requestTimeoutOffset;
   }
 
-  public void setActivateJobsResponseTimeoutOffset(
-      final Duration activateJobsResponseTimeoutOffset) {
-    this.activateJobsResponseTimeoutOffset = activateJobsResponseTimeoutOffset;
+  public void setRequestTimeoutOffset(final Duration requestTimeoutOffset) {
+    this.requestTimeoutOffset = requestTimeoutOffset;
   }
 
   public String getTenantId() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
@@ -33,13 +33,13 @@ class ActivateJobsTest {
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withGatewayConfig(c -> c.getLongPolling().setEnabled(false));
+          .withGatewayConfig(c -> c.getLongPolling().setEnabled(true));
 
   ZeebeResourcesHelper resourcesHelper;
 
   @BeforeEach
   void initClientAndInstances() {
-    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofMillis(500)).build();
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
@@ -62,14 +62,41 @@ class ActivateJobsTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldRespondNoActivatedJobsWhenNoJobsAvailable(final boolean useRest) {
+  public void shouldReturnEmptyListOnRequestTimeout(final boolean useRest) {
     // when
-    final CamundaFuture<ActivateJobsResponse> responseFuture =
-        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send();
+    final var actual =
+        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send().join();
 
     // then
-    final ActivateJobsResponse response = responseFuture.join();
-    assertThat(response.getJobs()).isEmpty();
+    assertThat(actual.getJobs()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldReturnEmptyListOnUserDefinedGlobalRequestTimeout(final boolean useRest) {
+    // when
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(1)).build();
+    final var actual =
+        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send().join();
+
+    // then
+    assertThat(actual.getJobs()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldReturnEmptyListOnUserDefinedCommandRequestTimeout(final boolean useRest) {
+    // when
+    final var actual =
+        getCommand(client, useRest)
+            .jobType("notExisting")
+            .maxJobsToActivate(1)
+            .requestTimeout(Duration.ofSeconds(1))
+            .send()
+            .join();
+
+    // then
+    assertThat(actual.getJobs()).isEmpty();
   }
 
   private ActivateJobsCommandStep1 getCommand(final CamundaClient client, final boolean useRest) {


### PR DESCRIPTION
## Description

- Configure ActivateJobsCommand's response timeout slightly higher than the request timeout
- Add client/java property for activate jobs response timeout offset

## Related issues

closes https://github.com/camunda/camunda/issues/28466
