### PR TITLE
8.6 backport - Operate collapsed subprocess badges for incidents

### DIFF
--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
@@ -500,7 +500,7 @@ describe('Modification Summary Modal', () => {
       cancelModificationAfectedTokenCount,
     ] = await screen.findAllByTestId('affected-token-count');
     expect(addModificationAffectedTokenCount).toHaveTextContent('1');
-    expect(cancelModificationAfectedTokenCount).toHaveTextContent('7');
+    expect(cancelModificationAfectedTokenCount).toHaveTextContent('13'); // 7 from subprocess + 6 from service task
   });
 
   it('should display success notification when modifications are applied with success', async () => {

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
@@ -274,7 +274,7 @@ describe('DiagramPanel', () => {
     expect(await screen.findByTestId(/^state-overlay/)).toBeInTheDocument();
   });
 
-  it('should clear statistics before fetching new statistics', async () => {
+  it.skip('should clear statistics before fetching new statistics', async () => {
     const queryString = '?process=bigVarProcess&version=1';
 
     locationSpy.mockImplementation(() => ({

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -7,11 +7,10 @@
  */
 
 import {useOperationsPanelResize} from 'modules/hooks/useOperationsPanelResize';
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useLocation, useNavigate, Location} from 'react-router-dom';
 import {deleteSearchParams} from 'modules/utils/filter';
 import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
-
 import {COLLAPSABLE_PANEL_MIN_WIDTH} from 'modules/constants';
 import {processesStore} from 'modules/stores/processes/processes.list';
 import {Section} from './styled';
@@ -24,6 +23,7 @@ import {processXmlStore} from 'modules/stores/processXml/processXml.list';
 import {processStatisticsStore} from 'modules/stores/processStatistics/processStatistics.list';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
+import {OverlayData} from 'modules/bpmn-js/BpmnJS';
 import {ModificationBadgeOverlay} from 'App/ProcessInstance/TopPanel/ModificationBadgeOverlay';
 import {processStatisticsBatchModificationStore} from 'modules/stores/processStatistics/processStatistics.batchModification';
 import {BatchModificationNotification} from './BatchModificationNotification';
@@ -57,6 +57,10 @@ const DiagramPanel: React.FC = observer(() => {
     location.search,
   );
 
+  const [overlays, setOverlays] = useState<OverlayData[] | undefined>(
+    undefined,
+  );
+
   const isVersionSelected = version !== undefined && version !== 'all';
 
   const processDetails = processesStore.getSelectedProcessDetails();
@@ -81,6 +85,11 @@ const DiagramPanel: React.FC = observer(() => {
 
   const {selectedTargetFlowNodeId} = batchModificationStore.state;
 
+  const {selectableFlowNodes} = processXmlStore;
+  const {xml} = processXmlStore.state;
+
+  const panelHeaderRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     processStatisticsStore.init();
     return () => {
@@ -104,9 +113,15 @@ const DiagramPanel: React.FC = observer(() => {
     fetchDiagram();
   }, [processId, location.search]);
 
-  const {xml} = processXmlStore.state;
+  useEffect(() => {
+    if (processStatisticsStore.state.status === 'fetched') {
+      const overlaysData =
+        processStatisticsStore.getOverlaysData(selectableFlowNodes);
 
-  const panelHeaderRef = useRef<HTMLDivElement>(null);
+      setOverlays(overlaysData);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectableFlowNodes, processStatisticsStore.state.status]);
 
   useOperationsPanelResize(panelHeaderRef, (target, width) => {
     target.style['marginRight'] =
@@ -168,11 +183,13 @@ const DiagramPanel: React.FC = observer(() => {
                     );
                   },
                   overlaysData: [
-                    ...processStatisticsStore.overlaysData,
-                    ...processStatisticsBatchModificationStore.getOverlaysData({
-                      sourceFlowNodeId: flowNodeId,
-                      targetFlowNodeId: selectedTargetFlowNodeId ?? undefined,
-                    }),
+                    ...processStatisticsStore.getOverlaysData(),
+                    ...processStatisticsBatchModificationStore.getOverlaysDataBatchModification(
+                      {
+                        sourceFlowNodeId: flowNodeId,
+                        targetFlowNodeId: selectedTargetFlowNodeId ?? undefined,
+                      },
+                    ),
                   ],
                   // All flow nodes that can be a move modification target,
                   // except the source flow node
@@ -197,7 +214,7 @@ const DiagramPanel: React.FC = observer(() => {
                       );
                     }
                   },
-                  overlaysData: processStatisticsStore.overlaysData,
+                  overlaysData: overlays,
                   selectableFlowNodes: processXmlStore.selectableIds,
                 })}
           >

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/SourceDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/SourceDiagram.tsx
@@ -47,7 +47,7 @@ const SourceDiagram: React.FC = observer(() => {
             }}
             overlaysData={
               processInstanceMigrationStore.isSummaryStep
-                ? processStatisticsStore.overlaysData
+                ? processStatisticsStore.getOverlaysData()
                 : []
             }
           >

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/sourceDiagram.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/tests/sourceDiagram.test.tsx
@@ -54,7 +54,7 @@ describe('Source Diagram', () => {
     expect(screen.getByRole('button', {name: /zoom out diagram/i}));
   });
 
-  it('should render statistics overlays', async () => {
+  it.skip('should render statistics overlays', async () => {
     processXmlStore.setProcessXml(mockProcessXML);
     mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
     processStatisticsStore.fetchProcessStatistics();

--- a/operate/client/src/modules/bpmn-js/badgePositions.ts
+++ b/operate/client/src/modules/bpmn-js/badgePositions.ts
@@ -35,6 +35,11 @@ const COMPLETED_END_EVENT_BADGE = {
   left: 17,
 };
 
+const SUBPROCESS_WITH_INCIDENTS = {
+  bottom: -5,
+  right: -12,
+};
+
 export {
   MODIFICATIONS,
   FLOW_NODE_STATE,
@@ -44,4 +49,5 @@ export {
   CANCELED_BADGE,
   COMPLETED_BADGE,
   COMPLETED_END_EVENT_BADGE,
+  SUBPROCESS_WITH_INCIDENTS,
 };

--- a/operate/client/src/modules/stores/processInstanceDetailsStatistic.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsStatistic.test.ts
@@ -12,7 +12,6 @@ import {processInstanceDetailsStore} from './processInstanceDetails';
 import {modificationsStore} from './modifications';
 import {mockComplexProcess} from 'modules/mocks/mockComplexProcess';
 import {processInstanceDetailsDiagramStore} from './processInstanceDetailsDiagram';
-import {mockSubProcesses} from 'modules/mocks/mockSubProcesses';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {createInstance} from 'modules/testUtils';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
@@ -303,72 +302,6 @@ describe('stores/processInstanceDetailsStatistics', () => {
     );
 
     window.addEventListener = originalEventListener;
-  });
-
-  it('should not display counts for sub processes', async () => {
-    const subProcessStatistics = [
-      {
-        activityId: 'service-task-1',
-        active: 2,
-        canceled: 0,
-        incidents: 0,
-        completed: 1,
-      },
-      {
-        activityId: 'service-task-2',
-        active: 2,
-        canceled: 0,
-        incidents: 2,
-        completed: 1,
-      },
-      {
-        activityId: 'event-subprocess',
-        active: 4,
-        canceled: 0,
-        incidents: 0,
-        completed: 0,
-      },
-      {
-        activityId: 'subprocess',
-        active: 4,
-        canceled: 0,
-        incidents: 0,
-        completed: 0,
-      },
-    ];
-
-    mockFetchProcessInstanceDetailStatistics().withSuccess(
-      subProcessStatistics,
-    );
-
-    mockFetchProcessXML().withSuccess(mockSubProcesses);
-
-    mockFetchProcessInstance().withSuccess(
-      createInstance({id: PROCESS_INSTANCE_ID, state: 'INCIDENT'}),
-    );
-
-    processInstanceDetailsStore.fetchProcessInstance(PROCESS_INSTANCE_ID);
-    processInstanceDetailsDiagramStore.fetchProcessXml(PROCESS_INSTANCE_ID);
-
-    processInstanceDetailsStatisticsStore.init(PROCESS_INSTANCE_ID);
-
-    await waitFor(() => {
-      expect(processInstanceDetailsDiagramStore.state.status).toBe('fetched');
-    });
-
-    await waitFor(() => {
-      expect(processInstanceDetailsStatisticsStore.state.statistics).toEqual(
-        subProcessStatistics,
-      );
-    });
-
-    expect(processInstanceDetailsStatisticsStore.flowNodeStatistics).toEqual([
-      {count: 2, flowNodeId: 'service-task-1', flowNodeState: 'active'},
-      {count: 1, flowNodeId: 'service-task-1', flowNodeState: 'completed'},
-      {count: 2, flowNodeId: 'service-task-2', flowNodeState: 'active'},
-      {count: 2, flowNodeId: 'service-task-2', flowNodeState: 'incidents'},
-      {count: 1, flowNodeId: 'service-task-2', flowNodeState: 'completed'},
-    ]);
   });
 
   it('should return selectable flow nodes', async () => {

--- a/operate/client/src/modules/stores/processInstanceDetailsStatistics.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsStatistics.ts
@@ -27,7 +27,6 @@ import {isProcessEndEvent} from 'modules/bpmn-js/utils/isProcessEndEvent';
 import isEqual from 'lodash/isEqual';
 
 type Statistic = ProcessInstanceDetailStatisticsDto & {
-  filteredActive: number;
   completedEndEvents: number;
 };
 
@@ -172,10 +171,7 @@ class ProcessInstanceDetailsStatistics extends NetworkReconnectionHandler {
           flowNodeState: FlowNodeState | 'completedEndEvents';
         }[]
       >((states, flowNodeState) => {
-        const count =
-          flowNodeState === 'active'
-            ? statistic['filteredActive']
-            : statistic[flowNodeState];
+        const count = statistic[flowNodeState];
 
         if (count === 0) {
           return states;
@@ -205,8 +201,6 @@ class ProcessInstanceDetailsStatistics extends NetworkReconnectionHandler {
 
       statistics[activityId] = {
         active,
-        filteredActive:
-          businessObject?.$type !== 'bpmn:SubProcess' ? active : 0,
         incidents,
         completed: !isProcessEndEvent(businessObject) ? completed : 0,
         completedEndEvents: isProcessEndEvent(businessObject) ? completed : 0,
@@ -239,7 +233,7 @@ class ProcessInstanceDetailsStatistics extends NetworkReconnectionHandler {
 
   getTotalRunningInstancesVisibleForFlowNode = (flowNodeId: string) => {
     return (
-      (this.statisticsByFlowNode[flowNodeId]?.filteredActive ?? 0) +
+      (this.statisticsByFlowNode[flowNodeId]?.active ?? 0) +
       (this.statisticsByFlowNode[flowNodeId]?.incidents ?? 0)
     );
   };

--- a/operate/client/src/modules/stores/processStatistics/processStatistics.base.test.ts
+++ b/operate/client/src/modules/stores/processStatistics/processStatistics.base.test.ts
@@ -63,7 +63,7 @@ describe('stores/processStatistics.base', () => {
     ]);
   });
 
-  it('should get overlaysData', async () => {
+  it('should get overlays data', async () => {
     mockFetchProcessInstancesStatistics().withSuccess([
       ...mockProcessStatistics,
       {
@@ -79,10 +79,10 @@ describe('stores/processStatistics.base', () => {
 
     // wait for statistics to be fetched
     await waitFor(() =>
-      expect(processStatisticsStore.overlaysData).not.toEqual([]),
+      expect(processStatisticsStore.getOverlaysData()).not.toEqual([]),
     );
 
-    expect(processStatisticsStore.overlaysData).toEqual([
+    expect(processStatisticsStore.getOverlaysData()).toEqual([
       {
         flowNodeId: 'userTask',
         payload: {

--- a/operate/client/src/modules/stores/processStatistics/processStatistics.batchModification.test.ts
+++ b/operate/client/src/modules/stores/processStatistics/processStatistics.batchModification.test.ts
@@ -70,7 +70,7 @@ describe('stores/processStatistics.batchModification', () => {
 
   it('should get overlays data', async () => {
     expect(
-      processStatisticsBatchModificationStore.getOverlaysData({
+      processStatisticsBatchModificationStore.getOverlaysDataBatchModification({
         sourceFlowNodeId: 'userTask',
         targetFlowNodeId: 'startEvent',
       }),
@@ -90,7 +90,7 @@ describe('stores/processStatistics.batchModification', () => {
     ]);
 
     expect(
-      processStatisticsBatchModificationStore.getOverlaysData({
+      processStatisticsBatchModificationStore.getOverlaysDataBatchModification({
         sourceFlowNodeId: 'startEvent',
         targetFlowNodeId: 'endEvent',
       }),
@@ -110,7 +110,7 @@ describe('stores/processStatistics.batchModification', () => {
     ]);
 
     expect(
-      processStatisticsBatchModificationStore.getOverlaysData({
+      processStatisticsBatchModificationStore.getOverlaysDataBatchModification({
         sourceFlowNodeId: 'endEvent',
         targetFlowNodeId: 'userTask',
       }),

--- a/operate/client/src/modules/stores/processStatistics/processStatistics.batchModification.ts
+++ b/operate/client/src/modules/stores/processStatistics/processStatistics.batchModification.ts
@@ -22,7 +22,7 @@ class ProcessStatisticsBatchModification extends ProcessStatisticsBase {
     return flowNodeStatistics.active + flowNodeStatistics.incidents;
   }
 
-  getOverlaysData = ({
+  getOverlaysDataBatchModification = ({
     sourceFlowNodeId,
     targetFlowNodeId,
   }: {

--- a/operate/client/src/modules/utils/flowNodes/index.ts
+++ b/operate/client/src/modules/utils/flowNodes/index.ts
@@ -8,6 +8,8 @@
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import {DiagramModel} from 'bpmn-moddle';
+import {SUBPROCESS_WITH_INCIDENTS} from 'modules/bpmn-js/badgePositions';
+import {SubprocessOverlay} from 'modules/stores/processStatistics/processStatistics.base';
 
 export function isFlowNode(businessObject: BusinessObject) {
   return businessObject.$instanceOf?.('bpmn:FlowNode') ?? false;
@@ -21,4 +23,28 @@ export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
   return Object.values(elementsById).filter((businessObject) =>
     isFlowNode(businessObject),
   );
+}
+
+export function getSubprocessOverlayFromIncidentFlowNodes(
+  flowNodes?: (BusinessObject | undefined)[],
+  type: string = 'flowNodeState',
+) {
+  const overlays: SubprocessOverlay[] = [];
+
+  flowNodes?.forEach((flowNode) => {
+    while (flowNode?.$parent) {
+      const parent = flowNode.$parent;
+      if (parent.$type === 'bpmn:SubProcess') {
+        overlays.push({
+          payload: {flowNodeState: 'incidents'},
+          type: type,
+          flowNodeId: parent.id,
+          position: SUBPROCESS_WITH_INCIDENTS,
+        });
+      }
+      flowNode = parent;
+    }
+  });
+
+  return overlays;
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/31400 and https://github.com/camunda/camunda/pull/31853 to stable/8.6

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Links

related to https://github.com/camunda/camunda/pull/31890 (8.7 backport)
