### PR TITLE
Allow searching of Mappings by Role id

### DIFF
--- a/db/rdbms/src/main/resources/mapper/MappingMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingMapper.xml
@@ -38,7 +38,12 @@
     SELECT COUNT(*)
     FROM ${prefix}MAPPINGS m
     <if test="filter.groupId != null">
-      JOIN ${prefix}GROUP_MEMBER gm ON m.MAPPING_ID = gm.ENTITY_ID AND gm.ENTITY_TYPE = 'MAPPING'
+      JOIN ${prefix}GROUP_MEMBER gm ON m.MAPPING_ID = gm.ENTITY_ID
+      AND gm.ENTITY_TYPE = 'MAPPING'
+    </if>
+    <if test="filter.roleId != null">
+      JOIN ${prefix}ROLE_MEMBER rm ON m.MAPPING_ID = rm.ENTITY_ID
+      AND rm.ENTITY_TYPE = 'MAPPING'
     </if>
     <include refid="io.camunda.db.rdbms.sql.MappingMapper.searchFilter"/>
   </select>
@@ -54,7 +59,12 @@
     NAME
     FROM ${prefix}MAPPINGS m
     <if test="filter.groupId != null">
-      JOIN ${prefix}GROUP_MEMBER gm ON m.MAPPING_ID = gm.ENTITY_ID AND gm.ENTITY_TYPE = 'MAPPING'
+      JOIN ${prefix}GROUP_MEMBER gm ON m.MAPPING_ID = gm.ENTITY_ID
+      AND gm.ENTITY_TYPE = 'MAPPING'
+    </if>
+    <if test="filter.roleId != null">
+      JOIN ${prefix}ROLE_MEMBER rm ON m.MAPPING_ID = rm.ENTITY_ID
+      AND rm.ENTITY_TYPE = 'MAPPING'
     </if>
     <include refid="io.camunda.db.rdbms.sql.MappingMapper.searchFilter"/>
     ) t
@@ -80,7 +90,12 @@
     <if test="filter.name != null">
       AND NAME = #{filter.name}
     </if>
-    <if test="filter.groupId != null">AND gm.GROUP_ID = #{filter.groupId}</if>
+    <if test="filter.roleId != null">
+        AND rm.ROLE_ID = #{filter.roleId}
+    </if>
+    <if test="filter.groupId != null">
+      AND gm.GROUP_ID = #{filter.groupId}
+    </if>
   </sql>
 
 </mapper>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.it.rdbms.db.fixtures;
 
-import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.MappingDbModel;
 import io.camunda.db.rdbms.write.domain.MappingDbModel.MappingDbModelBuilder;
