### PR TITLE
feat: initialize identity with rpa and connectors roles

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -211,7 +211,7 @@ class RoleAuthorizationIT {
 
     assertThat(roleSearchResponse.items())
         .map(RoleResult::getName)
-        .containsExactlyInAnyOrder("Admin", ROLE_NAME_1, ROLE_NAME_2);
+        .containsExactlyInAnyOrder("Admin", "RPA", "Connectors", ROLE_NAME_1, ROLE_NAME_2);
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -304,12 +304,7 @@ public final class EngineProcessors {
         commandDistributionBehavior);
 
     IdentitySetupProcessors.addIdentitySetupProcessors(
-        keyGenerator,
-        typedRecordProcessors,
-        writers,
-        securityConfig,
-        featureFlags,
-        processingState);
+        keyGenerator, typedRecordProcessors, writers, securityConfig, featureFlags);
 
     addResourceFetchProcessors(typedRecordProcessors, writers, processingState, authCheckBehavior);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -11,7 +11,6 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -23,13 +22,12 @@ public final class IdentitySetupProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final SecurityConfiguration securityConfig,
-      final FeatureFlags featureFlags,
-      final ProcessingState processingState) {
+      final FeatureFlags featureFlags) {
     typedRecordProcessors
         .onCommand(
             ValueType.IDENTITY_SETUP,
             IdentitySetupIntent.INITIALIZE,
-            new IdentitySetupInitializeProcessor(writers, keyGenerator, processingState))
+            new IdentitySetupInitializeProcessor(writers, keyGenerator))
         .withListener(new IdentitySetupInitializer(securityConfig, featureFlags));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -41,8 +41,6 @@ public class TenantDeleteProcessorTest {
             .create()
             .getValue()
             .getTenantKey();
-    assertThat(engine.getProcessingState().getTenantState().getTenantById(tenantId).get())
-        .isNotNull();
 
     // When
     engine.tenant().deleteTenant(tenantId).delete();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -57,12 +58,17 @@ public final class IdentitySetupClient {
     public IdentitySetupInitializeClient(final CommandWriter writer) {
       this.writer = writer;
       record = new IdentitySetupRecord();
-      record.setDefaultRole(defaultRole);
+      record.addRole(defaultRole);
       record.setDefaultTenant(defaultTenant);
     }
 
     public IdentitySetupInitializeClient withRole(final RoleRecord role) {
-      record.setDefaultRole(role);
+      record.addRole(role);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withRoleMember(final RoleRecord role) {
+      record.addRoleMember(role);
       return this;
     }
 
@@ -76,8 +82,19 @@ public final class IdentitySetupClient {
       return this;
     }
 
+    public IdentitySetupInitializeClient withTenantMember(final TenantRecord tenant) {
+      record.addTenantMember(tenant);
+      return this;
+    }
+
     public IdentitySetupInitializeClient withMapping(final MappingRecord mapping) {
       record.addMapping(mapping);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withAuthorization(
+        final AuthorizationRecord authorization) {
+      record.addAuthorization(authorization);
       return this;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -12,37 +12,50 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class IdentitySetupRecord extends UnifiedRecordValue implements IdentitySetupRecordValue {
 
-  private final ObjectProperty<RoleRecord> defaultRoleProp =
-      new ObjectProperty<>("defaultRole", new RoleRecord());
+  private final ArrayProperty<RoleRecord> rolesProp = new ArrayProperty<>("roles", RoleRecord::new);
+  private final ArrayProperty<RoleRecord> roleMembersProp =
+      new ArrayProperty<>("roleMembers", RoleRecord::new);
   private final ArrayProperty<UserRecord> usersProp = new ArrayProperty<>("users", UserRecord::new);
   private final ObjectProperty<TenantRecord> defaultTenantProp =
       new ObjectProperty<>("defaultTenant", new TenantRecord());
+  private final ArrayProperty<TenantRecord> tenantMembersProp =
+      new ArrayProperty<>("tenantMembers", TenantRecord::new);
   private final ArrayProperty<MappingRecord> mappingsProp =
       new ArrayProperty<>("mappings", MappingRecord::new);
+  private final ArrayProperty<AuthorizationRecord> authorizationsProp =
+      new ArrayProperty<>("authorizations", AuthorizationRecord::new);
 
   public IdentitySetupRecord() {
-    super(4);
-    declareProperty(defaultRoleProp)
+    super(7);
+    declareProperty(rolesProp)
+        .declareProperty(roleMembersProp)
         .declareProperty(usersProp)
         .declareProperty(defaultTenantProp)
-        .declareProperty(mappingsProp);
+        .declareProperty(tenantMembersProp)
+        .declareProperty(mappingsProp)
+        .declareProperty(authorizationsProp);
   }
 
   @Override
-  public RoleRecord getDefaultRole() {
-    return defaultRoleProp.getValue();
+  public Collection<RoleRecordValue> getRoles() {
+    return rolesProp.stream().map(RoleRecordValue.class::cast).collect(Collectors.toList());
   }
 
-  public IdentitySetupRecord setDefaultRole(final RoleRecord role) {
-    defaultRoleProp.getValue().copyFrom(role);
-    return this;
+  @Override
+  public Collection<RoleRecordValue> getRoleMembers() {
+    return roleMembersProp.stream().map(RoleRecordValue.class::cast).collect(Collectors.toList());
   }
 
   @Override
@@ -56,12 +69,41 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   @Override
+  public Collection<TenantRecordValue> getTenantMembers() {
+    return tenantMembersProp.stream()
+        .map(TenantRecordValue.class::cast)
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public List<MappingRecordValue> getMappings() {
     return mappingsProp.stream().map(MappingRecordValue.class::cast).toList();
   }
 
+  @Override
+  public Collection<AuthorizationRecordValue> getAuthorizations() {
+    return authorizationsProp.stream()
+        .map(AuthorizationRecordValue.class::cast)
+        .collect(Collectors.toList());
+  }
+
   public IdentitySetupRecord setDefaultTenant(final TenantRecord tenant) {
     defaultTenantProp.getValue().copyFrom(tenant);
+    return this;
+  }
+
+  public IdentitySetupRecord addTenantMember(final TenantRecord tenant) {
+    tenantMembersProp.add().copyFrom(tenant);
+    return this;
+  }
+
+  public IdentitySetupRecord addRole(final RoleRecord role) {
+    rolesProp.add().copyFrom(role);
+    return this;
+  }
+
+  public IdentitySetupRecord addRoleMember(final RoleRecord role) {
+    roleMembersProp.add().copyFrom(role);
     return this;
   }
 
@@ -72,6 +114,11 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
 
   public IdentitySetupRecord addMapping(final MappingRecord mapping) {
     mappingsProp.add().copyFrom(mapping);
+    return this;
+  }
+
+  public IdentitySetupRecord addAuthorization(final AuthorizationRecord authorization) {
+    authorizationsProp.add().copyFrom(authorization);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3066,7 +3066,7 @@ final class JsonSerializableToJsonTest {
         (Supplier<IdentitySetupRecord>)
             () ->
                 new IdentitySetupRecord()
-                    .setDefaultRole(
+                    .addRole(
                         new RoleRecord()
                             .setRoleKey(1)
                             .setRoleId("id")
@@ -3074,6 +3074,12 @@ final class JsonSerializableToJsonTest {
                             .setDescription("description")
                             .setEntityId("entityId")
                             .setEntityType(EntityType.USER))
+                    .addRoleMember(
+                        new RoleRecord()
+                            .setRoleKey(1)
+                            .setRoleId("id")
+                            .setEntityType(EntityType.USER)
+                            .setEntityId("username"))
                     .addUser(
                         new UserRecord()
                             .setUserKey(3L)
@@ -3090,6 +3096,12 @@ final class JsonSerializableToJsonTest {
                             .setPassword("qux"))
                     .setDefaultTenant(
                         new TenantRecord().setTenantKey(5).setTenantId("id").setName("name"))
+                    .addTenantMember(
+                        new TenantRecord()
+                            .setTenantKey(5)
+                            .setTenantId("id")
+                            .setEntityType(EntityType.ROLE)
+                            .setEntityId("id"))
                     .addMapping(
                         new MappingRecord()
                             .setMappingKey(6)
@@ -3106,14 +3118,24 @@ final class JsonSerializableToJsonTest {
                             .setName("Claim 2")),
         """
       {
-        "defaultRole": {
-          "roleKey": 1,
-          "roleId": "id",
-          "name": "roleName",
-          "description": "description",
-          "entityId": "entityId",
-          "entityType": "USER"
-        },
+        "roles": [
+          {
+            "roleKey": 1,
+            "roleId": "id",
+            "name": "roleName",
+            "description": "description",
+            "entityId": "entityId",
+            "entityType": "USER"
+          }
+        ],
+        "roleMembers": [
+          {
+            "roleKey": 1,
+            "roleId": "id",
+            "entityId": "username
+            "entityType": "USER"
+          }
+        ],
         "users": [
           {
             "userKey": 3,
@@ -3138,6 +3160,14 @@ final class JsonSerializableToJsonTest {
           "entityId": "",
           "entityType": "UNSPECIFIED"
         },
+        "tenantMembers": [
+          {
+            "tenantKey": 5,
+            "tenantId": "id",
+            "entityId": "id",
+            "entityType": "ROLE"
+          }
+        ],
         "mappings": [
           {
             "mappingKey": 6,
@@ -3165,18 +3195,10 @@ final class JsonSerializableToJsonTest {
         (Supplier<IdentitySetupRecord>)
             () ->
                 new IdentitySetupRecord()
-                    .setDefaultRole(new RoleRecord().setRoleId("roleId"))
                     .setDefaultTenant(new TenantRecord().setTenantId("tenantId")),
         """
       {
-          "defaultRole": {
-              "roleKey": -1,
-              "roleId": "roleId",
-              "name": "",
-              "description": "",
-              "entityId": "",
-              "entityType": "UNSPECIFIED"
-          },
+          "roles": [],
           "users": [],
           "defaultTenant": {
               "tenantKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3076,7 +3076,6 @@ final class JsonSerializableToJsonTest {
                             .setEntityType(EntityType.USER))
                     .addRoleMember(
                         new RoleRecord()
-                            .setRoleKey(1)
                             .setRoleId("id")
                             .setEntityType(EntityType.USER)
                             .setEntityId("username"))
@@ -3098,7 +3097,6 @@ final class JsonSerializableToJsonTest {
                         new TenantRecord().setTenantKey(5).setTenantId("id").setName("name"))
                     .addTenantMember(
                         new TenantRecord()
-                            .setTenantKey(5)
                             .setTenantId("id")
                             .setEntityType(EntityType.ROLE)
                             .setEntityId("id"))
@@ -3115,7 +3113,14 @@ final class JsonSerializableToJsonTest {
                             .setMappingId("id2")
                             .setClaimName("claim2")
                             .setClaimValue("value2")
-                            .setName("Claim 2")),
+                            .setName("Claim 2"))
+                    .addAuthorization(
+                        new AuthorizationRecord()
+                            .setOwnerId("id2")
+                            .setOwnerType(AuthorizationOwnerType.MAPPING)
+                            .setResourceType(AuthorizationResourceType.RESOURCE)
+                            .setResourceId("resource-id")
+                            .setPermissionTypes(Set.of(PermissionType.CREATE))),
         """
       {
         "roles": [
@@ -3130,9 +3135,11 @@ final class JsonSerializableToJsonTest {
         ],
         "roleMembers": [
           {
-            "roleKey": 1,
+            "roleKey": -1,
             "roleId": "id",
-            "entityId": "username
+            "name": "",
+            "description": "",
+            "entityId": "username",
             "entityType": "USER"
           }
         ],
@@ -3162,8 +3169,10 @@ final class JsonSerializableToJsonTest {
         },
         "tenantMembers": [
           {
-            "tenantKey": 5,
+            "tenantKey": -1,
             "tenantId": "id",
+            "name": "",
+            "description": "",
             "entityId": "id",
             "entityType": "ROLE"
           }
@@ -3182,6 +3191,16 @@ final class JsonSerializableToJsonTest {
             "claimName": "claim2",
             "claimValue": "value2",
             "name": "Claim 2"
+          }
+        ],
+        "authorizations": [
+          {
+            "authorizationKey": -1,
+            "ownerId": "id2",
+            "ownerType": "MAPPING",
+            "resourceId": "resource-id",
+            "resourceType": "RESOURCE",
+            "permissionTypes": ["CREATE"]
           }
         ]
       }
@@ -3208,7 +3227,10 @@ final class JsonSerializableToJsonTest {
               "entityId": "",
               "entityType": "UNSPECIFIED"
           },
-          "mappings": []
+          "mappings": [],
+          "roleMembers": [],
+          "tenantMembers": [],
+          "authorizations": []
       }
       """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.Collection;
 import java.util.List;
 import org.immutables.value.Value;
 
@@ -24,11 +25,17 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableIdentitySetupRecordValue.Builder.class)
 public interface IdentitySetupRecordValue extends RecordValue {
 
-  RoleRecordValue getDefaultRole();
+  Collection<RoleRecordValue> getRoles();
+
+  Collection<RoleRecordValue> getRoleMembers();
 
   List<UserRecordValue> getUsers();
 
   TenantRecordValue getDefaultTenant();
 
+  Collection<TenantRecordValue> getTenantMembers();
+
   List<MappingRecordValue> getMappings();
+
+  Collection<AuthorizationRecordValue> getAuthorizations();
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredDataDeletionTest.java
@@ -60,9 +60,9 @@ public final class ClusteredDataDeletionTest {
   private static void configureNoExporters(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
-    data.setLogSegmentSize(DataSize.ofKilobytes(16));
+    data.setLogSegmentSize(DataSize.ofKilobytes(32));
     data.setLogIndexDensity(50);
-    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
 
     brokerCfg.setExporters(Collections.emptyMap());
   }
@@ -70,9 +70,9 @@ public final class ClusteredDataDeletionTest {
   private static void configureCustomExporter(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
-    data.setLogSegmentSize(DataSize.ofKilobytes(16));
+    data.setLogSegmentSize(DataSize.ofKilobytes(32));
     data.setLogIndexDensity(50);
-    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
 
     final ExporterCfg exporterCfg = new ExporterCfg();
     exporterCfg.setClassName(TestExporter.class.getName());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -132,10 +132,10 @@ final class ClusteredSnapshotTest {
   }
 
   private void configureBroker(final BrokerCfg brokerCfg) {
-    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(4));
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
 
     final DataCfg data = brokerCfg.getData();
-    data.setLogSegmentSize(DataSize.ofKilobytes(4));
+    data.setLogSegmentSize(DataSize.ofKilobytes(32));
     data.setLogIndexDensity(5);
     data.setSnapshotPeriod(SNAPSHOT_INTERVAL);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -287,7 +287,7 @@ public class FailOverReplicationTest {
     final var data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
 
-    final var maxSize = DataSize.ofKilobytes(16);
+    final var maxSize = DataSize.ofKilobytes(32);
     data.setLogSegmentSize(maxSize);
     data.setLogIndexDensity(1);
     brokerCfg.getNetwork().setMaxMessageSize(maxSize);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -29,8 +29,8 @@ public class InstallRequestHandlingTest {
           3,
           3,
           config -> {
-            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
-            config.getData().setLogSegmentSize(DataSize.ofKilobytes(16));
+            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
+            config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
             config.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
           });
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -29,8 +29,8 @@ public class ReaderCloseTest {
           3,
           3,
           config -> {
-            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
-            config.getData().setLogSegmentSize(DataSize.ofKilobytes(16));
+            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
+            config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
             // no exporters so that segments are immediately compacted after a snapshot.
             config.setExporters(Map.of());
           });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
@@ -45,8 +45,8 @@ import org.springframework.util.unit.DataSize;
 public class SingleBrokerDataDeletionTest {
 
   private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
-  private static final DataSize LOG_SEGMENT_SIZE = DataSize.ofKilobytes(8);
-  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofKilobytes(4);
+  private static final DataSize LOG_SEGMENT_SIZE = DataSize.ofKilobytes(32);
+  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofKilobytes(32);
   private static final int PARTITION_ID = 1;
 
   @Rule

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -82,7 +82,7 @@ final class IdentitySetupInitializerIT {
     assertTrue(passwordMatches);
 
     final var createdRole = RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue();
-    Assertions.assertThat(createdRole).hasName(IdentitySetupInitializer.DEFAULT_ROLE_NAME);
+    Assertions.assertThat(createdRole).hasName("Admin");
 
     final var createdTenant =
         RecordingExporter.tenantRecords(TenantIntent.CREATED).getFirst().getValue();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -81,8 +81,9 @@ final class IdentitySetupInitializerIT {
     final var passwordMatches = passwordEncoder.matches(password, createdUser.getPassword());
     assertTrue(passwordMatches);
 
-    final var createdRole = RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue();
-    Assertions.assertThat(createdRole).hasName("Admin");
+    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).limit(3))
+        .extracting(record -> record.getValue().getName())
+        .containsExactlyInAnyOrder("Admin", "RPA", "Connectors");
 
     final var createdTenant =
         RecordingExporter.tenantRecords(TenantIntent.CREATED).getFirst().getValue();


### PR DESCRIPTION
This refactors the identity initialization to give more control to the initializer where we have access to configuration, instead of custom logic in the processor.
We use that control to create two new roles with custom permissions: rpa and connectors.

closes #31877
depends on #31946