### PR TITLE
fix: fix editing of variable with dot in name

### DIFF
--- a/tasklist/client/src/common/tasks/variables-editor/constants.ts
+++ b/tasklist/client/src/common/tasks/variables-editor/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const VARIABLE_NAME_DOT_ESCAPE_CHAR = '___DOT___';
+
+export {VARIABLE_NAME_DOT_ESCAPE_CHAR};

--- a/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.test.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.test.tsx
@@ -17,6 +17,13 @@ describe('createVariableFieldName', () => {
       '#someVariableName',
     );
   });
+
+  it('should escape dots in variable names', () => {
+    expect(createVariableFieldName('some.variable.name')).toBe(
+      '#some___DOT___variable___DOT___name',
+    );
+  });
+
   it('should create new variable field name', () => {
     expect(createNewVariableFieldName('newVariables[0]', 'name')).toBe(
       'newVariables[0].name',

--- a/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/createVariableFieldName.tsx
@@ -6,8 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {VARIABLE_NAME_DOT_ESCAPE_CHAR} from './constants';
+
 const createVariableFieldName = (name: string) => {
-  return `#${name}`;
+  const escapedName = name.replaceAll('.', VARIABLE_NAME_DOT_ESCAPE_CHAR);
+  return `#${escapedName}`;
 };
 
 const createNewVariableFieldName = (prefix: string, suffix: string) => {

--- a/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.test.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.test.tsx
@@ -15,6 +15,13 @@ describe('getVariableFieldName', () => {
   it('should get variable field name', () => {
     expect(getVariableFieldName('#someVariableName')).toBe('someVariableName');
   });
+
+  it('should unescape dots in variable names', () => {
+    expect(getVariableFieldName('#some___DOT___variable___DOT___name')).toBe(
+      'some.variable.name',
+    );
+  });
+
   it('should get new variable prefix', () => {
     expect(getNewVariablePrefix('newVariables[0].name')).toBe(
       'newVariables[0]',

--- a/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.tsx
+++ b/tasklist/client/src/common/tasks/variables-editor/getVariableFieldName.tsx
@@ -6,8 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {VARIABLE_NAME_DOT_ESCAPE_CHAR} from './constants';
+
 const getVariableFieldName = (variableNameWithPrefix: string) => {
-  return variableNameWithPrefix.substring(1);
+  const nameWithoutPrefix = variableNameWithPrefix.substring(1);
+  return nameWithoutPrefix.replaceAll(VARIABLE_NAME_DOT_ESCAPE_CHAR, '.');
 };
 
 const getNewVariablePrefix = (variableName: string) => {

--- a/tasklist/client/src/v1/TaskDetails/Variables/index.test.tsx
+++ b/tasklist/client/src/v1/TaskDetails/Variables/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, waitFor} from 'common/testing/testing-library';
+import {act, render, screen, waitFor} from 'common/testing/testing-library';
 import {Variables} from './index';
 import * as taskMocks from 'v1/mocks/task';
 import * as variableMocks from 'v1/mocks/variables';
@@ -425,7 +425,9 @@ describe('<Variables />', () => {
       '"valid_value"',
     );
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     await waitFor(() =>
       expect(
@@ -435,7 +437,9 @@ describe('<Variables />', () => {
 
     await user.clear(screen.getByLabelText(/1st variable name/i));
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     await waitFor(() =>
       expect(
@@ -445,7 +449,9 @@ describe('<Variables />', () => {
 
     await user.type(screen.getByLabelText(/1st variable name/i), 'test ');
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
 
     expect(await screen.findByText(/name is invalid/i)).toBeInTheDocument();
   });
@@ -672,7 +678,9 @@ describe('<Variables />', () => {
       },
     );
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     await waitFor(() =>
       expect(screen.getByText(/complete task/i)).toBeEnabled(),
     );
@@ -687,7 +695,9 @@ describe('<Variables />', () => {
     await user.type(screen.getByLabelText(/1st variable name/i), 'var');
     await user.type(screen.getByLabelText(/1st variable value/i), '1');
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     await waitFor(() =>
       expect(screen.getByText(/complete task/i)).toBeEnabled(),
     );
@@ -842,13 +852,17 @@ describe('<Variables />', () => {
       '"newVariableValue"',
     );
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     await waitFor(() =>
       expect(screen.getByText(/complete task/i)).toBeEnabled(),
     );
     await user.click(screen.getByText(/complete task/i));
 
-    vi.runOnlyPendingTimers();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
     await waitFor(() =>
       expect(mockOnSubmit).toHaveBeenCalledWith([
         {

--- a/tasklist/client/src/v2/TaskDetails/Variables/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/Variables/index.test.tsx
@@ -1625,4 +1625,70 @@ describe('<Variables />', () => {
       ).not.toHaveAccessibleDescription(/name must be unique/i);
     });
   });
+
+  it('should handle variables with dots in names correctly', async () => {
+    const variableWithDot = {
+      variableKey: 'var.with.dots',
+      name: 'var.with.dots',
+      value: '"dotted-value"',
+      isTruncated: false,
+      tenantId: DEFAULT_TENANT_ID,
+      scopeKey: 'var.with.dots',
+      processInstanceKey: 'var.with.dots',
+    } satisfies Variable;
+
+    nodeMockServer.use(
+      http.post<never, VariableSearchRequestBody>(
+        '/v2/user-tasks/:userTaskKey/variables/search',
+        async ({request}) => {
+          if (isRequestingAllVariables(await request.json())) {
+            return HttpResponse.json(
+              getQueryVariablesResponseMock([variableWithDot]),
+            );
+          }
+          return HttpResponse.json(
+            [
+              {
+                message: 'Invalid variables',
+              },
+            ],
+            {status: 400},
+          );
+        },
+      ),
+    );
+
+    const mockOnSubmit = vi.fn();
+    const {user} = render(
+      <Variables
+        task={taskMocks.assignedTask()}
+        user={currentUser}
+        onSubmit={mockOnSubmit}
+        onSubmitFailure={noop}
+        onSubmitSuccess={noop}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    expect(await screen.findByText('var.with.dots')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('"dotted-value"')).toBeInTheDocument();
+
+    await user.clear(await screen.findByLabelText('var.with.dots'));
+    await user.type(screen.getByLabelText('var.with.dots'), '"updated-value"');
+
+    vi.runOnlyPendingTimers();
+    await waitFor(() =>
+      expect(screen.getByText(/complete task/i)).toBeEnabled(),
+    );
+
+    await user.click(screen.getByText(/complete task/i));
+
+    await waitFor(() =>
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        'var.with.dots': 'updated-value',
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In some cases variables would have dots in their names. This would break `react-final-form` variable name propagation.

This PR fixes this issue

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)


