### PR TITLE
Fix skipping tests runs of dependent projects in case of failure

### DIFF
--- a/qa/core-application-e2e-test-suite/playwright.config.ts
+++ b/qa/core-application-e2e-test-suite/playwright.config.ts
@@ -58,39 +58,39 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium-subset',
+      name: 'chromium',
       use: devices['Desktop Chrome'],
       // Specify only tests in the changed folders for the 'chromium' project
       testMatch: changedFolders.includes('chromium')
         ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
         : undefined,
       testIgnore: 'task-panel.spec.ts',
+      teardown: 'chromium-subset',
     },
     {
-      name: 'firefox-subset',
-      use: devices['Desktop Firefox'],
-      testIgnore: 'task-panel.spec.ts',
-    },
-    {
-      name: 'msedge-subset',
-      use: devices['Desktop Edge'],
-      testIgnore: 'task-panel.spec.ts',
-    },
-    {
-      name: 'chromium',
-      dependencies: ['chromium-subset'],
+      name: 'chromium-subset',
       testMatch: 'task-panel.spec.ts',
       use: devices['Desktop Chrome'],
     },
     {
       name: 'firefox',
-      dependencies: ['firefox-subset'],
+      use: devices['Desktop Firefox'],
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'firefox-subset',
+    },
+    {
+      name: 'firefox-subset',
       testMatch: 'task-panel.spec.ts',
       use: devices['Desktop Firefox'],
     },
     {
       name: 'msedge',
-      dependencies: ['msedge-subset'],
+      use: devices['Desktop Edge'],
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'msedge-subset',
+    },
+    {
+      name: 'msedge-subset',
       testMatch: 'task-panel.spec.ts',
       use: devices['Desktop Edge'],
     },


### PR DESCRIPTION
## Description

This PR fixes an issue in the Playwright config project where dependent tests were being skipped if a dependency test failed. Since Playwright does not currently support running dependent tests after a failure, this workaround introduces a `teardown` step to ensure cleanup and continued execution of tests.

The goal is to improve the reliability and completeness of test runs, even in the presence of test failures.

There is an open feature request in the Playwright repository that aims to address this limitation natively:
👉 [https://github.com/microsoft/playwright/issues/26854](https://github.com/microsoft/playwright/issues/26854)

Once the feature request is implemented, we can revisit and possibly remove this workaround.

🧪 **Testing**:
- [Test Run](http://github.com/camunda/camunda/actions/runs/15015844096/job/42193475931) with a failing test
- [Test Run](https://github.com/camunda/camunda/actions/runs/15016194014/job/42194591090) without failures
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->

* [ ] for CI changes:

  * [ ] structural/foundational changes signed off by [[CI DRI](https://github.com/cmur2)](https://github.com/cmur2)
  * [ ] [[ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml)](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with [["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  * [ ] enable backports [[when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #