### PR TITLE
refactor: remove processInstanceDetailsDiagramStore dependency from incidentsStore

### DIFF
--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.test.tsx
@@ -13,6 +13,9 @@ import {mockIncidents} from './index.setup';
 import {incidentsStore} from 'modules/stores/incidents';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 import {useEffect} from 'react';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const {reset, fetchIncidents} = incidentsStore;
 
@@ -21,7 +24,13 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
     return reset;
   }, []);
 
-  return <>{children}</>;
+  return (
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        {children}
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
+  );
 };
 
 describe('IncidentsFilter', () => {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsFilter/index.tsx
@@ -11,16 +11,18 @@ import {incidentsStore} from 'modules/stores/incidents';
 import {observer} from 'mobx-react';
 import {tracking} from 'modules/tracking';
 import {Button, MultiSelect} from '@carbon/react';
+import {useIncidentsElements} from 'modules/hooks/incidents';
 
 const IncidentsFilter: React.FC = observer(() => {
   const {
-    flowNodes,
     errorTypes,
     setFlowNodeSelection,
     setErrorTypeSelection,
     clearSelection,
     state: {selectedErrorTypes, selectedFlowNodes},
   } = incidentsStore;
+
+  const flowNodes = useIncidentsElements();
 
   return (
     <Layer>

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/index.tsx
@@ -14,7 +14,7 @@ import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {observer} from 'mobx-react';
 import {useProcessInstancePageParams} from '../../useProcessInstancePageParams';
 import {FlexContainer, ErrorMessageCell} from './styled';
-import {Incident, incidentsStore} from 'modules/stores/incidents';
+import {Incident} from 'modules/stores/incidents';
 import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {useLocation} from 'react-router-dom';
@@ -24,6 +24,11 @@ import {Button} from '@carbon/react';
 import {SortableTable} from 'modules/components/SortableTable';
 import {useState} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {
+  getFilteredIncidents,
+  isSingleIncidentSelected,
+} from 'modules/utils/incidents';
+import {useIncidents} from 'modules/hooks/incidents';
 
 const IncidentsTable: React.FC = observer(function IncidentsTable() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -31,13 +36,14 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
   const [modalTitle, setModalTitle] = useState<string>('');
 
   const {processInstanceId = ''} = useProcessInstancePageParams();
+  const incidents = useIncidents();
   const location = useLocation();
   const {sortBy, sortOrder} = getSortParams(location.search) || {
     sortBy: 'creationTime',
     sortOrder: 'desc',
   };
 
-  const {filteredIncidents} = incidentsStore;
+  const filteredIncidents = getFilteredIncidents(incidents);
 
   const handleModalClose = () => {
     setIsModalVisible(false);
@@ -81,7 +87,7 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
             return;
           }
 
-          incidentsStore.isSingleIncidentSelected(incident.flowNodeInstanceId)
+          isSingleIncidentSelected(incidents, incident.flowNodeInstanceId)
             ? flowNodeSelectionStore.clearSelection()
             : flowNodeSelectionStore.selectFlowNode({
                 flowNodeId: incident.flowNodeId,

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/tests/mocks.tsx
@@ -12,8 +12,10 @@ import {useEffect} from 'react';
 import {authenticationStore} from 'modules/stores/authentication';
 import {incidentsStore} from 'modules/stores/incidents';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
-import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
 import {Paths} from 'modules/Routes';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => {
@@ -21,15 +23,18 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
       incidentsStore.reset();
       authenticationStore.reset();
       flowNodeSelectionStore.reset();
-      processInstanceDetailsDiagramStore.reset();
     };
   });
   return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route path={Paths.processInstance()} element={children} />
-      </Routes>
-    </MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route path={Paths.processInstance()} element={children} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/IncidentsTable/v2/index.tsx
@@ -14,7 +14,7 @@ import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {observer} from 'mobx-react';
 import {useProcessInstancePageParams} from '../../../useProcessInstancePageParams';
 import {FlexContainer, ErrorMessageCell} from '../styled';
-import {Incident, incidentsStore} from 'modules/stores/incidents';
+import {Incident} from 'modules/stores/incidents';
 import {Link} from 'modules/components/Link';
 import {Paths} from 'modules/Routes';
 import {useLocation} from 'react-router-dom';
@@ -24,6 +24,11 @@ import {SortableTable} from 'modules/components/SortableTable';
 import {useState} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {useHasPermissions} from 'modules/queries/permissions/useHasPermissions';
+import {
+  getFilteredIncidents,
+  isSingleIncidentSelected,
+} from 'modules/utils/incidents';
+import {useIncidents} from 'modules/hooks/incidents';
 
 const IncidentsTable: React.FC = observer(function IncidentsTable() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -34,13 +39,14 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
   const {data: hasPermissionForRetryOperation} = useHasPermissions([
     'UPDATE_PROCESS_INSTANCE',
   ]);
+  const incidents = useIncidents();
   const location = useLocation();
   const {sortBy, sortOrder} = getSortParams(location.search) || {
     sortBy: 'creationTime',
     sortOrder: 'desc',
   };
 
-  const {filteredIncidents} = incidentsStore;
+  const filteredIncidents = getFilteredIncidents(incidents);
 
   const handleModalClose = () => {
     setIsModalVisible(false);
@@ -82,7 +88,7 @@ const IncidentsTable: React.FC = observer(function IncidentsTable() {
             return;
           }
 
-          incidentsStore.isSingleIncidentSelected(incident.flowNodeInstanceId)
+          isSingleIncidentSelected(incidents, incident.flowNodeInstanceId)
             ? flowNodeSelectionStore.clearSelection()
             : flowNodeSelectionStore.selectFlowNode({
                 flowNodeId: incident.flowNodeId,

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/index.tsx
@@ -17,12 +17,17 @@ import {IncidentsTable} from './IncidentsTable';
 import {IncidentsTable as IncidentsTableV2} from './IncidentsTable/v2';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {IS_PROCESS_INSTANCE_V2_ENABLED} from 'modules/feature-flags';
+import {getFilteredIncidents} from 'modules/utils/incidents';
+import {useIncidents} from 'modules/hooks/incidents';
 
 type Props = {
   setIsInTransition: (isTransitionActive: boolean) => void;
 };
 
 const IncidentsWrapper: React.FC<Props> = observer(({setIsInTransition}) => {
+  const incidents = useIncidents();
+  const filteredIncidents = getFilteredIncidents(incidents);
+
   useEffect(() => {
     incidentsStore.init();
 
@@ -50,7 +55,7 @@ const IncidentsWrapper: React.FC<Props> = observer(({setIsInTransition}) => {
         <IncidentsOverlay>
           <PanelHeader
             title="Incidents View"
-            count={incidentsStore.filteredIncidents.length}
+            count={filteredIncidents.length}
             size="sm"
           >
             <IncidentsFilter />

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/mocks.tsx
@@ -10,6 +10,9 @@ import {Route, MemoryRouter, Routes} from 'react-router-dom';
 import {LocationLog} from 'modules/utils/LocationLog';
 import {createIncident} from 'modules/testUtils';
 import {Paths} from 'modules/Routes';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 
 const mockIncidents = {
   count: 2,
@@ -77,19 +80,23 @@ const mockResolvedIncidents = {
 
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
-    <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-      <Routes>
-        <Route
-          path={Paths.processInstance()}
-          element={
-            <>
-              {children}
-              <LocationLog />
-            </>
-          }
-        />
-      </Routes>
-    </MemoryRouter>
+    <ProcessDefinitionKeyContext.Provider value="123">
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+          <Routes>
+            <Route
+              path={Paths.processInstance()}
+              element={
+                <>
+                  {children}
+                  <LocationLog />
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ProcessDefinitionKeyContext.Provider>
   );
 };
 

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/v2/index.tsx
@@ -15,13 +15,17 @@ import {Transition} from '../styled';
 import {IncidentsFilter} from '../IncidentsFilter';
 import {IncidentsTable} from '../IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
-import {init} from 'modules/utils/incidents';
+import {getFilteredIncidents, init} from 'modules/utils/incidents';
+import {useIncidents} from 'modules/hooks/incidents';
 
 type Props = {
   setIsInTransition: (isTransitionActive: boolean) => void;
 };
 
 const IncidentsWrapper: React.FC<Props> = observer(({setIsInTransition}) => {
+  const incidents = useIncidents();
+  const filteredIncidents = getFilteredIncidents(incidents);
+
   useEffect(() => {
     init();
 
@@ -49,7 +53,7 @@ const IncidentsWrapper: React.FC<Props> = observer(({setIsInTransition}) => {
         <IncidentsOverlay>
           <PanelHeader
             title="Incidents View"
-            count={incidentsStore.filteredIncidents.length}
+            count={filteredIncidents.length}
             size="sm"
           >
             <IncidentsFilter />

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -151,6 +151,7 @@ describe('TopPanel', () => {
 
   it('should show an error when a server error occurs', async () => {
     mockFetchProcessDefinitionXml().withServerError();
+    mockFetchProcessDefinitionXml().withServerError();
 
     render(<TopPanel />, {
       wrapper: getWrapper(),

--- a/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/v2/index.test.tsx
@@ -171,6 +171,7 @@ describe('TopPanel', () => {
 
   it('should show an error when a server error occurs', async () => {
     mockFetchProcessDefinitionXml().withServerError();
+    mockFetchProcessDefinitionXml().withServerError();
 
     render(<TopPanel />, {
       wrapper: getWrapper(),

--- a/operate/client/src/modules/hooks/incidents.ts
+++ b/operate/client/src/modules/hooks/incidents.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
+import {incidentsStore} from 'modules/stores/incidents';
+import {getFlowNodeName} from '../utils/flowNodes';
+import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
+
+const useIncidents = () => {
+  const {data: businessObjects} = useBusinessObjects();
+
+  if (incidentsStore.state.response === null) {
+    return [];
+  }
+  return incidentsStore.state.response.incidents.map((incident) => ({
+    ...incident,
+    flowNodeName: getFlowNodeName({
+      businessObjects,
+      flowNodeId: incident.flowNodeId,
+    }),
+    isSelected: flowNodeSelectionStore.isSelected({
+      flowNodeId: incident.flowNodeId,
+      flowNodeInstanceId: incident.flowNodeInstanceId,
+      isMultiInstance: false,
+    }),
+  }));
+};
+
+const useIncidentsElements = () => {
+  const {data: businessObjects} = useBusinessObjects();
+
+  if (incidentsStore.state.response === null) {
+    return [];
+  }
+
+  return incidentsStore.state.response.flowNodes.map((flowNode) => ({
+    ...flowNode,
+    name: getFlowNodeName({
+      businessObjects,
+      flowNodeId: flowNode.id,
+    }),
+  }));
+};
+
+export {useIncidents, useIncidentsElements};

--- a/operate/client/src/modules/stores/incidents.test.ts
+++ b/operate/client/src/modules/stores/incidents.test.ts
@@ -102,47 +102,6 @@ describe('stores/incidents', () => {
     expect(incidentsStore.state.isLoaded).toBe(false);
   });
 
-  it('should get incidents', async () => {
-    expect(incidentsStore.incidents).toEqual([]);
-    incidentsStore.setIncidents(mockIncidents);
-
-    expect(incidentsStore.incidents).toEqual([
-      {
-        creationTime: '2020-10-08T09:18:58.258+0000',
-        errorMessage: 'Cannot connect to server delivery05',
-        errorType: {
-          id: '1',
-          name: 'No more retries left',
-        },
-        flowNodeId: 'Task_162x79i',
-        flowNodeInstanceId: '2251799813699889',
-        flowNodeName: 'Task_162x79i',
-        hasActiveOperation: false,
-        id: '2251799813700301',
-        jobId: '2251799813699901',
-        lastOperation: null,
-        isSelected: false,
-        rootCauseInstance: {
-          instanceId: '2251799813695335',
-          processDefinitionId: '2251799813687515',
-          processDefinitionName: 'Event based gateway with timer start',
-        },
-      },
-    ]);
-  });
-
-  it('should get flowNodes', async () => {
-    incidentsStore.setIncidents(mockIncidents);
-
-    expect(incidentsStore.flowNodes).toEqual([
-      {
-        id: 'Task_162x79i',
-        name: 'Task_162x79i',
-        count: 1,
-      },
-    ]);
-  });
-
   it('should get errorTypes', async () => {
     incidentsStore.setIncidents(mockIncidents);
 


### PR DESCRIPTION
## Description

This PR is removing the last store dependency from `processInstanceDetailsDiagramStore`. 
- I moved `get incidents` into a hook which can be used in components
- I moved other `get` methods into utils method

Note : In M3, incidents will be migrated to react-query and the current store will be removed

## Related issues

related to #30591
