### PR TITLE
ci: fix CI skip Profile and start running previously not running tests

### DIFF
--- a/operate/common/src/test/java/io/camunda/operate/util/CollectionUtilTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/CollectionUtilTest.java
@@ -14,7 +14,7 @@ import io.camunda.operate.exceptions.OperateRuntimeException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CollectionUtilTest {
 

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -18,8 +18,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,7 +36,7 @@ public class StackdriverJSONLayoutTest {
   private final ObjectReader jsonReader = new ObjectMapper().reader();
 
   @Test
-  @Ignore
+  @Disabled
   public void testLayout() throws Exception {
     // having Stackdriver appender activated
     final LoggerContext ctx = loggerRule.getLoggerContext();

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,7 @@ public class StackdriverJSONLayoutTest {
   private final ObjectReader jsonReader = new ObjectMapper().reader();
 
   @Test
+  @Ignore
   public void testLayout() throws Exception {
     // having Stackdriver appender activated
     final LoggerContext ctx = loggerRule.getLoggerContext();

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test ensures that StackdriverLayout defined in zeebe-util library is working as expected. If

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -36,7 +36,7 @@ public class StackdriverJSONLayoutTest {
   private final ObjectReader jsonReader = new ObjectMapper().reader();
 
   @Test
-  @Disabled
+  @Disabled("Currently failing. Will be fixed an re-enabled with https://github.com/camunda/product-hub/issues/2872")
   public void testLayout() throws Exception {
     // having Stackdriver appender activated
     final LoggerContext ctx = loggerRule.getLoggerContext();

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -36,7 +36,8 @@ public class StackdriverJSONLayoutTest {
   private final ObjectReader jsonReader = new ObjectMapper().reader();
 
   @Test
-  @Disabled("Currently failing. Will be fixed an re-enabled with https://github.com/camunda/product-hub/issues/2872")
+  @Disabled(
+      "Currently failing. Will be fixed an re-enabled with https://github.com/camunda/product-hub/issues/2872")
   public void testLayout() throws Exception {
     // having Stackdriver appender activated
     final LoggerContext ctx = loggerRule.getLoggerContext();

--- a/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
@@ -15,10 +15,7 @@ import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class PartitionHolderTest {
 
   Optional<List<Integer>> zeebePartitionIds, elasticSearchPartitionIds;

--- a/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class PartitionHolderTest {
@@ -41,7 +41,7 @@ public class PartitionHolderTest {
         }
       };
 
-  @Before
+  @BeforeEach
   public void setUp() {
     slept = 0;
     zeebePartitionIds = null;

--- a/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/zeebeimport/PartitionHolderTest.java
@@ -14,8 +14,11 @@ import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class PartitionHolderTest {
 
   Optional<List<Integer>> zeebePartitionIds, elasticSearchPartitionIds;

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
@@ -43,7 +43,8 @@ public class XXEPreventionTest {
             xmlInputStream,
             new DefaultHandler() {
               @Override
-              public void characters(final char[] ch, final int start, final int length) throws SAXException {
+              public void characters(final char[] ch, final int start, final int length)
+                  throws SAXException {
                 elementContent.append(new String(ch, start, length));
               }
             });

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/XXEPreventionTest.java
@@ -14,7 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -43,7 +43,7 @@ public class XXEPreventionTest {
             xmlInputStream,
             new DefaultHandler() {
               @Override
-              public void characters(char ch[], int start, int length) throws SAXException {
+              public void characters(final char[] ch, final int start, final int length) throws SAXException {
                 elementContent.append(new String(ch, start, length));
               }
             });

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -40,9 +40,9 @@
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
     <excludeUnitTestNames>**/*IT.java</excludeUnitTestNames>
-    <excludeCoreFeaturesTestNames/>
-    <excludeDataLayerTestNames/>
-    <excludeIdentityTestNames/>
+    <excludeCoreFeaturesTestNames></excludeCoreFeaturesTestNames>
+    <excludeDataLayerTestNames></excludeDataLayerTestNames>
+    <excludeIdentityTestNames></excludeIdentityTestNames>
     <itDatabase>elasticsearch</itDatabase>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -184,7 +184,7 @@
         </property>
       </activation>
       <properties>
-        <excludeCoreFeaturesTestNames>**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java,</excludeCoreFeaturesTestNames>
+        <excludeCoreFeaturesTestNames>**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java,</excludeCoreFeaturesTestNames>
       </properties>
     </profile>
 
@@ -196,7 +196,7 @@
         </property>
       </activation>
       <properties>
-        <excludeDataLayerTestNames>**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java,</excludeDataLayerTestNames>
+        <excludeDataLayerTestNames>**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,**/connect/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java,</excludeDataLayerTestNames>
       </properties>
     </profile>
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -40,6 +40,9 @@
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
     <excludeUnitTestNames>**/*IT.java</excludeUnitTestNames>
+    <excludeCoreFeaturesTestNames/>
+    <excludeDataLayerTestNames/>
+    <excludeIdentityTestNames/>
     <itDatabase>elasticsearch</itDatabase>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
@@ -79,7 +82,7 @@
               <testForkNumber>$${surefire.forkNumber}</testForkNumber>
             </systemPropertyVariables>
             <excludes>
-              <exclude>${excludeUnitTestNames}</exclude>
+              <exclude>${excludeCoreFeaturesTestNames}${excludeDataLayerTestNames}${excludeIdentityTestNames}</exclude>
             </excludes>
           </configuration>
         </plugin>
@@ -181,7 +184,7 @@
         </property>
       </activation>
       <properties>
-        <excludeUnitTestNames>**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java</excludeUnitTestNames>
+        <excludeCoreFeaturesTestNames>**/connect/**/*.java,**/util/**/*.java,**/entities/**/*.java,**/schema/**/*.java,**/rest/**/*.java,**/webapp/**/*.java,</excludeCoreFeaturesTestNames>
       </properties>
     </profile>
 
@@ -193,7 +196,7 @@
         </property>
       </activation>
       <properties>
-        <excludeUnitTestNames>**/elasticsearch/**/*.java,,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java</excludeUnitTestNames>
+        <excludeDataLayerTestNames>**/elasticsearch/**/*.java,**/opensearch/**/*.java,**/zeebeimport/**/*.java,*Elasticsearch*.java,*Opensearch*.java,*ElasticSearch*.java,*OpenSearch*.java,</excludeDataLayerTestNames>
       </properties>
     </profile>
 
@@ -205,7 +208,7 @@
         </property>
       </activation>
       <properties>
-        <excludeUnitTestNames>**/identity/**/*.java</excludeUnitTestNames>
+        <excludeIdentityTestNames>**/identity/**/*.java,</excludeIdentityTestNames>
       </properties>
     </profile>
 

--- a/operate/schema/src/test/java/io/camunda/operate/entities/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/entities/ListenerEventTypeTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.enties;
+package io.camunda.operate.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;

--- a/operate/schema/src/test/java/io/camunda/operate/entities/ListenerStateTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/entities/ListenerStateTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.enties;
+package io.camunda.operate.entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/operate/schema/src/test/java/io/camunda/operate/entities/OperationEntityTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/entities/OperationEntityTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.enties;
+package io.camunda.operate.entities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When working on https://github.com/camunda/camunda/pull/31680 I noticed that CI tests using the new consolidated Ci skip like `skipCoreFeaturesUTs` was not properly skipping all of the Core Features tests

After debugging, the skip that was the last one in the maven command string was the skip that was used. Any other skips were ignored
- For example, when running a command like this `./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipCoreFeaturesUTs -DskipIdentityUTs -DskipDockerProfile -DskipChecks ` only the Identity tests were skipped, Core features are incorrectly run. This command should be skipping the Core Features tests, and only be running the Data Layers tests!

To fix this, when a skip option is detected, the tests that it skips will be composed with all other skip options into one larger skip command that maven will use. This is done in `operate/pom.xml`

Other changes to tests include
- fixed a typo issue with a test package in this PR. Tests in this renamed package were not being run with the correct profile
- Moving the `connect` package to Data Layers. This package contains tests that interact with ES/OS and its DateTime
- Upgrade Operate's Unit tests to JUnit Jupiter so that all tests could run together
  - Added `@Disabled` for one test that was not running and is now failing. This test should be fixed in a future cleanup ticket. The fix is out of scope for this change

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/product-hub/issues/2870
