### PR TITLE
build: bump c8run version to 8.8.0-alpha4

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha4-rc1
+CAMUNDA_VERSION=8.8.0-alpha4
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0-alpha4-rc6
+CONNECTORS_VERSION=8.8.0-alpha4.1
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.7
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.7


### PR DESCRIPTION
## Description

Bump c8run version to 8.8.0-alpha4

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

May 2025 release.
