### PR TITLE
fix: re-add removed resource type for backwards-compatibility #30935

### DIFF
--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -18,6 +18,7 @@ public enum AuthorizationResourceType {
   MAPPING_RULE(
       PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   MESSAGE(PermissionType.CREATE, PermissionType.READ),
+  BATCH(PermissionType.CREATE, PermissionType.READ, PermissionType.DELETE), // deprecated
   APPLICATION(PermissionType.ACCESS),
   SYSTEM(PermissionType.READ, PermissionType.UPDATE),
   TENANT(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),


### PR DESCRIPTION
## Description

Fixes non-backwards-compatible removal of the `AuthorizationResourceType.BATCH` enum value.

## Related issues

relates to #30935 
