### PR TITLE
Feat/31777 bo item search api

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -93,6 +93,8 @@ import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.search.request.AdHocSubProcessActivitySearchRequest;
+import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
+import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
@@ -1834,6 +1836,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   BatchOperationGetRequest newBatchOperationGetRequest(Long batchOperationKey);
 
   /**
+   * Executes a search request to query batch operations.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newBatchOperationSearchRequest()
+   *  .filter((f) -> f.state(state))
+   *  .sort((s) -> s.startDate().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the groups search request
+   */
+  BatchOperationSearchRequest newBatchOperationSearchRequest();
+
+  /**
    * Request to get all items for a batch operation by batch operation key. This request is will
    * return <b>ALL</b> items of the batch operation. Depending on the number of elements, this may
    * be a large set of items.
@@ -1848,6 +1867,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request
    */
   BatchOperationItemsGetRequest newBatchOperationItemsGetRequest(Long batchOperationKey);
+
+  /**
+   * Executes a search request to query batch operation items.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newBatchOperationItemSearchRequest()
+   *  .filter((f) -> f.state(state))
+   *  .sort((s) -> s.itemKey().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the groups search request
+   */
+  BatchOperationItemSearchRequest newBatchOperationItemsSearchRequest();
 
   /**
    * Command to assign a mapping rule to a group.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+
+public interface BatchOperationFilter extends SearchRequestFilter {
+
+  /**
+   * Filters batch operations by the specified batchOperationId.
+   *
+   * @param batchOperationId the ID of the batch operation
+   * @return the updated filter
+   */
+  BatchOperationFilter batchOperationId(final String batchOperationId);
+
+  /**
+   * Filters batch operations by the specified type.
+   *
+   * @param operationType the operationType
+   * @return the updated filter
+   */
+  BatchOperationFilter operationType(final BatchOperationType operationType);
+
+  /**
+   * Filters batch operations by the specified state.
+   *
+   * @param state the state
+   * @return the updated filter
+   */
+  BatchOperationFilter state(final BatchOperationState state);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+
+public interface BatchOperationItemFilter extends SearchRequestFilter {
+
+  /**
+   * Filters batch operation items by the specified batchOperationId.
+   *
+   * @param batchOperationId the ID of the batch operation
+   * @return the updated filter
+   */
+  BatchOperationItemFilter batchOperationId(final String batchOperationId);
+
+  /**
+   * Filters batch operation items by the specified itemKey.
+   *
+   * @param itemKey the itemKey
+   * @return the updated filter
+   */
+  BatchOperationItemFilter itemKey(final long itemKey);
+
+  /**
+   * Filters batch operation items by the specified processInstanceKey.
+   *
+   * @param processInstanceKey the processInstanceKey
+   * @return the updated filter
+   */
+  BatchOperationItemFilter processInstanceKey(final long processInstanceKey);
+
+  /**
+   * Filters batch operations by the specified state.
+   *
+   * @param state the state
+   * @return the updated filter
+   */
+  BatchOperationItemFilter state(final BatchOperationItemState state);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/BatchOperationItemSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/BatchOperationItemSearchRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.BatchOperationItemFilter;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.sort.BatchOperationItemSort;
+
+public interface BatchOperationItemSearchRequest
+    extends TypedSearchRequest<
+            BatchOperationItemFilter, BatchOperationItemSort, BatchOperationItemSearchRequest>,
+        FinalSearchRequestStep<BatchOperationItem> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/BatchOperationSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/BatchOperationSearchRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.BatchOperationFilter;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.api.search.sort.BatchOperationSort;
+
+public interface BatchOperationSearchRequest
+    extends TypedSearchRequest<
+            BatchOperationFilter, BatchOperationSort, BatchOperationSearchRequest>,
+        FinalSearchRequestStep<BatchOperation> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -16,6 +16,8 @@
 package io.camunda.client.api.search.request;
 
 import io.camunda.client.api.search.filter.AdHocSubProcessActivityFilter;
+import io.camunda.client.api.search.filter.BatchOperationFilter;
+import io.camunda.client.api.search.filter.BatchOperationItemFilter;
 import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
@@ -30,6 +32,8 @@ import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.UserTaskVariableFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.filter.VariableValueFilter;
+import io.camunda.client.api.search.sort.BatchOperationItemSort;
+import io.camunda.client.api.search.sort.BatchOperationSort;
 import io.camunda.client.api.search.sort.DecisionDefinitionSort;
 import io.camunda.client.api.search.sort.DecisionInstanceSort;
 import io.camunda.client.api.search.sort.DecisionRequirementsSort;
@@ -44,6 +48,8 @@ import io.camunda.client.api.search.sort.UserTaskSort;
 import io.camunda.client.api.search.sort.VariableSort;
 import io.camunda.client.api.statistics.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.client.impl.search.filter.AdHocSubProcessActivityFilterImpl;
+import io.camunda.client.impl.search.filter.BatchOperationFilterImpl;
+import io.camunda.client.impl.search.filter.BatchOperationItemFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
@@ -59,6 +65,8 @@ import io.camunda.client.impl.search.filter.UserTaskVariableFilterImpl;
 import io.camunda.client.impl.search.filter.VariableFilterImpl;
 import io.camunda.client.impl.search.filter.VariableValueFilterImpl;
 import io.camunda.client.impl.search.request.SearchRequestPageImpl;
+import io.camunda.client.impl.search.sort.BatchOperationItemSortImpl;
+import io.camunda.client.impl.search.sort.BatchOperationSortImpl;
 import io.camunda.client.impl.search.sort.DecisionDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
 import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
@@ -260,6 +268,32 @@ public final class SearchRequestBuilders {
 
   public static MappingSort mappingSort(final Consumer<MappingSort> fn) {
     final MappingSort sort = new MappingSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static BatchOperationFilter batchOperationFilter(final Consumer<BatchOperationFilter> fn) {
+    final BatchOperationFilter filter = new BatchOperationFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static BatchOperationSort batchOperationSort(final Consumer<BatchOperationSort> fn) {
+    final BatchOperationSort sort = new BatchOperationSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static BatchOperationItemFilter batchOperationItemFilter(
+      final Consumer<BatchOperationItemFilter> fn) {
+    final BatchOperationItemFilter filter = new BatchOperationItemFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static BatchOperationItemSort batchOperationItemSort(
+      final Consumer<BatchOperationItemSort> fn) {
+    final BatchOperationItemSort sort = new BatchOperationItemSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+
+public interface BatchOperationItemSort extends SearchRequestSort<BatchOperationItemSort> {
+
+  BatchOperationItemSort batchOperationId();
+
+  BatchOperationItemSort state();
+
+  BatchOperationItemSort itemKey();
+
+  BatchOperationItemSort processInstanceKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+
+public interface BatchOperationSort extends SearchRequestSort<BatchOperationSort> {
+
+  BatchOperationSort batchOperationId();
+
+  BatchOperationSort state();
+
+  BatchOperationSort operationType();
+
+  BatchOperationSort startDate();
+
+  BatchOperationSort endDate();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -104,6 +104,8 @@ import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.api.search.request.AdHocSubProcessActivitySearchRequest;
+import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
+import io.camunda.client.api.search.request.BatchOperationSearchRequest;
 import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
@@ -193,6 +195,8 @@ import io.camunda.client.impl.fetch.VariableGetRequestImpl;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.http.HttpClientFactory;
 import io.camunda.client.impl.search.request.AdHocSubProcessActivitySearchRequestImpl;
+import io.camunda.client.impl.search.request.BatchOperationItemSearchRequestImpl;
+import io.camunda.client.impl.search.request.BatchOperationSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
@@ -1000,9 +1004,19 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
+  public BatchOperationSearchRequest newBatchOperationSearchRequest() {
+    return new BatchOperationSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
   public BatchOperationItemsGetRequest newBatchOperationItemsGetRequest(
       final Long batchOperationKey) {
     return new BatchOperationItemsGetRequestImpl(httpClient, batchOperationKey);
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest newBatchOperationItemsSearchRequest() {
+    return new BatchOperationItemSearchRequestImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.BatchOperationFilter;
+import io.camunda.client.protocol.rest.BatchOperationFilter.StateEnum;
+import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+
+public class BatchOperationFilterImpl
+    extends TypedSearchRequestPropertyProvider<BatchOperationFilter>
+    implements io.camunda.client.api.search.filter.BatchOperationFilter {
+
+  private final BatchOperationFilter filter;
+
+  public BatchOperationFilterImpl() {
+    filter = new BatchOperationFilter();
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter batchOperationId(
+      final String batchOperationId) {
+    filter.setBatchOperationId(batchOperationId);
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter operationType(
+      final BatchOperationType operationType) {
+    if (operationType == null) {
+      filter.setOperationType(null);
+      return this;
+    }
+
+    filter.setOperationType(BatchOperationTypeEnum.valueOf(operationType.name()));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter state(
+      final BatchOperationState state) {
+    if (state == null) {
+      filter.setState(null);
+      return this;
+    }
+
+    filter.setState(StateEnum.valueOf(state.name()));
+    return this;
+  }
+
+  @Override
+  protected BatchOperationFilter getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.BatchOperationItemFilter;
+import io.camunda.client.protocol.rest.BatchOperationItemFilter.StateEnum;
+
+public class BatchOperationItemFilterImpl
+    extends TypedSearchRequestPropertyProvider<BatchOperationItemFilter>
+    implements io.camunda.client.api.search.filter.BatchOperationItemFilter {
+
+  private final BatchOperationItemFilter filter;
+
+  public BatchOperationItemFilterImpl() {
+    filter = new BatchOperationItemFilter();
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter batchOperationId(
+      final String batchOperationId) {
+    filter.setBatchOperationId(batchOperationId);
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter itemKey(final long itemKey) {
+    filter.itemKey(Long.toString(itemKey));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter processInstanceKey(
+      final long processInstanceKey) {
+    filter.processInstanceKey(Long.toString(processInstanceKey));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter state(
+      final BatchOperationItemState state) {
+    if (state == null) {
+      filter.setState(null);
+      return this;
+    }
+
+    filter.setState(StateEnum.valueOf(state.name()));
+    return this;
+  }
+
+  @Override
+  protected BatchOperationItemFilter getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/BatchOperationItemSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/BatchOperationItemSearchRequestImpl.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.batchOperationItemFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.batchOperationItemSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.BatchOperationItemFilter;
+import io.camunda.client.api.search.request.BatchOperationItemSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.BatchOperationItemSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.BatchOperationItemSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class BatchOperationItemSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.BatchOperationItemSearchQuery>
+    implements BatchOperationItemSearchRequest {
+
+  private final io.camunda.client.protocol.rest.BatchOperationItemSearchQuery request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public BatchOperationItemSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    request = new io.camunda.client.protocol.rest.BatchOperationItemSearchQuery();
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest filter(final BatchOperationItemFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest filter(final Consumer<BatchOperationItemFilter> fn) {
+    return filter(batchOperationItemFilter(fn));
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest sort(final BatchOperationItemSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toBatchOperationItemSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest sort(final Consumer<BatchOperationItemSort> fn) {
+    return sort(batchOperationItemSort(fn));
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.BatchOperationItemSearchQuery
+      getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public FinalSearchRequestStep<BatchOperationItem> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<BatchOperationItem>> send() {
+    final HttpCamundaFuture<SearchResponse<BatchOperationItem>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/batch-operation-items/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        BatchOperationItemSearchQueryResult.class,
+        SearchResponseMapper::toBatchOperationItemsResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/BatchOperationSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/BatchOperationSearchRequestImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.batchOperationFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.batchOperationSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.BatchOperationFilter;
+import io.camunda.client.api.search.request.BatchOperationSearchRequest;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.BatchOperationSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.BatchOperationSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class BatchOperationSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.BatchOperationSearchQuery>
+    implements BatchOperationSearchRequest {
+
+  private final io.camunda.client.protocol.rest.BatchOperationSearchQuery request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public BatchOperationSearchRequestImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    request = new io.camunda.client.protocol.rest.BatchOperationSearchQuery();
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public BatchOperationSearchRequest filter(final BatchOperationFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public BatchOperationSearchRequest filter(final Consumer<BatchOperationFilter> fn) {
+    return filter(batchOperationFilter(fn));
+  }
+
+  @Override
+  public BatchOperationSearchRequest sort(final BatchOperationSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toBatchOperationSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public BatchOperationSearchRequest sort(final Consumer<BatchOperationSort> fn) {
+    return sort(batchOperationSort(fn));
+  }
+
+  @Override
+  public BatchOperationSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public BatchOperationSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected io.camunda.client.protocol.rest.BatchOperationSearchQuery getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public FinalSearchRequestStep<BatchOperation> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<BatchOperation>> send() {
+    final HttpCamundaFuture<SearchResponse<BatchOperation>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/batch-operations/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        BatchOperationSearchQueryResult.class,
+        SearchResponseMapper::toBatchOperationsResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -357,6 +357,36 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<BatchOperationSearchQuerySortRequest> toBatchOperationSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final BatchOperationSearchQuerySortRequest request =
+                  new BatchOperationSearchQuerySortRequest();
+              request.setField(
+                  BatchOperationSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
+  public static List<BatchOperationItemSearchQuerySortRequest>
+      toBatchOperationItemSearchQuerySortRequest(final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final BatchOperationItemSearchQuerySortRequest request =
+                  new BatchOperationItemSearchQuerySortRequest();
+              request.setField(
+                  BatchOperationItemSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   private static SearchRequestSort createFrom(final Object field, final SortOrderEnum order) {
     final SearchRequestSort request = new SearchRequestSort();
     request.setField(field.toString());

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.search.response;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationItems;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
@@ -34,6 +35,7 @@ import io.camunda.client.api.search.response.SearchResponsePage;
 import io.camunda.client.api.search.response.User;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.client.impl.search.response.BatchOperationItemsImpl.BatchOperationItemImpl;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
 import java.util.Arrays;
@@ -203,6 +205,22 @@ public final class SearchResponseMapper {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Mapping> instances =
         toSearchResponseInstances(response.getItems(), SearchResponseMapper::toMappingResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<BatchOperation> toBatchOperationsResponse(
+      final BatchOperationSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<BatchOperation> instances =
+        toSearchResponseInstances(response.getItems(), BatchOperationImpl::new);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<BatchOperationItem> toBatchOperationItemsResponse(
+      final BatchOperationItemSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<BatchOperationItem> instances =
+        toSearchResponseInstances(response.getItems(), BatchOperationItemImpl::new);
     return new SearchResponseImpl<>(instances, page);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationItemSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationItemSortImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.BatchOperationItemSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class BatchOperationItemSortImpl extends SearchRequestSortBase<BatchOperationItemSort>
+    implements BatchOperationItemSort {
+
+  @Override
+  public BatchOperationItemSort batchOperationId() {
+    return field("batchOperationId");
+  }
+
+  @Override
+  public BatchOperationItemSort state() {
+    return field("state");
+  }
+
+  @Override
+  public BatchOperationItemSort itemKey() {
+    return field("itemKey");
+  }
+
+  @Override
+  public BatchOperationItemSort processInstanceKey() {
+    return field("processInstanceKey");
+  }
+
+  @Override
+  protected BatchOperationItemSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/BatchOperationSortImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.BatchOperationSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class BatchOperationSortImpl extends SearchRequestSortBase<BatchOperationSort>
+    implements BatchOperationSort {
+
+  @Override
+  public BatchOperationSort batchOperationId() {
+    return field("batchOperationId");
+  }
+
+  @Override
+  public BatchOperationSort state() {
+    return field("state");
+  }
+
+  @Override
+  public BatchOperationSort operationType() {
+    return field("operationType");
+  }
+
+  @Override
+  public BatchOperationSort startDate() {
+    return field("startDate");
+  }
+
+  @Override
+  public BatchOperationSort endDate() {
+    return field("endDate");
+  }
+
+  @Override
+  protected BatchOperationSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.BatchOperationItemFilter.StateEnum;
+import io.camunda.client.protocol.rest.BatchOperationItemSearchQuerySortRequest.FieldEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+class SearchBatchOperationItemsTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchBatchOperation() {
+    // when
+    client
+        .newBatchOperationItemsSearchRequest()
+        .filter(f -> f.batchOperationId("123"))
+        .sort(s -> s.state().asc())
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest restRequest = RestGatewayService.getLastRequest();
+    assertThat(restRequest.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operation-items/search");
+    assertThat(restRequest.getBodyAsString())
+        .isEqualTo(
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":\"123\"}}");
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithoutFilter() {
+    // when
+    client.newBatchOperationItemsSearchRequest().send().join();
+
+    // then
+    final BatchOperationItemSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationItemSearchQuery.class);
+    assertThat(request.getFilter()).isNull();
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithFullFilters() {
+    // when
+    client
+        .newBatchOperationItemsSearchRequest()
+        .filter(
+            f ->
+                f.batchOperationId("123")
+                    .state(BatchOperationItemState.ACTIVE)
+                    .processInstanceKey(123L)
+                    .itemKey(456L))
+        .send()
+        .join();
+
+    // then
+    final BatchOperationItemSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationItemSearchQuery.class);
+    assertThat(request.getFilter().getBatchOperationId()).isEqualTo("123");
+    assertThat(request.getFilter().getState()).isEqualTo(StateEnum.ACTIVE);
+    assertThat(request.getFilter().getProcessInstanceKey()).isEqualTo("123");
+    assertThat(request.getFilter().getItemKey()).isEqualTo("456");
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithFullSorting() {
+    // when
+    client
+        .newBatchOperationItemsSearchRequest()
+        .sort(
+            s ->
+                s.batchOperationId()
+                    .asc()
+                    .state()
+                    .asc()
+                    .processInstanceKey()
+                    .desc()
+                    .itemKey()
+                    .asc())
+        .send()
+        .join();
+
+    // then
+    final BatchOperationItemSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationItemSearchQuery.class);
+    assertThat(request.getSort().size()).isEqualTo(4);
+    assertThat(request.getSort().get(0).getField()).isEqualTo(FieldEnum.BATCH_OPERATION_ID);
+    assertThat(request.getSort().get(0).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(1).getField()).isEqualTo(FieldEnum.STATE);
+    assertThat(request.getSort().get(1).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(2).getField()).isEqualTo(FieldEnum.PROCESS_INSTANCE_KEY);
+    assertThat(request.getSort().get(2).getOrder()).isEqualTo(SortOrderEnum.DESC);
+    assertThat(request.getSort().get(3).getField()).isEqualTo(FieldEnum.ITEM_KEY);
+    assertThat(request.getSort().get(3).getOrder()).isEqualTo(SortOrderEnum.ASC);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.BatchOperationFilter.StateEnum;
+import io.camunda.client.protocol.rest.BatchOperationSearchQuerySortRequest.FieldEnum;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+class SearchBatchOperationsTest extends ClientRestTest {
+
+  @Test
+  void shouldSearchBatchOperation() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .filter(f -> f.batchOperationId("123"))
+        .sort(s -> s.state().asc())
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest restRequest = RestGatewayService.getLastRequest();
+    assertThat(restRequest.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operations/search");
+    assertThat(restRequest.getBodyAsString())
+        .isEqualTo(
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":\"123\"}}");
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithoutFilter() {
+    // when
+    client.newBatchOperationSearchRequest().send().join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+    assertThat(request.getFilter()).isNull();
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithFullFilters() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .filter(
+            f ->
+                f.batchOperationId("123")
+                    .state(BatchOperationState.ACTIVE)
+                    .operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE))
+        .send()
+        .join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+    assertThat(request.getFilter().getBatchOperationId()).isEqualTo("123");
+    assertThat(request.getFilter().getState()).isEqualTo(StateEnum.ACTIVE);
+    assertThat(request.getFilter().getOperationType())
+        .isEqualTo(BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE);
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithFullSorting() {
+    // when
+    client
+        .newBatchOperationSearchRequest()
+        .sort(
+            s ->
+                s.batchOperationId()
+                    .asc()
+                    .state()
+                    .asc()
+                    .startDate()
+                    .desc()
+                    .endDate()
+                    .asc()
+                    .operationType()
+                    .asc())
+        .send()
+        .join();
+
+    // then
+    final BatchOperationSearchQuery request =
+        gatewayService.getLastRequest(BatchOperationSearchQuery.class);
+    assertThat(request.getSort().size()).isEqualTo(5);
+    assertThat(request.getSort().get(0).getField())
+        .isEqualTo(BatchOperationSearchQuerySortRequest.FieldEnum.BATCH_OPERATION_ID);
+    assertThat(request.getSort().get(0).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(1).getField()).isEqualTo(FieldEnum.STATE);
+    assertThat(request.getSort().get(1).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(2).getField()).isEqualTo(FieldEnum.START_DATE);
+    assertThat(request.getSort().get(2).getOrder()).isEqualTo(SortOrderEnum.DESC);
+    assertThat(request.getSort().get(3).getField()).isEqualTo(FieldEnum.END_DATE);
+    assertThat(request.getSort().get(3).getOrder()).isEqualTo(SortOrderEnum.ASC);
+    assertThat(request.getSort().get(4).getField()).isEqualTo(FieldEnum.OPERATION_TYPE);
+    assertThat(request.getSort().get(4).getOrder()).isEqualTo(SortOrderEnum.ASC);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -544,6 +544,7 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
         .items();
   }
 
+  @Override
   public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
       final BatchOperationItemQuery query) {
     return getSearchExecutor()

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -30,6 +30,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -300,5 +301,11 @@ public class RdbmsSearchClient implements SearchClientsProxy {
         batchOperationId);
 
     return rdbmsService.getBatchOperationReader().getItems(batchOperationId);
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final BatchOperationItemQuery query) {
+    throw new UnsupportedOperationException("Not implemented yet");
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/BatchOperationSearchClient.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
@@ -19,6 +20,9 @@ public interface BatchOperationSearchClient {
   SearchQueryResult<BatchOperationEntity> searchBatchOperations(BatchOperationQuery query);
 
   List<BatchOperationItemEntity> getBatchOperationItems(String batchOperationId);
+
+  SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      BatchOperationItemQuery query);
 
   BatchOperationSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -13,6 +13,7 @@ import static io.camunda.search.query.SearchQueryBuilders.batchOperationQuery;
 import io.camunda.search.clients.BatchOperationSearchClient;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
@@ -59,6 +60,15 @@ public final class BatchOperationServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(Builder::read)))
         .searchBatchOperations(query);
+  }
+
+  public SearchQueryResult<BatchOperationItemEntity> searchItems(
+      final BatchOperationItemQuery query) {
+    return batchOperationSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(Builder::read)))
+        .searchBatchOperationItems(query);
   }
 
   public BatchOperationEntity getById(final String batchOperationId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
@@ -31,6 +31,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationItemQuery;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -74,6 +75,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public List<BatchOperationItemEntity> getBatchOperationItems(final String batchOperationId) {
     return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationItemEntity> searchBatchOperationItems(
+      final BatchOperationItemQuery query) {
+    return SearchQueryResult.empty();
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3126,7 +3126,7 @@ paths:
       tags:
         - Group
       operationId: createGroup
-      summary: Create group 
+      summary: Create group
       description: |
         Create a new group.
       requestBody:
@@ -4883,6 +4883,34 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           description: Not found. The batch operation was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /batch-operation-items/search:
+    post:
+      tags:
+        - Batch operation
+      operationId: searchBatchOperationItems
+      summary: Search batch operation items
+      description: Search for batch operation items based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchOperationItemSearchQuery"
+      responses:
+        "200":
+          description: The batch operation search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchOperationItemSearchQueryResult"
+        "400":
+          description: The provided data is not valid.
           content:
             application/problem+json:
               schema:
@@ -8998,6 +9026,7 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - batchOperationId
             - operationType
             - state
             - startDate
@@ -9041,6 +9070,57 @@ components:
             - COMPLETED_WITH_ERRORS
             - CANCELED
             - INCOMPLETED
+    BatchOperationItemSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - batchOperationId
+            - itemKey
+            - processInstanceKey
+            - state
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
+    BatchOperationItemSearchQuery:
+      description: Batch operation item search request.
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchOperationItemSearchQuerySortRequest"
+        filter:
+          description: The batch operation search filters.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationItemFilter"
+    BatchOperationItemFilter:
+      description: Batch operation item filter request.
+      type: object
+      properties:
+        batchOperationId:
+          description: The key (or operate legacy ID) of the batch operation.
+          type: string
+        itemKey:
+          description: The key of the item, e.g. a process instance key.
+          type: string
+        processInstanceKey:
+          description: The process instance key of the processed item.
+          type: string
+        state:
+          type: string
+          description: The state of the batch operation.
+          enum:
+            - ACTIVE
+            - COMPLETED
+            - CANCELED
+            - FAILED
     BatchOperationSearchQueryResult:
       type: object
       allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -284,6 +284,17 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
+  public static BatchOperationItemSearchQueryResult toBatchOperationItemSearchQueryResult(
+      final SearchQueryResult<BatchOperationItemEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new BatchOperationItemSearchQueryResult()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toBatchOperationItems)
+                .orElseGet(Collections::emptyList));
+  }
+
   public static IncidentSearchQueryResult toIncidentSearchQueryResponse(
       final SearchQueryResult<IncidentEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -369,6 +380,13 @@ public final class SearchQueryResponseMapper {
     return new BatchOperationItemSearchQueryResult()
         .items(
             batchOperations.stream().map(SearchQueryResponseMapper::toBatchOperationItem).toList());
+  }
+
+  public static List<BatchOperationItemResponse> toBatchOperationItems(
+      final List<BatchOperationItemEntity> batchOperationItems) {
+    return batchOperationItems.stream()
+        .map(SearchQueryResponseMapper::toBatchOperationItem)
+        .toList();
   }
 
   public static BatchOperationItemResponse toBatchOperationItem(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -106,6 +106,12 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<BatchOperationItemSearchQuerySortRequest.FieldEnum>>
+      fromBatchOperationItemSearchQuerySortRequest(
+          final List<BatchOperationItemSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   private static <T> SearchQuerySortRequest<T> createFrom(
       final T field, final SortOrderEnum order) {
     return new SearchQuerySortRequest<T>(field, order);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -52,6 +52,7 @@ public class BatchOperationController {
     }
   }
 
+  // TODO remove when secondaryDb support search for items
   @CamundaGetMapping(path = "/{batchOperationId}/items")
   public ResponseEntity<BatchOperationItemSearchQueryResult> getItemsById(
       @PathVariable("batchOperationId") final String batchOperationId) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemsController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.BatchOperationItemQuery;
+import io.camunda.service.BatchOperationServices;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQuery;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQueryResult;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/batch-operation-items")
+public class BatchOperationItemsController {
+
+  private final BatchOperationServices batchOperationServices;
+
+  public BatchOperationItemsController(final BatchOperationServices batchOperationServices) {
+    this.batchOperationServices = batchOperationServices;
+  }
+
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<BatchOperationItemSearchQueryResult> searchBatchOperationItems(
+      @RequestBody(required = false) final BatchOperationItemSearchQuery query) {
+    return SearchQueryRequestMapper.toBatchOperationItemQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<BatchOperationItemSearchQueryResult> search(
+      final BatchOperationItemQuery query) {
+    try {
+      final var result =
+          batchOperationServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .searchItems(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toBatchOperationItemSearchQueryResult(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.search.query.BatchOperationItemQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.BatchOperationServices;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemFilter;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemSearchQuery;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(value = BatchOperationItemsController.class)
+class BatchOperationItemControllerTest extends RestControllerTest {
+
+  @MockitoBean private BatchOperationServices batchOperationServices;
+
+  @BeforeEach
+  void setUpServices() {
+    when(batchOperationServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(batchOperationServices);
+  }
+
+  @Test
+  void shouldSearchBatchOperationItems() {
+    final var entity = getBatchOperationItemEntity("1");
+    when(batchOperationServices.searchItems(any(BatchOperationItemQuery.class)))
+        .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
+
+    final var searchQuery =
+        new BatchOperationItemSearchQuery()
+            .filter(
+                new BatchOperationItemFilter().state(BatchOperationItemFilter.StateEnum.ACTIVE));
+
+    webClient
+        .post()
+        .uri("/v2/batch-operation-items/search")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(searchQuery)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+                 {
+                    "items":
+                    [
+                        {
+                            "batchOperationId":"1",
+                            "itemKey":"11",
+                            "processInstanceKey":"12",
+                            "state":"FAILED",
+                            "processedDate":"2025-03-18T10:57:44.000+01:00",
+                            "errorMessage": "error"
+                        }
+                    ],
+                    "page":{"totalItems":1,"firstSortValues":[],"lastSortValues":[]}
+                }""");
+  }
+
+  private static BatchOperationItemEntity getBatchOperationItemEntity(
+      final String batchOperationId) {
+    return new BatchOperationEntity.BatchOperationItemEntity(
+        batchOperationId,
+        11L,
+        12L,
+        BatchOperationItemState.FAILED,
+        OffsetDateTime.parse("2025-03-18T10:57:44+01:00"),
+        "error");
+  }
+}


### PR DESCRIPTION
## Description

This PR adds APIs for paginated search of `BatchOperationItems`:
- add method to BatchOperationSearchClient interface and implementations ("Not yet implemented")
- add service layer methods
- add REST API, controller and mapper classes
- enhance CamundaCient by
  - BatchOperationSearchRequest
  - BatchOperationItemSearchRequest

Currently there is also a now legacy method BatchOperationSearchClient#getBatchOperationItems(id). This is still used in integration tests. In the follow-up issue https://github.com/camunda/camunda/issues/31852 this will be removed from the interface, when the RDBMS implements the new search method.

closes #31777 