### PR TITLE
feat: check SaaS token claims

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/AudienceValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/AudienceValidator.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.authentication.config;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +41,7 @@ final class AudienceValidator implements OAuth2TokenValidator<Jwt> {
 
   @Override
   public OAuth2TokenValidatorResult validate(final Jwt token) {
-    final var tokenAudiences = token.getAudience();
+    final var tokenAudiences = Objects.requireNonNullElse(token.getAudience(), List.<String>of());
 
     // Iterate over token audiences first, usually there is only one
     for (final var tokenAudience : tokenAudiences) {

--- a/authentication/src/main/java/io/camunda/authentication/config/ClusterValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClusterValidator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class ClusterValidator implements OAuth2TokenValidator<Jwt> {
+  static final String CLUSTER_CLAIM_KEY = "https://camunda.com/clusterId";
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterValidator.class);
+
+  private final String clusterId;
+
+  public ClusterValidator(final String clusterId) {
+    this.clusterId = Objects.requireNonNull(clusterId, "clusterId must not be null");
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var claimValue = token.getClaims().get(CLUSTER_CLAIM_KEY);
+
+    if (claimValue == null) {
+      // Not all tokens contain a cluster id claim, only validate those that do.
+      return OAuth2TokenValidatorResult.success();
+    }
+
+    if (clusterId.equals(claimValue)) {
+      return OAuth2TokenValidatorResult.success();
+    }
+
+    LOG.debug("Rejected token with cluster id '{}', expected {}", claimValue, clusterId);
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Token claims cluster id %s, expected %s".formatted(claimValue, clusterId),
+            null));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OrganizationValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OrganizationValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class OrganizationValidator implements OAuth2TokenValidator<Jwt> {
+
+  static final String ORGANIZATION_CLAIM_KEY = "https://camunda.com/orgs";
+  private static final Logger LOG = LoggerFactory.getLogger(OrganizationValidator.class);
+  private final String organizationId;
+
+  public OrganizationValidator(final String organizationId) {
+    this.organizationId = Objects.requireNonNull(organizationId, "organizationId must not be null");
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var claimValue = token.getClaims().get(ORGANIZATION_CLAIM_KEY);
+    if (claimValue instanceof final Collection<?> claimedOrgs) {
+      for (final Object claimedOrg : claimedOrgs) {
+        if (claimedOrg instanceof final Map<?, ?> orgDetails) {
+          if (organizationId.equals(orgDetails.get("id"))) {
+            return OAuth2TokenValidatorResult.success();
+          }
+        }
+      }
+    }
+
+    LOG.debug("Rejected token with organizations '{}', expected {}", claimValue, organizationId);
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Token claims organizations %s, expected %s".formatted(claimValue, organizationId),
+            null));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/OrganizationValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OrganizationValidator.java
@@ -31,6 +31,11 @@ public class OrganizationValidator implements OAuth2TokenValidator<Jwt> {
   @Override
   public OAuth2TokenValidatorResult validate(final Jwt token) {
     final var claimValue = token.getClaims().get(ORGANIZATION_CLAIM_KEY);
+    if (claimValue == null) {
+      // Not all tokens contain an organization claim, only validate those that do.
+      return OAuth2TokenValidatorResult.success();
+    }
+
     if (claimValue instanceof final Collection<?> claimedOrgs) {
       for (final Object claimedOrg : claimedOrgs) {
         if (claimedOrg instanceof final Map<?, ?> orgDetails) {

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -24,7 +24,6 @@ import io.camunda.service.UserServices;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,12 +42,15 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
@@ -281,6 +283,15 @@ public class WebSecurityConfig {
         final SecurityConfiguration securityConfiguration) {
       return new InMemoryClientRegistrationRepository(
           OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
+    }
+
+    @Bean
+    public JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory(
+        final SecurityConfiguration securityConfiguration) {
+      final var decoderFactory = new OidcIdTokenDecoderFactory();
+      decoderFactory.setJwtValidatorFactory(
+          registration -> getTokenValidator(securityConfiguration.getAuthentication().getOidc()));
+      return decoderFactory;
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -319,6 +319,7 @@ public class WebSecurityConfig {
       }
       if (configuration.getSaas().isConfigured()) {
         validators.add(new OrganizationValidator(configuration.getSaas().getOrganizationId()));
+        validators.add(new ClusterValidator(configuration.getSaas().getClusterId()));
       }
 
       if (!validators.isEmpty()) {

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterValidatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static io.camunda.authentication.config.ClusterValidator.CLUSTER_CLAIM_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+final class ClusterValidatorTest {
+
+  @Test
+  void shouldThrowExceptionWhenClusterIdIsNull() {
+    // when/then
+    assertThatThrownBy(() -> new ClusterValidator(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("clusterId must not be null");
+  }
+
+  @Test
+  void shouldValidateTokenWithMatchingClusterId() {
+    // given
+    final var clusterId = "valid-cluster-id";
+    final var validator = new ClusterValidator(clusterId);
+    final var token = createJwtWithCluster(clusterId);
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldValidateTokenWithNoClusterClaim() {
+    // given
+    final var clusterId = "valid-cluster-id";
+    final var validator = new ClusterValidator(clusterId);
+    final var token = createJwtWithoutClusterClaim();
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldRejectTokenWithNonMatchingClusterId() {
+    // given
+    final var clusterId = "valid-cluster-id";
+    final var validator = new ClusterValidator(clusterId);
+    final var token = createJwtWithCluster("invalid-cluster-id");
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription())
+        .contains("Token claims cluster id")
+        .contains("expected " + clusterId);
+  }
+
+  private static Jwt createJwtWithCluster(final String clusterId) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of(CLUSTER_CLAIM_KEY, clusterId));
+  }
+
+  private static Jwt createJwtWithoutClusterClaim() {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of("sub", "user"));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OrganizationValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OrganizationValidatorTest.java
@@ -81,7 +81,7 @@ final class OrganizationValidatorTest {
   }
 
   @Test
-  void shouldRejectTokenWithNoOrganizationClaim() {
+  void shouldValidateTokenWithNoOrganizationClaim() {
     // given
     final var organizationId = "valid-org-id";
     final var validator = new OrganizationValidator(organizationId);
@@ -91,16 +91,7 @@ final class OrganizationValidatorTest {
     final var result = validator.validate(token);
 
     // then
-    assertThat(result.hasErrors()).isTrue();
-
-    final var errors = result.getErrors();
-    assertThat(errors).hasSize(1);
-
-    final var error = errors.iterator().next();
-    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
-    assertThat(error.getDescription())
-        .contains("Token claims organizations")
-        .contains("expected " + organizationId);
+    assertThat(result.hasErrors()).isFalse();
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/OrganizationValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OrganizationValidatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static io.camunda.authentication.config.OrganizationValidator.ORGANIZATION_CLAIM_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+final class OrganizationValidatorTest {
+
+  @Test
+  void shouldThrowExceptionWhenOrganizationIdIsNull() {
+    // when/then
+    assertThatThrownBy(() -> new OrganizationValidator(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("organizationId must not be null");
+  }
+
+  @Test
+  void shouldValidateTokenWithMatchingOrganizationId() {
+    // given
+    final var organizationId = "valid-org-id";
+    final var validator = new OrganizationValidator(organizationId);
+    final var token = createJwtWithOrganization(organizationId);
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldValidateTokenWithMatchingOrganizationIdAmongMany() {
+    // given
+    final var organizationId = "valid-org-id";
+    final var validator = new OrganizationValidator(organizationId);
+    final var token =
+        createJwtWithMultipleOrganizations(List.of("other-org-id", organizationId, "third-org-id"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldRejectTokenWithNoMatchingOrganizationId() {
+    // given
+    final var organizationId = "valid-org-id";
+    final var validator = new OrganizationValidator(organizationId);
+    final var token = createJwtWithOrganization("invalid-org-id");
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription())
+        .contains("Token claims organizations")
+        .contains("expected " + organizationId);
+  }
+
+  @Test
+  void shouldRejectTokenWithNoOrganizationClaim() {
+    // given
+    final var organizationId = "valid-org-id";
+    final var validator = new OrganizationValidator(organizationId);
+    final var token = createJwtWithoutOrganizationClaim();
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription())
+        .contains("Token claims organizations")
+        .contains("expected " + organizationId);
+  }
+
+  @Test
+  void shouldRejectTokenWithInvalidOrganizationClaimFormat() {
+    // given
+    final var organizationId = "valid-org-id";
+    final var validator = new OrganizationValidator(organizationId);
+    final var token = createJwtWithInvalidOrganizationFormat();
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription())
+        .contains("Token claims organizations")
+        .contains("expected " + organizationId);
+  }
+
+  private static Jwt createJwtWithOrganization(final String organizationId) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of(ORGANIZATION_CLAIM_KEY, List.of(Map.of("id", organizationId))));
+  }
+
+  private static Jwt createJwtWithMultipleOrganizations(final List<String> organizationIds) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of(
+            ORGANIZATION_CLAIM_KEY, organizationIds.stream().map(id -> Map.of("id", id)).toList()));
+  }
+
+  private static Jwt createJwtWithoutOrganizationClaim() {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of("sub", "user"));
+  }
+
+  private static Jwt createJwtWithInvalidOrganizationFormat() {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of(ORGANIZATION_CLAIM_KEY, "not-a-collection"));
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -23,6 +23,7 @@ public class OidcAuthenticationConfiguration {
   private Set<String> audiences;
   private String usernameClaim = "sub";
   private String applicationIdClaim;
+  private String organizationId;
 
   public String getIssuerUri() {
     return issuerUri;
@@ -110,5 +111,13 @@ public class OidcAuthenticationConfiguration {
 
   public void setApplicationIdClaim(final String applicationIdClaim) {
     this.applicationIdClaim = applicationIdClaim;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SaasConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SaasConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public final class SaasConfiguration {
+
+  private String organizationId;
+  private String clusterId;
+
+  public boolean isConfigured() {
+    if (organizationId != null && clusterId != null) {
+      return true;
+    }
+    if (organizationId == null && clusterId == null) {
+      return false;
+    }
+    throw new IllegalStateException("Must configure both organizationId and clusterId");
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -13,6 +13,7 @@ public class SecurityConfiguration {
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
   private InitializationConfiguration initialization = new InitializationConfiguration();
   private MultiTenancyConfiguration multiTenancy = new MultiTenancyConfiguration();
+  private SaasConfiguration saas = new SaasConfiguration();
 
   public AuthenticationConfiguration getAuthentication() {
     return authentication;
@@ -48,5 +49,13 @@ public class SecurityConfiguration {
 
   public boolean isApiProtected() {
     return !authentication.getUnprotectedApi();
+  }
+
+  public SaasConfiguration getSaas() {
+    return saas;
+  }
+
+  public void setSaas(final SaasConfiguration saas) {
+    this.saas = saas;
   }
 }

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
@@ -61,7 +61,7 @@ public final class ClaimTransformer {
         || value instanceof Collection<?>) {
       claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value);
     } else {
-      LOG.debug("Dropping claim '{}' with unsupported value type '{}'", key, value.getClass());
+      LOG.trace("Dropping claim '{}' with unsupported value type '{}'", key, value.getClass());
     }
   }
 }


### PR DESCRIPTION
This adds two new configuration properties `camunda.security.saas.clusterId` and `camunda.security.saas.organizationId`. If both of them are set (only setting one but not the other is invalid), two new token validators are active.

The validators check if tokens contain the cluster/org claim and check that it matches the configured values. If the token does not contain such a claim, it is not validated.

In 33b01637c89a8085e38a8ccc3f0c3f301d83f3fe, I've made changes to ensure that the token validator applies to id tokens too. With this change, login via the web UI fails if the OIDC id token contains unexpected org/cluster claims.
The UX for this is not good yet, essentially resulting in an NPE further down the filter chain because no principal was set. This can be improved later

closes #29425
