### PR TITLE
Search groups by tenantId

### DIFF
--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -13,6 +13,9 @@
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.GroupDbQuery">
     SELECT COUNT(*)
     FROM ${prefix}GROUPS g
+    <if test="filter.tenantId != null">
+      JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
+    </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
   </select>
 
@@ -29,6 +32,9 @@
     gm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}GROUPS g
     LEFT JOIN ${prefix}GROUP_MEMBER gm ON g.GROUP_ID = gm.GROUP_ID
+    <if test="filter.tenantId != null">
+      JOIN ${prefix}TENANT_MEMBER tm ON g.GROUP_ID = tm.ENTITY_ID AND tm.ENTITY_TYPE = 'GROUP'
+    </if>
     <include refid="io.camunda.db.rdbms.sql.GroupMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -41,6 +47,7 @@
     <if test="filter.groupKey != null">AND g.GROUP_KEY = #{filter.groupKey}</if>
     <if test="filter.groupId != null">AND g.GROUP_ID = #{filter.groupId}</if>
     <if test="filter.name != null">AND g.NAME = #{filter.name}</if>
+    <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
   </sql>
 
   <resultMap id="groupResultMap" type="io.camunda.db.rdbms.write.domain.GroupDbModel">

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -51,6 +51,9 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
             ? term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType())
             : hasParentQuery(
                 IdentityJoinRelationshipType.GROUP.getType(),
-                term(GROUP_ID, filter.joinParentId())));
+                term(GROUP_ID, filter.joinParentId())),
+        filter.groupIds() == null
+            ? null
+            : filter.groupIds().isEmpty() ? matchNone() : stringTerms(GROUP_ID, filter.groupIds()));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -18,8 +18,23 @@ public record GroupFilter(
     String description,
     String joinParentId,
     Set<String> memberIds,
-    EntityType memberType)
+    EntityType memberType,
+    String tenantId,
+    Set<String> groupIds)
     implements FilterBase {
+
+  public Builder toBuilder() {
+    return new Builder()
+        .groupKey(groupKey)
+        .groupId(groupId)
+        .name(name)
+        .description(description)
+        .joinParentId(joinParentId)
+        .memberIds(memberIds)
+        .memberType(memberType)
+        .tenantId(tenantId)
+        .groupIds(groupIds);
+  }
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
     private Long groupKey;
@@ -29,6 +44,8 @@ public record GroupFilter(
     private String joinParentId;
     private Set<String> memberIds;
     private EntityType memberType;
+    private String tenantId;
+    private Set<String> groupIds;
 
     public Builder groupKey(final Long value) {
       groupKey = value;
@@ -69,10 +86,28 @@ public record GroupFilter(
       return this;
     }
 
+    public Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
+    public Builder groupIds(final Set<String> value) {
+      groupIds = value;
+      return this;
+    }
+
     @Override
     public GroupFilter build() {
       return new GroupFilter(
-          groupKey, groupId, name, description, joinParentId, memberIds, memberType);
+          groupKey,
+          groupId,
+          name,
+          description,
+          joinParentId,
+          memberIds,
+          memberType,
+          tenantId,
+          groupIds);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/GroupQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/GroupQuery.java
@@ -23,6 +23,10 @@ public record GroupQuery(GroupFilter filter, GroupSort sort, SearchQueryPage pag
     return fn.apply(new GroupQuery.Builder()).build();
   }
 
+  public Builder toBuilder() {
+    return new Builder().filter(filter).sort(sort).page(page);
+  }
+
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<GroupQuery.Builder>
       implements TypedSearchQueryBuilder<GroupQuery, GroupQuery.Builder, GroupFilter, GroupSort> {
     private static final GroupFilter EMPTY_FILTER = FilterBuilders.group().build();

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -563,6 +563,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserSearchResult"
+  /tenants/{tenantId}/groups/search:
+    post:
+      tags:
+        - Tenant
+      operationId: searchGroupsForTenant
+      summary: Search groups for tenant
+      description: Retrieves a filtered and sorted list of groups for a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupSearchQueryRequest"
+      responses:
+        "200":
+          description: The search result of groups for the tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupSearchQueryResult"
   /tenants/{tenantId}/applications/{applicationId}:
     put:
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7242,11 +7242,6 @@ components:
         description:
           type: string
           description: The group description.
-        assignedMemberIds:
-          type: array
-          description: The IDs of members assigned to the group.
-          items:
-            type: string
     GroupSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
@@ -47,10 +48,9 @@ public class TenantControllerTest extends RestControllerTest {
   private static final String TENANT_BASE_URL = "/v2/tenants";
 
   @MockBean private TenantServices tenantServices;
-
   @MockBean private UserServices userServices;
-
   @MockBean private MappingServices mappingServices;
+  @MockBean private GroupServices groupServices;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -243,7 +243,6 @@ public class GroupQueryControllerTest extends RestControllerTest {
               "groupId": "%s",
               "name": "%s",
               "description": "%s",
-              "assignedMemberIds": []
             }"""
                 .formatted(groupKey, groupId, groupName, groupDescription));
 
@@ -333,22 +332,19 @@ public class GroupQueryControllerTest extends RestControllerTest {
                  "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
-                 "description": "%s",
-                 "assignedMemberIds": []
+                 "description": "%s"
                },
                {
                  "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
-                 "description": "%s",
-                 "assignedMemberIds": []
+                 "description": "%s"
                },
                {
                  "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
-                 "description": "%s",
-                 "assignedMemberIds": []
+                 "description": "%s"
                }
              ],
              "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -239,10 +239,10 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "groupKey": "%d",
+              "groupKey": "%s",
               "groupId": "%s",
               "name": "%s",
-              "description": "%s",
+              "description": "%s"
             }"""
                 .formatted(groupKey, groupId, groupName, groupDescription));
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds an endpoint `/tenants/{tenantId}/groups/search` to search groups by a given tenantId

## Related issues

closes #31747 
