### PR TITLE
chore(fossa): check PRs for newly introduced license issues

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -10,6 +10,10 @@ on:
     - stable/*
     tags:
     - '*'
+  pull_request:
+    types:
+    - opened
+    - synchronize
 
 jobs:
   analyze:
@@ -17,6 +21,7 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       # The matrix is necessary to run separate analyses
       matrix:
         project:
@@ -64,6 +69,9 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
     - name: Setup fossa-cli
       uses: camunda/infra-global-github-actions/fossa/setup@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+    - name: Get context info
+      id: info
+      uses: camunda/infra-global-github-actions/fossa/info@0e82486eaa9ef8589e051c556a1b5218efa6d37f
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
       run: |
@@ -87,6 +95,19 @@ jobs:
       uses: camunda/infra-global-github-actions/fossa/analyze@0e82486eaa9ef8589e051c556a1b5218efa6d37f
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
-        branch: ${{ github.ref_name }}
+        branch: ${{  steps.info.outputs.head-ref }}
         path: ${{ matrix.project.path }}
-        revision-id: ${{ github.sha }}
+        revision-id: ${{ steps.info.outputs.head-revision }}
+    # PR-only: Check for newly introduced license issues
+    # This step only fails if the PR introduces new license violations.
+    # It does not fail for pre-existing issues already present in the base branch.
+    - name: Check Pull Request for new License Issues
+      if: steps.info.outputs.is-pull-request == 'true'
+      uses: camunda/infra-global-github-actions/fossa/pr-check@0e82486eaa9ef8589e051c556a1b5218efa6d37f
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        base-ref: ${{ steps.info.outputs.base-ref }}
+        base-revision: ${{ steps.info.outputs.base-revision }}
+        path: ${{ matrix.project.path }}
+        project: ${{ matrix.project.name }}
+        revision: ${{ steps.info.outputs.head-revision }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/752.

This PR introduces a new job step in `check-licenses.yml` workflow that runs only on pull requests, and checks for newly introduced license policy violations, such as those from new dependencies or updated versions:
- if license issues are found, they are listed in the logs with actionable links to the FOSSA dashboard and Confluence [page](https://confluence.camunda.com/spaces/HAN/pages/277024795/FOSSA#FOSSA-Handlelicenseissues)
- a job annotation is added for visibility, showing `License Check: X issues found. Please check the logs and resolve before merging`
- the step does not fail for pre-existing license issues in the base branch

The job waits for the FOSSA analysis to complete, which typically takes under a minute. If additional dependency scans (at file-level) are required (if results for a new dependency/version are not already in FOSSA's shared database), it may take an extra 3–4 minutes.

This changes apply all projects within the monorepo, but scans for references like `main`, `stable/*`, and tags are not affected.

TL;DR; FOSSA License analyses (file-level scan) are currently run only on `main`, `stable/*`, and tags. This change adds analysis for pull requests, including a policy violation check. It helps support shift-left license compliance (via FOSSA) by catching issues directly at the PR level.

Test workflow run (introducing a temporary issue): https://github.com/camunda/camunda/actions/runs/14974061132?pr=31929

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
