### PR TITLE
pg-minio-version-bump

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/testcontainers/MinioContainer.java
@@ -43,7 +43,7 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
    * this.
    */
   public MinioContainer() {
-    this("RELEASE.2023-11-20T22-40-07Z");
+    this("RELEASE.2025-04-22T22-12-26Z");
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Version bump Minio image used in Backups tests. It does not seem to comply with S3 SDK  in the latest renovate version bump. Manually verified S3 access of backups procedure.

Unblocks renovate PR: https://github.com/camunda/camunda/pull/26845
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
