### PR TITLE
[Backport stable/8.6] fix: moved package commands out to their out package leaving only the start/stop cmd in the distributed binary

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -66,10 +66,10 @@ runs:
       name: disable and stop mono-xsp4.service
       shell: bash
       run: |
-           sudo systemctl stop mono-xsp4.service || true
-           sudo systemctl disable mono-xsp4.service || true
-           sudo killall mono || true
-           sudo killall xsp4 || true
+        sudo systemctl stop mono-xsp4.service || true
+        sudo systemctl disable mono-xsp4.service || true
+        sudo killall mono || true
+        sudo killall xsp4 || true
 
     - if: ${{ inputs.checkout == 'true' }}
       uses: actions/checkout@v4
@@ -96,8 +96,8 @@ runs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: '>=1.23.1'
-        cache: false  # disabling since not working anyways without a cache-dependency-path specified
+        go-version: ">=1.23.1"
+        cache: false # disabling since not working anyways without a cache-dependency-path specified
 
     - uses: ./.github/actions/setup-build
       if: ${{ inputs.source-build == 'true' }}
@@ -171,12 +171,17 @@ runs:
       working-directory: ./c8run
 
     - name: Build c8run
-      run: go build
+      run: go build -o c8run ./cmd/c8run
+      shell: bash
+      working-directory: ./c8run
+
+    - name: Build c8run packager
+      run: go build -o packager ./cmd/packager
       shell: bash
       working-directory: ./c8run
 
     - name: make a package
-      run: ./c8run package
+      run: ./packager package
       shell: bash
       working-directory: ./c8run
       env:
@@ -230,4 +235,3 @@ runs:
       id: path-to-build
       run: echo "path-to-c8run-build=$( ls ./c8run/camunda8-run* )" >> $GITHUB_OUTPUT
       shell: bash
-

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -135,6 +135,9 @@ jobs:
 
       - name: Wait for camunda process to start
         run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'
+      - name: Unit tests
+        run: go test ./...
+        working-directory: ./c8run
 
       - name: Run Playwright tests
         run: npx playwright test
@@ -192,12 +195,16 @@ jobs:
         shell: bash
         working-directory: .\c8run
 
-      - name: Build c8run
-        run: go build
+      - name: Build c8run runtime
+        run: go build -o c8run .\cmd\c8run
+        working-directory: .\c8run
+
+      - name: Build c8run packager
+        run: go build -o packager .\cmd\packager
         working-directory: .\c8run
 
       - name: make a package
-        run: .\c8run.exe package
+        run: .\packager.exe package
         working-directory: .\c8run
         env:
           GH_TOKEN: ${{ github.token }}
@@ -216,6 +223,13 @@ jobs:
       - name: Set env
         run: echo "JAVA_HOME=${JAVA_HOME_22_X64}" >> $GITHUB_ENV
         shell: bash
+
+      - name: Unit tests
+        run: go test .\...
+        working-directory: .\c8run
+        shell: bash
+        env:
+          JAVA_VERSION: "22.0.2"
 
       - name: Run c8run
         run: bash -c './c8run.exe start --config e2e_tests/prefix-config.yaml'

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -224,7 +224,7 @@ jobs:
         shell: bash
 
       - name: Unit tests
-        run: go test .\...
+        run: go test ./...
         working-directory: .\c8run
         shell: bash
         env:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -81,14 +81,13 @@ jobs:
     timeout-minutes: 15
     needs: camunda-dist-build
     steps:
-
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: disable and stop mono-xsp4.service
         run: |
-             sudo systemctl stop mono-xsp4.service || true
-             sudo systemctl disable mono-xsp4.service || true
-             sudo killall mono || true
-             sudo killall xsp4 || true
+          sudo systemctl stop mono-xsp4.service || true
+          sudo systemctl disable mono-xsp4.service || true
+          sudo killall mono || true
+          sudo killall xsp4 || true
 
       - uses: actions/checkout@v4
 
@@ -122,8 +121,8 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           os: ${{ matrix.os }}
           github-token: ${{ github.token }}
-          local-archive-build: 'true'
-          checkout: 'false'
+          local-archive-build: "true"
+          checkout: "false"
 
       - name: Install dependencies
         run: npm ci
@@ -182,7 +181,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version: ">=1.23.1"
 
       - name: Download Camunda Core Dist
         uses: actions/download-artifact@v4
