### PR TITLE
poc: use variables update semantics on user task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -75,13 +75,25 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
 
     final long userTaskElementInstanceKey = userTaskRecord.getElementInstanceKey();
     if (userTaskRecord.getChangedAttributes().contains(UserTaskRecord.VARIABLES)) {
-      variableBehavior.mergeLocalDocument(
-          userTaskElementInstanceKey,
-          userTaskRecord.getProcessDefinitionKey(),
-          userTaskRecord.getProcessInstanceKey(),
-          userTaskRecord.getBpmnProcessIdBuffer(),
-          userTaskRecord.getTenantId(),
-          command.getValue().getVariablesBuffer());
+      switch (userTaskRecord.getVariableUpdateSemantics()) {
+        case LOCAL ->
+            variableBehavior.mergeLocalDocument(
+                userTaskElementInstanceKey,
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                command.getValue().getVariablesBuffer());
+        case PROPAGATE ->
+            variableBehavior.mergeDocument(
+                userTaskElementInstanceKey,
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                command.getValue().getVariablesBuffer());
+        case NULL -> throw new IllegalArgumentException("Totally unexpected");
+      }
     }
 
     if (command.hasRequestMetadata()) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -52,6 +52,8 @@ public interface UserTaskRecordValue
 
   String getExternalFormReference();
 
+  UserTaskVariablesUpdateSemantic getVariableUpdateSemantics();
+
   Map<String, String> getCustomHeaders();
 
   long getCreationTimestamp();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskVariablesUpdateSemantic.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskVariablesUpdateSemantic.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum UserTaskVariablesUpdateSemantic {
+  NULL,
+  LOCAL,
+  PROPAGATE,
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

By adding this property to user task record, we can easily access the intentions of the initial variabledocument update command.

The property could be re-used in the future for changing the propagation semantics of the variables payload when completing the task.

## Related issues

relates to #30053 
