### PR TITLE
feat: handle `GetScaleUpProgress` in the engine

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -75,7 +75,7 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
           }
           final Set<Integer> currentlyRedistributedPartitions =
               new TreeSet<>(response.getRedistributedPartitions());
-          if (currentlyRedistributedPartitions.equals(redistributedPartitions)) {
+          if (currentlyRedistributedPartitions.containsAll(redistributedPartitions)) {
             result.complete(null);
           } else {
             final var missingPartitions = new TreeSet<>(redistributedPartitions);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -21,18 +21,26 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class BrokerClientPartitionScalingExecutorTest {
+
+  static final List<Set<Integer>> incompletePartitionList = List.of(Set.of(1, 2, 3, 4), Set.of(4));
+
+  static final List<Set<Integer>> completePartitionList =
+      List.of(Set.of(1, 2, 3, 4, 5), Set.of(4, 5));
 
   TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
   BrokerClientPartitionScalingExecutor executor;
@@ -53,10 +61,11 @@ public class BrokerClientPartitionScalingExecutorTest {
             "expected to await redistribution completion for partition count 5, but got 2");
   }
 
-  @Test
-  public void shouldFailFutureResponseWhenNotAllPartitionsAreReady() {
+  @ParameterizedTest
+  @FieldSource("incompletePartitionList")
+  public void shouldFailFutureResponseWhenNotAllPartitionsAreReady(final Set<Integer> partitions) {
     final var scaleRecord =
-        new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitionsProperty(Set.of(4));
+        new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitions(partitions);
 
     // then
     assertThat(awaitRedistributionWith(Either.right(scaleRecord)))
@@ -66,12 +75,11 @@ public class BrokerClientPartitionScalingExecutorTest {
             "Redistribution not completed yet: waiting for these partitions: [5]");
   }
 
-  @Test
-  public void shouldCompleteResponseWhenAllPartitionsAreReady() {
+  @ParameterizedTest
+  @FieldSource("completePartitionList")
+  public void shouldCompleteResponseWhenAllPartitionsAreReady(final Set<Integer> partitions) {
     final var scaleRecord =
-        new ScaleRecord()
-            .setDesiredPartitionCount(5)
-            .setRedistributedPartitionsProperty(Set.of(4, 5));
+        new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitions(partitions);
 
     // then
     assertThat(awaitRedistributionWith(Either.right(scaleRecord))).isCompleted();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -37,9 +37,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BrokerClientPartitionScalingExecutorTest {
 
-  static final List<Set<Integer>> incompletePartitionList = List.of(Set.of(1, 2, 3, 4), Set.of(4));
+  static final List<Set<Integer>> INCOMPLETE_PARTITION_LIST =
+      List.of(Set.of(1, 2, 3, 4), Set.of(4));
 
-  static final List<Set<Integer>> completePartitionList =
+  static final List<Set<Integer>> COMPLETE_PARTITION_LIST =
       List.of(Set.of(1, 2, 3, 4, 5), Set.of(4, 5));
 
   TestConcurrencyControl concurrencyControl = new TestConcurrencyControl();
@@ -62,7 +63,7 @@ public class BrokerClientPartitionScalingExecutorTest {
   }
 
   @ParameterizedTest
-  @FieldSource("incompletePartitionList")
+  @FieldSource("INCOMPLETE_PARTITION_LIST")
   public void shouldFailFutureResponseWhenNotAllPartitionsAreReady(final Set<Integer> partitions) {
     final var scaleRecord =
         new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitions(partitions);
@@ -76,7 +77,7 @@ public class BrokerClientPartitionScalingExecutorTest {
   }
 
   @ParameterizedTest
-  @FieldSource("completePartitionList")
+  @FieldSource("COMPLETE_PARTITION_LIST")
   public void shouldCompleteResponseWhenAllPartitionsAreReady(final Set<Integer> partitions) {
     final var scaleRecord =
         new ScaleRecord().setDesiredPartitionCount(5).setRedistributedPartitions(partitions);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
@@ -40,7 +40,7 @@ public class ScaleUpStatusProcessor implements TypedRecordProcessor<ScaleRecord>
       final String message =
           String.format(
               "In progress scale up number of desired partitions is %d, but desired partitions in the request are %d.",
-              request.getDesiredPartitionCount(), desiredPartitions.size());
+              desiredPartitions.size(), request.getDesiredPartitionCount());
       writers.rejection().appendRejection(command, RejectionType.INVALID_ARGUMENT, message);
       writers.response().writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, message);
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class ScaleUpStatusProcessor implements TypedRecordProcessor<ScaleRecord> {
+
+  private final Writers writers;
+  private final KeyGenerator keyGenerator;
+  private final RoutingState routingState;
+
+  public ScaleUpStatusProcessor(
+      final KeyGenerator keyGenerator, final Writers writers, final RoutingState routingState) {
+    this.keyGenerator = keyGenerator;
+    this.writers = writers;
+    this.routingState = routingState;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ScaleRecord> command) {
+    final var key = keyGenerator.nextKey();
+    final var request = command.getValue();
+    final var desiredPartitions = routingState.desiredPartitions();
+    // The desired partition count in the request can be smaller than the value in the state in case
+    // a late request is received and another scale up is in progress
+    if (request.getDesiredPartitionCount() > desiredPartitions.size()) {
+      final String message =
+          String.format(
+              "In progress scale up number of desired partitions is %d, but desired partitions in the request are %d.",
+              request.getDesiredPartitionCount(), desiredPartitions.size());
+      writers.rejection().appendRejection(command, RejectionType.INVALID_ARGUMENT, message);
+      writers.response().writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, message);
+    } else {
+      final var response = new ScaleRecord();
+      response
+          .setDesiredPartitionCount(desiredPartitions.size())
+          .setRedistributedPartitions(routingState.currentPartitions());
+      writers.state().appendFollowUpEvent(key, ScaleIntent.STATUS_RESPONSE, response);
+      writers.response().writeEventOnCommand(key, ScaleIntent.STATUS_RESPONSE, response, command);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusResponseApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusResponseApplier.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+
+public class ScaleUpStatusResponseApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+
+  @Override
+  public void applyState(final long key, final ScaleRecord value) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -34,6 +34,10 @@ public final class ScalingProcessors {
         ScaleIntent.SCALE_UP,
         new ScaleUpProcessor(keyGenerator, writers, processingState));
     typedRecordProcessors.onCommand(
+        ValueType.SCALE,
+        ScaleIntent.STATUS,
+        new ScaleUpStatusProcessor(keyGenerator, writers, processingState.getRoutingState()));
+    typedRecordProcessors.onCommand(
         ValueType.REDISTRIBUTION,
         RedistributionIntent.START,
         new RedistributionStartProcessor(redistributionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.scaling.ScaleUpStatusResponseApplier;
 import io.camunda.zeebe.engine.scaling.ScaledUpApplier;
 import io.camunda.zeebe.engine.scaling.ScalingUpApplier;
 import io.camunda.zeebe.engine.scaling.redistribution.RedistributionCompletedApplier;
@@ -567,6 +568,7 @@ public final class EventAppliers implements EventApplier {
   private void registerScalingAppliers(final MutableProcessingState state) {
     register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
     register(ScaleIntent.SCALED_UP, new ScaledUpApplier(state.getRoutingState()));
+    register(ScaleIntent.STATUS_RESPONSE, new ScaleUpStatusResponseApplier());
     register(RedistributionIntent.STARTED, new RedistributionStartedApplier(state));
     register(RedistributionIntent.CONTINUED, new RedistributionContinuedApplier(state));
     register(RedistributionIntent.COMPLETED, new RedistributionCompletedApplier(state));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -22,10 +22,12 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
@@ -219,6 +221,70 @@ public class ScaleUpTest {
                 .map(Record::getKey)
                 .limit(2))
         .containsExactly(deploymentKey1, deploymentKey2);
+  }
+
+  @Test
+  public void shouldRejectScaleUpStatusCommandWhenDesiredPartitionCountIsWrong() {
+    // given
+    initRoutingState();
+
+    final var command =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.STATUS,
+                new ScaleRecord()
+                    .setDesiredPartitionCount(4)
+                    .setRedistributedPartitions(List.of(4)));
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    assertThat(
+            RecordingExporter.scaleRecords()
+                .filter(r -> r.getRecordType() == RecordType.COMMAND_REJECTION))
+        .hasSize(1)
+        .allSatisfy(
+            r -> {
+              assertThat(r.getIntent()).isEqualTo(ScaleIntent.STATUS);
+              assertThat(r.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+              assertThat(r.getRejectionReason()).contains("desired partition count");
+            });
+  }
+
+  @Test
+  public void shouldRespondWithTheCurrentNumberOfRedistributedPartitions() {
+    // given
+    initRoutingState();
+
+    final var scaleUpCommand =
+        RecordToWrite.command()
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(4));
+
+    final var getStatusCommand =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.STATUS,
+                new ScaleRecord()
+                    .setDesiredPartitionCount(4)
+                    .setRedistributedPartitions(List.of(4)));
+    // when
+    engine.writeRecords(scaleUpCommand, getStatusCommand);
+
+    // then
+
+    assertThat(
+            RecordingExporter.scaleRecords()
+                .filter(r -> r.getIntent() == ScaleIntent.STATUS_RESPONSE))
+        .hasSize(1)
+        .allSatisfy(
+            r -> {
+              assertThat(r.getValue().getRedistributedPartitions())
+                  // NOTE: currently scaling up is immediate as it's implemented as noop.
+                  // In the future, the expected number of partitions should be (1,2,3)
+                  // until redistribution is completed
+                  .containsExactlyInAnyOrder(1, 2, 3, 4);
+            });
   }
 
   private void initRoutingState() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/GetScaleUpProgress.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/GetScaleUpProgress.java
@@ -19,10 +19,18 @@ public class GetScaleUpProgress extends BrokerExecuteCommand<ScaleRecord> {
 
   private final ScaleRecord requestDto = new ScaleRecord();
 
-  public GetScaleUpProgress(final int desiredPartitionCount) {
-    super(ValueType.SCALE, ScaleIntent.SCALE_UP);
-    requestDto.setDesiredPartitionCount(desiredPartitionCount);
+  public GetScaleUpProgress() {
+    super(ValueType.SCALE, ScaleIntent.STATUS);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  public GetScaleUpProgress(final int desiredPartitionCount) {
+    this();
+    setDesiredPartitionCount(desiredPartitionCount);
+  }
+
+  public void setDesiredPartitionCount(final int desiredPartitionCount) {
+    requestDto.setDesiredPartitionCount(desiredPartitionCount);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -54,18 +54,18 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
     return relocatedPartitions.stream().map(IntegerValue::getValue).toList();
   }
 
-  public ScaleRecord setRedistributedPartitionsProperty(final Collection<Integer> partitions) {
-    redistributedPartitions.reset();
+  public ScaleRecord setRelocatedPartitions(final Collection<Integer> partitions) {
+    relocatedPartitions.reset();
     for (final int partition : partitions) {
-      redistributedPartitions.add().setValue(partition);
+      relocatedPartitions.add().setValue(partition);
     }
     return this;
   }
 
-  public ScaleRecord setRelocatedPartitionsProperty(final Collection<Integer> partitions) {
-    relocatedPartitions.reset();
+  public ScaleRecord setRedistributedPartitions(final Collection<Integer> partitions) {
+    redistributedPartitions.reset();
     for (final int partition : partitions) {
-      relocatedPartitions.add().setValue(partition);
+      redistributedPartitions.add().setValue(partition);
     }
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2935,8 +2935,8 @@ final class JsonSerializableToJsonTest {
             () ->
                 new ScaleRecord()
                     .setDesiredPartitionCount(5)
-                    .setRelocatedPartitionsProperty(List.of(4, 5))
-                    .setRedistributedPartitionsProperty(List.of(4, 5)),
+                    .setRelocatedPartitions(List.of(4, 5))
+                    .setRedistributedPartitions(List.of(4, 5)),
         """
         {
          "desiredPartitionCount": 5,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
@@ -26,7 +26,7 @@ public enum RedistributionIntent implements Intent {
   COMPLETED((short) 6, true);
 
   // A static field is needed as values() would allocate at every call
-  private static final RedistributionIntent[] intents = values();
+  private static final RedistributionIntent[] INTENTS = values();
 
   private final short value;
   private final boolean isEvent;
@@ -48,7 +48,7 @@ public enum RedistributionIntent implements Intent {
 
   public static Intent from(final short intent) {
     try {
-      return intents[intent - 1];
+      return INTENTS[intent - 1];
     } catch (final ArrayIndexOutOfBoundsException e) {
       return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
@@ -25,6 +25,9 @@ public enum RedistributionIntent implements Intent {
   COMPLETE((short) 5, false),
   COMPLETED((short) 6, true);
 
+  // A static field is needed as values() would allocate at every call
+  private static final RedistributionIntent[] intents = values();
+
   private final short value;
   private final boolean isEvent;
 
@@ -44,21 +47,10 @@ public enum RedistributionIntent implements Intent {
   }
 
   public static Intent from(final short intent) {
-    switch (intent) {
-      case 1:
-        return START;
-      case 2:
-        return STARTED;
-      case 3:
-        return CONTINUE;
-      case 4:
-        return CONTINUED;
-      case 5:
-        return COMPLETE;
-      case 6:
-        return COMPLETED;
-      default:
-        return Intent.UNKNOWN;
+    try {
+      return intents[intent - 1];
+    } catch (final ArrayIndexOutOfBoundsException e) {
+      return Intent.UNKNOWN;
     }
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
@@ -25,7 +25,7 @@ public enum ScaleIntent implements Intent {
   STATUS_RESPONSE((short) 5, true);
 
   // A static field is needed as values() would allocate at every call
-  private static final ScaleIntent[] intents = values();
+  private static final ScaleIntent[] INTENTS = values();
   private final short value;
   private final boolean isEvent;
 
@@ -46,7 +46,7 @@ public enum ScaleIntent implements Intent {
 
   public static Intent from(final short intent) {
     try {
-      return intents[intent - 1];
+      return INTENTS[intent - 1];
     } catch (final ArrayIndexOutOfBoundsException e) {
       return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
@@ -20,8 +20,12 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 public enum ScaleIntent implements Intent {
   SCALE_UP((short) 1, false),
   SCALING_UP((short) 2, true),
-  SCALED_UP((short) 3, true);
+  SCALED_UP((short) 3, true),
+  STATUS((short) 4, false),
+  STATUS_RESPONSE((short) 5, true);
 
+  // A static field is needed as values() would allocate at every call
+  private static final ScaleIntent[] intents = values();
   private final short value;
   private final boolean isEvent;
 
@@ -41,15 +45,10 @@ public enum ScaleIntent implements Intent {
   }
 
   public static Intent from(final short intent) {
-    switch (intent) {
-      case 1:
-        return SCALE_UP;
-      case 2:
-        return SCALING_UP;
-      case 3:
-        return SCALED_UP;
-      default:
-        return Intent.UNKNOWN;
+    try {
+      return intents[intent - 1];
+    } catch (final ArrayIndexOutOfBoundsException e) {
+      return Intent.UNKNOWN;
     }
   }
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -18,6 +18,8 @@ package io.camunda.zeebe.protocol.record.intent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -78,6 +80,8 @@ final class IntentEncodingDecodingTest {
         buildParameterSets(SignalSubscriptionIntent.class, SignalSubscriptionIntent::from));
     result.addAll(buildParameterSets(ClockIntent.class, ClockIntent::from));
     result.addAll(buildParameterSets(TenantIntent.class, TenantIntent::from));
+    result.addAll(buildParameterSets(ScaleIntent.class, ScaleIntent::from));
+    result.addAll(buildParameterSets(RedistributionIntent.class, RedistributionIntent::from));
 
     return result.stream();
   }


### PR DESCRIPTION
## Description
The engine will now handle `ScaleRecord` related to the `BrokerRequest` `GetScaleUpProgress`, which comes with `ScalingIntent.STATUS`.

A small refactoring on `ScalingIntent#from` and `RedistributionIntent#from` so that whenever a new intent is added, there is no need to change that function. 
I added those two enums to a test suite that verifies that `from(int i)` and `value()` are consistent.


## Related issues
closes #31686
