### PR TITLE
fix: force flush moved snapshots

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.snapshots.impl;
 
 import static io.camunda.zeebe.util.FileUtil.deleteFolder;
 import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -671,7 +673,11 @@ public final class FileBasedSnapshotStoreImpl {
       final String name, final Path source, final Path targetDirectory) {
     final var targetFilePath = targetDirectory.resolve(name);
     try {
-      Files.move(source, targetFilePath);
+      try {
+        Files.move(source, targetFilePath, ATOMIC_MOVE);
+      } catch (final AtomicMoveNotSupportedException e) {
+        Files.move(source, targetFilePath);
+      }
       FileUtil.flush(targetFilePath);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -633,7 +633,6 @@ public final class FileBasedSnapshotStoreImpl {
                 () ->
                     new IllegalArgumentException(
                         "Failed to parse snapshot id %s".formatted(snapshotId)));
-    final var checksumPath = buildSnapshotsChecksumPath(parsedSnapshotId);
     final var snapshotPath = buildSnapshotDirectory(parsedSnapshotId);
     ensureDirectoryExists(snapshotPath);
 
@@ -642,7 +641,7 @@ public final class FileBasedSnapshotStoreImpl {
     final var snapshotFileNames = snapshotFiles.keySet();
     snapshotFileNames.stream()
         .filter(name -> !isChecksumFile(name))
-        .forEach(name -> copyNamedFileToDirectory(name, snapshotFiles.get(name), snapshotPath));
+        .forEach(name -> moveNamedFileToDirectory(name, snapshotFiles.get(name), snapshotPath));
 
     final var checksumFile =
         snapshotFileNames.stream()
@@ -651,7 +650,8 @@ public final class FileBasedSnapshotStoreImpl {
             .map(snapshotFiles::get)
             .orElseThrow();
 
-    Files.copy(checksumFile, checksumPath);
+    moveNamedFileToDirectory(
+        checksumFile.getFileName().toString(), checksumFile, snapshotsDirectory);
 
     // Flush directory of this snapshot as well as root snapshot directory
     FileUtil.flushDirectory(snapshotPath);
@@ -667,11 +667,12 @@ public final class FileBasedSnapshotStoreImpl {
     }
   }
 
-  private void copyNamedFileToDirectory(
+  private void moveNamedFileToDirectory(
       final String name, final Path source, final Path targetDirectory) {
     final var targetFilePath = targetDirectory.resolve(name);
     try {
       Files.move(source, targetFilePath);
+      FileUtil.flush(targetFilePath);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -677,8 +677,8 @@ public final class FileBasedSnapshotStoreImpl {
         Files.move(source, targetFilePath, ATOMIC_MOVE);
       } catch (final AtomicMoveNotSupportedException e) {
         Files.move(source, targetFilePath);
+        FileUtil.flush(targetFilePath);
       }
-      FileUtil.flush(targetFilePath);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Flush snapshot files after moving
- Instead of copying `checksum` file move it as well
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28407
