### PR TITLE
Make archiver wait for templated indices to be created/updated

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.search.schema;
 
+import com.google.common.base.Equivalence;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -37,7 +41,8 @@ public record IndexMappingDifference(
   public static IndexMappingDifference of(final IndexMapping left, final IndexMapping right) {
     final Map<String, Object> leftMap = left == null ? Map.of() : left.toMap();
     final Map<String, Object> rightMap = right == null ? Map.of() : right.toMap();
-    final MapDifference<String, Object> difference = Maps.difference(leftMap, rightMap);
+    final MapDifference<String, Object> difference =
+        Maps.difference(leftMap, rightMap, OrderInsensitiveEquivalence.equals());
     return new IndexMappingDifference(
         difference.areEqual(),
         difference.entriesOnlyOnLeft().entrySet().stream()
@@ -69,4 +74,92 @@ public record IndexMappingDifference(
 
   private record PropertyDifference(
       String name, IndexMappingProperty leftValue, IndexMappingProperty rightValue) {}
+
+  /**
+   * A recursive equivalence for comparing Elasticsearch/Opensearch index mappings, specifically
+   * required to handle nested structures and ignore list ordering.
+   *
+   * <p>The default({@link com.google.common.base.Equivalence.Equals#equals(Object)}) is
+   * insufficient for our use case because:
+   *
+   * <ul>
+   *   <li>Elasticsearch mappings include deeply nested structures (e.g., nested fields, join
+   *       relations).
+   *   <li>Some fields, such as "relations" in join mappings, represent lists where element order
+   *       does not affect semantics (example, ["task", "variable"] vs ["variable", "task"]).
+   *   <li>Default map or list equality in Java considers order, causing false positives in diffs.
+   * </ul>
+   *
+   * <p>This custom equivalence:
+   *
+   * <ul>
+   *   <li>Recursively traverses maps and lists in the mapping structure.
+   *   <li>Treats lists as sets (acutally as multisets to compare also compare duplicate elements)
+   *       to ignore ordering or handle duplicates appropriately.
+   *   <li>Ensures that mappings with semantically identical structures (despite ordering
+   *       differences) are treated as equivalent.
+   * </ul>
+   */
+  private static final class OrderInsensitiveEquivalence extends Equivalence<Object> {
+
+    private static final OrderInsensitiveEquivalence INSTANCE = new OrderInsensitiveEquivalence();
+
+    public static OrderInsensitiveEquivalence equals() {
+      return INSTANCE;
+    }
+
+    @Override
+    protected boolean doEquivalent(final Object a, final Object b) {
+      if (a == b) {
+        return true;
+      }
+      if (a == null || b == null) {
+        return false;
+      }
+
+      if (a instanceof final Map<?, ?> mapA && b instanceof final Map<?, ?> mapB) {
+        if (mapA.size() != mapB.size()) {
+          return false;
+        }
+        for (final Object key : mapA.keySet()) {
+          if (!mapB.containsKey(key) || !equivalent(mapA.get(key), mapB.get(key))) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      // Handle lists as multisets to ignore order and count duplicates
+      if (a instanceof final List<?> listA && b instanceof final List<?> listB) {
+        if (listA.size() != listB.size()) {
+          return false;
+        }
+
+        final var countA = countElements(listA);
+        final var countB = countElements(listB);
+        return countA.equals(countB);
+      }
+
+      return a.equals(b);
+    }
+
+    @Override
+    protected int doHash(final Object o) {
+      if (o instanceof final Map<?, ?> oMap) {
+        return oMap.entrySet().stream()
+            .mapToInt(entry -> Objects.hash(entry.getKey(), doHash(entry.getValue())))
+            .sum();
+      } else if (o instanceof final List<?> oList) {
+        // Use a multiset-like approach to handle duplicates and ignore order
+        return oList.stream().mapToInt(this::doHash).sum();
+      } else {
+        return Objects.hashCode(o);
+      }
+    }
+
+    private Map<Object, Long> countElements(final List<?> list) {
+      return list.stream()
+          .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+  }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexSchemaValidator.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexSchemaValidator.java
@@ -8,12 +8,11 @@
 package io.camunda.search.schema;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
 import io.camunda.search.schema.exceptions.IndexSchemaValidationException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.*;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,16 +151,8 @@ public class IndexSchemaValidator {
    */
   private Map<String, IndexMapping> filterIndexMappings(
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
-    if (indexDescriptor instanceof IndexTemplateDescriptor) {
-      return indexMappings.entrySet().stream()
-          .filter(
-              e -> e.getKey().equals(((IndexTemplateDescriptor) indexDescriptor).getTemplateName()))
-          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    } else {
-      return indexMappings.entrySet().stream()
-          .filter(e -> e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()))
-          .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-    }
+    return Maps.filterKeys(
+        indexMappings, k -> k.matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
   }
 
   private void failIfIndexNotDynamic(

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
@@ -47,6 +47,8 @@ public final class SchemaTestUtil {
     when(descriptor.getComposedOf()).thenReturn(composedOf);
     when(descriptor.getTemplateName()).thenReturn(templateName);
     when(descriptor.getMappingsClasspathFilename()).thenReturn(mappingsFileName);
+    when(descriptor.getAllVersionsIndexNameRegexPattern())
+        .thenAnswer(ignored -> descriptor.getFullQualifiedName() + ".*");
 
     return descriptor;
   }

--- a/schema-manager/src/test/resources/mappings-with-list-1.json
+++ b/schema-manager/src/test/resources/mappings-with-list-1.json
@@ -1,0 +1,17 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "process": [
+            "variable",
+            "task"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schema-manager/src/test/resources/mappings-with-list-2.json
+++ b/schema-manager/src/test/resources/mappings-with-list-2.json
@@ -1,0 +1,17 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "join": {
+        "type": "join",
+        "eager_global_ordinals": true,
+        "relations": {
+          "process": [
+            "task",
+            "variable"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

The archiver process consists in reading from a live index and writing into date-based indices (archive indices) that are linked to the same index template.

**Problem**

Currently, before starting the archiver, via `CamundaExporter`, we only check:
* That the index template exists
* That the index mappings for the template is correct.

This leads to failures in the following scenarios:
* Live index not ready: If the live index hasn't yet been created by the schema manager, the archiver tries to access it prematurely and fails.
* Dated indices missing properties: If the dated indices (which use strict mappings) are missing required properties, the archiver attempts to insert documents containing fields not present in the mapping, causing failures due to strict mapping enforcement.

**Solution**

This pull request modifies the `SchemaManager#isSchemaReadyForUse` to:
* Wait for the live index to be ready: it checks that the live index is created and has the expected mappings.
* Wait for the dated indices to be ready: it ensures that all dated indices linked to the index template are ready for write operations and have the correct mappings.

**Additional changes**

I noticed a change in the logic previously used in Operate and Tasklist when computing index mapping diffs:
* [Previous logic ](https://github.com/camunda/camunda/blob/bff04e9577f8905e9484298642573016e990eb69/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java#L152-L167)(in Operate & Tasklist): All mappings of indices linked to a given index template were fetched. Then, a diff computation was performed for each index to ensure either no diff or the same diff with respect to the expected mapping.
* Current logic: The diff computation is performed only on the index template mappings, not on the actual indices.

This PR aligns the diff computation with the previous approach.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/28896
