### PR TITLE
Perform Incident notification on the background

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -151,7 +151,6 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void close() {
-    provider.close();
 
     if (writer != null) {
       try {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -289,7 +289,7 @@ public class CamundaExporter implements Exporter {
 
     if (writer.getBatchSize() == configuration.getBulk().getSize()) {
       LOG.info(
-"""
+          """
 Cached maximum batch size [{}] number of records, exporting will block at the current position of [{}] while waiting for the importers to finish
 processing records from previous version
 """,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -123,7 +123,9 @@ public class CamundaExporter implements Exporter {
                 provider,
                 metrics,
                 context.getLogger(),
-                metadata)
+                metadata,
+                clientAdapter.objectMapper(),
+                provider.getProcessCache())
             .build();
     LOG.debug("Exporter configured with {}", configuration);
   }
@@ -287,7 +289,7 @@ public class CamundaExporter implements Exporter {
 
     if (writer.getBatchSize() == configuration.getBulk().getSize()) {
       LOG.info(
-          """
+"""
 Cached maximum batch size [{}] number of records, exporting will block at the current position of [{}] while waiting for the importers to finish
 processing records from previous version
 """,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -154,18 +154,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new CaffeineCacheStatsCounter(NAMESPACE, "form", meterRegistry));
 
-    final M2mTokenManager m2mTokenManager =
-        new M2mTokenManager(
-            configuration.getNotifier(), HttpClientWrapper.newHttpClient(), objectMapper);
-    executor = Executors.newVirtualThreadPerTaskExecutor();
-    final IncidentNotifier incidentNotifier =
-        new IncidentNotifier(
-            m2mTokenManager,
-            processCache,
-            configuration.getNotifier(),
-            HttpClientWrapper.newHttpClient(),
-            executor,
-            objectMapper);
     exportHandlers =
         Set.of(
             new RoleCreateUpdateHandler(
@@ -221,9 +209,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new FlowNodeInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new IncidentHandler(
-                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(),
-                processCache,
-                incidentNotifier),
+                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
             new SequenceFlowHandler(
                 indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
             new DecisionEvaluationHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -109,7 +109,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 /**
@@ -118,11 +117,9 @@ import java.util.function.BiConsumer;
  */
 public class DefaultExporterResourceProvider implements ExporterResourceProvider {
   public static final String NAMESPACE = "zeebe.camunda.exporter.cache";
+
   private IndexDescriptors indexDescriptors;
   private Set<ExportHandler<?, ?>> exportHandlers;
-
-  private ExporterMetadata exporterMetadata;
-  private ExecutorService executor;
   private Map<String, ErrorHandler> indicesWithCustomErrorHandlers;
   private ExporterEntityCacheImpl<String, CachedFormEntity> formCache;
   private ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
@@ -138,7 +135,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     final var isElasticsearch =
         ConnectionTypes.isElasticSearch(configuration.getConnect().getType());
     indexDescriptors = new IndexDescriptors(globalPrefix, isElasticsearch);
-    this.exporterMetadata = exporterMetadata;
 
     processCache =
         new ExporterEntityCacheImpl<>(
@@ -280,13 +276,6 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
         Map.of(
             indexDescriptors.get(OperationTemplate.class).getFullQualifiedName(),
             ErrorHandlers.IGNORE_DOCUMENT_DOES_NOT_EXIST);
-  }
-
-  @Override
-  public void close() {
-    if (executor != null) {
-      executor.shutdown();
-    }
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -8,7 +8,10 @@
 package io.camunda.exporter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.cache.ExporterEntityCacheImpl;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.handlers.ExportHandler;
@@ -64,4 +67,18 @@ public interface ExporterResourceProvider {
    * @return A {@link BiConsumer} of {@link String} and {@link Error} to handle custom errors
    */
   BiConsumer<String, Error> getCustomErrorHandlers();
+
+  /**
+   * Returns the reference to the Process Cache
+   *
+   * @return {@link ExporterEntityCacheImpl} of {@link CachedProcessEntity}
+   */
+  ExporterEntityCacheImpl<Long, CachedProcessEntity> getProcessCache();
+
+  /**
+   * Returns the reference to the Form Cache
+   *
+   * @return {@link ExporterEntityCacheImpl} of {@link CachedFormEntity}
+   */
+  ExporterEntityCacheImpl<String, CachedFormEntity> getFormCache();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -31,8 +31,6 @@ public interface ExporterResourceProvider {
       final ExporterMetadata exporterMetadata,
       final ObjectMapper objectMapper);
 
-  void close();
-
   /**
    * This should return descriptors describing the desired state of all indices provided.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -11,7 +11,6 @@ import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.*;
 
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
-import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.exporter.utils.ProcessCacheUtil;
@@ -30,7 +29,6 @@ import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,15 +37,11 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final IncidentNotifier incidentNotifier;
 
   public IncidentHandler(
-      final String indexName,
-      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final IncidentNotifier incidentNotifier) {
+      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
     this.indexName = indexName;
     this.processCache = processCache;
-    this.incidentNotifier = incidentNotifier;
   }
 
   @Override
@@ -116,9 +110,6 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     final Intent intent = (record == null) ? null : record.getIntent();
     if (intent == null) {
       LOGGER.warn("Intent is null for incident: id {}", entity.getId());
-    }
-    if (Objects.equals(intent, IncidentIntent.CREATED)) {
-      incidentNotifier.notifyAsync(List.of(entity));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -74,9 +74,9 @@ public class IncidentNotifier {
     objectWriter = objectMapper.writer();
   }
 
-  public void notifyAsync(final List<IncidentEntity> incidents) {
-    CompletableFuture.runAsync(() -> notifyOnIncidents(incidents), executor);
+  public CompletableFuture<Void> notifyAsync(final List<IncidentEntity> incidents) {
     LOGGER.debug("Incident notification is scheduled");
+    return CompletableFuture.runAsync(() -> notifyOnIncidents(incidents), executor);
   }
 
   public void notifyOnIncidents(final List<IncidentEntity> incidents) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -9,11 +9,17 @@ package io.camunda.exporter.tasks;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.cache.ExporterEntityCacheImpl;
+import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.notifier.HttpClientWrapper;
+import io.camunda.exporter.notifier.IncidentNotifier;
+import io.camunda.exporter.notifier.M2mTokenManager;
 import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
@@ -53,11 +59,13 @@ public final class BackgroundTaskManagerFactory {
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
   private final ExporterMetadata metadata;
+  private final ObjectMapper objectMapper;
 
   private ScheduledThreadPoolExecutor executor;
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
   private BatchOperationUpdateRepository batchOperationUpdateRepository;
+  private final ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache;
 
   public BackgroundTaskManagerFactory(
       final int partitionId,
@@ -66,7 +74,9 @@ public final class BackgroundTaskManagerFactory {
       final ExporterResourceProvider resourceProvider,
       final CamundaExporterMetrics metrics,
       final Logger logger,
-      final ExporterMetadata metadata) {
+      final ExporterMetadata metadata,
+      final ObjectMapper objectMapper,
+      final ExporterEntityCacheImpl<Long, CachedProcessEntity> processCache) {
     this.partitionId = partitionId;
     this.exporterId = exporterId;
     this.config = config;
@@ -74,6 +84,8 @@ public final class BackgroundTaskManagerFactory {
     this.metrics = metrics;
     this.logger = logger;
     this.metadata = metadata;
+    this.objectMapper = objectMapper;
+    this.processCache = processCache;
   }
 
   public BackgroundTaskManager build() {
@@ -115,6 +127,19 @@ public final class BackgroundTaskManagerFactory {
   }
 
   private ReschedulingTask buildIncidentMarkerTask() {
+
+    final M2mTokenManager m2mTokenManager =
+        new M2mTokenManager(config.getNotifier(), HttpClientWrapper.newHttpClient(), objectMapper);
+
+    final IncidentNotifier incidentNotifier =
+        new IncidentNotifier(
+            m2mTokenManager,
+            processCache,
+            config.getNotifier(),
+            HttpClientWrapper.newHttpClient(),
+            executor,
+            objectMapper);
+
     final var postExport = config.getPostExport();
     return new ReschedulingTask(
         new IncidentUpdateTask(
@@ -123,6 +148,7 @@ public final class BackgroundTaskManagerFactory {
             postExport.isIgnoreMissingData(),
             postExport.getBatchSize(),
             executor,
+            incidentNotifier,
             logger),
         1,
         postExport.getDelayBetweenRuns(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -97,7 +97,7 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * @param update the bulk update to execute
    * @return the number of documents updated
    */
-  CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update);
+  CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update);
 
   /**
    * Returns the tree path as tokenized by an analyze request to the underlying document store.
@@ -210,8 +210,8 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update) {
-      return CompletableFuture.completedFuture(0);
+    public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update) {
+      return CompletableFuture.completedFuture(List.of());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -534,9 +534,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     if (incidentsToNotify.isEmpty()) {
       return CompletableFuture.completedFuture(updatedIds.size());
     }
-    return incidentNotifier
-        .notifyAsync(incidentsToNotify)
-        .thenApply(ignored -> updatedIds.size());
+    return incidentNotifier.notifyAsync(incidentsToNotify).thenApply(ignored -> updatedIds.size());
   }
 
   private boolean shouldNotifyAboutUpdate(final DocumentUpdate update) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -536,7 +536,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
     return incidentNotifier
         .notifyAsync(incidentsToNotify)
-        .thenCompose(ignored -> CompletableFuture.completedFuture(updatedIds.size()));
+        .thenApply(ignored -> updatedIds.size());
   }
 
   private boolean shouldNotifyAboutUpdate(final DocumentUpdate update) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks.incident;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
@@ -44,6 +45,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   private final ScheduledExecutorService executor;
   private final Logger logger;
   private final Duration waitForRefreshInterval;
+  private final IncidentNotifier incidentNotifier;
 
   public IncidentUpdateTask(
       final ExporterMetadata metadata,
@@ -51,6 +53,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final boolean ignoreMissingData,
       final int batchSize,
       final ScheduledExecutorService executor,
+      final IncidentNotifier incidentNotifier,
       final Logger logger) {
     this(
         metadata,
@@ -58,6 +61,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
         ignoreMissingData,
         batchSize,
         executor,
+        incidentNotifier,
         logger,
         Duration.ofSeconds(5));
   }
@@ -69,6 +73,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final boolean ignoreMissingData,
       final int batchSize,
       final ScheduledExecutorService executor,
+      final IncidentNotifier incidentNotifier,
       final Logger logger,
       final Duration waitForRefreshInterval) {
     this.metadata = metadata;
@@ -78,6 +83,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     this.executor = executor;
     this.logger = logger;
     this.waitForRefreshInterval = waitForRefreshInterval;
+    this.incidentNotifier = incidentNotifier;
   }
 
   @Override
@@ -277,6 +283,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
                     executor),
             executor)
         .thenCompose(ignored -> repository.bulkUpdate(bulkUpdate))
+        .thenCompose(
+            updatedIds ->
+                notifyIncidents(updatedIds, bulkUpdate.incidentRequests(), data.incidents()))
         .join();
   }
 
@@ -509,6 +518,33 @@ public final class IncidentUpdateTask implements BackgroundTask {
           .listViewRequests()
           .put(piId, newListViewInstanceUpdate(piId, index, hasIncident, piId));
     }
+  }
+
+  private CompletableFuture<Integer> notifyIncidents(
+      final List<String> updatedIds,
+      final Map<String, DocumentUpdate> incidentUpdates,
+      final Map<String, IncidentDocument> incidents) {
+    final var incidentsToNotify =
+        updatedIds.stream()
+            .filter(incidentUpdates::containsKey)
+            .filter(id -> shouldNotifyAboutUpdate(incidentUpdates.get(id)))
+            .map(incidents::get)
+            .map(IncidentDocument::incident)
+            .toList();
+    if (incidentsToNotify.isEmpty()) {
+      return CompletableFuture.completedFuture(updatedIds.size());
+    }
+    return incidentNotifier
+        .notifyAsync(incidentsToNotify)
+        .thenCompose(ignored -> CompletableFuture.completedFuture(updatedIds.size()));
+  }
+
+  private boolean shouldNotifyAboutUpdate(final DocumentUpdate update) {
+    if (update.doc().containsKey(IncidentTemplate.STATE)) {
+      final var stateUpdate = update.doc().get(IncidentTemplate.STATE);
+      return IncidentState.RESOLVED != stateUpdate && IncidentState.MIGRATED != stateUpdate;
+    }
+    return false;
   }
 
   private DocumentUpdate newIncidentUpdate(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
-import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
@@ -41,9 +40,7 @@ public class IncidentHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-incident";
   private final TestProcessCache processCache = new TestProcessCache();
-  private final IncidentNotifier incidentNotifier = mock(IncidentNotifier.class);
-  private final IncidentHandler underTest =
-      new IncidentHandler(indexName, processCache, incidentNotifier);
+  private final IncidentHandler underTest = new IncidentHandler(indexName, processCache);
 
   @Test
   void testGetHandledValueType() {
@@ -154,7 +151,6 @@ public class IncidentHandlerTest {
                 incidentRecordValue.getProcessDefinitionKey(),
                 "treePath",
                 incidentEntity.getTreePath()));
-    verify(incidentNotifier).notifyAsync(List.of(incidentEntity));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -146,14 +146,17 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update) {
+    public CompletionStage<List<String>> bulkUpdate(final IncidentBulkUpdate update) {
       updated = update;
-      return bulkUpdate != null
-          ? bulkUpdate
-          : CompletableFuture.completedFuture(
-              update.incidentRequests().size()
-                  + update.listViewRequests().size()
-                  + update.flowNodeInstanceRequests().size());
+      final List<String> aggregatedIds =
+          new ArrayList<>() {
+            {
+              addAll(update.incidentRequests().keySet());
+              addAll(update.listViewRequests().keySet());
+              addAll(update.flowNodeInstanceRequests().keySet());
+            }
+          };
+      return bulkUpdate != null ? bulkUpdate : CompletableFuture.completedFuture(aggregatedIds);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -441,7 +441,15 @@ final class IncidentUpdateTaskTest {
           .containsEntry(
               "4",
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
-      verify(incidentNotifier, times(0)).notifyAsync(any());
+      final var incident =
+          new IncidentEntity()
+              .setKey(5L)
+              .setId("5")
+              .setFlowNodeInstanceKey(4L)
+              .setTreePath("PI_1/FNI_2/PI_3/FNI_4")
+              .setProcessInstanceKey(3L)
+              .setState(IncidentState.PENDING);
+      verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
     }
 
     @Test
@@ -466,6 +474,15 @@ final class IncidentUpdateTaskTest {
               "4",
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
+      final var incident =
+          new IncidentEntity()
+              .setKey(5L)
+              .setId("5")
+              .setFlowNodeInstanceKey(4L)
+              .setTreePath("PI_1/FNI_2/PI_3/FNI_4")
+              .setProcessInstanceKey(3L)
+              .setState(IncidentState.PENDING);
+      verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
     }
 
     @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -8,8 +8,17 @@
 package io.camunda.exporter.tasks.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.cache.ExporterEntityCache;
+import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.exporter.notifier.IncidentNotifier;
+import io.camunda.exporter.notifier.M2mTokenManager;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
@@ -25,7 +34,9 @@ import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentState;
 import io.camunda.zeebe.exporter.api.ExporterException;
+import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -51,24 +62,28 @@ final class IncidentUpdateTaskTest {
   private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
 
   private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
+  private final IncidentNotifier incidentNotifier = Mockito.spy(createIncidentNotifier());
   private final TestRepository repository = Mockito.spy(new TestRepository());
 
   @Test
   void shouldReturnNothingDoneOnEmptyPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+    final var task =
+        new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER);
 
     // when
     final var result = task.execute();
 
     // then
     assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
+    verify(incidentNotifier, times(0)).notifyAsync(any());
   }
 
   @Test
   void shouldUseMetadataPositionToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+    final var task =
+        new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER);
     metadata.setLastIncidentUpdatePosition(5);
 
     // when
@@ -81,7 +96,8 @@ final class IncidentUpdateTaskTest {
   @Test
   void shouldUseBatchSizeToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+    final var task =
+        new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER);
 
     // when
     task.execute().toCompletableFuture().join();
@@ -90,12 +106,24 @@ final class IncidentUpdateTaskTest {
     Mockito.verify(repository).getPendingIncidentsBatch(Mockito.anyLong(), Mockito.eq(10));
   }
 
+  private IncidentNotifier createIncidentNotifier() {
+    final var config = new IncidentNotifierConfiguration();
+    config.setWebhook(null);
+    final var m2mTokenManager = mock(M2mTokenManager.class);
+    final var processCache = mock(ExporterEntityCache.class);
+    final var httpClient = mock(HttpClient.class);
+    final var objectMapper = new ObjectMapper();
+
+    return new IncidentNotifier(
+        m2mTokenManager, processCache, config, httpClient, EXECUTOR, objectMapper);
+  }
+
   private static final class TestRepository extends NoopIncidentUpdateRepository {
     private CompletableFuture<PendingIncidentUpdateBatch> batch;
     private CompletableFuture<Map<String, IncidentDocument>> incidents;
     private CompletableFuture<Collection<ProcessInstanceDocument>> processInstances;
     private CompletableFuture<Collection<ActiveIncident>> activeIncidentsByTreePaths;
-    private CompletableFuture<Integer> bulkUpdate;
+    private CompletableFuture<List<String>> bulkUpdate;
     private CompletableFuture<Collection<Document>> flowNodesInListView;
     private CompletableFuture<Collection<Document>> flowNodeInstances;
     private CompletableFuture<Boolean> wasProcessInstanceDeleted;
@@ -243,7 +271,9 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldUpdateMetadataOnSuccess() {
       // given
-      final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+      final var task =
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER);
 
       // when
       task.execute().toCompletableFuture().join();
@@ -255,7 +285,9 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldReturnNumberOfDocumentsUpdated() {
       // given
-      final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+      final var task =
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER);
 
       // when
       final var result = task.execute();
@@ -271,7 +303,8 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       repository.incidents = CompletableFuture.completedFuture(Map.of());
 
       // when
@@ -283,13 +316,15 @@ final class IncidentUpdateTaskTest {
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Failed to fetch incidents");
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
     void shouldFailOnMissingProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       repository.processInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -301,13 +336,15 @@ final class IncidentUpdateTaskTest {
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Process instance 3 is not yet imported for incident 5");
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
     void shouldFailOnMissingFlowNodeInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       repository.flowNodesInListView = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -319,13 +356,15 @@ final class IncidentUpdateTaskTest {
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
     void shouldFailOnMissingFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       repository.flowNodeInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -337,13 +376,15 @@ final class IncidentUpdateTaskTest {
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
     void shouldUpdateIncidents() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -363,13 +404,23 @@ final class IncidentUpdateTaskTest {
                       IncidentTemplate.TREE_PATH,
                       "PI_1/FNI_2/PI_3/FNI_4"),
                   null));
+      final var incident =
+          new IncidentEntity()
+              .setKey(5L)
+              .setId("5")
+              .setFlowNodeInstanceKey(4L)
+              .setTreePath("PI_1/FNI_2/PI_3/FNI_4")
+              .setProcessInstanceKey(3L)
+              .setState(IncidentState.PENDING);
+      verify(incidentNotifier, times(1)).notifyAsync(List.of(incident));
     }
 
     @Test
     void shouldUpdateListView() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -390,13 +441,15 @@ final class IncidentUpdateTaskTest {
           .containsEntry(
               "4",
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
     void shouldUpdateFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -419,7 +472,8 @@ final class IncidentUpdateTaskTest {
     void shouldResolveIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -464,6 +518,8 @@ final class IncidentUpdateTaskTest {
           .containsEntry(
               "4",
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
+
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
 
     @Test
@@ -471,7 +527,8 @@ final class IncidentUpdateTaskTest {
       // given - we have another active incident with an overlapping tree path, but only covering
       // process instance
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -522,7 +579,8 @@ final class IncidentUpdateTaskTest {
     void shouldIgnoreDeletedProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, EXECUTOR, incidentNotifier, LOGGER, Duration.ZERO);
       repository.processInstances =
           CompletableFuture.completedFuture(List.of(parentProcessInstance));
       repository.wasProcessInstanceDeleted = CompletableFuture.completedFuture(true);
@@ -535,6 +593,7 @@ final class IncidentUpdateTaskTest {
       assertThat(repository.updated.listViewRequests()).isEmpty();
       assertThat(repository.updated.incidentRequests()).isEmpty();
       assertThat(repository.updated.flowNodeInstanceRequests()).isEmpty();
+      verify(incidentNotifier, times(0)).notifyAsync(any());
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Perform the process of notifying regarding Incidents in the Background task of `IncidentUpdateTask`. We already have access to the Incident's in that part of the code and it would be more efficient to batch the notifications instead of send one per exported Incident in the respective `IncidentHandler`.

In this PR the Process and Form caches are also being exposed by the `ExporterResourceProvider` so as to be reused for the background task, as I believe their implementation is not of a shared cache but distinct instances.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31794
