### PR TITLE
fix: make actuator autoconfigure and micrometer optional in spring sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -106,6 +106,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -96,6 +96,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -106,7 +107,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fix for the issue mentioned here: https://github.com/camunda/zeebe-process-test/pull/1617#issuecomment-2877467613

Question: Should we backport this to older versions?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
