### PR TITLE
fix: use default result config in API query objects

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/query/DecisionInstanceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/DecisionInstanceQuery.java
@@ -38,6 +38,8 @@ public record DecisionInstanceQuery(
         FilterBuilders.decisionInstance().build();
     private static final DecisionInstanceSort EMPTY_SORT =
         SortOptionBuilders.decisionInstance().build();
+    private static final DecisionInstanceQueryResultConfig EMPTY_CONFIG =
+        QueryResultConfigBuilders.decisionInstance().build();
 
     private DecisionInstanceFilter filter;
     private DecisionInstanceSort sort;
@@ -87,6 +89,7 @@ public record DecisionInstanceQuery(
     public DecisionInstanceQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      resultConfig = Objects.requireNonNullElse(resultConfig, EMPTY_CONFIG);
       return new DecisionInstanceQuery(filter, sort, page(), resultConfig);
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/DecisionRequirementsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/DecisionRequirementsQuery.java
@@ -42,7 +42,7 @@ public record DecisionRequirementsQuery(
     private static final DecisionRequirementsSort EMPTY_SORT =
         SortOptionBuilders.decisionRequirements().build();
     private static final DecisionRequirementsQueryResultConfig EMPTY_RESULT_CONFIG =
-        DecisionRequirementsQueryResultConfig.of(b -> b);
+        QueryResultConfigBuilders.decisionRequirements().build();
 
     private DecisionRequirementsFilter filter;
     private DecisionRequirementsSort sort;

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceQuery.java
@@ -38,6 +38,8 @@ public record ProcessInstanceQuery(
         FilterBuilders.processInstance().build();
     private static final ProcessInstanceSort EMPTY_SORT =
         SortOptionBuilders.processInstance().build();
+    private static final ProcessInstanceQueryResultConfig RESULT_CONFIG =
+        QueryResultConfigBuilders.processInstance().build();
 
     private ProcessInstanceFilter filter;
     private ProcessInstanceSort sort;
@@ -87,6 +89,7 @@ public record ProcessInstanceQuery(
     public ProcessInstanceQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      resultConfig = Objects.requireNonNullElse(resultConfig, RESULT_CONFIG);
       return new ProcessInstanceQuery(filter, sort, page(), resultConfig);
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/result/DecisionInstanceQueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/DecisionInstanceQueryResultConfig.java
@@ -41,6 +41,10 @@ public record DecisionInstanceQueryResultConfig(
       return this;
     }
 
+    public Builder includeAll() {
+      return includeEvaluatedInputs(true).includeEvaluatedOutputs(true);
+    }
+
     @Override
     public DecisionInstanceQueryResultConfig build() {
       return new DecisionInstanceQueryResultConfig(includeEvaluatedInputs, includeEvaluatedOutputs);

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -8,13 +8,11 @@
 package io.camunda.service;
 
 import static io.camunda.search.query.SearchQueryBuilders.decisionRequirementsSearchQuery;
-import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
 import io.camunda.service.exception.ForbiddenException;
@@ -54,21 +52,7 @@ public final class DecisionRequirementsServices
                 authentication, Authorization.of(a -> a.decisionRequirementsDefinition().read())))
         .searchDecisionRequirements(
             decisionRequirementsSearchQuery(
-                q ->
-                    q.filter(query.filter())
-                        .sort(query.sort())
-                        .page(query.page())
-                        .resultConfig(
-                            ofNullable(query.resultConfig())
-                                .orElseGet(this::defaultSearchResultConfig))));
-  }
-
-  /**
-   * Default search result configuration excluding XML field to reduce the size of the response
-   * fetched from the database.
-   */
-  private DecisionRequirementsQueryResultConfig defaultSearchResultConfig() {
-    return DecisionRequirementsQueryResultConfig.of(r -> r);
+                q -> q.filter(query.filter()).sort(query.sort()).page(query.page())));
   }
 
   public DecisionRequirementsEntity getByKey(final Long key) {

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -88,7 +88,10 @@ class DecisionInstanceServiceTest {
     verify(client)
         .searchDecisionInstances(
             SearchQueryBuilders.decisionInstanceSearchQuery(
-                q -> q.filter(f -> f.decisionInstanceIds(decisionInstanceId))));
+                q ->
+                    q.filter(f -> f.decisionInstanceIds(decisionInstanceId))
+                        .resultConfig(
+                            c -> c.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
   }
 
   @Test


### PR DESCRIPTION
## Description

This fix ensures, that every query object which defines a resultConfig, always has a default result config defined in the builder.

Before, the behaviour was in decisionInstanceServices was different between the secondary database implementations, when the `decisionInstanceQuery#resultConfig` is `NULL`:
- ES/OS automatically includes inputs and outputs
- RDBMS automatically excludes inputs and outputs