@@ -196,11 +195,11 @@ jobs:
         working-directory: .\c8run
 
       - name: Build c8run runtime
-        run: go build -o c8run .\cmd\c8run
+        run: go build -o c8run.exe .\cmd\c8run
         working-directory: .\c8run
 
       - name: Build c8run packager
-        run: go build -o packager .\cmd\packager
+        run: go build -o packager.exe .\cmd\packager
         working-directory: .\c8run
 
       - name: make a package
@@ -217,8 +216,8 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '22'
+          distribution: "temurin"
+          java-version: "22"
 
       - name: Set env
         run: echo "JAVA_HOME=${JAVA_HOME_22_X64}" >> $GITHUB_ENV

--- a/c8run/.gitignore
+++ b/c8run/.gitignore
@@ -1,4 +1,11 @@
 # build artifacts
 camunda-platform-8*
 pax_global_header
+docker-compose-8*
+camunda.process
 camunda8-run-8*
+connectors.process
+
+/c8run
+/main
+/packager

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -202,7 +202,6 @@ func main() {
 	elasticsearchVersion := os.Getenv("ELASTICSEARCH_VERSION")
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
-	composeExtractedFolder := os.Getenv("COMPOSE_EXTRACTED_FOLDER")
 
 	expectedJavaVersion := 21
 	elasticsearchPidPath := filepath.Join(baseDir, "elasticsearch.process")

--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/camunda/camunda/c8run/internal/health"
 	"github.com/camunda/camunda/c8run/internal/overrides"
-	"github.com/camunda/camunda/c8run/internal/packages"
 	"github.com/camunda/camunda/c8run/internal/types"
 	"github.com/camunda/camunda/c8run/internal/unix"
 	"github.com/camunda/camunda/c8run/internal/windows"
@@ -62,7 +61,7 @@ func getC8RunPlatform() types.C8Run {
 }
 
 func usage(exitcode int) {
-	fmt.Printf("Usage: %s [command] [options]\nCommands:\n  start\n  stop\n  package\n", os.Args[0])
+	fmt.Printf("Usage: %s [command] [options]\nCommands:\n  start\n  stop\n", os.Args[0])
 	os.Exit(exitcode)
 }
 
@@ -76,10 +75,6 @@ func getBaseCommand() (string, error) {
 		return "start", nil
 	case "stop":
 		return "stop", nil
-	case "package":
-		return "package", nil
-	case "clean":
-		return "clean", nil
 	case "-h", "--help":
 		usage(0)
 	default:
@@ -207,6 +202,7 @@ func main() {
 	elasticsearchVersion := os.Getenv("ELASTICSEARCH_VERSION")
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
+	composeExtractedFolder := os.Getenv("COMPOSE_EXTRACTED_FOLDER")
 
 	expectedJavaVersion := 21
 	elasticsearchPidPath := filepath.Join(baseDir, "elasticsearch.process")
@@ -256,14 +252,6 @@ func main() {
 		startCommand(c8, settings, processInfo, parentDir, javaBinary, expectedJavaVersion)
 	case "stop":
 		stopCommand(c8, settings, processInfo)
-	case "package":
-		err := packages.New(camundaVersion, elasticsearchVersion, connectorsVersion)
-		if err != nil {
-			fmt.Printf("%+v", err)
-			os.Exit(1)
-		}
-	case "clean":
-		cleanCommand(camundaVersion, elasticsearchVersion)
 	}
 }
 
@@ -389,10 +377,6 @@ func stopCommand(c8 types.C8Run, settings types.C8RunSettings, processes process
 		fmt.Printf("%+v", err)
 	}
 	fmt.Println("Camunda is stopped.")
-}
-
-func cleanCommand(camundaVersion string, elasticsearchVersion string) {
-	packages.Clean(camundaVersion, elasticsearchVersion)
 }
 
 func startApplication(cmd *exec.Cmd, pid string, logPath string) {

--- a/c8run/cmd/packager/main.go
+++ b/c8run/cmd/packager/main.go
@@ -71,7 +71,6 @@ func main() {
 	elasticsearchVersion := os.Getenv("ELASTICSEARCH_VERSION")
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
-	composeTag := os.Getenv("COMPOSE_TAG")
 
 	baseCommand, err := getBaseCommand()
 	if err != nil {
@@ -85,7 +84,7 @@ func main() {
 
 	switch baseCommand {
 	case "package":
-		err := packages.New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
+		err := packages.New(camundaVersion, elasticsearchVersion, connectorsVersion)
 		if err != nil {
 			fmt.Printf("%+v", err)
 			os.Exit(1)

--- a/c8run/cmd/packager/main.go
+++ b/c8run/cmd/packager/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/camunda/camunda/c8run/internal/packages"
+	"github.com/joho/godotenv"
+)
+
+func usage(exitcode int) {
+	fmt.Printf("Usage: %s [command] [options]\nCommands:\n package\n clean\n", os.Args[0])
+	os.Exit(exitcode)
+}
+
+func getBaseCommand() (string, error) {
+	if len(os.Args) == 1 {
+		usage(1)
+	}
+
+	switch os.Args[1] {
+	case "package":
+		return "package", nil
+	case "clean":
+		return "clean", nil
+	case "-h", "--help":
+		usage(0)
+	default:
+		return "", fmt.Errorf("unsupported operation: %s", os.Args[1])
+	}
+
+	return "", nil
+}
+
+func GetJavaVersion(javaBinary string) (string, error) {
+	javaVersionCmd := exec.Command(javaBinary, "JavaVersion")
+	var out strings.Builder
+	var stderr strings.Builder
+	javaVersionCmd.Stdout = &out
+	javaVersionCmd.Stderr = &stderr
+	err := javaVersionCmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to run java version command: %w", err)
+	}
+	javaVersionOutput := out.String()
+	return javaVersionOutput, nil
+}
+
+func GetJavaHome(javaBinary string) (string, error) {
+	javaHomeCmd := exec.Command(javaBinary, "JavaHome")
+	var out strings.Builder
+	var stderr strings.Builder
+	javaHomeCmd.Stdout = &out
+	javaHomeCmd.Stderr = &stderr
+	err := javaHomeCmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to run java version command: %w", err)
+	}
+	javaHomeOutput := out.String()
+	return javaHomeOutput, nil
+}
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	elasticsearchVersion := os.Getenv("ELASTICSEARCH_VERSION")
+	camundaVersion := os.Getenv("CAMUNDA_VERSION")
+	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
+	composeTag := os.Getenv("COMPOSE_TAG")
+
+	baseCommand, err := getBaseCommand()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	switch baseCommand {
+	case "package":
+		err := packages.New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
+		if err != nil {
+			fmt.Printf("%+v", err)
+			os.Exit(1)
+		}
+	case "clean":
+		cleanCommand(camundaVersion, elasticsearchVersion)
+	}
+}
+
+type processes struct {
+	camunda       process
+	connectors    process
+	elasticsearch process
+}
+
+type process struct {
+	version string
+	pid     string
+}
+
+func cleanCommand(camundaVersion string, elasticsearchVersion string) {
+	packages.Clean(camundaVersion, elasticsearchVersion)
+}

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 )
 
-const OpenFlagsForWriting = os.O_RDWR | os.O_CREATE | os.O_TRUNC
-const ReadWriteMode = 0755
+const (
+	OpenFlagsForWriting = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	ReadWriteMode       = 0755
+)
 
 func DownloadFile(filepath string, url string, authToken string) error {
 	// if the file already exists locally, don't download a new copy
@@ -33,7 +35,7 @@ func DownloadFile(filepath string, url string, authToken string) error {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url)
+		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url, err, debug.Stack())
 	}
 
 	if strings.HasPrefix(authToken, "Basic ") {

--- a/c8run/internal/windows/process_tree.go
+++ b/c8run/internal/windows/process_tree.go
@@ -25,7 +25,7 @@ func process_tree(pid int) []*os.Process {
 	for i, pid := range tree {
 		process, err := os.FindProcess(int(pid))
 		if err != nil {
-			fmt.Println("Process " + string(pid) + " not found")
+			fmt.Printf("Process %d not found", pid)
 			continue
 		}
 		processList[i] = process

--- a/c8run/package.bat
+++ b/c8run/package.bat
@@ -1,3 +1,3 @@
 @echo on
-go build
-.\c8run.exe package
+go build -o packager .\cmd\packager
+.\packager.exe package

--- a/c8run/package.sh
+++ b/c8run/package.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-go build
-./c8run package
+go build -o packager ./cmd/packager/main.go
+./packager package


### PR DESCRIPTION
# Description
Backport of #31694 to `stable/8.6`.

relates to 