### PR TITLE
feat: add a AuthorizationQueryTransformer for batch operations

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.auth;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ;
 import static io.camunda.client.api.search.enums.ResourceType.BATCH_OPERATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
@@ -45,6 +47,7 @@ class BatchOperationAuthorizationIT {
 
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";
+  private static final String RESTRICTED_READ = "restrictedReadUser";
   private static final String FORBIDDEN = "forbiddenUser";
 
   @UserDefinition
@@ -56,12 +59,23 @@ class BatchOperationAuthorizationIT {
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(
-                  BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*"))));
+                  BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(BATCH_OPERATION, READ, List.of("*"))));
 
   @UserDefinition
   private static final User RESTRICTED_USER =
       new User(
           RESTRICTED,
+          "password",
+          List.of(
+              new Permissions(
+                  BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(BATCH_OPERATION, READ, List.of("*"))));
+
+  @UserDefinition
+  private static final User RESTRICTED_READ_USER =
+      new User(
+          RESTRICTED_READ,
           "password",
           List.of(
               new Permissions(
@@ -88,11 +102,44 @@ class BatchOperationAuthorizationIT {
   @Test
   void adminShouldStartBatchOperation(@Authenticated(ADMIN) final CamundaClient camundaClient) {
     // when
+    final var batchOperationResponse = createProcessInstanceCancelBatchOperation(camundaClient);
+
+    // then
+    assertThat(batchOperationResponse).isNotNull();
+  }
+
+  @Test
+  void adminShouldReadSingleBatchOperation(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+
+    // when
+    waitForBatchOperation(camundaClient, batchOperationKey);
+
+    // when
+    final var batchOperationResponse =
+        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+
+    // then
+    assertThat(batchOperationResponse).isNotNull();
+  }
+
+  @Test
+  void adminShouldQueryBatchOperation(@Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+
+    // when
+    waitForBatchOperation(camundaClient, batchOperationKey);
+
+    // when
     final var batchOperationResponse =
         camundaClient
-            .newCreateBatchOperationCommand()
-            .processInstanceCancel()
-            .filter(b -> {})
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
             .send()
             .join();
 
@@ -104,11 +151,45 @@ class BatchOperationAuthorizationIT {
   void restrictedUserShouldStartBatchOperation(
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
     // when
+    final var batchOperationResponse = createProcessInstanceCancelBatchOperation(camundaClient);
+
+    // then
+    assertThat(batchOperationResponse).isNotNull();
+  }
+
+  @Test
+  void restrictedUserShouldReadSingleBatchOperation(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+
+    // when
+    waitForBatchOperation(camundaClient, batchOperationKey);
+
+    // when
+    final var batchOperationResponse =
+        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+
+    // then
+    assertThat(batchOperationResponse).isNotNull();
+  }
+
+  @Test
+  void restrictedUserShouldQueryBatchOperation(
+      @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+
+    // when
+    waitForBatchOperation(camundaClient, batchOperationKey);
+
+    // when
     final var batchOperationResponse =
         camundaClient
-            .newCreateBatchOperationCommand()
-            .processInstanceCancel()
-            .filter(b -> {})
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
             .send()
             .join();
 
@@ -137,6 +218,61 @@ class BatchOperationAuthorizationIT {
             "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE' on resource 'BATCH_OPERATION'");
   }
 
+  @Test
+  void shouldReturnForbiddenForUnauthorizedReadOfBatchOperation(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
+      @Authenticated(RESTRICTED_READ) final CamundaClient camundaRestictedClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaRestictedClient).getBatchOperationKey();
+
+    // when our admin finds something
+    waitForBatchOperation(camundaAdminClient, batchOperationKey);
+
+    // then we should find nothing with our restricted user
+    Awaitility.await("should not return batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(
+            () -> {
+              try {
+                camundaRestictedClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+              } catch (final ProblemException e) {
+                assertThat(e.code()).isEqualTo(404);
+              }
+            });
+  }
+
+  @Test
+  void shouldReturnForbiddenForUnauthorizedQueryOfBatchOperation(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
+      @Authenticated(RESTRICTED_READ) final CamundaClient camundaRestictedClient) {
+    // given
+    final var batchOperationKey =
+        createProcessInstanceCancelBatchOperation(camundaRestictedClient).getBatchOperationKey();
+
+    // when our admin finds something
+    waitForBatchOperation(camundaAdminClient, batchOperationKey);
+
+    // then we should find nothing with our restricted user
+    Awaitility.await("should not return batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(
+            () -> {
+              try {
+                final var batchOperationResponse =
+                    camundaRestictedClient
+                        .newBatchOperationSearchRequest()
+                        .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+                        .send()
+                        .join();
+              } catch (final ProblemException e) {
+                assertThat(e.code()).isEqualTo(404);
+              }
+            });
+  }
+
   private static void deployResource(final CamundaClient camundaClient, final String resourceName) {
     camundaClient.newDeployResourceCommand().addResourceFromClasspath(resourceName).send().join();
   }
@@ -151,5 +287,31 @@ class BatchOperationAuthorizationIT {
               final var result = camundaClient.newProcessDefinitionSearchRequest().send().join();
               assertThat(result.items().size()).isEqualTo(expectedCount);
             });
+  }
+
+  public static void waitForBatchOperation(
+      final CamundaClient camundaClient, final long batchOperationKey) {
+    Awaitility.await("should wait for started batch operation")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(100))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+              assertThat(batch).isNotNull();
+            });
+  }
+
+  private static CreateBatchOperationResponse createProcessInstanceCancelBatchOperation(
+      final CamundaClient camundaClient) {
+    final var batchOperationResponse =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> {})
+            .send()
+            .join();
+    return batchOperationResponse;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/AuthorizationQueryTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/AuthorizationQueryTransformers.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static java.util.Map.entry;
 
+import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
@@ -29,6 +30,7 @@ public final class AuthorizationQueryTransformers {
   private static final Map<Class<? extends SearchQueryBase>, AuthorizationQueryTransformer>
       TRANSFORMERS =
           Map.ofEntries(
+              entry(BatchOperationQuery.class, new BatchOperationAuthorizationQueryTransformer()),
               entry(
                   DecisionDefinitionQuery.class,
                   new DecisionDefinitionAuthorizationQueryTransformer()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/BatchOperationAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/BatchOperationAuthorizationQueryTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.auth;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.BATCH_OPERATION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
+
+public class BatchOperationAuthorizationQueryTransformer implements AuthorizationQueryTransformer {
+
+  @Override
+  public SearchQuery toSearchQuery(
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final List<String> resourceKeys) {
+    if (resourceType == BATCH_OPERATION && permissionType == READ) {
+      // If the user has READ permission, he can see all Batch Operations
+      return matchAll();
+    }
+    throw new IllegalArgumentException(
+        "Unsupported authorizations with resource:%s and permission:%s: "
+            .formatted(resourceType, permissionType));
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/auth/BatchOperationAuthorizationQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/auth/BatchOperationAuthorizationQueryTransformerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.auth;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.BATCH_OPERATION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationAuthorizationQueryTransformerTest {
+
+  private final BatchOperationAuthorizationQueryTransformer transformer =
+      new BatchOperationAuthorizationQueryTransformer();
+
+  @Test
+  void shouldReturnMatchAllForValidAuthorization() {
+    // given
+    final AuthorizationResourceType resourceType = BATCH_OPERATION;
+    final PermissionType permissionType = READ;
+    final List<String> resourceKeys = List.of("key1", "key2");
+
+    // when
+    final SearchQuery result =
+        transformer.toSearchQuery(resourceType, permissionType, resourceKeys);
+
+    // then
+    assertThat(result).isEqualTo(matchAll());
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidResourceType() {
+    // given
+    final AuthorizationResourceType resourceType = AuthorizationResourceType.PROCESS_DEFINITION;
+    final PermissionType permissionType = READ;
+    final List<String> resourceKeys = List.of("key1", "key2");
+
+    // when & then
+    assertThatThrownBy(() -> transformer.toSearchQuery(resourceType, permissionType, resourceKeys))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported authorizations with resource");
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidPermissionType() {
+    // given
+    final AuthorizationResourceType resourceType = BATCH_OPERATION;
+    final PermissionType permissionType = PermissionType.UPDATE;
+    final List<String> resourceKeys = List.of("key1", "key2");
+
+    // when & then
+    assertThatThrownBy(() -> transformer.toSearchQuery(resourceType, permissionType, resourceKeys))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported authorizations with resource");
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -8,6 +8,7 @@
 package io.camunda.security.auth;
 
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.BATCH_OPERATION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.GROUP;
@@ -174,6 +175,10 @@ public final class Authorization {
 
     public Builder readDecisionInstance() {
       return permissionType(READ_DECISION_INSTANCE);
+    }
+
+    public Builder batchOperation() {
+      return resourceType(BATCH_OPERATION);
     }
 
     public Authorization build() {

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -58,7 +58,7 @@ public final class BatchOperationServices
     return batchOperationSearchClient
         .withSecurityContext(
             securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(Builder::read)))
+                authentication, Authorization.of(a -> a.batchOperation().read())))
         .searchBatchOperations(query);
   }
 
@@ -73,8 +73,12 @@ public final class BatchOperationServices
 
   public BatchOperationEntity getById(final String batchOperationId) {
     final var result =
-        batchOperationSearchClient.searchBatchOperations(
-            batchOperationQuery(q -> q.filter(f -> f.batchOperationIds(batchOperationId))));
+        batchOperationSearchClient
+            .withSecurityContext(
+                securityContextProvider.provideSecurityContext(
+                    authentication, Authorization.of(a -> a.batchOperation().read())))
+            .searchBatchOperations(
+                batchOperationQuery(q -> q.filter(f -> f.batchOperationIds(batchOperationId))));
     return getSingleResultOrThrow(result, batchOperationId, "BatchOperation");
   }
 


### PR DESCRIPTION
## Description

* Adds a new AuthorizationQueryTransformers for batch operations
* Use the new permission types in the batch operation service
* Adds a E2E test for read + query of batch operations (admin/restricted/forbidden)

## Related issues

closes #30934 #31483
