### PR TITLE
chore: upgrade springboot to 3.3.11 to resolve CVE-2025-31650

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.10</version>
+    <version>3.3.11</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Description

[CVE-2025-31650](https://cve-registry.infosec.camunda-it.rocks/finding/7071) is resolved by bumping Apache Tomcat to 10.1.40. This is similar to what was done for [8.4](https://github.com/camunda/operate/pull/6874).

```
[INFO] |  +- org.springframework.boot:spring-boot-starter-web:jar:3.3.10:compile
…
[INFO] |  |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:3.3.10:compile
```
Since that is a transitive dependency brought in by spring-boot-starter-web we'd need to bump that and bumping it to 3.3.11 seems to be doing the trick.
```
[INFO] |  +- org.springframework.boot:spring-boot-starter-web:jar:3.3.11:compile
…
[INFO] |  |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:3.3.11:compile
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/31703
