### PR TITLE
fix: allow adding applications to roles

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRoleEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerRoleEntityRequest.java
@@ -37,12 +37,6 @@ public final class BrokerRoleEntityRequest extends BrokerExecuteCommand<RoleReco
   }
 
   public BrokerRoleEntityRequest setEntity(final EntityType entityType, final String entityId) {
-    if (entityType != EntityType.USER
-        && entityType != EntityType.MAPPING
-        && entityType != EntityType.GROUP) {
-      throw new IllegalArgumentException(
-          "For now, roles can only be granted to users, mappings and groups");
-    }
     roleDto.setEntityType(entityType);
     roleDto.setEntityId(entityId);
     return this;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -12,19 +12,9 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.EnumSet;
-import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<TenantRecord> {
-  private static final Set<EntityType> ALLOWED_ENTITY_TYPES =
-      EnumSet.of(
-          EntityType.USER,
-          EntityType.MAPPING,
-          EntityType.GROUP,
-          EntityType.ROLE,
-          EntityType.APPLICATION);
-
   private final TenantRecord tenantDto = new TenantRecord();
 
   private BrokerTenantEntityRequest(final TenantIntent intent) {
@@ -50,10 +40,6 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
   }
 
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final String entityId) {
-    if (!ALLOWED_ENTITY_TYPES.contains(entityType)) {
-      throw new IllegalArgumentException(
-          "For now, tenants can only be assigned to %s".formatted(ALLOWED_ENTITY_TYPES));
-    }
     tenantDto.setEntityType(entityType);
     tenantDto.setEntityId(entityId);
     return this;


### PR DESCRIPTION
There was some validation logic in the request builder that prevented adding applications to roles.
This is now removed entirely because request validation should mostly occur during processing. Case in point, the
`shouldAddApplicationEntityToRole` worked despite the API being broken because it circumvented the request builder.

relates to https://github.com/camunda/camunda/issues/31376
