### PR TITLE
ci: creation of the issue migration labeler GHA

### DIFF
--- a/.github/workflows/migration-labeler.yml
+++ b/.github/workflows/migration-labeler.yml
@@ -1,3 +1,4 @@
+# owner: @vheinila
 name: Issue Migration Labeler
 
 on:

--- a/.github/workflows/migration-labeler.yml
+++ b/.github/workflows/migration-labeler.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label migrated issues
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/migration-labeler.yml
+++ b/.github/workflows/migration-labeler.yml
@@ -1,0 +1,66 @@
+name: Issue Migration Labeler
+
+on:
+  workflow_dispatch:
+    
+jobs:
+  label_migrated_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label migrated issues
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Define labeling schemes as an array of objects
+            const labelingSchemes = [
+              {
+                labelsToCheck: ['component:frontend'],
+                labelToAdd: 'component/frontend',
+              },
+              {
+                labelsToCheck: ['easy-pick'],
+                labelToAdd: 'good first issue',
+              },
+              {
+                labelsToCheck: ['technical-debt'],
+                labelToAdd: 'tech-dept',
+              },
+              // Add more labeling schemes here if needed (Current setup is for Operate)
+            ];
+
+            // Function to add labels to issues
+            async function addLabelToIssues(labelingScheme) {
+              for (const label of labelingScheme.labelsToCheck) {
+                let page = 1;
+                let batch;
+
+                do {
+                  batch = await github.rest.issues.listForRepo({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: label,
+                    state: 'open',
+                    per_page: 100,
+                    page: page
+                  });
+
+                  for (const issue of batch.data) {
+                    if (!issue.labels.some(issueLabel => issueLabel.name === labelingScheme.labelToAdd)) {
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        labels: [labelingScheme.labelToAdd]
+                      });
+                    }
+                  }
+                  page++;
+                } while (batch.data.length === 100);
+              }
+            }
+
+            // Process each labeling scheme
+            for (const labelingScheme of labelingSchemes) {
+              await addLabelToIssues(labelingScheme);
+            }

--- a/.github/workflows/migration-labeler.yml
+++ b/.github/workflows/migration-labeler.yml
@@ -1,6 +1,10 @@
 # owner: @vheinila
 name: Issue Migration Labeler
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   workflow_dispatch:
     


### PR DESCRIPTION
## Description

Creation of the issue migration labeler to unify labeling for issues migrated from other repositories. This script is run manually once issues from a repository has been migrated.

This GHA script is needed for the [Central Public issue tracker project](https://github.com/camunda/engineering-leadership-team/issues/216) to make the labeling uniform for issues from other repositories.

The initial setup for this script is to unify labels transferred from [Operate repository](https://github.com/camunda/operate). This script needs to be amended for the other repositories once they are migrated.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
