### PR TITLE
Fix skipping dependency projects 8.6

### DIFF
--- a/qa/core-application-e2e-test-suite/playwright.config.ts
+++ b/qa/core-application-e2e-test-suite/playwright.config.ts
@@ -60,13 +60,34 @@ export default defineConfig({
       testMatch: changedFolders.includes('chromium')
         ? changedFolders.map((folder) => `**/${folder}/*.spec.ts`)
         : undefined,
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'chromium-subset',
+    },
+    {
+      name: 'chromium-subset',
+      testMatch: 'task-panel.spec.ts',
+      use: devices['Desktop Chrome'],
     },
     {
       name: 'firefox',
       use: devices['Desktop Firefox'],
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'firefox-subset',
+    },
+    {
+      name: 'firefox-subset',
+      testMatch: 'task-panel.spec.ts',
+      use: devices['Desktop Firefox'],
     },
     {
       name: 'msedge',
+      use: devices['Desktop Edge'],
+      testIgnore: 'task-panel.spec.ts',
+      teardown: 'msedge-subset',
+    },
+    {
+      name: 'msedge-subset',
+      testMatch: 'task-panel.spec.ts',
       use: devices['Desktop Edge'],
     },
   ],


### PR DESCRIPTION
## Description

This PR fixes an issue in the Playwright config project where dependent tests were being skipped if a dependency test failed. Since Playwright does not currently support running dependent tests after a failure, this workaround introduces a `teardown` step to ensure cleanup and continued execution of tests.

The goal is to improve the reliability and completeness of test runs, even in the presence of test failures.

There is an open feature request in the Playwright repository that aims to address this limitation natively:
👉 [https://github.com/microsoft/playwright/issues/26854](https://github.com/microsoft/playwright/issues/26854)

Once the feature request is implemented, we can revisit and possibly remove this workaround.

🧪 **Testing:**
- Successful test run cane be found [here](https://github.com/camunda/camunda/actions/runs/15017503870/job/42198755160) 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
