### PR TITLE
refactor: rename entity application to client

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -45,7 +45,7 @@ public class CamundaOAuthPrincipalService {
   private final GroupServices groupServices;
   private final AuthorizationServices authorizationServices;
   private final String usernameClaim;
-  private final String applicationIdClaim;
+  private final String clientIdClaim;
 
   public CamundaOAuthPrincipalService(
       final MappingServices mappingServices,
@@ -60,8 +60,7 @@ public class CamundaOAuthPrincipalService {
     this.groupServices = groupServices;
     this.authorizationServices = authorizationServices;
     usernameClaim = securityConfiguration.getAuthentication().getOidc().getUsernameClaim();
-    applicationIdClaim =
-        securityConfiguration.getAuthentication().getOidc().getApplicationIdClaim();
+    clientIdClaim = securityConfiguration.getAuthentication().getOidc().getClientIdClaim();
   }
 
   public OAuthContext loadOAuthContext(final Map<String, Object> claims)
@@ -94,19 +93,19 @@ public class CamundaOAuthPrincipalService {
             .withRoles(assignedRoles);
 
     final var username = getUsernameFromClaims(claims);
-    final var applicationId = getApplicationIdFromClaims(claims);
+    final var clientId = getClientIdFromClaims(claims);
 
-    if (username == null && applicationId == null) {
+    if (username == null && clientId == null) {
       throw new IllegalArgumentException(
-          "Neither username claim (%s) nor applicationId claim (%s) could be found in the claims. Please check your OIDC configuration."
-              .formatted(usernameClaim, applicationIdClaim));
+          "Neither username claim (%s) nor clientId claim (%s) could be found in the claims. Please check your OIDC configuration."
+              .formatted(usernameClaim, clientIdClaim));
     }
     if (username != null) {
       authContextBuilder.withUsername(getUsernameFromClaims(claims));
     }
 
-    if (applicationId != null) {
-      authContextBuilder.withApplicationId(getApplicationIdFromClaims(claims));
+    if (clientId != null) {
+      authContextBuilder.withClientId(getClientIdFromClaims(claims));
     }
 
     return new OAuthContext(mappingIds, authContextBuilder.build());
@@ -126,18 +125,17 @@ public class CamundaOAuthPrincipalService {
     }
   }
 
-  private String getApplicationIdFromClaims(final Map<String, Object> claims) {
-    final var maybeApplicationId = Optional.ofNullable(claims.get(applicationIdClaim));
+  private String getClientIdFromClaims(final Map<String, Object> claims) {
+    final var maybeClientId = Optional.ofNullable(claims.get(clientIdClaim));
 
-    if (maybeApplicationId.isEmpty()) {
+    if (maybeClientId.isEmpty()) {
       return null;
     }
 
-    if (maybeApplicationId.get() instanceof final String applicationId) {
-      return applicationId;
+    if (maybeClientId.get() instanceof final String clientId) {
+      return clientId;
     } else {
-      throw new IllegalArgumentException(
-          CLAIM_NOT_STRING.formatted("application", applicationIdClaim));
+      throw new IllegalArgumentException(CLAIM_NOT_STRING.formatted("client", clientIdClaim));
     }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public record AuthenticationContext(
     String username,
-    String applicationId,
+    String clientId,
     List<RoleEntity> roles,
     List<String> authorizedApplications,
     List<TenantDTO> tenants,
@@ -24,7 +24,7 @@ public record AuthenticationContext(
 
   public static final class AuthenticationContextBuilder {
     private String username;
-    private String applicationId;
+    private String clientId;
     private List<RoleEntity> roles = new ArrayList<>();
     private List<String> authorizedApplications = new ArrayList<>();
     private List<TenantDTO> tenants = new ArrayList<>();
@@ -35,8 +35,8 @@ public record AuthenticationContext(
       return this;
     }
 
-    public AuthenticationContextBuilder withApplicationId(final String applicationId) {
-      this.applicationId = applicationId;
+    public AuthenticationContextBuilder withClientId(final String clientId) {
+      this.clientId = clientId;
       return this;
     }
 
@@ -63,7 +63,7 @@ public record AuthenticationContext(
 
     public AuthenticationContext build() {
       return new AuthenticationContext(
-          username, applicationId, roles, authorizedApplications, tenants, groups);
+          username, clientId, roles, authorizedApplications, tenants, groups);
     }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -44,8 +44,8 @@ public class CamundaOAuthPrincipalServiceTest {
   private CamundaOAuthPrincipalService camundaOAuthPrincipalService;
 
   @Nested
-  class ApplicationIdClaimConfiguration {
-    private static final String APPLICATION_ID_CLAIM = "application-id";
+  class ClientIdClaimConfiguration {
+    private static final String APPLICATION_ID_CLAIM = "client-id";
     @Mock private MappingServices mappingServices;
     @Mock private TenantServices tenantServices;
     @Mock private RoleServices roleServices;
@@ -62,8 +62,7 @@ public class CamundaOAuthPrincipalServiceTest {
       when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
       when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("not-tested");
-      when(oidcAuthenticationConfiguration.getApplicationIdClaim())
-          .thenReturn(APPLICATION_ID_CLAIM);
+      when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalService(
@@ -76,7 +75,7 @@ public class CamundaOAuthPrincipalServiceTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenNoApplicationIdClaimFound() {
+    public void shouldThrowExceptionWhenNoClientIdClaimFound() {
       // given
       final Map<String, Object> claims = Map.of("sub", "user@example.com");
 
@@ -88,15 +87,14 @@ public class CamundaOAuthPrincipalServiceTest {
 
       assertThat(exception.getMessage())
           .isEqualTo(
-              "Neither username claim (%s) nor applicationId claim (%s) could be found in the claims. Please check your OIDC configuration."
+              "Neither username claim (%s) nor clientId claim (%s) could be found in the claims. Please check your OIDC configuration."
                   .formatted("not-tested", APPLICATION_ID_CLAIM));
     }
 
     @Test
-    public void shouldThrowExceptionWhenApplicationIdClaimIsNotAString() {
+    public void shouldThrowExceptionWhenClientIdClaimIsNotAString() {
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn("not-tested");
-      when(oidcAuthenticationConfiguration.getApplicationIdClaim())
-          .thenReturn(APPLICATION_ID_CLAIM);
+      when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn(APPLICATION_ID_CLAIM);
       // given
       final Map<String, Object> claims = Map.of(APPLICATION_ID_CLAIM, List.of("app-1", "app-2"));
 
@@ -107,11 +105,11 @@ public class CamundaOAuthPrincipalServiceTest {
               () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
 
       assertThat(exception.getMessage())
-          .isEqualTo(CLAIM_NOT_STRING.formatted("application", APPLICATION_ID_CLAIM));
+          .isEqualTo(CLAIM_NOT_STRING.formatted("client", APPLICATION_ID_CLAIM));
     }
 
     @Test
-    public void shouldLoadUserWhenUsingApplicationIdClaim() {
+    public void shouldLoadUserWhenUsingClientIdClaim() {
       // given
       final Map<String, Object> claims =
           Map.of("sub", UUID.randomUUID().toString(), APPLICATION_ID_CLAIM, "app-1");
@@ -122,7 +120,7 @@ public class CamundaOAuthPrincipalServiceTest {
       // then
       assertThat(oAuthContext).isNotNull();
       final AuthenticationContext authenticationContext = oAuthContext.authenticationContext();
-      assertThat(authenticationContext.applicationId()).isEqualTo("app-1");
+      assertThat(authenticationContext.clientId()).isEqualTo("app-1");
     }
   }
 
@@ -145,7 +143,7 @@ public class CamundaOAuthPrincipalServiceTest {
       when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfiguration);
       when(authenticationConfiguration.getOidc()).thenReturn(oidcAuthenticationConfiguration);
       when(oidcAuthenticationConfiguration.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
-      when(oidcAuthenticationConfiguration.getApplicationIdClaim()).thenReturn("not-tested");
+      when(oidcAuthenticationConfiguration.getClientIdClaim()).thenReturn("not-tested");
 
       camundaOAuthPrincipalService =
           new CamundaOAuthPrincipalService(
@@ -170,7 +168,7 @@ public class CamundaOAuthPrincipalServiceTest {
 
       assertThat(exception.getMessage())
           .isEqualTo(
-              "Neither username claim (%s) nor applicationId claim (%s) could be found in the claims. Please check your OIDC configuration."
+              "Neither username claim (%s) nor clientId claim (%s) could be found in the claims. Please check your OIDC configuration."
                   .formatted(USERNAME_CLAIM, "not-tested"));
     }
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -90,7 +90,7 @@ public class CamundaOidcUserServiceTest {
   }
 
   @Test
-  public void applicationIdIsSetInAuthContext() {
+  public void clientIdIsSetInAuthContext() {
     // given
     final Map<String, Object> claims = Map.of("sub", "test|foo@camunda.test", "client_id", "blah");
 
@@ -99,14 +99,14 @@ public class CamundaOidcUserServiceTest {
             new OAuthContext(
                 Set.of("test-id", "test-id-2"),
                 new AuthenticationContext.AuthenticationContextBuilder()
-                    .withApplicationId("blah")
+                    .withClientId("blah")
                     .build()));
 
     final var oidcUser = camundaOidcUserService.loadUser(createOidcUserRequest(claims));
     final var camundaUser = (CamundaOidcUser) oidcUser;
     final var authenticationContext = camundaUser.getAuthenticationContext();
 
-    assertThat(authenticationContext.applicationId()).isEqualTo("blah");
+    assertThat(authenticationContext.clientId()).isEqualTo("blah");
     assertThat(authenticationContext.username()).isNull();
   }
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/OwnerType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/OwnerType.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.enums;
 
 public enum OwnerType {
   USER,
-  APPLICATION,
+  CLIENT,
   ROLE,
   GROUP,
   MAPPING,

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -10,7 +10,7 @@ erDiagram
     string email
     string password
   }
-  Application {
+  Client {
     string id PK
   }
   Role {
@@ -56,14 +56,14 @@ erDiagram
   Mapping }o..o{ Role: "assigned"
   Mapping }o..o{ Group: "member"
   Role }o--o{ Tenant: "assigned"
-  Application ||--o{ Authorization: "granted"
-  Application }o..o{ Group: "member"
-  Application }o..o{ Role: "assigned"
-  Application }o..o{ Tenant: "assigned"
+  Client ||--o{ Authorization: "granted"
+  Client }o..o{ Group: "member"
+  Client }o..o{ Role: "assigned"
+  Client }o..o{ Tenant: "assigned"
 ```
 
 ### Unmanaged entities
 
-Under the "simple mapping" feature, users and applications are not managed as their own entities.
+Under the "simple mapping" feature, users and clients are not managed as their own entities.
 All relationships such as group, role and tenant membership, and assigned authorizations, are purely
-based on the username or application id.
+based on the username or client id.

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.it.auth;
 
-import static io.camunda.client.api.search.enums.OwnerType.APPLICATION;
+import static io.camunda.client.api.search.enums.OwnerType.CLIENT;
 import static io.camunda.client.api.search.enums.OwnerType.USER;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
@@ -136,7 +136,7 @@ class AuthorizationSearchIT {
         adminClient
             .newCreateAuthorizationCommand()
             .ownerId(ADMIN)
-            .ownerType(APPLICATION)
+            .ownerType(CLIENT)
             .resourceId(resourceId)
             .resourceType(PROCESS_DEFINITION)
             .permissionTypes(READ_PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE)

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public final class Authentication {
   private final String authenticatedUsername;
-  private final String authenticationApplicationId;
+  private final String authenticatedClientId;
   private final List<Long> authenticatedGroupKeys;
   private final List<String> authenticatedRoleIds;
   private final List<String> authenticatedTenantIds;
@@ -32,14 +32,14 @@ public final class Authentication {
   @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
   public Authentication(
       final @JsonProperty("authenticated_username") String authenticatedUsername,
-      final @JsonProperty("authenticated_application_id") String authenticationApplicationId,
+      final @JsonProperty("authenticated_client_id") String authenticatedClientId,
       final @JsonProperty("authenticated_group_keys") List<Long> authenticatedGroupKeys,
       final @JsonProperty("authenticated_role_ids") List<String> authenticatedRoleIds,
       final @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
       final @JsonProperty("authenticated_mapping_ids") List<String> authenticatedMappingIds,
       final @JsonProperty("claims") Map<String, Object> claims) {
     this.authenticatedUsername = authenticatedUsername;
-    this.authenticationApplicationId = authenticationApplicationId;
+    this.authenticatedClientId = authenticatedClientId;
     this.authenticatedGroupKeys = authenticatedGroupKeys;
     this.authenticatedRoleIds = authenticatedRoleIds;
     this.authenticatedTenantIds = authenticatedTenantIds;
@@ -59,8 +59,8 @@ public final class Authentication {
     return authenticatedUsername;
   }
 
-  public String authenticationApplicationId() {
-    return authenticationApplicationId;
+  public String authenticatedClientId() {
+    return authenticatedClientId;
   }
 
   public List<Long> authenticatedGroupKeys() {
@@ -104,7 +104,7 @@ public final class Authentication {
     }
     final Authentication that = (Authentication) obj;
     return Objects.equals(authenticatedUsername, that.authenticatedUsername)
-        && Objects.equals(authenticationApplicationId, that.authenticationApplicationId)
+        && Objects.equals(authenticatedClientId, that.authenticatedClientId)
         && Objects.equals(authenticatedGroupKeys, that.authenticatedGroupKeys)
         && Objects.equals(authenticatedRoleIds, that.authenticatedRoleIds)
         && Objects.equals(authenticatedTenantIds, that.authenticatedTenantIds)
@@ -118,8 +118,8 @@ public final class Authentication {
         + "authenticatedUsername="
         + authenticatedUsername
         + ", "
-        + "authenticatedApplicationId="
-        + authenticationApplicationId
+        + "authenticatedClientId="
+        + authenticatedClientId
         + ", "
         + "authenticatedGroupKeys="
         + authenticatedGroupKeys
@@ -141,7 +141,7 @@ public final class Authentication {
   public static final class Builder {
 
     private String username;
-    private String applicationId;
+    private String clientId;
     private final List<Long> groupKeys = new ArrayList<>();
     private final List<String> roleIds = new ArrayList<>();
     private final List<String> tenants = new ArrayList<>();
@@ -153,8 +153,8 @@ public final class Authentication {
       return this;
     }
 
-    public Builder applicationId(final String value) {
-      applicationId = value;
+    public Builder clientId(final String value) {
+      clientId = value;
       return this;
     }
 
@@ -210,7 +210,7 @@ public final class Authentication {
     public Authentication build() {
       return new Authentication(
           username,
-          applicationId,
+          clientId,
           unmodifiableList(groupKeys),
           unmodifiableList(roleIds),
           unmodifiableList(tenants),

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -22,7 +22,7 @@ public class OidcAuthenticationConfiguration {
   private String authorizationUri;
   private Set<String> audiences;
   private String usernameClaim = "sub";
-  private String applicationIdClaim;
+  private String clientIdClaim;
   private String organizationId;
 
   public String getIssuerUri() {
@@ -105,12 +105,12 @@ public class OidcAuthenticationConfiguration {
     this.usernameClaim = usernameClaim;
   }
 
-  public String getApplicationIdClaim() {
-    return applicationIdClaim;
+  public String getClientIdClaim() {
+    return clientIdClaim;
   }
 
-  public void setApplicationIdClaim(final String applicationIdClaim) {
-    this.applicationIdClaim = applicationIdClaim;
+  public void setClientIdClaim(final String clientIdClaim) {
+    this.clientIdClaim = clientIdClaim;
   }
 
   public String getOrganizationId() {

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationOwnerType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationOwnerType.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum AuthorizationOwnerType {
   USER,
-  APPLICATION,
+  CLIENT,
   ROLE,
   GROUP,
   MAPPING,

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -129,8 +129,8 @@ public class AuthorizationChecker {
     if (authentication.authenticatedUsername() != null) {
       ownerIds.add(authentication.authenticatedUsername());
     }
-    if (authentication.authenticationApplicationId() != null) {
-      ownerIds.add(authentication.authenticationApplicationId());
+    if (authentication.authenticatedClientId() != null) {
+      ownerIds.add(authentication.authenticatedClientId());
     }
     ownerIds.addAll(authentication.authenticatedMappingIds());
     ownerIds.addAll(

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -193,7 +193,7 @@ public class TenantServiceTest {
   @ParameterizedTest
   @EnumSource(
       value = EntityType.class,
-      names = {"USER", "MAPPING", "GROUP", "ROLE", "APPLICATION"})
+      names = {"USER", "MAPPING", "GROUP", "ROLE", "CLIENT"})
   public void shouldAddEntityToTenant(final EntityType entityType) {
     // given
     final var tenantId = "tenantId";
@@ -216,7 +216,7 @@ public class TenantServiceTest {
   @ParameterizedTest
   @EnumSource(
       value = EntityType.class,
-      names = {"USER", "MAPPING", "GROUP", "ROLE", "APPLICATION"})
+      names = {"USER", "MAPPING", "GROUP", "ROLE", "CLIENT"})
   public void shouldRemoveEntityFromTenant(final EntityType entityType) {
     // given
     final var tenantId = "tenantId";

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
@@ -12,6 +12,6 @@ public class Authorization {
   public static final String AUTHORIZED_ANONYMOUS_USER = "authorized_anonymous_user";
   public static final String AUTHORIZED_TENANTS = "authorized_tenants";
   public static final String AUTHORIZED_USERNAME = "authorized_username";
-  public static final String AUTHORIZED_APPLICATION_ID = "authorized_application_id";
+  public static final String AUTHORIZED_CLIENT_ID = "authorized_client_id";
   public static final String USER_TOKEN_CLAIM_PREFIX = "user_token_";
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -133,8 +133,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case EntityType.USER, APPLICATION ->
-          true; // With simple mappings, any username or application id can be assigned
+      case EntityType.USER, CLIENT ->
+          true; // With simple mappings, any username or client id can be assigned
       case EntityType.MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -138,8 +138,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER, APPLICATION ->
-          true; // With simple mappings, any username or application id can be assigned
+      case USER, CLIENT -> true; // With simple mappings, any username or client id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       default -> false;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -135,8 +135,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER, APPLICATION ->
-          true; // With simple mappings, any username and application id can be assigned
+      case USER, CLIENT -> true; // With simple mappings, any username and client id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -140,8 +140,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
-      case USER, APPLICATION ->
-          true; // With simple mappings, any username or application id can be assigned
+      case USER, CLIENT -> true; // With simple mappings, any username or client id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       default -> false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -136,7 +136,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private boolean isEntityPresent(final String entityId, final EntityType entityType) {
     return switch (entityType) {
       case USER -> true; // With simple mappings, any username can be assigned
-      case APPLICATION -> true; // With simple mappings, any application id can be assigned
+      case CLIENT -> true; // With simple mappings, any client id can be assigned
       case MAPPING -> mappingState.get(entityId).isPresent();
       case GROUP -> groupState.get(entityId).isPresent();
       case ROLE -> roleState.getRole(entityId).isPresent();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.authorization;
 
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
-import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_APPLICATION_ID;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_CLIENT_ID;
 import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
 import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -650,19 +650,15 @@ final class AuthorizationCheckBehaviorTest {
   }
 
   @Test
-  void shouldBeAuthorizedWhenApplicationHasPermission() {
+  void shouldBeAuthorizedWhenClientHasPermission() {
     // given
-    final var applicationId = createApplicationId();
+    final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        applicationId,
-        AuthorizationOwnerType.APPLICATION,
-        resourceType,
-        permissionType,
-        resourceId);
-    final var command = mockCommandWithApplicationId(applicationId);
+        clientId, AuthorizationOwnerType.CLIENT, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithClientId(clientId);
 
     // when
     final var request =
@@ -676,11 +672,11 @@ final class AuthorizationCheckBehaviorTest {
   @Test
   void shouldNotBeAuthorizedWhenApplicationHasNoPermission() {
     // given
-    final var applicationId = createApplicationId();
+    final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
     final var resourceId = UUID.randomUUID().toString();
-    final var command = mockCommandWithApplicationId(applicationId);
+    final var command = mockCommandWithClientId(clientId);
 
     // when
     final var request =
@@ -694,19 +690,19 @@ final class AuthorizationCheckBehaviorTest {
   @Test
   void shouldGetResourceIdentifiersWhenApplicationHasPermissions() {
     // given
-    final var applicationId = createApplicationId();
+    final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
     addPermission(
-        applicationId,
-        AuthorizationOwnerType.APPLICATION,
+        clientId,
+        AuthorizationOwnerType.CLIENT,
         resourceType,
         permissionType,
         resourceId1,
         resourceId2);
-    final var command = mockCommandWithApplicationId(applicationId);
+    final var command = mockCommandWithClientId(clientId);
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
@@ -720,10 +716,10 @@ final class AuthorizationCheckBehaviorTest {
   @Test
   void shouldGetEmptySetWhenApplicationHasNoPermissions() {
     // given
-    final var applicationId = createApplicationId();
+    final var clientId = createClientId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
-    final var command = mockCommandWithApplicationId(applicationId);
+    final var command = mockCommandWithClientId(clientId);
 
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
@@ -828,14 +824,14 @@ final class AuthorizationCheckBehaviorTest {
     return command;
   }
 
-  private TypedRecord<?> mockCommandWithApplicationId(final String applicationId) {
+  private TypedRecord<?> mockCommandWithClientId(final String clientId) {
     final var command = mock(TypedRecord.class);
-    when(command.getAuthorizations()).thenReturn(Map.of(AUTHORIZED_APPLICATION_ID, applicationId));
+    when(command.getAuthorizations()).thenReturn(Map.of(AUTHORIZED_CLIENT_ID, clientId));
     when(command.hasRequestMetadata()).thenReturn(true);
     return command;
   }
 
-  private String createApplicationId() {
+  private String createClientId() {
     return Strings.newRandomValidIdentityId();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -395,10 +395,10 @@ public class GroupTest {
   }
 
   @Test
-  public void shouldAddApplicationEntityToGroup() {
+  public void shouldAddClientEntityToGroup() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(name).create();
 
@@ -407,27 +407,27 @@ public class GroupTest {
         engine
             .group()
             .addEntity(groupId)
-            .withEntityId(applicationId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityId(clientId)
+            .withEntityType(EntityType.CLIENT)
             .add()
             .getValue();
 
     // then
-    assertThat(updatedGroup).hasEntityId(applicationId).hasEntityType(EntityType.APPLICATION);
+    assertThat(updatedGroup).hasEntityId(clientId).hasEntityType(EntityType.CLIENT);
   }
 
   @Test
-  public void shouldRemoveApplicationEntityFromGroup() {
+  public void shouldRemoveClientEntityFromGroup() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(name).create();
     engine
         .group()
         .addEntity(groupId)
-        .withEntityId(applicationId)
-        .withEntityType(EntityType.APPLICATION)
+        .withEntityId(clientId)
+        .withEntityType(EntityType.CLIENT)
         .add();
 
     // when
@@ -435,30 +435,30 @@ public class GroupTest {
         engine
             .group()
             .removeEntity(groupId)
-            .withEntityId(applicationId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityId(clientId)
+            .withEntityType(EntityType.CLIENT)
             .remove()
             .getValue();
 
     // then
     assertThat(groupWithRemovedEntity)
         .hasGroupId(groupId)
-        .hasEntityId(applicationId)
-        .hasEntityType(EntityType.APPLICATION);
+        .hasEntityId(clientId)
+        .hasEntityType(EntityType.CLIENT);
   }
 
   @Test
-  public void shouldRejectIfApplicationEntityIsAlreadyAssigned() {
+  public void shouldRejectIfClientEntityIsAlreadyAssigned() {
     // given
     final var groupId = Strings.newRandomValidIdentityId();
     final var name = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(name).create();
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     engine
         .group()
         .addEntity(groupId)
-        .withEntityId(applicationId)
-        .withEntityType(EntityType.APPLICATION)
+        .withEntityId(clientId)
+        .withEntityType(EntityType.CLIENT)
         .add();
 
     // when
@@ -466,8 +466,8 @@ public class GroupTest {
         engine
             .group()
             .addEntity(groupId)
-            .withEntityId(applicationId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityId(clientId)
+            .withEntityType(EntityType.CLIENT)
             .expectRejection()
             .add();
 
@@ -476,7 +476,7 @@ public class GroupTest {
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             "Expected to add entity with ID '%s' to group with ID '%s', but the entity is already assigned to this group."
-                .formatted(applicationId, groupId));
+                .formatted(clientId, groupId));
   }
 
   @Test
@@ -493,7 +493,7 @@ public class GroupTest {
             .group()
             .removeEntity(groupId)
             .withEntityId(notPresentEntityId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityType(EntityType.CLIENT)
             .expectRejection()
             .remove();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -412,9 +412,9 @@ public class RoleTest {
   }
 
   @Test
-  public void shouldAddApplicationEntityToRole() {
+  public void shouldAddClientEntityToRole() {
     // given
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     final var roleId = Strings.newRandomValidIdentityId();
     engine.role().newRole(roleId).create().getValue().getRoleKey();
 
@@ -423,8 +423,8 @@ public class RoleTest {
         engine
             .role()
             .addEntity(roleId)
-            .withEntityId(applicationId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityId(clientId)
+            .withEntityType(EntityType.CLIENT)
             .add()
             .getValue();
 
@@ -432,30 +432,25 @@ public class RoleTest {
     assertThat(updatedRole)
         .isNotNull()
         .hasRoleId(roleId)
-        .hasEntityId(applicationId)
-        .hasEntityType(EntityType.APPLICATION);
+        .hasEntityId(clientId)
+        .hasEntityType(EntityType.CLIENT);
   }
 
   @Test
-  public void shouldRejectIfApplicationEntityIsAlreadyAssigned() {
+  public void shouldRejectIfClientEntityIsAlreadyAssigned() {
     // given
     final var roleId = Strings.newRandomValidIdentityId();
     engine.role().newRole(roleId).create();
-    final var applicationId = "application-" + UUID.randomUUID().toString();
-    engine
-        .role()
-        .addEntity(roleId)
-        .withEntityId(applicationId)
-        .withEntityType(EntityType.APPLICATION)
-        .add();
+    final var clientId = "application-" + UUID.randomUUID().toString();
+    engine.role().addEntity(roleId).withEntityId(clientId).withEntityType(EntityType.CLIENT).add();
 
     // when
     final var notPresentUpdateRecord =
         engine
             .role()
             .addEntity(roleId)
-            .withEntityId(applicationId)
-            .withEntityType(EntityType.APPLICATION)
+            .withEntityId(clientId)
+            .withEntityType(EntityType.CLIENT)
             .expectRejection()
             .add();
 
@@ -464,6 +459,6 @@ public class RoleTest {
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             "Expected to add entity with ID '%s' to role with ID '%s', but the entity is already assigned to this role."
-                .formatted(applicationId, roleId));
+                .formatted(clientId, roleId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -246,40 +246,38 @@ public class TenantAppliersTest {
   }
 
   @Test
-  void shouldAddEntityToTenantWithTypeApplication() {
+  void shouldAddEntityToTenantWithTypeClient() {
     // given
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     final var tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
     tenantState.createTenant(tenantRecord);
-    tenantRecord.setEntityId(applicationId).setEntityType(EntityType.APPLICATION);
+    tenantRecord.setEntityId(clientId).setEntityType(EntityType.CLIENT);
 
     // when
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // then
     assertThat(
-            membershipState.hasRelation(
-                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+            membershipState.hasRelation(EntityType.CLIENT, clientId, RelationType.TENANT, tenantId))
         .isTrue();
   }
 
   @Test
-  void shouldRemoveEntityFromTenantWithTypeApplication() {
+  void shouldRemoveEntityFromTenantWithTypeClient() {
     // given
-    final var applicationId = "application-" + UUID.randomUUID();
+    final var clientId = "application-" + UUID.randomUUID();
     final var tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
     tenantState.createTenant(tenantRecord);
-    tenantRecord.setEntityId(applicationId).setEntityType(EntityType.APPLICATION);
+    tenantRecord.setEntityId(clientId).setEntityType(EntityType.CLIENT);
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // Ensure the application is associated with the tenant before removal
     assertThat(
-            membershipState.hasRelation(
-                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+            membershipState.hasRelation(EntityType.CLIENT, clientId, RelationType.TENANT, tenantId))
         .isTrue();
 
     // when
@@ -287,8 +285,7 @@ public class TenantAppliersTest {
 
     // then
     assertThat(
-            membershipState.hasRelation(
-                EntityType.APPLICATION, applicationId, RelationType.TENANT, tenantId))
+            membershipState.hasRelation(EntityType.CLIENT, clientId, RelationType.TENANT, tenantId))
         .isFalse();
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -504,10 +504,10 @@ public final class EndpointManager {
       claims.put(Authorization.AUTHORIZED_USERNAME, username);
     }
 
-    // retrieve the application id from the context and add it to the authorization if present
-    final String applicationId = Context.current().call(AuthenticationHandler.APPLICATION_ID::get);
-    if (applicationId != null) {
-      claims.put(Authorization.AUTHORIZED_APPLICATION_ID, applicationId);
+    // retrieve the client id from the context and add it to the authorization if present
+    final String clientId = Context.current().call(AuthenticationHandler.CLIENT_ID::get);
+    if (clientId != null) {
+      claims.put(Authorization.AUTHORIZED_CLIENT_ID, clientId);
     }
 
     brokerRequest.setAuthorization(claims);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
-import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.BasicAuth.USERNAME;
-
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
@@ -28,7 +26,7 @@ import org.springframework.security.oauth2.jwt.JwtException;
 /** Used by the {@link AuthenticationInterceptor} to authenticate incoming requests. */
 public sealed interface AuthenticationHandler {
   Context.Key<String> USERNAME = Context.key("io.camunda.zeebe:username");
-  Context.Key<String> APPLICATION_ID = Context.key("io.camunda.zeebe:application_id");
+  Context.Key<String> CLIENT_ID = Context.key("io.camunda.zeebe:client_id");
 
   /**
    * Applies authentication logic for the given authorization header. Must not throw exceptions, but
@@ -92,29 +90,29 @@ public sealed interface AuthenticationHandler {
         }
       }
 
-      final var applicationId =
-          token.getClaims().get(oidcAuthenticationConfiguration.getApplicationIdClaim());
+      final var clientId =
+          token.getClaims().get(oidcAuthenticationConfiguration.getClientIdClaim());
 
-      if (applicationId != null) {
-        if (applicationId instanceof String) {
+      if (clientId != null) {
+        if (clientId instanceof String) {
           return Either.right(
               Context.current()
-                  .withValue(APPLICATION_ID, applicationId.toString())
+                  .withValue(CLIENT_ID, clientId.toString())
                   .withValue(USER_CLAIMS, token.getClaims()));
         } else {
           return Either.left(
               Status.UNAUTHENTICATED.augmentDescription(
                   CONFIGURED_CLAIM_NOT_A_STRING.formatted(
-                      "application id", oidcAuthenticationConfiguration.getApplicationIdClaim())));
+                      "client id", oidcAuthenticationConfiguration.getClientIdClaim())));
         }
       }
 
       return Either.left(
           Status.UNAUTHENTICATED.augmentDescription(
-              "Expected either a username (claim: %s) or application ID (claim: %s) on the token, but no matching claim found"
+              "Expected either a username (claim: %s) or client ID (claim: %s) on the token, but no matching claim found"
                   .formatted(
                       oidcAuthenticationConfiguration.getUsernameClaim(),
-                      oidcAuthenticationConfiguration.getApplicationIdClaim())));
+                      oidcAuthenticationConfiguration.getClientIdClaim())));
     }
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
-import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.APPLICATION_ID;
+import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.CLIENT_ID;
 import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc.CONFIGURED_CLAIM_NOT_A_STRING;
 import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -181,7 +181,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
         .interceptCall(
@@ -197,7 +197,7 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void missingUsernameAndApplicationIdIsRejected() {
+  public void missingUsernameAndClientIdIsRejected() {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
@@ -211,7 +211,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("sub");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
         .interceptCall(
@@ -228,7 +228,7 @@ public class AuthenticationInterceptorTest {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
                   .isEqualTo(
-                      "Expected either a username (claim: sub) or application ID (claim: application_id) on the token, but no matching claim found");
+                      "Expected either a username (claim: sub) or client ID (claim: client_id) on the token, but no matching claim found");
             });
   }
 
@@ -247,7 +247,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
         .interceptCall(
@@ -268,13 +268,13 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void nonStringApplicationIdIsRejected() {
+  public void nonStringClientIdIsRejected() {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
 
     final var jwt = mock(org.springframework.security.oauth2.jwt.Jwt.class);
-    final Map<String, Object> claims = Map.of("application_id", List.of("test-user"));
+    final Map<String, Object> claims = Map.of("client_id", List.of("test-user"));
     when(jwt.getClaims()).thenReturn(claims);
 
     final var jwtDecoder = mock(JwtDecoder.class);
@@ -282,7 +282,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
         .interceptCall(
@@ -298,8 +298,7 @@ public class AuthenticationInterceptorTest {
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
-                  .isEqualTo(
-                      CONFIGURED_CLAIM_NOT_A_STRING.formatted("application id", "application_id"));
+                  .isEqualTo(CONFIGURED_CLAIM_NOT_A_STRING.formatted("client id", "client_id"));
             });
   }
 
@@ -326,7 +325,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
@@ -360,7 +359,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
@@ -376,7 +375,7 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void addsApplicationIdInOidcToContext() {
+  public void addsClientIdInOidcToContext() {
     // given
     final Metadata metadata = createAuthHeader();
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
@@ -393,7 +392,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
@@ -402,7 +401,7 @@ public class AuthenticationInterceptorTest {
             metadata,
             (call, headers) -> {
               // then;
-              assertApplicationId().isEqualTo("app-id");
+              assertClientId().isEqualTo("app-id");
 
               call.close(Status.OK, headers);
               return null;
@@ -410,7 +409,7 @@ public class AuthenticationInterceptorTest {
   }
 
   @Test
-  public void addsUsernameInPreferenceToApplicationIdInOidcToContext() {
+  public void addsUsernameInPreferenceToClientIdInOidcToContext() {
     // given
     final Metadata metadata = createAuthHeader();
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
@@ -427,7 +426,7 @@ public class AuthenticationInterceptorTest {
 
     final var oidcAuthenticationConfiguration = new OidcAuthenticationConfiguration();
     oidcAuthenticationConfiguration.setUsernameClaim("username");
-    oidcAuthenticationConfiguration.setApplicationIdClaim("application_id");
+    oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
     new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
@@ -437,7 +436,7 @@ public class AuthenticationInterceptorTest {
             (call, headers) -> {
               // then
               assertUsername().isEqualTo("test-user");
-              assertApplicationId().isNull();
+              assertClientId().isNull();
 
               call.close(Status.OK, headers);
               return null;
@@ -481,9 +480,9 @@ public class AuthenticationInterceptorTest {
     }
   }
 
-  private static StringAssert assertApplicationId() {
+  private static StringAssert assertClientId() {
     try {
-      return (StringAssert) assertThat(Context.current().call(() -> APPLICATION_ID.get()));
+      return (StringAssert) assertThat(Context.current().call(() -> CLIENT_ID.get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve user key from context", e);
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -617,7 +617,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RoleSearchQueryResult"
-  /tenants/{tenantId}/applications/{applicationId}:
+  /tenants/{tenantId}/applications/{clientId}:
     put:
       tags:
         - Tenant
@@ -631,15 +631,15 @@ paths:
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
-          description: The ID of the application to assign.
+          description: The ID of the client to assign.
           schema:
             type: string
       responses:
         "204":
-          description: The application was successfully assigned to the tenant.
+          description: The client was successfully assigned to the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -656,8 +656,8 @@ paths:
       tags:
         - Tenant
       operationId: removeApplicationFromTenant
-      summary: Remove an application from a tenant
-      description: Removes a single application from a specified tenant.
+      summary: Remove a client from a tenant
+      description: Removes a single client from a specified tenant.
       parameters:
         - name: tenantId
           in: path
@@ -665,7 +665,7 @@ paths:
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
           description: The unique identifier of the application.
@@ -673,13 +673,13 @@ paths:
             type: string
       responses:
         "204":
-          description: The application was successfully removed from the tenant.
+          description: The client was successfully removed from the tenant.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The tenant does not exist or the application was not assigned to it.
+          description: The tenant does not exist or the client was not assigned to it.
           content:
             application/problem+json:
               schema:
@@ -2814,14 +2814,14 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /roles/{roleId}/applications/{applicationId}:
+  /roles/{roleId}/clients/{clientId}:
     put:
       tags:
         - Role
-      operationId: addApplicationToRole
-      summary: Assign an application to a role
+      operationId: addClientToRole
+      summary: Assign a client to a role
       description: |
-        Assigns an application to a role.
+        Assigns a client to a role.
       parameters:
         - name: roleId
           in: path
@@ -2829,15 +2829,15 @@ paths:
           description: The role ID.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
-          description: The application ID.
+          description: The client ID.
           schema:
             type: string
       responses:
         "202":
-          description: The application was assigned successfully to the role.
+          description: The client was assigned successfully to the role.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -2849,7 +2849,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The application with the given ID is already assigned to the role.
+          description: The client with the given ID is already assigned to the role.
           content:
             application/problem+json:
               schema:
@@ -2859,10 +2859,10 @@ paths:
     delete:
       tags:
         - Role
-      operationId: removeApplicationFromRole
-      summary: Unassign an application from a role
+      operationId: removeClientFromRole
+      summary: Unassign a client from a role
       description: |
-        Unassigns an application from a role.
+        Unassigns a client from a role.
       parameters:
         - name: roleId
           in: path
@@ -2870,21 +2870,21 @@ paths:
           description: The role ID.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
-          description: The application ID.
+          description: The client ID.
           schema:
             type: string
       responses:
         "202":
-          description: The application was unassigned successfully from the role.
+          description: The client was unassigned successfully from the role.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The role or application with the given ID or username was not found.
+          description: The role or client with the given ID or username was not found.
           content:
             application/problem+json:
               schema:
@@ -3126,7 +3126,7 @@ paths:
       tags:
         - Group
       operationId: createGroup
-      summary: Create group 
+      summary: Create group
       description: |
         Create a new group.
       requestBody:
@@ -3452,14 +3452,14 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /groups/{groupId}/applications/{applicationId}:
+  /groups/{groupId}/clients/{clientId}:
     put:
       tags:
         - Group
-      operationId: addApplicationToGroup
-      summary: Assign an application to a group
+      operationId: addClientToGroup
+      summary: Assign a client to a group
       description: |
-        Assigns an application to a group.
+        Assigns a client to a group.
       parameters:
         - name: groupId
           in: path
@@ -3467,15 +3467,15 @@ paths:
           description: The group ID.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
-          description: The application ID.
+          description: The client ID.
           schema:
             type: string
       responses:
         "202":
-          description: The application was assigned successfully to the group.
+          description: The client was assigned successfully to the group.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
@@ -3487,7 +3487,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "409":
-          description: The application with the given ID is already assigned to the group.
+          description: The client with the given ID is already assigned to the group.
           content:
             application/problem+json:
               schema:
@@ -3497,10 +3497,10 @@ paths:
     delete:
       tags:
         - Group
-      operationId: unassignApplicationFromGroup
-      summary: Unassign an application from a group
+      operationId: unassignClientFromGroup
+      summary: Unassign a client from a group
       description: |
-        Unassigns an appliction from a group.
+        Unassigns a client from a group.
       parameters:
         - name: groupId
           in: path
@@ -3508,21 +3508,21 @@ paths:
           description: The group ID.
           schema:
             type: string
-        - name: applicationId
+        - name: clientId
           in: path
           required: true
-          description: The application ID.
+          description: The client ID.
           schema:
             type: string
       responses:
         "202":
-          description: The application was unassigned successfully from the group.
+          description: The client was unassigned successfully from the group.
         "400":
           $ref: "#/components/responses/InvalidData"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: The group with the given ID was not found, or the application is not assigned to this group.
+          description: The group with the given ID was not found, or the client is not assigned to this group.
           content:
             application/problem+json:
               schema:
@@ -6686,7 +6686,7 @@ components:
       description: The type of the owner of permissions.
       enum:
         - USER
-        - APPLICATION
+        - CLIENT
         - ROLE
         - GROUP
         - MAPPING

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -630,9 +630,9 @@ public class RequestMapper {
           claims.put(Authorization.AUTHORIZED_USERNAME, authenticatedUsername);
           authenticationBuilder.user(authenticatedUsername);
         } else {
-          final var authenticatedApplicationId = authenticationContext.applicationId();
-          claims.put(Authorization.AUTHORIZED_APPLICATION_ID, authenticatedApplicationId);
-          authenticationBuilder.applicationId(authenticatedApplicationId);
+          final var authenticatedClientId = authenticationContext.clientId();
+          claims.put(Authorization.AUTHORIZED_CLIENT_ID, authenticatedClientId);
+          authenticationBuilder.clientId(authenticatedClientId);
         }
 
         if (authenticatedPrincipal instanceof final CamundaOAuthPrincipal principal) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -124,10 +124,10 @@ public class TenantController {
             userQuery -> searchUsersInTenant(tenantId, userQuery));
   }
 
-  @CamundaPutMapping(path = "/{tenantId}/applications/{applicationId}")
-  public CompletableFuture<ResponseEntity<Object>> assignApplicationToTenant(
-      @PathVariable final String tenantId, @PathVariable final String applicationId) {
-    return RequestMapper.toTenantMemberRequest(tenantId, applicationId, EntityType.APPLICATION)
+  @CamundaPutMapping(path = "/{tenantId}/clients/{clientId}")
+  public CompletableFuture<ResponseEntity<Object>> assignClientToTenant(
+      @PathVariable final String tenantId, @PathVariable final String clientId) {
+    return RequestMapper.toTenantMemberRequest(tenantId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToTenant);
   }
 
@@ -169,10 +169,10 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 
-  @CamundaDeleteMapping(path = "/{tenantId}/applications/{applicationId}")
-  public CompletableFuture<ResponseEntity<Object>> removeApplicationFromTenant(
-      @PathVariable final String tenantId, @PathVariable final String applicationId) {
-    return RequestMapper.toTenantMemberRequest(tenantId, applicationId, EntityType.APPLICATION)
+  @CamundaDeleteMapping(path = "/{tenantId}/clients/{clientId}")
+  public CompletableFuture<ResponseEntity<Object>> removeClientFromTenant(
+      @PathVariable final String tenantId, @PathVariable final String clientId) {
+    return RequestMapper.toTenantMemberRequest(tenantId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromTenant);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -101,11 +101,11 @@ public class GroupController {
   }
 
   @CamundaPutMapping(
-      path = "/{groupId}/applications/{applicationId}",
+      path = "/{groupId}/clients/{clientId}",
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> assignApplicationToGroup(
-      @PathVariable final String groupId, @PathVariable final String applicationId) {
-    return RequestMapper.toGroupMemberRequest(groupId, applicationId, EntityType.APPLICATION)
+      @PathVariable final String groupId, @PathVariable final String clientId) {
+    return RequestMapper.toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignMember);
   }
 
@@ -125,10 +125,10 @@ public class GroupController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 
-  @CamundaDeleteMapping(path = "/{groupId}/applications/{applicationId}")
+  @CamundaDeleteMapping(path = "/{groupId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> unassignApplicationFromGroup(
-      @PathVariable final String groupId, @PathVariable final String applicationId) {
-    return RequestMapper.toGroupMemberRequest(groupId, applicationId, EntityType.APPLICATION)
+      @PathVariable final String groupId, @PathVariable final String clientId) {
+    return RequestMapper.toGroupMemberRequest(groupId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::unassignMember);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -201,11 +201,11 @@ public class RoleController {
   }
 
   @CamundaPutMapping(
-      path = "/{roleId}/applications/{applicationId}",
+      path = "/{roleId}/clients/{clientId}",
       consumes = {})
   public CompletableFuture<ResponseEntity<Object>> addApplicationToRole(
-      @PathVariable final String roleId, @PathVariable final String applicationId) {
-    return RequestMapper.toRoleMemberRequest(roleId, applicationId, EntityType.APPLICATION)
+      @PathVariable final String roleId, @PathVariable final String clientId) {
+    return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.CLIENT)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::addMemberToRole);
   }
 
@@ -248,10 +248,10 @@ public class RoleController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 
-  @CamundaDeleteMapping(path = "/{roleId}/applications/{applicationId}")
+  @CamundaDeleteMapping(path = "/{roleId}/clients/{clientId}")
   public CompletableFuture<ResponseEntity<Object>> removeApplicationFromRole(
-      @PathVariable final String roleId, @PathVariable final String applicationId) {
-    return RequestMapper.toRoleMemberRequest(roleId, applicationId, EntityType.USER)
+      @PathVariable final String roleId, @PathVariable final String clientId) {
+    return RequestMapper.toRoleMemberRequest(roleId, clientId, EntityType.USER)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::removeMemberFromRole);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -96,8 +96,8 @@ public final class TenantRequestValidator {
       case ROLE:
         validateId(entityId, "roleId", violations);
         break;
-      case APPLICATION:
-        validateId(entityId, "applicationId", violations);
+      case CLIENT:
+        validateId(entityId, "clientId", violations);
         break;
       default:
         validateId(entityId, "entityId", violations);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -174,15 +174,15 @@ class RequestMapperTest {
 
     // then
     assertThat(authentication.authenticatedUsername()).isEqualTo(username);
-    assertThat(authentication.authenticationApplicationId()).isNull();
+    assertThat(authentication.authenticatedClientId()).isNull();
   }
 
   @Test
-  void applicationIdIsSetInAuthenticationWhenOnAuthenticationContext() {
+  void clientIdIsSetInAuthenticationWhenOnAuthenticationContext() {
     // given
-    final var applicationId = "my-application";
+    final var clientId = "my-application";
     final var authenticationContext =
-        new AuthenticationContextBuilder().withApplicationId(applicationId).build();
+        new AuthenticationContextBuilder().withClientId(clientId).build();
 
     final var principal =
         new CamundaOidcUser(
@@ -192,7 +192,7 @@ class RequestMapperTest {
                     "tokenValue",
                     Instant.now(),
                     Instant.now().plusSeconds(3600),
-                    Map.of("sub", applicationId))),
+                    Map.of("sub", clientId))),
             Collections.emptySet(),
             authenticationContext);
 
@@ -204,7 +204,7 @@ class RequestMapperTest {
 
     // then
     assertThat(authContext.authenticatedUsername()).isNull();
-    assertThat(authContext.authenticationApplicationId()).isEqualTo(applicationId);
+    assertThat(authContext.authenticatedClientId()).isEqualTo(clientId);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -599,7 +599,7 @@ public class TenantControllerTest extends RestControllerTest {
         Arguments.of(EntityType.MAPPING, "mappings", "mappingId"),
         Arguments.of(EntityType.GROUP, "groups", "groupId"),
         Arguments.of(EntityType.ROLE, "roles", "roleId"),
-        Arguments.of(EntityType.APPLICATION, "applications", "applicationId"));
+        Arguments.of(EntityType.CLIENT, "clients", "clientId"));
   }
 
   private static Stream<Arguments> provideRemoveMemberByIdTestCases() {
@@ -608,6 +608,6 @@ public class TenantControllerTest extends RestControllerTest {
         Arguments.of(EntityType.MAPPING, "mappings", "mappingId"),
         Arguments.of(EntityType.GROUP, "groups", "groupId"),
         Arguments.of(EntityType.ROLE, "roles", "roleId"),
-        Arguments.of(EntityType.APPLICATION, "applications", "applicationId"));
+        Arguments.of(EntityType.CLIENT, "clients", "clientId"));
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EntityType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/EntityType.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 public enum EntityType {
   UNSPECIFIED,
   USER,
-  APPLICATION,
+  CLIENT,
   MAPPING,
   GROUP,
   ROLE


### PR DESCRIPTION
I've searched for `applicationId` and `application id` and looked at every result, replacing all mentions of applications with client.

I'm sure I've missed a few spots but as long as every public API is adjusted, a few missed mentions of application in test methods and the like won't hurt.

Closes #31945