### PR TITLE
fix: handle listener errors in direct broker mode

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.tasklist.webapp.es;
 
-import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_ALREADY_ASSIGNED;
-import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_IS_NOT_ACTIVE;
-import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED;
-import static io.camunda.tasklist.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED_TO_CURRENT_USER;
-import static io.camunda.tasklist.util.ErrorHandlingUtils.createErrorMessage;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.TASK_ALREADY_ASSIGNED;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.TASK_IS_NOT_ACTIVE;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.TASK_NOT_ASSIGNED_TO_CURRENT_USER;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.createErrorMessage;
 
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.dto.UserDTO;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.service;
 
-import static io.camunda.tasklist.util.ErrorHandlingUtils.getErrorMessage;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessage;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.service;
 
-import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessage;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessageFromClientException;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
@@ -76,7 +76,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
       try {
         camundaClient.newUserTaskAssignCommand(task.getKey()).assignee(assignee).send().join();
       } catch (final ClientException exception) {
-        throw new TasklistRuntimeException(getErrorMessage(exception));
+        throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));
       }
     }
   }
@@ -92,7 +92,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
       try {
         camundaClient.newUserTaskUnassignCommand(task.getKey()).send().join();
       } catch (final ClientException exception) {
-        throw new TasklistRuntimeException(getErrorMessage(exception));
+        throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));
       }
     }
   }
@@ -111,7 +111,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
         camundaClient.newUserTaskCompleteCommand(task.getKey()).variables(variables).send().join();
       }
     } catch (final ClientException exception) {
-      throw new TasklistRuntimeException(getErrorMessage(exception));
+      throw new TasklistRuntimeException(getErrorMessageFromClientException(exception));
     }
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.service;
 
-import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessage;
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessageFromBrokerException;
 
 import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.security.auth.Authentication;
@@ -268,6 +268,6 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
         return new ForbiddenActionException("Process not found", exception);
       }
     }
-    return new TasklistRuntimeException(getErrorMessage(exception));
+    return new TasklistRuntimeException(getErrorMessageFromBrokerException(exception));
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaServicesBasedAdapter.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.webapp.service;
 
+import static io.camunda.tasklist.webapp.util.ErrorHandlingUtils.getErrorMessage;
+
 import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.JobServices;
@@ -266,7 +268,6 @@ public class CamundaServicesBasedAdapter implements TasklistServicesAdapter {
         return new ForbiddenActionException("Process not found", exception);
       }
     }
-    return new TasklistRuntimeException(
-        String.format("Failed to execute request with %s", exception.getMessage()), exception);
+    return new TasklistRuntimeException(getErrorMessage(exception));
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtils.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtils.java
@@ -59,6 +59,7 @@ public abstract class ErrorHandlingUtils {
   public static boolean isCausedByTimeoutException(final Throwable throwable) {
     return throwable != null
         && (throwable.getCause() instanceof TimeoutException
-            || throwable.getCause().getCause() instanceof java.net.SocketTimeoutException);
+            || throwable.getCause() != null
+                && throwable.getCause().getCause() instanceof java.net.SocketTimeoutException);
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtilsTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/util/ErrorHandlingUtilsTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist.util;
+package io.camunda.tasklist.webapp.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request fixes [#27846](https://github.com/camunda/camunda/issues/27846), where the Tasklist UI incorrectly displayed a generic service unreachable message when task assignment or completion failed or was delayed due to task listeners.

### Background

The original implementation correctly handled task listener errors (e.g., task rejections or delays) when communication with Zeebe occurred via the gateway. In that case, errors returned from Zeebe were properly propagated to the Tasklist UI as meaningful messages like _task cannot be completed_ or _task assignment delayed_.
However, when Tasklist communicates directly with the broker, the same error scenarios were not handled. Instead, the UI displayed a misleading service unreachable message, even when the underlying issue was a task listener rejecting or delaying the action.

### Fix

This update ensures that task listener responses received via direct broker communication are handled in the same way as those received via the gateway. Now, when the broker returns a task listener-related error, the UI presents a clear and accurate message to the user, rather than a generic service error.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27846
