### PR TITLE
Fix role authorization it flakiness

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -40,14 +40,12 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-@Disabled("Temporarily disabled due to flakiness")
 class RoleAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -40,12 +40,14 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@Disabled("Temporarily disabled due to flakiness")
 class RoleAuthorizationIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -144,11 +145,8 @@ class RoleAuthorizationIT {
         .send()
         .join();
 
-    adminClient.newDeleteRoleCommand(roleId).send().join();
-
-    assertThatThrownBy(() -> adminClient.newRoleGetRequest(roleId).send().join())
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("404: 'Not Found'");
+    assertThatNoException()
+        .isThrownBy(() -> adminClient.newDeleteRoleCommand(roleId).send().join());
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This test was flaky as it didn't wait for role creation and deletion to be imported to secondary storage. Retrieving 
data this way would be inconsistent.

I chose to fully remove the data retrieval. The goal of this test is not to verify if the role is properly deleted from 
secondary storage. The goal is to verify that the deletion is authorized properly and no unauthorized rejection is 
thrown. Therefore, we can just assert that our deletion request does not throw an exception. If it doesn't that means we
 were authorized to delete the role.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

N/A