### PR TITLE
fix: fix  flaky test complete process with start node having deployed…

### DIFF
--- a/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -206,9 +206,28 @@ class TaskDetailsPage {
 
   async fillTextInput(label: string, value: string): Promise<void> {
     const input = this.page.getByLabel(label, {exact: true});
-    await input.click({timeout: 60000});
-    await input.fill(value);
-    await expect(input).toHaveValue(value, {timeout: 5000});
+    const maxRetries = 3;
+    let attempt = 0;
+    while (attempt < maxRetries) {
+      try {
+        await input.click({timeout: 120000});
+        await input.fill(value);
+        await input.blur();
+        await expect(input).toHaveValue(value);
+        return;
+      } catch (error) {
+        attempt++;
+        console.log(
+          `Attempt ${attempt} to fill input "${label}" failed with error: ${error}`,
+        );
+        if (attempt === maxRetries) {
+          throw new Error(
+            `Failed to set value "${value}" for label "${label}" after ${maxRetries} attempts.`,
+          );
+        }
+        await sleep(500);
+      }
+    }
   }
 
   async priorityAssertion(priority: string): Promise<void> {

--- a/qa/core-application-e2e-test-suite/tests/tasklist/login.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/login.spec.ts
@@ -94,12 +94,9 @@ test.describe.parallel('Login Tests', () => {
     taskListLoginPage,
     tasklistHeader,
     page,
-    taskPanelPage,
   }) => {
     await page.goto('tasklist/123');
-    await expect(taskPanelPage.taskListPageBanner).toBeVisible({
-      timeout: 60000,
-    });
+
     await taskListLoginPage.login('demo', 'demo');
     await expect(page).toHaveURL('/tasklist/123');
 


### PR DESCRIPTION
## Description
Filling Text input is flaky as observed from [nightly runs](https://github.com/camunda/camunda/actions/runs/14985328762/job/42098088804) so in this PR i added some retries in order to stabilize the test, also 
removed un needed assertion in `redirect to the correct URL after login` test
<!-- Describe the goal and purpose of this PR. -->
🧪 **Tetsting:**
 Since it has been flaky i ran the tests multiple times:
- [TestRun1](https://github.com/camunda/camunda/actions/runs/14990172020/job/42111562538)
- [TestRun2](https://github.com/camunda/camunda/actions/runs/14990176352/job/42111574865)
- [TestRun3](https://github.com/camunda/camunda/actions/runs/14990178694/job/42111582211)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
