### PR TITLE
deps: fix CVE-2025-31650 in main

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -103,7 +103,7 @@
     <version.rest-assured>5.5.1</version.rest-assured>
     <version.spring>6.2.3</version.spring>
     <version.spring-security>6.4.4</version.spring-security>
-    <version.spring-boot>3.4.3</version.spring-boot>
+    <version.spring-boot>3.4.5</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

I recently had to investigate a fix for the CVE https://cve-registry.infosec.camunda-it.rocks/finding/7076 in the monorepo.

We needed to bump the Tomcat version to an unaffected version. The fix for this in Tasklist 8.4/[8.5](https://github.com/camunda/tasklist/pull/5168) was to bump the spring boot version as it was bringing in Tomcat as a transitive dependency.

The vulnerability existed in 8.7 but renovate resolved it unknowingly with [this PR](https://github.com/camunda/camunda/pull/31479). Since `stable/8.7` uses Spring Boot `3.4.5` I thought it would be good to bump that version on `main` too, which should also address the aforementioned vulnerability.

With Spring Boot 3.4.3

```
[INFO] --- dependency:3.8.1:tree (default-cli) @ zeebe-gateway-rest ---
[INFO] io.camunda:zeebe-gateway-rest:jar:8.8.0-SNAPSHOT
[INFO] \- org.springframework.boot:spring-boot-starter-web:jar:3.4.3:test
[INFO]    \- org.springframework.boot:spring-boot-starter-tomcat:jar:3.4.3:test
[INFO]       \- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.36:test
```
You can see in https://cve-registry.infosec.camunda-it.rocks/finding/7076 that `10.1.36` is an affected version.

With Spring Boot 3.4.5

```
[INFO] --- dependency:3.8.1:tree (default-cli) @ zeebe-gateway-rest ---
[INFO] io.camunda:zeebe-gateway-rest:jar:8.8.0-SNAPSHOT
[INFO] \- org.springframework.boot:spring-boot-starter-web:jar:3.4.5:test
[INFO]    \- org.springframework.boot:spring-boot-starter-tomcat:jar:3.4.5:test
[INFO]       \- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.40:test
```

You can see in https://cve-registry.infosec.camunda-it.rocks/finding/7076 that `10.1.40` is not an affected version.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/31830
