### PR TITLE
Refactor: migrate tasklist settings page tests to 8.7 core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/tests/tasklist/settings.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/settings.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureFailureVideo, captureScreenshot} from '@setup';
+
+test.describe('settings', () => {
+  test.beforeEach(async ({page, taskListLoginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await taskListLoginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('change language', async ({page, tasklistHeader}) => {
+    await tasklistHeader.changeLanguage('Français');
+    await expect(
+      page.getByRole('heading', {name: 'Bienvenue dans Tasklist'}),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {name: 'Tâches ouvertes'}),
+    ).toBeVisible();
+    await expect(page.getByRole('button', {name: 'Déconnexion'})).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR migrates `setting.spec` to `8.7` core application test suite 

🧪 successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/14966884594/job/42038728420) 
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
related to https://github.com/camunda/camunda/issues/30910