### PR TITLE
refactor: remove groupKey field from the response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateGroupResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateGroupResponse.java
@@ -16,12 +16,6 @@
 package io.camunda.client.api.response;
 
 public interface CreateGroupResponse {
-  /**
-   * Returns the key of the created group.
-   *
-   * @return the key of the created group.
-   */
-  long getGroupKey();
 
   /**
    * Returns the ID of the created group.

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateGroupResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateGroupResponse.java
@@ -16,15 +16,6 @@
 package io.camunda.client.api.response;
 
 public interface UpdateGroupResponse {
-  /**
-   * Returns the unique key of the updated group.
-   *
-   * <p>The group key is a system-generated identifier that is unique across all groups. It is
-   * primarily used internally by the system for efficient indexing and processing.
-   *
-   * @return the system-generated group key.
-   */
-  long getGroupKey();
 
   /**
    * Returns the unique identifier (ID) of the updated group.

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Group.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Group.java
@@ -17,8 +17,6 @@ package io.camunda.client.api.search.response;
 
 public interface Group {
 
-  Long getGroupKey();
-
   String getGroupId();
 
   String getName();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateGroupResponseImpl.java
@@ -20,15 +20,9 @@ import io.camunda.client.protocol.rest.GroupCreateResult;
 
 public class CreateGroupResponseImpl implements CreateGroupResponse {
 
-  private long groupKey;
   private String groupId;
   private String name;
   private String description;
-
-  @Override
-  public long getGroupKey() {
-    return groupKey;
-  }
 
   @Override
   public String getGroupId() {
@@ -46,7 +40,6 @@ public class CreateGroupResponseImpl implements CreateGroupResponse {
   }
 
   public CreateGroupResponseImpl setResponse(final GroupCreateResult response) {
-    groupKey = Long.parseLong(response.getGroupKey());
     groupId = response.getGroupId();
     name = response.getName();
     description = response.getDescription();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateGroupResponseImpl.java
@@ -19,15 +19,9 @@ import io.camunda.client.api.response.UpdateGroupResponse;
 import io.camunda.client.protocol.rest.GroupUpdateResult;
 
 public class UpdateGroupResponseImpl implements UpdateGroupResponse {
-  private long groupKey;
   private String groupId;
   private String name;
   private String description;
-
-  @Override
-  public long getGroupKey() {
-    return groupKey;
-  }
 
   @Override
   public String getGroupId() {
@@ -45,7 +39,6 @@ public class UpdateGroupResponseImpl implements UpdateGroupResponse {
   }
 
   public UpdateGroupResponseImpl setResponse(final GroupUpdateResult response) {
-    groupKey = Long.parseLong(response.getGroupKey());
     groupId = response.getGroupId();
     name = response.getName();
     description = response.getDescription();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupImpl.java
@@ -19,22 +19,14 @@ import io.camunda.client.api.search.response.Group;
 
 public class GroupImpl implements Group {
 
-  private final long groupKey;
   private final String groupId;
   private final String name;
   private final String description;
 
-  public GroupImpl(
-      final Long groupKey, final String groupId, final String name, final String description) {
-    this.groupKey = groupKey;
+  public GroupImpl(final String groupId, final String name, final String description) {
     this.groupId = groupId;
     this.name = name;
     this.description = description;
-  }
-
-  @Override
-  public Long getGroupKey() {
-    return groupKey;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -164,11 +164,7 @@ public final class SearchResponseMapper {
   }
 
   public static Group toGroupResponse(final GroupResult response) {
-    return new GroupImpl(
-        ParseUtil.parseLongOrNull(response.getGroupKey()),
-        response.getGroupId(),
-        response.getName(),
-        response.getDescription());
+    return new GroupImpl(response.getGroupId(), response.getName(), response.getDescription());
   }
 
   public static User toUserResponse(final UserResult response) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -55,13 +55,6 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public Optional<PersistedGroup> get(final long groupKey) {
-    groupId.wrapString(String.valueOf(groupKey));
-    final var persistedGroup = groupColumnFamily.get(groupId);
-    return Optional.ofNullable(persistedGroup);
-  }
-
-  @Override
   public Optional<PersistedGroup> get(final String groupId) {
     this.groupId.wrapString(groupId);
     final var persistedGroup = groupColumnFamily.get(this.groupId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -12,9 +12,5 @@ import java.util.Optional;
 
 public interface GroupState {
 
-  // TODO: remove this method once every entity is switched to IDs
-  // this method is used in AuthorizationCheckBehavior to retrieve groups by key from mapping
-  Optional<PersistedGroup> get(long groupKey);
-
   Optional<PersistedGroup> get(String groupId);
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7229,9 +7229,6 @@ components:
     GroupCreateResult:
       type: object
       properties:
-        groupKey:
-          description: The key of the created group.
-          type: string
         groupId:
           description: The ID of the created group.
           type: string
@@ -7265,9 +7262,6 @@ components:
         description:
           type: string
           description: The description of the group.
-        groupKey:
-          type: string
-          description: The unique system-generated internal group key.
     GroupResult:
       description: Group search response item.
       type: object
@@ -7275,9 +7269,6 @@ components:
         name:
           type: string
           description: The group name.
-        groupKey:
-          type: string
-          description: The group key.
         groupId:
           type: string
           description: The group ID.
@@ -7291,7 +7282,6 @@ components:
           description: The field to sort by.
           type: string
           enum:
-            - groupKey
             - name
             - groupId
         order:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -539,7 +539,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toGroupCreateResponse(final GroupRecord groupRecord) {
     final var response =
         new GroupCreateResult()
-            .groupKey(KeyUtil.keyToString(groupRecord.getGroupKey()))
             .name(groupRecord.getName())
             .groupId(groupRecord.getGroupId())
             .description(groupRecord.getDescription());
@@ -549,7 +548,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toGroupUpdateResponse(final GroupRecord groupRecord) {
     final var response =
         new GroupUpdateResult()
-            .groupKey(KeyUtil.keyToString(groupRecord.getGroupKey()))
             .groupId(groupRecord.getGroupId())
             .description(groupRecord.getDescription())
             .name(groupRecord.getName());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1027,7 +1027,6 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case GROUP_KEY -> builder.groupKey();
         case GROUP_ID -> builder.groupId();
         case NAME -> builder.name();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -400,7 +400,6 @@ public final class SearchQueryResponseMapper {
 
   public static GroupResult toGroup(final GroupEntity groupEntity) {
     return new GroupResult()
-        .groupKey(KeyUtil.keyToString(groupEntity.groupKey()))
         .groupId(groupEntity.groupId())
         .name(groupEntity.name())
         .description(groupEntity.description());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -148,13 +148,11 @@ public class TenantQueryControllerTest extends RestControllerTest {
       {
          "items": [
            {
-             "groupKey": %s,
              "name": "%s",
              "description": "%s",
              "groupId": "%s"
            },
            {
-             "groupKey": %s,
              "name": "%s",
              "description": "%s",
              "groupId": "%s"
@@ -170,11 +168,9 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   private static final String EXPECTED_GROUP_RESPONSE =
       GROUP_RESPONSE.formatted(
-          "\"%s\"".formatted(GROUP_ENTITIES.get(0).groupKey()),
           GROUP_ENTITIES.get(0).name(),
           GROUP_ENTITIES.get(0).description(),
           GROUP_ENTITIES.get(0).groupId(),
-          "\"%s\"".formatted(GROUP_ENTITIES.get(1).groupKey()),
           GROUP_ENTITIES.get(1).name(),
           GROUP_ENTITIES.get(1).description(),
           GROUP_ENTITIES.get(1).groupId(),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -260,13 +260,12 @@ public class GroupControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "groupKey": "%d",
               "groupId": "%s",
               "name": "%s",
               "description": "%s"
             }
             """
-                .formatted(groupKey, groupId, groupName, description));
+                .formatted(groupId, groupName, description));
 
     // then
     verify(groupServices, times(1)).updateGroup(groupId, groupName, description);
@@ -275,9 +274,9 @@ public class GroupControllerTest extends RestControllerTest {
   @Test
   void shouldFailOnUpdateGroupWithEmptyName() {
     // given
-    final var groupKey = 111L;
+    final var groupId = "groupId";
     final var emptyGroupName = "";
-    final var uri = "%s/%s".formatted(GROUP_BASE_URL, groupKey);
+    final var uri = "%s/%s".formatted(GROUP_BASE_URL, groupId);
 
     // when / then
     webClient
@@ -307,9 +306,9 @@ public class GroupControllerTest extends RestControllerTest {
   @Test
   void shouldFailOnUpdateGroupWithoutDescription() {
     // given
-    final var groupKey = 111L;
+    final var groupId = "groupId";
     final var name = "name";
-    final var uri = "%s/%s".formatted(GROUP_BASE_URL, groupKey);
+    final var uri = "%s/%s".formatted(GROUP_BASE_URL, groupId);
 
     // when / then
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -51,19 +51,16 @@ public class GroupQueryControllerTest extends RestControllerTest {
       {
         "items":[
           {
-            "groupKey":"111",
             "groupId":"%s",
             "name":"Group 1",
             "description":"Description 1"
           },
           {
-            "groupKey":"222",
             "groupId":"%s",
             "name":"Group 2",
             "description":"Description 2"
           },
           {
-            "groupKey":"333",
             "groupId":"%s",
             "name":"Group 3",
             "description":"Description 3"
@@ -239,12 +236,11 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "groupKey": "%s",
               "groupId": "%s",
               "name": "%s",
               "description": "%s"
             }"""
-                .formatted(groupKey, groupId, groupName, groupDescription));
+                .formatted(groupId, groupName, groupDescription));
 
     // then
     verify(groupServices, times(1)).getGroup(group.groupId());
@@ -329,19 +325,16 @@ public class GroupQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
                  "description": "%s"
                },
                {
-                 "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
                  "description": "%s"
                },
                {
-                 "groupKey": "%d",
                  "groupId": "%s",
                  "name": "%s",
                  "description": "%s"
@@ -354,15 +347,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
              }
            }"""
                 .formatted(
-                    groupKey1,
                     groupId1,
                     groupName1,
                     description1,
-                    groupKey2,
                     groupId2,
                     groupName2,
                     description2,
-                    groupKey3,
                     groupId3,
                     groupName3,
                     description3));
@@ -654,7 +644,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
                 {
                     "sort": [
                         {
-                            "field": "groupKey",
+                            "field": "groupId",
                             "order": "dsc"
                         }
                     ]
@@ -686,7 +676,7 @@ public class GroupQueryControllerTest extends RestControllerTest {
                       "type": "about:blank",
                       "title": "Bad Request",
                       "status": 400,
-                      "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [groupKey, name, groupId]",
+                      "detail": "Unexpected value 'unknownField' for enum field 'field'. Use any of the following values: [name, groupId]",
                       "instance": "%s"
                     }""",
                 endpoint)),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateGroupTest.java
@@ -53,7 +53,6 @@ class CreateGroupTest {
             .join();
 
     // then
-    assertThat(response.getGroupKey()).isGreaterThan(0);
     assertThat(response.getGroupId()).isEqualTo(GROUP_ID);
     assertThat(response.getName()).isEqualTo(GROUP_NAME);
     assertThat(response.getDescription()).isEqualTo(GROUP_DESCRIPTION);
@@ -73,7 +72,6 @@ class CreateGroupTest {
         client.newCreateGroupCommand().groupId(GROUP_ID).name(GROUP_NAME).send().join();
 
     // then
-    assertThat(response.getGroupKey()).isGreaterThan(0);
     assertThat(response.getGroupId()).isEqualTo(GROUP_ID);
     assertThat(response.getName()).isEqualTo(GROUP_NAME);
     assertThat(response.getDescription()).isEqualTo("");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes the field `groupKey` from the Group endpoints response
