### PR TITLE
Add client command to search mappings by groupId

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -78,6 +78,7 @@ import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.GroupsSearchRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
+import io.camunda.client.api.fetch.MappingsByGroupSearchRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
@@ -1933,4 +1934,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    */
   ProcessInstanceGetCallHierarchyRequest newProcessInstanceGetCallHierarchyRequest(
       Long processInstanceKey);
+
+  /**
+   * Executes a search request to query mappings by group.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newMappingsByGroupSearchRequest(groupId)
+   *    .filter((f) -> f.mappingId(mappingId))
+   *    .sort((s) -> s.mappingId().asc())
+   *    .page((p) -> p.limit(100))
+   *    .send();
+   * </pre>
+   *
+   * @param groupId the ID of the group
+   * @return a builder for the mappings by group search request
+   */
+  MappingsByGroupSearchRequest newMappingsByGroupSearchRequest(String groupId);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/MappingsByGroupSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/MappingsByGroupSearchRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.search.filter.MappingFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.TypedSearchRequest;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.client.api.search.sort.MappingSort;
+
+public interface MappingsByGroupSearchRequest
+    extends TypedSearchRequest<MappingFilter, MappingSort, MappingsByGroupSearchRequest>,
+        FinalSearchRequestStep<Mapping> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+
+public interface MappingFilter extends SearchRequestFilter {
+
+  /**
+   * Filter mappings by the specified mapping id.
+   *
+   * @param mappingId the id of the mapping
+   * @return the updated filter
+   */
+  MappingFilter mappingId(final String mappingId);
+
+  /**
+   * Filter mappings by the specified claim name.
+   *
+   * @param claimName the name of the claim
+   * @return the updated filter
+   */
+  MappingFilter claimName(final String claimName);
+
+  /**
+   * Filter mappings by the specified claim value.
+   *
+   * @param claimValue the value of the claim
+   * @return the updated filter
+   */
+  MappingFilter claimValue(final String claimValue);
+
+  /**
+   * Filter mappings by the specified name.
+   *
+   * @param name the name of the mapping
+   * @return the updated filter
+   */
+  MappingFilter name(final String name);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
+import io.camunda.client.api.search.filter.MappingFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserFilter;
@@ -35,6 +36,7 @@ import io.camunda.client.api.search.sort.DecisionRequirementsSort;
 import io.camunda.client.api.search.sort.ElementInstanceSort;
 import io.camunda.client.api.search.sort.GroupSort;
 import io.camunda.client.api.search.sort.IncidentSort;
+import io.camunda.client.api.search.sort.MappingSort;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.search.sort.UserSort;
@@ -48,6 +50,7 @@ import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
 import io.camunda.client.impl.search.filter.ElementInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.GroupFilterImpl;
 import io.camunda.client.impl.search.filter.IncidentFilterImpl;
+import io.camunda.client.impl.search.filter.MappingFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.UserFilterImpl;
@@ -62,6 +65,7 @@ import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
 import io.camunda.client.impl.search.sort.ElementInstanceSortImpl;
 import io.camunda.client.impl.search.sort.GroupSortImpl;
 import io.camunda.client.impl.search.sort.IncidentSortImpl;
+import io.camunda.client.impl.search.sort.MappingSortImpl;
 import io.camunda.client.impl.search.sort.ProcessDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.ProcessInstanceSortImpl;
 import io.camunda.client.impl.search.sort.UserSortImpl;
@@ -244,6 +248,18 @@ public final class SearchRequestBuilders {
 
   public static UserSort userSort(final Consumer<UserSort> fn) {
     final UserSort sort = new UserSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static MappingFilter mappingFilter(final Consumer<MappingFilter> fn) {
+    final MappingFilter filter = new MappingFilterImpl();
+    fn.accept(filter);
+    return filter;
+  }
+
+  public static MappingSort mappingSort(final Consumer<MappingSort> fn) {
+    final MappingSort sort = new MappingSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Mapping.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Mapping.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+public interface Mapping {
+
+  String getMappingId();
+
+  String getClaimName();
+
+  String getClaimValue();
+
+  String getName();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/MappingSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/MappingSort.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.sort;
+
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+
+public interface MappingSort extends SearchRequestSort<MappingSort> {
+
+  MappingSort mappingId();
+
+  MappingSort claimName();
+
+  MappingSort claimValue();
+
+  MappingSort name();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -89,6 +89,7 @@ import io.camunda.client.api.fetch.ElementInstanceGetRequest;
 import io.camunda.client.api.fetch.GroupGetRequest;
 import io.camunda.client.api.fetch.GroupsSearchRequest;
 import io.camunda.client.api.fetch.IncidentGetRequest;
+import io.camunda.client.api.fetch.MappingsByGroupSearchRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetFormRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetRequest;
 import io.camunda.client.api.fetch.ProcessDefinitionGetXmlRequest;
@@ -196,6 +197,7 @@ import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestIm
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
+import io.camunda.client.impl.search.request.MappingsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.UserTaskSearchRequestImpl;
@@ -1025,6 +1027,11 @@ public final class CamundaClientImpl implements CamundaClient {
   public ProcessInstanceGetCallHierarchyRequest newProcessInstanceGetCallHierarchyRequest(
       final Long processInstanceKey) {
     return new ProcessInstanceGetCallHierarchyRequestImpl(httpClient, processInstanceKey);
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest newMappingsByGroupSearchRequest(final String groupId) {
+    return new MappingsByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.filter.MappingFilter;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.protocol.rest.MappingFilterRequest;
+
+public class MappingFilterImpl extends TypedSearchRequestPropertyProvider<MappingFilterRequest>
+    implements MappingFilter {
+
+  private final MappingFilterRequest filter;
+
+  public MappingFilterImpl() {
+    filter = new MappingFilterRequest();
+  }
+
+  @Override
+  public MappingFilter mappingId(final String mappingId) {
+    filter.setMappingId(mappingId);
+    return this;
+  }
+
+  @Override
+  public MappingFilter claimName(final String claimName) {
+    filter.setClaimName(claimName);
+    return this;
+  }
+
+  @Override
+  public MappingFilter claimValue(final String claimValue) {
+    filter.setClaimValue(claimValue);
+    return this;
+  }
+
+  @Override
+  public MappingFilter name(final String name) {
+    filter.setName(name);
+    return this;
+  }
+
+  @Override
+  protected MappingFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByGroupSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.fetch.MappingsByGroupSearchRequest;
+import io.camunda.client.api.search.filter.MappingFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.MappingSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.MappingSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class MappingsByGroupSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<MappingSearchQueryRequest>
+    implements MappingsByGroupSearchRequest {
+
+  private final MappingSearchQueryRequest request;
+  private final String groupId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public MappingsByGroupSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String groupId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.groupId = groupId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new MappingSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Mapping> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Mapping>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("groupId", groupId);
+    final HttpCamundaFuture<SearchResponse<Mapping>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/groups/%s/mapping-rules/search", groupId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        MappingSearchQueryResult.class,
+        SearchResponseMapper::toMappingsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest filter(final MappingFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest filter(final Consumer<MappingFilter> fn) {
+    return filter(mappingFilter(fn));
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest sort(final MappingSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toMappingSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest sort(final Consumer<MappingSort> fn) {
+    return sort(mappingSort(fn));
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingsByGroupSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected MappingSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MappingImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MappingImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.Mapping;
+
+public class MappingImpl implements Mapping {
+
+  private final String mappingId;
+  private final String claimName;
+  private final String claimValue;
+  private final String name;
+
+  public MappingImpl(
+      final String mappingId, final String claimName, final String claimValue, final String name) {
+    this.mappingId = mappingId;
+    this.claimName = claimName;
+    this.claimValue = claimValue;
+    this.name = name;
+  }
+
+  @Override
+  public String getMappingId() {
+    return mappingId;
+  }
+
+  @Override
+  public String getClaimName() {
+    return claimName;
+  }
+
+  @Override
+  public String getClaimValue() {
+    return claimValue;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.Mapping;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.ProcessInstanceCallHierarchyEntryResponse;
@@ -175,6 +176,14 @@ public final class SearchResponseMapper {
         response.getEmail());
   }
 
+  public static Mapping toMappingResponse(final MappingResult response) {
+    return new MappingImpl(
+        response.getMappingId(),
+        response.getClaimName(),
+        response.getClaimValue(),
+        response.getName());
+  }
+
   public static SearchResponse<Group> toGroupsResponse(final GroupSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Group> instances =
@@ -186,6 +195,14 @@ public final class SearchResponseMapper {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<User> instances =
         toSearchResponseInstances(response.getItems(), SearchResponseMapper::toUserResponse);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static SearchResponse<Mapping> toMappingsResponse(
+      final MappingSearchQueryResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<Mapping> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toMappingResponse);
     return new SearchResponseImpl<>(instances, page);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/MappingSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/MappingSortImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.sort;
+
+import io.camunda.client.api.search.sort.MappingSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
+
+public class MappingSortImpl extends SearchRequestSortBase<MappingSort> implements MappingSort {
+
+  @Override
+  public MappingSort mappingId() {
+    return field("mappingId");
+  }
+
+  @Override
+  public MappingSort claimName() {
+    return field("claimName");
+  }
+
+  @Override
+  public MappingSort claimValue() {
+    return field("claimValue");
+  }
+
+  @Override
+  public MappingSort name() {
+    return field("name");
+  }
+
+  @Override
+  protected MappingSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.sort.MappingSort;
 import io.camunda.client.api.search.sort.UserSort;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,24 @@ public class GroupSearchTest extends ClientRestTest {
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/groups/groupId/users/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  public void testMappingsByGroupSearch() {
+    // when
+    final String groupId = "groupId";
+    client
+        .newMappingsByGroupSearchRequest(groupId)
+        .filter(fn -> fn.mappingId("mappingId"))
+        .sort(MappingSort::name)
+        .page(fn -> fn.limit(5))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/groups/groupId/mapping-rules/search");
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingsByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MappingsByGroupSearchTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class MappingsByGroupSearchTest {
+
+  private static CamundaClient camundaClient;
+
+  private static final String MAPPING_ID_1 = "a" + Strings.newRandomValidUsername();
+  private static final String MAPPING_ID_2 = "b" + Strings.newRandomValidUsername();
+  private static final String MAPPING_ID_3 = "c" + Strings.newRandomValidUsername();
+  private static final String GROUP_ID = Strings.newRandomValidIdentityId();
+
+  @BeforeAll
+  static void setup() {
+    createMapping(MAPPING_ID_1);
+    createMapping(MAPPING_ID_2);
+    createMapping(MAPPING_ID_3);
+
+    createGroup(GROUP_ID);
+
+    assignMappingToGroup(MAPPING_ID_1, GROUP_ID);
+    assignMappingToGroup(MAPPING_ID_2, GROUP_ID);
+
+    waitForGroupsToBeUpdated();
+  }
+
+  @Test
+  void shouldReturnMappingsByGroup() {
+    final var mappings = camundaClient.newMappingsByGroupSearchRequest(GROUP_ID).send().join();
+
+    assertThat(mappings.items().size()).isEqualTo(2);
+    assertThat(mappings.items())
+        .extracting(
+            Mapping::getMappingId, Mapping::getClaimName, Mapping::getClaimValue, Mapping::getName)
+        .contains(
+            tuple(MAPPING_ID_1, MAPPING_ID_1 + "claimName", MAPPING_ID_1 + "claimValue", "name"),
+            tuple(MAPPING_ID_2, MAPPING_ID_2 + "claimName", MAPPING_ID_2 + "claimValue", "name"));
+  }
+
+  @Test
+  void shouldReturnMappingsByGroupFiltered() {
+    final var mappings =
+        camundaClient
+            .newMappingsByGroupSearchRequest(GROUP_ID)
+            .filter(fn -> fn.mappingId(MAPPING_ID_1))
+            .send()
+            .join();
+
+    assertThat(mappings.items().size()).isEqualTo(1);
+    assertThat(mappings.items()).extracting(Mapping::getMappingId).containsExactly(MAPPING_ID_1);
+  }
+
+  @Test
+  void shouldReturnMappingByGroupSorted() {
+    final var mappings =
+        camundaClient
+            .newMappingsByGroupSearchRequest(GROUP_ID)
+            .sort(fn -> fn.mappingId().desc())
+            .send()
+            .join();
+
+    assertThat(mappings.items().size()).isEqualTo(2);
+    assertThat(mappings.items())
+        .extracting(Mapping::getMappingId)
+        .containsExactly(MAPPING_ID_2, MAPPING_ID_1);
+  }
+
+  @Test
+  void shouldRejectIfMissingGroupId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newMappingsByGroupSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be null");
+  }
+
+  @Test
+  void shouldRejectIfEmptyGroupId() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newMappingsByGroupSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be empty");
+  }
+
+  private static void createMapping(final String mappingId) {
+    camundaClient
+        .newCreateMappingCommand()
+        .mappingId(mappingId)
+        .name("name")
+        .claimName(mappingId + "claimName")
+        .claimValue(mappingId + "claimValue")
+        .send()
+        .join();
+  }
+
+  private static void createGroup(final String groupId) {
+    camundaClient.newCreateGroupCommand().groupId(groupId).name("name").send().join();
+  }
+
+  private static void assignMappingToGroup(final String mappingId, final String groupId) {
+    camundaClient.newAssignMappingToGroupCommand(groupId).mappingId(mappingId).send().join();
+  }
+
+  private static void waitForGroupsToBeUpdated() {
+    Awaitility.await("should receive data from ES")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var mappings =
+                  camundaClient.newMappingsByGroupSearchRequest(GROUP_ID).send().join();
+              assertThat(mappings.items().size()).isEqualTo(2);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
@@ -18,11 +18,8 @@ import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class UsersByGroupSearchTest {
 
   private static CamundaClient camundaClient;
@@ -43,7 +40,7 @@ public class UsersByGroupSearchTest {
     assignUserToGroup(USER_USERNAME_1, GROUP_ID);
     assignUserToGroup(USER_USERNAME_2, GROUP_ID);
 
-    waitForGroupsToBeCreated();
+    waitForGroupsToBeUpdated();
   }
 
   @Test
@@ -104,15 +101,12 @@ public class UsersByGroupSearchTest {
     camundaClient.newAssignUserToGroupCommand(groupId).username(username).send().join();
   }
 
-  private static void waitForGroupsToBeCreated() {
+  private static void waitForGroupsToBeUpdated() {
     Awaitility.await("should receive data from ES")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
-              final var result = camundaClient.newGroupsSearchRequest().send().join();
-              assertThat(result.items().size()).isEqualTo(1);
-
               final var users = camundaClient.newUsersByGroupSearchRequest(GROUP_ID).send().join();
               assertThat(users.items().size()).isEqualTo(2);
             });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a new client command to search mappings that have been assigned to a specific group

## Related issues

closes #31749 
