### PR TITLE
fix: Preserve initial command context for retried listener job

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -491,7 +491,7 @@ public final class BpmnJobBehavior {
     if (changedAttributes != null && !changedAttributes.isEmpty()) {
       headers.put(
           Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME,
-          ExpressionTransformer.asListLiteral(changedAttributes));
+          ExpressionTransformer.asListLiteral(changedAttributes.stream().sorted().toList()));
     }
 
     if (userTaskRecord.getPriority() > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -214,7 +214,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             intent -> {
               final var userTaskRecord = new UserTaskRecord();
               userTaskRecord.wrap(intermediateState.getRecord());
-              return new IncidentRecordWrapper<>(userTaskKey, intent, userTaskRecord);
+              return new RetryTypedRecord<>(userTaskKey, intent, userTaskRecord);
             });
   }
 
@@ -226,7 +226,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             intent -> {
               final var record = new ProcessInstanceRecord();
               record.wrap(elementInstance.getValue());
-              return new IncidentRecordWrapper<>(elementInstance.getKey(), intent, record);
+              return new RetryTypedRecord<>(elementInstance.getKey(), intent, record);
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -18,18 +18,24 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.Map;
 
 /**
- * A wrapper class for records that facilitates retrying commands after an incident is resolved.
+ * A minimal implementation of {@link TypedRecord} used to reprocess a command, typically after an
+ * incident has been resolved.
  *
  * <p>This class is designed to handle different types of records and their corresponding intents,
  * allowing seamless recovery by re-processing the failed command.
+ *
+ * <p>Consumers can use the type of this class to identify and handle retried commands differently,
+ * if special logic is needed during reprocessing.
+ *
+ * @param <T> the type of the record value being retried
  */
-final class IncidentRecordWrapper<T extends UnifiedRecordValue> implements TypedRecord<T> {
+public final class RetryTypedRecord<T extends UnifiedRecordValue> implements TypedRecord<T> {
 
   private final long key;
   private final Intent intent;
   private final T record;
 
-  IncidentRecordWrapper(final long key, final Intent intent, final T record) {
+  RetryTypedRecord(final long key, final Intent intent, final T record) {
     this.key = key;
     this.intent = intent;
     this.record = record;
@@ -67,7 +73,7 @@ final class IncidentRecordWrapper<T extends UnifiedRecordValue> implements Typed
 
   @Override
   public RecordType getRecordType() {
-    return null;
+    return RecordType.COMMAND;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -220,16 +220,6 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     }
   }
 
-  /**
-   * Determines whether the given {@link TypedRecord} is a retried command reconstructed for
-   * reprocessing after an incident was resolved.
-   *
-   * <p>Used to skip redundant processing steps that were already performed during the original
-   * command execution.
-   *
-   * @param command the typed record to check
-   * @return {@code true} if the record represents a retried command
-   */
   private boolean isRetriedCommand(final TypedRecord<UserTaskRecord> command) {
     return command instanceof RetryTypedRecord<UserTaskRecord>;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.incident.IncidentRecordWrapper;
+import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -233,7 +233,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
    * @return {@code true} if the record represents a retried command
    */
   private boolean isRetriedCommand(final TypedRecord<UserTaskRecord> command) {
-    return command instanceof IncidentRecordWrapper<UserTaskRecord>;
+    return command instanceof RetryTypedRecord<UserTaskRecord>;
   }
 
   private void storeUserTaskRecordRequestMetadata(final TypedRecord<UserTaskRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -62,19 +62,14 @@ public class UserTaskCommandPreconditionChecker {
 
   protected Either<Rejection, UserTaskRecord> check(final TypedRecord<UserTaskRecord> command) {
     final long userTaskKey = command.getKey();
-    final UserTaskRecord persistedRecord = fetchUserTaskRecord(command);
+    final var persistedRecord =
+        userTaskState.getUserTask(userTaskKey, authCheckBehavior.getAuthorizedTenantIds(command));
 
     if (persistedRecord == null) {
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
               String.format(NO_USER_TASK_FOUND_MESSAGE, intent, userTaskKey)));
-    }
-
-    // Skip remaining checks for Zeebe-retried commands (missing request metadata),
-    // as they were already performed during the initial command processing.
-    if (!command.hasRequestMetadata()) {
-      return Either.right(persistedRecord);
     }
 
     final var authRequest =
@@ -101,13 +96,5 @@ public class UserTaskCommandPreconditionChecker {
         .map(checks -> checks.apply(command, persistedRecord))
         .filter(Either::isLeft)
         .orElse(Either.right(persistedRecord));
-  }
-
-  private UserTaskRecord fetchUserTaskRecord(final TypedRecord<UserTaskRecord> command) {
-    final long userTaskKey = command.getKey();
-    return command.hasRequestMetadata()
-        ? userTaskState.getUserTask(userTaskKey, authCheckBehavior.getAuthorizedTenantIds(command))
-        // For Zeebe-retried commands (missing metadata), fetch the user task without tenant checks.
-        : userTaskState.getUserTask(userTaskKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerIncidentsTest.java
@@ -565,9 +565,9 @@ public class TaskListenerIncidentsTest {
             ENGINE
                 .userTask()
                 .ofInstance(pik)
-                .withCandidateUsers("bob", "alice")
                 .withDueDate("new_due_date")
                 .withPriority(88)
+                .withCandidateUsers("bob", "alice")
                 .withAction("custom_update")
                 .update(),
         Map.of(


### PR DESCRIPTION
## Description
This PR fixes an issue where task listener jobs retried after incident resolution lacked the expected headers derived from the original user task command.

### Root cause
When listener job creation failed and was retried after incident resolution, the recreated listener job lost the context of the initial command (e.g., `UPDATE`, `ASSIGN`, `CLAIM`) that triggered the transition. As a result, it did not receive the correct headers such as `assignee`, `dueDate`, `candidateUsers`, `changedAttributes`, `action`, etc. This was due to reading the persisted user task state that represents the task state that was before the transition-triggering command.

### Fix
The issue was resolved by using the value of the retried command directly. After an incident is resolved, the `IncidentResolveProcessor` reconstructs and emits the user task command with the latest user task taken from the intermediate state. This ensures the recreated listener job has access to the correct context.

### Additional improvements (refactoring)
* Refactored `processOperationCommand` for better readability and separation of concerns;
* Skipped redundant `validateCommand` and `onCommand` invocations for retried commands;
* Introduced deterministic sorting for the `changedAttributes` header to ensure consistent listener job metadata;
* Renamed `IncidentRecordWrapper` to `RetryTypedRecord` for better clarity.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31089 