@@ -38,9 +37,8 @@ public final class MappingFixtures extends CommonFixtures {
   }
 
   public static void createAndSaveRandomMappings(
-      final RdbmsService rdbmsService,
+      final RdbmsWriter rdbmsWriter,
       final Function<MappingDbModelBuilder, MappingDbModelBuilder> builderFunction) {
-    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(1L);
     for (int i = 0; i < 20; i++) {
       rdbmsWriter.getMappingWriter().create(MappingFixtures.createRandomized(builderFunction));
     }
@@ -48,13 +46,12 @@ public final class MappingFixtures extends CommonFixtures {
   }
 
   public static void createAndSaveMapping(
-      final RdbmsService rdbmsService, final MappingDbModel mapping) {
-    createAndSaveMappings(rdbmsService, List.of(mapping));
+      final RdbmsWriter rdbmsWriter, final MappingDbModel mapping) {
+    createAndSaveMappings(rdbmsWriter, List.of(mapping));
   }
 
   public static void createAndSaveMappings(
-      final RdbmsService rdbmsService, final List<MappingDbModel> mappingList) {
-    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(1L);
+      final RdbmsWriter rdbmsWriter, final List<MappingDbModel> mappingList) {
     for (final MappingDbModel mapping : mappingList) {
       rdbmsWriter.getMappingWriter().create(mapping);
     }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
@@ -29,13 +29,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class MappingIT {
+  private static final long PARTITION_ID = 0L;
 
   @TestTemplate
   public void shouldSaveAndFindMappingByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final MappingDbModel randomizedMapping = MappingFixtures.createRandomized();
-    createAndSaveMapping(rdbmsService, randomizedMapping);
+    createAndSaveMapping(rdbmsWriter, randomizedMapping);
 
     final var mapping =
         rdbmsService.getMappingReader().findOne(randomizedMapping.mappingId()).orElse(null);
@@ -46,10 +48,11 @@ public class MappingIT {
   @TestTemplate
   public void shouldDeleteMapping(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     // Create and save a mapping
     final MappingDbModel randomizedMapping = MappingFixtures.createRandomized();
-    createAndSaveMapping(rdbmsService, randomizedMapping);
+    createAndSaveMapping(rdbmsWriter, randomizedMapping);
 
     // Verify the mapping is saved
     final var mappingId = randomizedMapping.mappingId();
@@ -70,10 +73,11 @@ public class MappingIT {
   @TestTemplate
   public void shouldFindMappingByClaimName(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     // Create and save a mapping
     final MappingDbModel randomizedMapping = MappingFixtures.createRandomized();
-    createAndSaveMapping(rdbmsService, randomizedMapping);
+    createAndSaveMapping(rdbmsWriter, randomizedMapping);
 
     // Search for the mapping by claimName
     final var searchResult =
@@ -97,10 +101,11 @@ public class MappingIT {
   @TestTemplate
   public void shouldFindMappingByClaimValue(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     // Create and save a mapping
     final MappingDbModel randomizedMapping = MappingFixtures.createRandomized();
-    createAndSaveMapping(rdbmsService, randomizedMapping);
+    createAndSaveMapping(rdbmsWriter, randomizedMapping);
 
     // Search for the mapping by claimValue
     final var searchResult =
@@ -124,9 +129,10 @@ public class MappingIT {
   @TestTemplate
   public void shouldFindAllMappingsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
 
     final var searchResult =
         rdbmsService
@@ -145,13 +151,14 @@ public class MappingIT {
   @TestTemplate
   public void shouldFindMappingWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final MappingReader mappingReader = rdbmsService.getMappingReader();
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
     final MappingDbModel randomizedMapping =
         MappingFixtures.createRandomized(b -> b.claimName(claimName));
-    createAndSaveMapping(rdbmsService, randomizedMapping);
+    createAndSaveMapping(rdbmsWriter, randomizedMapping);
 
     final var searchResult =
         mappingReader.search(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSortIT.java
@@ -11,6 +11,7 @@ import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.createAndSaveRando
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.fixtures.MappingFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
@@ -28,12 +29,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
 public class MappingSortIT {
 
+  public static final long PARTITION_ID = 0L;
+
   @TestTemplate
   public void shouldSortMappingsByClaimNameAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
 
     final var searchResult =
         rdbmsService
@@ -52,9 +56,10 @@ public class MappingSortIT {
   @TestTemplate
   public void shouldSortMappingsByClaimNameDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
 
     final var searchResult =
         rdbmsService
@@ -73,9 +78,10 @@ public class MappingSortIT {
   @TestTemplate
   public void shouldSortMappingsByClaimValueAsc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
 
     final var searchResult =
         rdbmsService
@@ -95,9 +101,10 @@ public class MappingSortIT {
   public void shouldSortMappingsByClaimValueDesc(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String claimName = "claimName-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.claimName(claimName));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.claimName(claimName));
 
     final var searchResult =
         rdbmsService
@@ -116,9 +123,10 @@ public class MappingSortIT {
   @TestTemplate
   public void shouldSortMappingsByNameValueDesc(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
 
     final String name = "name-" + MappingFixtures.nextStringId();
-    createAndSaveRandomMappings(rdbmsService, b -> b.name(name));
+    createAndSaveRandomMappings(rdbmsWriter, b -> b.name(name));
 
     final var searchResult =
         rdbmsService

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSpecificFilterIT.java
@@ -19,9 +19,9 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.MappingReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
+import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.MappingFixtures;
-import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.MappingEntity;
@@ -63,9 +63,9 @@ public class MappingSpecificFilterIT {
     final var mapping1 = MappingFixtures.createRandomized();
     final var mapping2 = MappingFixtures.createRandomized();
     final var mapping3 = MappingFixtures.createRandomized();
-    createAndSaveMapping(rdbmsService, mapping1);
-    createAndSaveMapping(rdbmsService, mapping2);
-    createAndSaveMapping(rdbmsService, mapping3);
+    createAndSaveMapping(rdbmsWriter, mapping1);
+    createAndSaveMapping(rdbmsWriter, mapping2);
+    createAndSaveMapping(rdbmsWriter, mapping3);
 
     final var group = GroupFixtures.createRandomized(b -> b);
     final var anotherGroup = GroupFixtures.createRandomized(b -> b);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSpecificFilterIT.java
@@ -8,7 +8,10 @@
 package io.camunda.it.rdbms.db.mapping;
 
 import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
+import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.*;
 import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.createAndSaveMapping;
+import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
+import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
@@ -18,11 +21,15 @@ import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.fixtures.MappingFixtures;
+import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
+import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.sort.MappingSort;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -79,8 +86,48 @@ public class MappingSpecificFilterIT {
     assertThat(mappings.total()).isEqualTo(2);
   }
 
+  @Test
+  public void shouldFilterMappingsForRole() {
+    final var role = RoleFixtures.createRandomized(b -> b);
+    final var anotherRole = RoleFixtures.createRandomized(b -> b);
+    createAndSaveRole(rdbmsWriter, role);
+    createAndSaveRole(rdbmsWriter, anotherRole);
+
+    final var mappingId1 = nextStringId();
+    final var mappingId2 = nextStringId();
+    final var mappingId3 = nextStringId();
+    Arrays.asList(mappingId1, mappingId2, mappingId3)
+        .forEach(
+            mappingId ->
+                createAndSaveMapping(rdbmsWriter, createRandomized(m -> m.mappingId(mappingId))));
+
+    addMappingToRole(role.roleId(), mappingId1);
+    addMappingToRole(anotherRole.roleId(), mappingId2);
+    addMappingToRole(anotherRole.roleId(), mappingId3);
+
+    final var mappings =
+        mappingReader.search(
+            new MappingQuery(
+                new MappingFilter.Builder().roleId(role.roleId()).build(),
+                MappingSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(mappings.total()).isEqualTo(1);
+    assertThat(mappings.items())
+        .hasSize(1)
+        .extracting(MappingEntity::mappingId)
+        .containsOnly(mappingId1);
+  }
+
   private void addMappingToGroup(final String groupId, final String mappingId) {
     rdbmsWriter.getGroupWriter().addMember(new GroupMemberDbModel(groupId, mappingId, "MAPPING"));
+    rdbmsWriter.flush();
+  }
+
+  private void addMappingToRole(final String roledId, final String mappingId) {
+    rdbmsWriter
+        .getRoleWriter()
+        .addMember(new RoleMemberDbModel(roledId, mappingId, MAPPING.name()));
     rdbmsWriter.flush();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -412,6 +412,9 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     if (mappingQuery.filter().groupId() != null) {
       return expandGroupFilter(mappingQuery);
     }
+    if (mappingQuery.filter().roleId() != null) {
+      return expandRoleFilter(mappingQuery);
+    }
     return mappingQuery;
   }
 
@@ -488,19 +491,21 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   private UserQuery expandRoleFilter(final UserQuery userQuery) {
+    final var usernames = getRoleMemberIds(userQuery.filter().roleId(), EntityType.USER);
+    return userQuery.toBuilder()
+        .filter(userQuery.filter().toBuilder().usernames(usernames).build())
+        .build();
+  }
+
+  public Set<String> getRoleMemberIds(final String roleId, final EntityType memberType) {
     final List<RoleMemberEntity> roleMembers =
         getSearchExecutor()
             .findAll(
                 new RoleQuery.Builder()
-                    .filter(f -> f.joinParentId(userQuery.filter().roleId()).memberType(USER))
+                    .filter(f -> f.joinParentId(roleId).memberType(memberType))
                     .build(),
                 io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity.class);
-    final var usernames =
-        roleMembers.stream().map(RoleMemberEntity::id).collect(Collectors.toSet());
-
-    return userQuery.toBuilder()
-        .filter(userQuery.filter().toBuilder().usernames(usernames).build())
-        .build();
+    return roleMembers.stream().map(RoleMemberEntity::id).collect(Collectors.toSet());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -497,6 +497,13 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
         .build();
   }
 
+  private MappingQuery expandRoleFilter(final MappingQuery mappingQuery) {
+    final var mappingIds = getRoleMemberIds(mappingQuery.filter().roleId(), MAPPING);
+    return mappingQuery.toBuilder()
+        .filter(mappingQuery.filter().toBuilder().mappingIds(mappingIds).build())
+        .build();
+  }
+
   public Set<String> getRoleMemberIds(final String roleId, final EntityType memberType) {
     final List<RoleMemberEntity> roleMembers =
         getSearchExecutor()

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
@@ -24,7 +24,8 @@ public record MappingFilter(
     List<Claim> claims,
     String tenantId,
     Set<String> mappingIds,
-    String groupId)
+    String groupId,
+    String roleId)
     implements FilterBase {
 
   public MappingFilter.Builder toBuilder() {
@@ -38,7 +39,8 @@ public record MappingFilter(
         .claims(claims)
         .tenantId(tenantId)
         .mappingIds(mappingIds)
-        .groupId(groupId);
+        .groupId(groupId)
+        .roleId(roleId);
   }
 
   public static final class Builder implements ObjectBuilder<MappingFilter> {
@@ -52,6 +54,7 @@ public record MappingFilter(
     private List<Claim> claims;
     private String tenantId;
     private String groupId;
+    private String roleId;
 
     public Builder mappingId(final String value) {
       mappingId = value;
@@ -103,6 +106,11 @@ public record MappingFilter(
       return this;
     }
 
+    public Builder roleId(final String roleId) {
+      this.roleId = roleId;
+      return this;
+    }
+
     @Override
     public MappingFilter build() {
       return new MappingFilter(
@@ -115,7 +123,8 @@ public record MappingFilter(
           claims,
           tenantId,
           mappingIds,
-          groupId);
+          groupId,
+          roleId);
     }
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3092,6 +3092,48 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /roles/{roleId}/mapping-rules/search:
+    post:
+      tags:
+        - Role
+      operationId: searchMappingRulesForRole
+      summary: Search role mapping rules
+      description: |
+        Search mapping rules assigned to a role.
+      parameters:
+        - name: roleId
+          in: path
+          required: true
+          description: The role ID.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MappingSearchQueryRequest"
+      responses:
+        "200":
+          description: The mapping rules assigned to the role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MappingSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /groups:
     post:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.service.RoleServices.RoleMemberRequest;
@@ -46,11 +47,13 @@ public class RoleControllerTest extends RestControllerTest {
 
   @MockBean private RoleServices roleServices;
   @MockBean private UserServices userServices;
+  @MockBean private MappingServices mappingServices;
 
   @BeforeEach
   void setup() {
     when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
     when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
+    when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->


Adds a new endpoint to the V2 API. It allows querying for Mappings that are member of a specific role.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31733
