### PR TITLE
Filter for membertype on child query

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -58,7 +58,8 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final var roles =
         roleServices.findAll(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(username).memberType(EntityType.USER))));
+            RoleQuery.of(
+                q -> q.filter(f -> f.memberId(username).childMemberType(EntityType.USER))));
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -65,7 +65,8 @@ public class CamundaUserDetailsServiceTest {
         .thenReturn(List.of("operate", "identity"));
     final RoleEntity adminRole = new RoleEntity(2L, roleId, "ADMIN", "description");
     when(roleServices.findAll(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(TEST_USER_ID).memberType(EntityType.USER)))))
+            RoleQuery.of(
+                q -> q.filter(f -> f.memberId(TEST_USER_ID).childMemberType(EntityType.USER)))))
         .thenReturn(List.of(adminRole));
 
     // when

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -15,7 +15,7 @@
     FROM ${prefix}ROLES r
     <if test="filter.memberIds != null">
       JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_ID = rm.ROLE_ID
-      AND rm.ENTITY_TYPE = #{filter.memberType}
+      AND rm.ENTITY_TYPE = #{filter.childMemberType}
     </if>
     <if test="filter.tenantId != null">
       JOIN ${prefix}TENANT_MEMBER tm ON r.ROLE_ID = tm.ENTITY_ID
@@ -58,7 +58,7 @@
       <foreach collection="filter.memberIds" item="memberId" open="(" separator="," close=")">
         #{memberId}
       </foreach>
-      AND rm.ENTITY_TYPE = #{filter.memberType}
+      AND rm.ENTITY_TYPE = #{filter.childMemberType}
     </if>
     <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
   </sql>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -97,7 +97,7 @@ public class RoleSpecificFilterIT {
             new RoleQuery(
                 new RoleFilter.Builder()
                     .memberId(group.groupId())
-                    .memberType(EntityType.GROUP)
+                    .childMemberType(EntityType.GROUP)
                     .build(),
                 RoleSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
@@ -160,7 +160,7 @@ public class RoleSpecificFilterIT {
         new RoleFilter.Builder().roleId(ROLE_ID).build(),
         new RoleFilter.Builder().roleKey(ROLE_KEY).build(),
         new RoleFilter.Builder().name(ROLE_NAME).build(),
-        new RoleFilter.Builder().memberId(ENTITY_ID).memberType(ENTITY_TYPE).build());
+        new RoleFilter.Builder().memberId(ENTITY_ID).childMemberType(ENTITY_TYPE).build());
   }
 
   private void addGroupToRole(final String roleId, final String entityId) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -47,6 +47,11 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
                     stringTerms(RoleIndex.MEMBER_ID, filter.memberIds())),
+        filter.childMemberType() == null
+            ? null
+            : hasChildQuery(
+                IdentityJoinRelationshipType.MEMBER.getType(),
+                term(RoleIndex.MEMBER_TYPE, filter.childMemberType().name())),
         filter.roleIds() == null
             ? null
             : filter.roleIds().isEmpty()

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -20,10 +20,20 @@ public record RoleFilter(
     Set<String> memberIds,
     EntityType memberType,
     Set<String> roleIds,
+    EntityType childMemberType,
     String tenantId)
     implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).roleId(roleId).name(name).memberIds(memberIds);
+    return new Builder()
+        .roleKey(roleKey)
+        .roleId(roleId)
+        .name(name)
+        .description(description)
+        .memberIds(memberIds)
+        .memberType(memberType)
+        .roleIds(roleIds)
+        .childMemberType(childMemberType)
+        .tenantId(tenantId);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
@@ -35,6 +45,7 @@ public record RoleFilter(
     private Set<String> memberIds;
     private EntityType memberType;
     private Set<String> roleIds;
+    private EntityType childMemberType;
     private String tenantId;
 
     public Builder roleKey(final Long value) {
@@ -81,6 +92,11 @@ public record RoleFilter(
       return this;
     }
 
+    public Builder childMemberType(final EntityType value) {
+      childMemberType = value;
+      return this;
+    }
+
     public Builder tenantId(final String value) {
       tenantId = value;
       return this;
@@ -88,8 +104,8 @@ public record RoleFilter(
 
     @Override
     public RoleFilter build() {
-      if (memberIds != null && memberType == null) {
-        throw new IllegalArgumentException("If memberIds is set, memberType must be set too");
+      if (memberIds != null && childMemberType == null) {
+        throw new IllegalArgumentException("If memberIds is set, childMemberType must be set too");
       }
       return new RoleFilter(
           roleKey,
@@ -100,6 +116,7 @@ public record RoleFilter(
           memberIds,
           memberType,
           roleIds,
+          childMemberType,
           tenantId);
     }
   }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -54,7 +54,8 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
 
   public List<RoleEntity> getRolesByMemberIds(
       final Set<String> memberIds, final EntityType entityType) {
-    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds).memberType(entityType))));
+    return findAll(
+        RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds).childMemberType(entityType))));
   }
 
   public List<RoleEntity> findAll(final RoleQuery query) {

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -191,13 +191,13 @@ public class RoleServicesTest {
     final var memberType = EntityType.USER;
     final var roleEntity = mock(RoleEntity.class);
     when(client.findAllRoles(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).memberType(memberType)))))
+            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(memberType)))))
         .thenReturn(List.of(roleEntity));
 
     // when
     final var result =
         services.findAll(
-            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).memberType(memberType))));
+            RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(memberType))));
 
     // then
     assertThat(result).isEqualTo(List.of(roleEntity));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -287,7 +287,7 @@ public class GroupController {
 
   private RoleQuery buildRoleQuery(final String groupId, final RoleQuery roleQuery) {
     return roleQuery.toBuilder()
-        .filter(roleQuery.filter().toBuilder().memberId(groupId).memberType(GROUP).build())
+        .filter(roleQuery.filter().toBuilder().memberId(groupId).childMemberType(GROUP).build())
         .build();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The member type is stored on the document of the child, not of the role itself.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31960
Related to https://camunda.slack.com/archives/C06UYJMMETZ/p1747044361499869
