### PR TITLE
refactor: add processes page specs to 8.6 core apps

### DIFF
--- a/qa/core-application-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -7,7 +7,6 @@
  */
 
 import {Page, Locator} from '@playwright/test';
-import {sleep} from 'utils/sleep';
 
 class OperateProcessesPage {
   private page: Page;
@@ -19,6 +18,8 @@ class OperateProcessesPage {
   readonly processPageHeading: Locator;
   readonly noMatchingInstancesMessage: Locator;
   readonly processFinishedInstancesCheckbox: Locator;
+  readonly processNameFilter: Locator;
+  readonly processInstanceLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -44,6 +45,12 @@ class OperateProcessesPage {
     this.processFinishedInstancesCheckbox = page
       .getByTestId('filter-finished-instances')
       .getByRole('checkbox');
+    this.processNameFilter = page.getByRole('combobox', {name: 'name'});
+    this.processInstanceLink = page
+      .getByRole('link', {
+        name: 'view instance',
+      })
+      .first();
   }
 
   async clickProcessActiveCheckbox(): Promise<void> {
@@ -66,22 +73,40 @@ class OperateProcessesPage {
     await this.processFinishedInstancesCheckbox.click({timeout: 90000});
   }
 
-  async clickProcessInstanceLink(processName: string): Promise<void> {
-    let retryCount = 0;
+  async filterByProcessName(name: string): Promise<void> {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await this.processNameFilter.click({timeout: 20000});
+        break;
+      } catch (error) {
+        if (attempt < 3) {
+          console.log(
+            `Attempt ${attempt} failed to click processNameFilter. Reloading page and retrying...`,
+          );
+          await this.page.reload();
+        } else {
+          throw new Error(
+            `Failed to click processNameFilter after 3 attempts: ${error}`,
+          );
+        }
+      }
+    }
+    await this.processNameFilter.fill(name);
+    await this.page.keyboard.press('Enter');
+    await this.page.getByRole('heading', {name}).waitFor({state: 'visible'});
+  }
+
+  async clickProcessInstanceLink(): Promise<void> {
     const maxRetries = 3;
+    let retryCount = 0;
     while (retryCount < maxRetries) {
       try {
-        await this.page
-          .locator('td:right-of(:text("' + processName + '"))')
-          .first()
-          .click({timeout: 90000});
-        return; // Exit the function if the click is successful
+        await this.processInstanceLink.click();
+        return;
       } catch {
-        // If process isn't found, reload the page and try again
         retryCount++;
         console.log(`Attempt ${retryCount} failed. Retrying...`);
         await this.page.reload();
-        await sleep(10000);
       }
     }
     throw new Error(

--- a/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 function cardinalToOrdinal(numberValue: number): string {
   const realOrderIndex = numberValue.toString();
@@ -57,8 +58,10 @@ class TaskDetailsPage {
   readonly selectDropdown: Locator;
   readonly tagList: Locator;
   readonly detailsInfo: Locator;
-  readonly textInput: Locator;
   readonly taskCompletedBanner: Locator;
+  readonly addDynamicListRowButton: Locator;
+  readonly processTab: Locator;
+  readonly bpmnDiagram: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -77,7 +80,7 @@ class TaskDetailsPage {
       name: 'Pick a task to work on',
     });
     this.emptyTaskMessage = page.getByRole('heading', {
-      name: /task has no variables/i,
+      name: 'task has no variables',
     });
     this.nameInput = page.getByLabel('Name*');
     this.addressInput = page.getByLabel('Address*');
@@ -99,12 +102,16 @@ class TaskDetailsPage {
     this.selectDropdown = this.form.getByText('Select').last();
     this.tagList = page.getByPlaceholder('Search');
     this.detailsInfo = page.getByTestId('details-info');
-    this.textInput = page.locator('[class="fjs-input"]');
     this.taskCompletedBanner = this.page.getByText('Task completed');
+    this.addDynamicListRowButton = page.getByRole('button', {name: 'add new'});
+    this.processTab = page.getByRole('link', {
+      name: 'show associated bpmn process',
+    });
+    this.bpmnDiagram = page.getByTestId('diagram');
   }
 
   async clickAssignToMeButton() {
-    await this.assignToMeButton.click();
+    await this.assignToMeButton.click({timeout: 60000});
   }
 
   async clickUnassignButton() {
@@ -153,22 +160,20 @@ class TaskDetailsPage {
   }
 
   async clickIncrementButton(): Promise<void> {
-    await this.incrementButton.click();
+    await this.incrementButton.click({timeout: 60000});
   }
 
   async clickDecrementButton(): Promise<void> {
-    await this.decrementButton.click();
+    await this.decrementButton.click({timeout: 60000});
   }
 
-  async fillDate(date: string): Promise<void> {
-    await this.dateInput.click();
-    await this.dateInput.fill(date);
-    await this.dateInput.press('Enter');
-  }
-
-  async enterTime(time: string): Promise<void> {
-    await this.timeInput.click();
-    await this.page.getByText(time).click();
+  async fillDatetimeField(label: string, value: string) {
+    const input = this.page.getByRole('textbox', {name: label});
+    await expect(input).toBeVisible();
+    await input.click();
+    await input.fill(value);
+    await this.page.keyboard.press('Enter');
+    await expect(input).toHaveValue(value);
   }
 
   async checkCheckbox(): Promise<void> {
@@ -180,8 +185,13 @@ class TaskDetailsPage {
     await this.page.getByText(value).click();
   }
 
-  async clickRadioButton(radioBtnLabel: string): Promise<void> {
-    await this.page.getByText(radioBtnLabel).click();
+  async selectDropdownOption(label: string, value: string) {
+    await this.page.getByText(label).click();
+    await this.page.getByText(value).click();
+  }
+
+  async clickRadioButton(label: string): Promise<void> {
+    await this.page.getByText(label).click();
   }
 
   async checkChecklistBox(label: string): Promise<void> {
@@ -194,13 +204,32 @@ class TaskDetailsPage {
     await this.page.getByText(value2, {exact: true}).click();
   }
 
-  async clickTextInput(): Promise<void> {
-    await this.textInput.click();
+  async fillTextInput(label: string, value: string): Promise<void> {
+    const input = this.page.getByLabel(label, {exact: true});
+    const maxRetries = 3;
+    let attempt = 0;
+    while (attempt < maxRetries) {
+      try {
+        await input.click({timeout: 120000});
+        await input.fill(value);
+        await input.blur();
+        await expect(input).toHaveValue(value);
+        return;
+      } catch (error) {
+        attempt++;
+        console.log(
+          `Attempt ${attempt} to fill input "${label}" failed with error: ${error}`,
+        );
+        if (attempt === maxRetries) {
+          throw new Error(
+            `Failed to set value "${value}" for label "${label}" after ${maxRetries} attempts.`,
+          );
+        }
+        await sleep(500);
+      }
+    }
   }
 
-  async fillTextInput(value: string): Promise<void> {
-    await this.textInput.fill(value);
-  }
   async priorityAssertion(priority: string): Promise<void> {
     let retryCount = 0;
     const maxRetries = 2;
@@ -247,5 +276,66 @@ class TaskDetailsPage {
       variableValue,
     );
   }
+
+  async fillDynamicList(label: string, value: string) {
+    const locator = this.page.getByLabel(label);
+    const elements = await locator.all();
+    if (elements.length === 0) {
+      throw new Error(
+        `No elements found for label "${label}" in the dynamic list`,
+      );
+    }
+
+    for (const [index, element] of elements.entries()) {
+      const expectedValue = `${value}${index + 1}`;
+      await element.fill(expectedValue);
+
+      // Assert that the value was added correctly
+      await expect(element).toHaveValue(expectedValue);
+    }
+  }
+
+  async getDynamicListValues(label: string): Promise<string[]> {
+    const locator = this.page.getByLabel(label);
+    const elements = await locator.all();
+    if (elements.length === 0) {
+      throw new Error(`No elements found for label "${label}"`);
+    }
+
+    return Promise.all(elements.map((element) => element.inputValue()));
+  }
+
+  async addDynamicListRow(): Promise<void> {
+    await this.addDynamicListRowButton.click();
+  }
+
+  async assertFieldValue(label: string, expectedValue: string): Promise<void> {
+    const input = this.page.getByLabel(label, {exact: true});
+    await waitForAssertion({
+      assertion: async () => {
+        const actualValue = input;
+        await expect(actualValue).toHaveValue(expectedValue);
+      },
+      onFailure: async () => {
+        console.log(`Retrying assertion for field "${label}"...`);
+      },
+    });
+  }
+
+  async assertItemChecked(label: string): Promise<void> {
+    await expect(this.page.getByLabel(label)).toBeChecked();
+  }
+
+  async selectTaglistValues(values: string[]) {
+    await this.tagList.click();
+    for (const value of values) {
+      await this.page.getByText(value, {exact: true}).click();
+    }
+  }
+
+  async clickProcessTab(): Promise<void> {
+    await this.processTab.click();
+  }
 }
+
 export {TaskDetailsPage};

--- a/qa/core-application-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskPanelPage.ts
@@ -6,32 +6,25 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator, expect} from '@playwright/test';
+import {Page, Locator} from '@playwright/test';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {expect} from '@playwright/test';
 
 class TaskPanelPage {
-  readonly assignmentTag: Locator;
-  readonly assignToMeButton: Locator;
   readonly availableTasks: Locator;
-  readonly completeTaskButton: Locator;
   readonly collapseSidePanelButton: Locator;
-  readonly emptyTaskMessage: Locator;
   readonly expandSidePanelButton: Locator;
   private page: Page;
   readonly taskListPageBanner: Locator;
   readonly collapseFilter: Locator;
+  readonly completedHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.assignmentTag = page.locator(' header > div').nth(2);
-    this.assignToMeButton = page.getByRole('button', {name: 'Assign to me'});
     this.availableTasks = page.getByTitle('Available tasks');
-    this.completeTaskButton = page.getByRole('button', {name: 'Complete Task'});
     this.collapseSidePanelButton = page.locator(
       'button[aria-controls="task-nav-bar"][aria-expanded="true"]',
     );
-    this.emptyTaskMessage = this.emptyTaskMessage = page.getByRole('heading', {
-      name: /Task has no variables/i,
-    });
     this.expandSidePanelButton = page
       .locator('[aria-label="Filter controls"] li')
       .filter({hasText: 'Expand to show filters'});
@@ -41,38 +34,16 @@ class TaskPanelPage {
     this.collapseFilter = page.locator(
       'button[aria-controls="task-nav-bar"][aria-expanded="true"]',
     );
-  }
-
-  async assertAssignmentStatus(status: string): Promise<void> {
-    await expect(this.assignmentTag).toContainText(status);
-  }
-
-  async assignTaskToMe(): Promise<void> {
-    await this.filterBy('Unassigned');
-    await this.openTask('usertask_to_be_assigned');
-    await this.assignToMeButton.click();
-  }
-
-  async completeATask(): Promise<void> {
-    await this.filterBy('Unassigned');
-    await this.openTask('usertask_to_be_assigned');
-    await this.assignToMeButton.click();
-    await this.completeTaskButton.click();
+    this.completedHeading = page.getByRole('heading', {
+      name: 'completed',
+    });
   }
 
   async openTask(name: string) {
     await this.availableTasks
       .getByText(name, {exact: true})
       .nth(0)
-      .click({timeout: 20000});
-  }
-
-  async taskListBannerIsVisible(): Promise<void> {
-    await expect(this.taskListPageBanner).toBeVisible();
-  }
-
-  async asssertUnnassignedTaskEmptyMessage(): Promise<void> {
-    await expect(this.emptyTaskMessage).toBeVisible();
+      .click({timeout: 60000});
   }
 
   async filterBy(
@@ -85,11 +56,41 @@ class TaskPanelPage {
   ) {
     await this.expandSidePanelButton.click();
     await this.page.getByRole('link', {name: option, exact: true}).click();
+
+    const expectedSegment =
+      option === 'All open tasks'
+        ? 'all-open'
+        : option === 'Assigned to me'
+          ? 'assigned-to-me'
+          : option.toLowerCase().replace(/\s+/g, '-');
+
+    await expect(this.page).toHaveURL(new RegExp(`${expectedSegment}`));
+
     await this.collapseSidePanelButton.click();
   }
 
   async clickCollapseFilter(): Promise<void> {
     await this.collapseFilter.click({timeout: 45000});
+  }
+
+  async assertCompletedHeadingVisible() {
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.completedHeading).toBeVisible();
+      },
+      onFailure: async () => {
+        console.log('Filter not applied, retrying...');
+        await this.filterBy('Completed'); // Reapply the filter if necessary
+      },
+    });
+  }
+
+  async scrollToLastTask(name: string) {
+    await this.page.getByText(name).last().scrollIntoViewIfNeeded();
+  }
+
+  async scrollToFirstTask(name: string) {
+    await this.page.getByText(name).first().scrollIntoViewIfNeeded();
   }
 }
 

--- a/qa/core-application-e2e-test-suite/resources/Zeebe_Priority_User_Task_Process.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/Zeebe_Priority_User_Task_Process.bpmn
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="dc1daa9" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Zeebe_Priority_User_Task_Process" name="Zeebe_Priority_User_Task_Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1x7997h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1x7997h" sourceRef="StartEvent_1" targetRef="Gateway_1m7wnq1" />
+    <bpmn:parallelGateway id="Gateway_1m7wnq1">
+      <bpmn:incoming>Flow_1x7997h</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gab52t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1j9h704</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00zf9xm</bpmn:outgoing>
+      <bpmn:outgoing>Flow_189bq3i</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0gab52t" sourceRef="Gateway_1m7wnq1" targetRef="priorityTest1" />
+    <bpmn:userTask id="priorityTest1" name="priorityTest1">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:priorityDefinition priority="1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0gab52t</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ademok</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1ademok" sourceRef="priorityTest1" targetRef="Gateway_16cdqge" />
+    <bpmn:parallelGateway id="Gateway_16cdqge">
+      <bpmn:incoming>Flow_1ademok</bpmn:incoming>
+      <bpmn:incoming>Flow_1x2r0b5</bpmn:incoming>
+      <bpmn:incoming>Flow_0ai3qq1</bpmn:incoming>
+      <bpmn:incoming>Flow_16atxkp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e7mcib</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1j9h704" sourceRef="Gateway_1m7wnq1" targetRef="priorityTest2" />
+    <bpmn:userTask id="priorityTest2" name="priorityTest2">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:priorityDefinition priority="26" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1j9h704</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x2r0b5</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1x2r0b5" sourceRef="priorityTest2" targetRef="Gateway_16cdqge" />
+    <bpmn:sequenceFlow id="Flow_00zf9xm" sourceRef="Gateway_1m7wnq1" targetRef="priorityTest3" />
+    <bpmn:userTask id="priorityTest3" name="priorityTest3">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:priorityDefinition priority="51" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00zf9xm</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ai3qq1</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0ai3qq1" sourceRef="priorityTest3" targetRef="Gateway_16cdqge" />
+    <bpmn:sequenceFlow id="Flow_189bq3i" sourceRef="Gateway_1m7wnq1" targetRef="priorityTest4" />
+    <bpmn:userTask id="priorityTest4" name="priorityTest4">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:priorityDefinition priority="76" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_189bq3i</bpmn:incoming>
+      <bpmn:outgoing>Flow_16atxkp</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_16atxkp" sourceRef="priorityTest4" targetRef="Gateway_16cdqge" />
+    <bpmn:endEvent id="Event_17pryo7">
+      <bpmn:incoming>Flow_1e7mcib</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1e7mcib" sourceRef="Gateway_16cdqge" targetRef="Event_17pryo7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Zeebe_Priority_User_Task_Process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1rn4edo_di" bpmnElement="Gateway_1m7wnq1">
+        <dc:Bounds x="245" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bk6x6f_di" bpmnElement="priorityTest1">
+        <dc:Bounds x="360" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gfs85z_di" bpmnElement="Gateway_16cdqge">
+        <dc:Bounds x="525" y="93" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nbjcze_di" bpmnElement="priorityTest2">
+        <dc:Bounds x="360" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0svictp_di" bpmnElement="priorityTest3">
+        <dc:Bounds x="360" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1we5nt4_di" bpmnElement="priorityTest4">
+        <dc:Bounds x="360" y="410" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17pryo7_di" bpmnElement="Event_17pryo7">
+        <dc:Bounds x="642" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1x7997h_di" bpmnElement="Flow_1x7997h">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="245" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gab52t_di" bpmnElement="Flow_0gab52t">
+        <di:waypoint x="295" y="118" />
+        <di:waypoint x="360" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ademok_di" bpmnElement="Flow_1ademok">
+        <di:waypoint x="460" y="118" />
+        <di:waypoint x="525" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j9h704_di" bpmnElement="Flow_1j9h704">
+        <di:waypoint x="270" y="143" />
+        <di:waypoint x="270" y="230" />
+        <di:waypoint x="360" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x2r0b5_di" bpmnElement="Flow_1x2r0b5">
+        <di:waypoint x="460" y="230" />
+        <di:waypoint x="550" y="230" />
+        <di:waypoint x="550" y="143" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00zf9xm_di" bpmnElement="Flow_00zf9xm">
+        <di:waypoint x="270" y="143" />
+        <di:waypoint x="270" y="340" />
+        <di:waypoint x="360" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ai3qq1_di" bpmnElement="Flow_0ai3qq1">
+        <di:waypoint x="460" y="340" />
+        <di:waypoint x="550" y="340" />
+        <di:waypoint x="550" y="143" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189bq3i_di" bpmnElement="Flow_189bq3i">
+        <di:waypoint x="270" y="143" />
+        <di:waypoint x="270" y="450" />
+        <di:waypoint x="360" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16atxkp_di" bpmnElement="Flow_16atxkp">
+        <di:waypoint x="460" y="450" />
+        <di:waypoint x="550" y="450" />
+        <di:waypoint x="550" y="143" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e7mcib_di" bpmnElement="Flow_1e7mcib">
+        <di:waypoint x="575" y="118" />
+        <di:waypoint x="642" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/checkbox_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/checkbox_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="0d6a46ee-4bdf-44d0-ae40-0ea75d5eb9ae">
+  <bpmn:process id="Checkbox_User_Task" name="Checkbox Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17447e9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17447e9" sourceRef="StartEvent_1" targetRef="Checkbox_Task" />
+    <bpmn:endEvent id="Event_0kgtq2q">
+      <bpmn:incoming>Flow_1aw5gfq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1aw5gfq" sourceRef="Checkbox_Task" targetRef="Event_0kgtq2q" />
+    <bpmn:userTask id="Checkbox_Task" name="Checkbox Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_checkbox" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17447e9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1aw5gfq</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Checkbox_User_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0kgtq2q_di" bpmnElement="Event_0kgtq2q">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_007mah4_di" bpmnElement="Checkbox_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17447e9_di" bpmnElement="Flow_17447e9">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1aw5gfq_di" bpmnElement="Flow_1aw5gfq">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/checklist_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/checklist_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="6f1a20da-2006-4d48-83ef-34dc77aad979">
+  <bpmn:process id="Checklist_Task" name="Checklist Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_091cdf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_091cdf1" sourceRef="StartEvent_1" targetRef="Checklist_User_Task" />
+    <bpmn:endEvent id="Event_10j26bv">
+      <bpmn:incoming>Flow_07qb93n</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_07qb93n" sourceRef="Checklist_User_Task" targetRef="Event_10j26bv" />
+    <bpmn:userTask id="Checklist_User_Task" name="Checklist User Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_checklist" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_091cdf1</bpmn:incoming>
+      <bpmn:outgoing>Flow_07qb93n</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Checklist_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10j26bv_di" bpmnElement="Event_10j26bv">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1j9wvks_di" bpmnElement="Checklist_User_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_091cdf1_di" bpmnElement="Flow_091cdf1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07qb93n_di" bpmnElement="Flow_07qb93n">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/create_invoice.form
+++ b/qa/core-application-e2e-test-suite/resources/create_invoice.form
@@ -1,0 +1,246 @@
+{
+  "components": [
+    {
+      "components": [
+        {
+          "text": "### Invoice",
+          "type": "text",
+          "id": "Heading_0",
+          "layout": {
+            "row": "Row_0fp5znu",
+            "columns": null
+          }
+        }
+      ],
+      "showOutline": false,
+      "label": "",
+      "type": "group",
+      "layout": {
+        "row": "row_0",
+        "columns": null
+      },
+      "id": "Field_1ll8pgn"
+    },
+    {
+      "components": [
+        {
+          "type": "textfield",
+          "id": "Textfield_1",
+          "label": "Client Name",
+          "validate": {
+            "minLength": 2,
+            "maxLength": 50,
+            "required": true
+          },
+          "key": "name",
+          "layout": {
+            "row": "Row_18tb43e",
+            "columns": null
+          }
+        },
+        {
+          "label": "Client Address",
+          "type": "textarea",
+          "layout": {
+            "row": "Row_053xglo",
+            "columns": null
+          },
+          "id": "Field_0e9lblu",
+          "key": "address",
+          "validate": {
+            "required": true
+          }
+        }
+      ],
+      "showOutline": false,
+      "label": "Billed to",
+      "type": "group",
+      "layout": {
+        "row": "Row_0o7mon1",
+        "columns": null
+      },
+      "id": "Field_0g2mpc9",
+      "path": "client"
+    },
+    {
+      "components": [
+        {
+          "subtype": "date",
+          "dateLabel": "Invoice Date",
+          "type": "datetime",
+          "id": "Date_4",
+          "validate": {
+            "required": true
+          },
+          "key": "invoiceDate",
+          "layout": {
+            "row": "Row_0pc7qah",
+            "columns": null
+          }
+        },
+        {
+          "subtype": "date",
+          "dateLabel": "Due Date",
+          "type": "datetime",
+          "id": "Date_5",
+          "validate": {
+            "required": true
+          },
+          "key": "dueDate",
+          "layout": {
+            "row": "Row_0pc7qah",
+            "columns": null
+          }
+        },
+        {
+          "values": [
+            {
+              "label": "USD - United States Dollar",
+              "value": "USD"
+            },
+            {
+              "label": "EUR - Euro",
+              "value": "EUR"
+            }
+          ],
+          "label": "Currency",
+          "type": "select",
+          "layout": {
+            "row": "Row_1fv40q7",
+            "columns": null
+          },
+          "id": "Field_0nz4fgu",
+          "key": "currency",
+          "defaultValue": "USD"
+        },
+        {
+          "type": "textfield",
+          "id": "Textfield_3",
+          "label": "Invoice Number",
+          "validate": {
+            "minLength": 1,
+            "maxLength": 10,
+            "required": true
+          },
+          "key": "invoiceNumber",
+          "layout": {
+            "row": "Row_0rugl5w",
+            "columns": null
+          }
+        },
+        {
+          "label": "Reference #",
+          "type": "textfield",
+          "layout": {
+            "row": "Row_0rugl5w",
+            "columns": null
+          },
+          "id": "Field_1l6w9gw",
+          "key": "referenceNumber"
+        }
+      ],
+      "showOutline": false,
+      "label": "Invoice Details",
+      "type": "group",
+      "layout": {
+        "row": "Row_0o7mon1",
+        "columns": null
+      },
+      "id": "Field_1g6x01a"
+    },
+    {
+      "components": [
+        {
+          "type": "textfield",
+          "id": "Textfield_7",
+          "label": "Item Name",
+          "validate": {
+            "minLength": 2,
+            "maxLength": 50,
+            "required": true
+          },
+          "key": "itemName",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 6
+          }
+        },
+        {
+          "type": "number",
+          "id": "Number_9",
+          "label": "Unit Price",
+          "decimalDigits": 2,
+          "defaultValue": 0,
+          "validate": {
+            "min": 0,
+            "max": 1000,
+            "step": 0.5,
+            "required": true
+          },
+          "key": "unitPrice",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 4
+          },
+          "appearance": {
+            "prefixAdorner": "=currency"
+          }
+        },
+        {
+          "type": "number",
+          "id": "Number_8",
+          "label": "Quantity",
+          "decimalDigits": 2,
+          "defaultValue": 1,
+          "validate": {
+            "min": 1,
+            "max": 100,
+            "step": 1,
+            "required": true
+          },
+          "key": "quantity",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": 4
+          },
+          "increment": "1"
+        },
+        {
+          "text": "{{currency}} {{this.unitPrice * this.quantity}}",
+          "label": "Text view",
+          "type": "text",
+          "layout": {
+            "row": "Row_0kspk8y",
+            "columns": null
+          },
+          "id": "Field_1cyz9yt"
+        }
+      ],
+      "showOutline": false,
+      "isRepeating": true,
+      "allowAddRemove": true,
+      "defaultRepetitions": 1,
+      "label": "Items",
+      "type": "dynamiclist",
+      "layout": {
+        "row": "Row_1k6j1pw",
+        "columns": null
+      },
+      "id": "Field_104boo3",
+      "path": "items",
+      "verticalAlignment": "end"
+    },
+    {
+      "content": "<style>\n    .invoice-total {\n      border: 1px solid #ccc;\n      padding: 10px;\n      max-width: 300px;\n      margin-left: auto;\n      text-align: right;\n    }\n</style>\n\n\n<div class=\"invoice-total\">\n    <h4>Invoice Total</h4>\n    <p>Subtotal: {{currency}} {{sum(items[unitPrice * quantity])}}</p>\n    <p>Tax (10%): {{currency}} {{floor(sum(items[unitPrice * quantity]) * 0.1, 2)}}</p>\n    <hr>\n    <p>Total: {{currency}} {{floor(sum(items[unitPrice * quantity ]) * 1.1, 2)}}</p>\n</div>\n",
+      "label": "HTML",
+      "type": "html",
+      "layout": {
+        "row": "Row_0cd4anm",
+        "columns": null
+      },
+      "id": "Field_0nl093o"
+    }
+  ],
+  "id": "Form_Invoice",
+  "type": "default"
+}

--- a/qa/core-application-e2e-test-suite/resources/date_and_time_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/date_and_time_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7f61c05a-ceda-4bf0-8f13-f48bb25008b7">
+  <bpmn:process id="Date_and_Time_Task" name="Date and Time Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0jd2ks5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0jd2ks5" sourceRef="StartEvent_1" targetRef="Date_and_Time_" />
+    <bpmn:endEvent id="Event_017cgng">
+      <bpmn:incoming>Flow_18fhpz1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_18fhpz1" sourceRef="Date_and_Time_" targetRef="Event_017cgng" />
+    <bpmn:userTask id="Date_and_Time_" name="Date and Time Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_date_and_time" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jd2ks5</bpmn:incoming>
+      <bpmn:outgoing>Flow_18fhpz1</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Date_and_Time_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_017cgng_di" bpmnElement="Event_017cgng">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kr8l4w_di" bpmnElement="Date_and_Time_">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jd2ks5_di" bpmnElement="Flow_0jd2ks5">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18fhpz1_di" bpmnElement="Flow_18fhpz1">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/form_with_checkbox.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_checkbox.form
@@ -1,0 +1,16 @@
+{
+  "components": [
+    {
+      "label": "Checkbox",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_1tez7ti",
+        "columns": null
+      },
+      "id": "Field_1psculp",
+      "key": "field_1q27emv"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_checkbox"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_checklist.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_checklist.form
@@ -1,0 +1,38 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "Value1",
+          "value": "value"
+        }
+      ],
+      "label": "Checklist",
+      "type": "checklist",
+      "layout": {
+        "row": "Row_198n042",
+        "columns": null
+      },
+      "id": "Field_02lp2es",
+      "key": "field_0c2vunw"
+    },
+    {
+      "values": [
+        {
+          "label": "Value2",
+          "value": "value"
+        }
+      ],
+      "label": "Checklist",
+      "type": "checklist",
+      "layout": {
+        "row": "Row_0yoff12",
+        "columns": null
+      },
+      "id": "Field_189wcqd",
+      "key": "field_0zkzia0"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_checklist"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_date_and_time.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_date_and_time.form
@@ -1,0 +1,21 @@
+{
+  "components": [
+    {
+      "subtype": "datetime",
+      "dateLabel": "Date",
+      "label": "Date time",
+      "type": "datetime",
+      "layout": {
+        "row": "Row_0d3trez",
+        "columns": null
+      },
+      "id": "Field_124m3oh",
+      "key": "field_0sccnu9",
+      "timeLabel": "Time",
+      "timeSerializingFormat": "utc_offset",
+      "timeInterval": 15
+    }
+  ],
+  "type": "default",
+  "id": "form_with_date_and_time"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_number.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_number.form
@@ -1,0 +1,16 @@
+{
+  "components": [
+    {
+      "label": "Number",
+      "type": "number",
+      "layout": {
+        "row": "Row_19tsbk6",
+        "columns": null
+      },
+      "id": "Field_13msghy",
+      "key": "field_1nmvdj2"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_number"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_radio_button.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_radio_button.form
@@ -1,0 +1,22 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "Value",
+          "value": "value"
+        }
+      ],
+      "label": "Radio",
+      "type": "radio",
+      "layout": {
+        "row": "Row_1tcnaek",
+        "columns": null
+      },
+      "id": "Field_0r84gaq",
+      "key": "field_0koka0e"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_radio_button"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_select.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_select.form
@@ -1,0 +1,24 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "Value",
+          "value": "value"
+        }
+      ],
+      "label": "Select",
+      "type": "select",
+      "layout": {
+        "row": "Row_09kimyg",
+        "columns": null
+      },
+      "id": "Field_04maj5g",
+      "key": "field_12k11wu",
+      "defaultValue": "&lt;none&gt;",
+      "searchable": false
+    }
+  ],
+  "type": "default",
+  "id": "form_with_select"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_tag_list.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_tag_list.form
@@ -1,0 +1,26 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "Value",
+          "value": "value"
+        },
+        {
+          "label": "Value 2",
+          "value": "value2"
+        }
+      ],
+      "label": "Tag list",
+      "type": "taglist",
+      "layout": {
+        "row": "Row_1ygbwjl",
+        "columns": null
+      },
+      "id": "Field_03604cb",
+      "key": "field_05jv3ul"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_tag_list"
+}

--- a/qa/core-application-e2e-test-suite/resources/form_with_text_templating.form
+++ b/qa/core-application-e2e-test-suite/resources/form_with_text_templating.form
@@ -1,0 +1,16 @@
+{
+  "components": [
+    {
+      "text": "# Hello {{ name }} \n\n You are {{ age }} years old",
+      "label": "Text view",
+      "type": "text",
+      "layout": {
+        "row": "Row_1ie54my",
+        "columns": null
+      },
+      "id": "Field_08hxldt"
+    }
+  ],
+  "type": "default",
+  "id": "form_with_text_templating"
+}

--- a/qa/core-application-e2e-test-suite/resources/number_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/number_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1414ef84-eb93-47ca-9c7f-43f3356aa550">
+  <bpmn:process id="Number_Task" name="Number Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_02yuo0k</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_02yuo0k" sourceRef="StartEvent_1" targetRef="Activity_1mx5rn7" />
+    <bpmn:endEvent id="Event_0tu9rci">
+      <bpmn:incoming>Flow_0mcil84</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mcil84" sourceRef="Activity_1mx5rn7" targetRef="Event_0tu9rci" />
+    <bpmn:userTask id="Activity_1mx5rn7" name="UserTask_Number">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_number" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_02yuo0k</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mcil84</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Number_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tu9rci_di" bpmnElement="Event_0tu9rci">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11vynox_di" bpmnElement="Activity_1mx5rn7">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02yuo0k_di" bpmnElement="Flow_02yuo0k">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mcil84_di" bpmnElement="Flow_0mcil84">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/processWithDeployedForm.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/processWithDeployedForm.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="4f7b0418-9d14-48bd-b8fd-359ce3c0d6d5">
+  <bpmn:process id="processWithDeployedForm" name="processWithDeployedForm" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0prs3ev</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0prs3ev" sourceRef="StartEvent_1" targetRef="userTaskWithDeployedForm" />
+    <bpmn:endEvent id="Event_084jqvj">
+      <bpmn:incoming>Flow_0oscp1v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0oscp1v" sourceRef="userTaskWithDeployedForm" targetRef="Event_084jqvj" />
+    <bpmn:userTask id="userTaskWithDeployedForm" name="userTaskWithDeployedForm">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="Form_Invoice" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0prs3ev</bpmn:incoming>
+      <bpmn:outgoing>Flow_0oscp1v</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithDeployedForm">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_084jqvj_di" bpmnElement="Event_084jqvj">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j4a3k8_di" bpmnElement="userTaskWithDeployedForm">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0prs3ev_di" bpmnElement="Flow_0prs3ev">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0oscp1v_di" bpmnElement="Flow_0oscp1v">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/processWithStartNodeFormDeployed.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/processWithStartNodeFormDeployed.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7640587b-ab4b-4660-8e4e-4064a21c9626">
+  <bpmn:process id="processWithStartNodeFormDeployed" name="processWithStartNodeFormDeployed" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="Form_Invoice" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0d7gldh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0d7gldh" sourceRef="StartEvent_1" targetRef="processStartedByForm_user_task" />
+    <bpmn:endEvent id="Event_1cu4vf1">
+      <bpmn:incoming>Flow_1g7mhgj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1g7mhgj" sourceRef="processStartedByForm_user_task" targetRef="Event_1cu4vf1" />
+    <bpmn:userTask id="processStartedByForm_user_task" name="processStartedByForm_user_task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0d7gldh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g7mhgj</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithStartNodeFormDeployed">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cu4vf1_di" bpmnElement="Event_1cu4vf1">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14rkwl1_di" bpmnElement="processStartedByForm_user_task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0d7gldh_di" bpmnElement="Flow_0d7gldh">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g7mhgj_di" bpmnElement="Flow_1g7mhgj">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/radio_button_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/radio_button_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7aabe175-d57d-4dc4-ab75-3fc3690f4444">
+  <bpmn:process id="Radio_Button_User_Task" name="Radio Button Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0870r7r</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0870r7r" sourceRef="StartEvent_1" targetRef="Radio_Button_Task" />
+    <bpmn:endEvent id="Event_1qsnfvb">
+      <bpmn:incoming>Flow_1k9nx3a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1k9nx3a" sourceRef="Radio_Button_Task" targetRef="Event_1qsnfvb" />
+    <bpmn:userTask id="Radio_Button_Task" name="Radio Button Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_radio_button" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0870r7r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k9nx3a</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Radio_Button_User_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1qsnfvb_di" bpmnElement="Event_1qsnfvb">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qgy7o7_di" bpmnElement="Radio_Button_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0870r7r_di" bpmnElement="Flow_0870r7r">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k9nx3a_di" bpmnElement="Flow_1k9nx3a">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/select_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/select_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="03efdd37-e864-4497-afbe-c3512ef718f8">
+  <bpmn:process id="Select" name="Select User Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1lzycj0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1lzycj0" sourceRef="StartEvent_1" targetRef="Select_User_Task" />
+    <bpmn:endEvent id="Event_0rfk35h">
+      <bpmn:incoming>Flow_0l8hxqs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0l8hxqs" sourceRef="Select_User_Task" targetRef="Event_0rfk35h" />
+    <bpmn:userTask id="Select_User_Task" name="Select User Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_select" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1lzycj0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0l8hxqs</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Select">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rfk35h_di" bpmnElement="Event_0rfk35h">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x3thwx_di" bpmnElement="Select_User_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1lzycj0_di" bpmnElement="Flow_1lzycj0">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l8hxqs_di" bpmnElement="Flow_0l8hxqs">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/subscribeForm.form
+++ b/qa/core-application-e2e-test-suite/resources/subscribeForm.form
@@ -1,0 +1,35 @@
+{
+  "components": [
+    {
+      "text": "# Subscribe to newsletter",
+      "type": "text",
+      "layout": {
+        "row": "Row_0jjnqip",
+        "columns": null
+      },
+      "id": "Field_1xn41dw"
+    },
+    {
+      "label": "Name",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_15ghdy6",
+        "columns": null
+      },
+      "id": "Field_0ibsmz4",
+      "key": "field_1lfayry"
+    },
+    {
+      "label": "Email",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_1klibf9",
+        "columns": null
+      },
+      "id": "Field_0msuoi3",
+      "key": "field_1prtdvl"
+    }
+  ],
+  "type": "default",
+  "id": "subscribe"
+}

--- a/qa/core-application-e2e-test-suite/resources/subscribeFormProcess.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/subscribeFormProcess.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pg20dm" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="a3b2585" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="subscribeFormProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="subscribe" />
+        <zeebe:properties>
+          <zeebe:property name="publicAccess" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_15vkolf" sourceRef="StartEvent_1" targetRef="task" />
+    <bpmn:sequenceFlow id="Flow_1i3gdwk" sourceRef="task" targetRef="Event_07rdhb7" />
+    <bpmn:endEvent id="Event_07rdhb7">
+      <bpmn:incoming>Flow_1i3gdwk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="task" name="task">
+      <bpmn:incoming>Flow_15vkolf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1i3gdwk</bpmn:outgoing>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="subscribeFormProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07rdhb7_di" bpmnElement="Event_07rdhb7">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06qd63g_di" bpmnElement="task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_15vkolf_di" bpmnElement="Flow_15vkolf">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i3gdwk_di" bpmnElement="Flow_1i3gdwk">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/tag_list_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/tag_list_task_with_form.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="b5fdae33-fb32-4186-b333-96d041e25ba4">
+  <bpmn:process id="Tag_List_Task" name="Tag list Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0hr7qpq</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0hr7qpq" sourceRef="StartEvent_1" targetRef="Tag_List_User_Task" />
+    <bpmn:endEvent id="Event_129vtie">
+      <bpmn:incoming>Flow_1hd4bjx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1hd4bjx" sourceRef="Tag_List_User_Task" targetRef="Event_129vtie" />
+    <bpmn:userTask id="Tag_List_User_Task" name="Tag list Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_tag_list" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0hr7qpq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hd4bjx</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Tag_List_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_129vtie_di" bpmnElement="Event_129vtie">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yd6zje_di" bpmnElement="Tag_List_User_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0hr7qpq_di" bpmnElement="Flow_0hr7qpq">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hd4bjx_di" bpmnElement="Flow_1hd4bjx">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/text_templating_form_task.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/text_templating_form_task.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1203f19c-fa9d-4278-a420-53ad652d18ad">
+  <bpmn:process id="Text_Templating_Form_Task" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0qvpk5w</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0qvpk5w" sourceRef="StartEvent_1" targetRef="Activity_11z9iig" />
+    <bpmn:endEvent id="Event_196oxp1">
+      <bpmn:incoming>Flow_03mt2zd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_03mt2zd" sourceRef="Activity_11z9iig" targetRef="Event_196oxp1" />
+    <bpmn:userTask id="Activity_11z9iig" name="Text Templating Form Task">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="form_with_text_templating" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0qvpk5w</bpmn:incoming>
+      <bpmn:outgoing>Flow_03mt2zd</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Text_Templating_Form_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_196oxp1_di" bpmnElement="Event_196oxp1">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0i2jsg1_di" bpmnElement="Activity_11z9iig">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0qvpk5w_di" bpmnElement="Flow_0qvpk5w">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03mt2zd_di" bpmnElement="Flow_03mt2zd">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_process.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_process.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="a790e7ab-0639-412e-a17c-7823129f4511">
+  <bpmn:process id="User_Process" name="User_Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06a3ybp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_06a3ybp" sourceRef="StartEvent_1" targetRef="User_Task" />
+    <bpmn:endEvent id="End_Event">
+      <bpmn:incoming>Flow_1xn2vgi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xn2vgi" sourceRef="User_Task" targetRef="End_Event" />
+    <bpmn:userTask id="User_Task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06a3ybp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xn2vgi</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="User_Process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10qqfb6_di" bpmnElement="End_Event">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kuvhuk_di" bpmnElement="User_Task">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06a3ybp_di" bpmnElement="Flow_06a3ybp">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xn2vgi_di" bpmnElement="Flow_1xn2vgi">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_task_form.form
+++ b/qa/core-application-e2e-test-suite/resources/user_task_form.form
@@ -1,0 +1,32 @@
+{
+  "type": "default",
+  "id": "user_task_form",
+  "components": [
+    {
+      "key": "name",
+      "label": "Name",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "key": "address",
+      "label": "Address",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "key": "age",
+      "label": "Age",
+      "type": "textfield"
+    },
+    {
+      "key": "button1",
+      "label": "Save",
+      "type": "button"
+    }
+  ]
+}

--- a/qa/core-application-e2e-test-suite/resources/user_task_with_form.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_task_with_form.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fm2i7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="user_registration" name="User registration" isExecutable="true">
+    <bpmn:startEvent id="user_signed_up" name="User signed up">
+      <bpmn:outgoing>Flow_1l32p59</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1l32p59" sourceRef="user_signed_up" targetRef="register_new_user" />
+    <bpmn:endEvent id="user_registered" name="User registered">
+      <bpmn:incoming>Flow_1prqcqh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1prqcqh" sourceRef="register_new_user" targetRef="user_registered" />
+    <bpmn:userTask id="register_new_user" name="Register new user">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="user_task_form" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1l32p59</bpmn:incoming>
+      <bpmn:outgoing>Flow_1prqcqh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user_registration">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="user_signed_up">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="145" width="75" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10m6hs2_di" bpmnElement="user_registered">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="145" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1p9e693_di" bpmnElement="register_new_user">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l32p59_di" bpmnElement="Flow_1l32p59">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1prqcqh_di" bpmnElement="Flow_1prqcqh">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_task_with_form_and_vars.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_task_with_form_and_vars.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fm2i7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="user_registration_with_vars" name="User registration with vars" isExecutable="true">
+    <bpmn:startEvent id="user_signed_up" name="User signed up">
+      <bpmn:outgoing>Flow_1l32p59</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1l32p59" sourceRef="user_signed_up" targetRef="register_new_user" />
+    <bpmn:endEvent id="user_registered" name="User registered">
+      <bpmn:incoming>Flow_1prqcqh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1prqcqh" sourceRef="register_new_user" targetRef="user_registered" />
+    <bpmn:userTask id="register_new_user" name="Register new user with vars">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="user_task_form" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1l32p59</bpmn:incoming>
+      <bpmn:outgoing>Flow_1prqcqh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user_registration_with_vars">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="user_signed_up">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="145" width="75" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10m6hs2_di" bpmnElement="user_registered">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="145" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1p9e693_di" bpmnElement="register_new_user">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l32p59_di" bpmnElement="Flow_1l32p59">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1prqcqh_di" bpmnElement="Flow_1prqcqh">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_task_with_form_rerender_1.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_task_with_form_rerender_1.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fm2i7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="user_task_with_form_rerender_1" name="User Task with form rerender 1" isExecutable="true">
+    <bpmn:startEvent id="user_signed_up" name="User signed up">
+      <bpmn:outgoing>Flow_1l32p59</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1l32p59" sourceRef="user_signed_up" targetRef="register_new_user" />
+    <bpmn:endEvent id="user_registered" name="User registered">
+      <bpmn:incoming>Flow_1prqcqh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1prqcqh" sourceRef="register_new_user" targetRef="user_registered" />
+    <bpmn:userTask id="register_new_user" name="Register new user with vars">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="user_task_form" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1l32p59</bpmn:incoming>
+      <bpmn:outgoing>Flow_1prqcqh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user_task_with_form_rerender_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="user_signed_up">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="145" width="75" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10m6hs2_di" bpmnElement="user_registered">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="145" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1p9e693_di" bpmnElement="register_new_user">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l32p59_di" bpmnElement="Flow_1l32p59">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1prqcqh_di" bpmnElement="Flow_1prqcqh">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/user_task_with_form_rerender_2.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/user_task_with_form_rerender_2.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0fm2i7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="user_task_with_form_rerender_2" name="User Task with form rerender 2" isExecutable="true">
+    <bpmn:startEvent id="user_signed_up" name="User signed up">
+      <bpmn:outgoing>Flow_1l32p59</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1l32p59" sourceRef="user_signed_up" targetRef="register_new_user" />
+    <bpmn:endEvent id="user_registered" name="User registered">
+      <bpmn:incoming>Flow_1prqcqh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1prqcqh" sourceRef="register_new_user" targetRef="user_registered" />
+    <bpmn:userTask id="register_new_user" name="Register new user with vars">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="user_task_form" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1l32p59</bpmn:incoming>
+      <bpmn:outgoing>Flow_1prqcqh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="user_task_with_form_rerender_2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="user_signed_up">
+        <dc:Bounds x="172" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="145" width="75" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10m6hs2_di" bpmnElement="user_registered">
+        <dc:Bounds x="412" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="393" y="145" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1p9e693_di" bpmnElement="register_new_user">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l32p59_di" bpmnElement="Flow_1l32p59">
+        <di:waypoint x="208" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1prqcqh_di" bpmnElement="Flow_1prqcqh">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="412" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_1.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_1.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_for_scrolling_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c1" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c1" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c1" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_for_scrolling_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c1">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_2.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_2.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_for_scrolling_2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c2" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c2" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c2" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_for_scrolling_2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c2">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_3.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_for_scrolling_3.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_for_scrolling_3" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c3" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c3" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c3" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_for_scrolling_3">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c3">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_to_be_assigned.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_to_be_assigned.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_to_be_assigned" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c0" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c0" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c0" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_to_be_assigned">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c0">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_to_be_completed.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_to_be_completed.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_to_be_completed" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_to_be_completed">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_with_variables.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_with_variables.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_with_variables" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_variables">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/usertask_without_variables.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/usertask_without_variables.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_190h7pv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_without_variables" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c" name="Some user activity">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_without_variables">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/zeebe_and_job_worker_process.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/zeebe_and_job_worker_process.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1c9w32z" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="zeebe_and_job_worker_process" name="zeebe_and_job_worker_process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1bor05q</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1bor05q" sourceRef="StartEvent_1" targetRef="Gateway_0hvsk8o" />
+    <bpmn:sequenceFlow id="Flow_0ckqo0b" sourceRef="Gateway_0hvsk8o" targetRef="Activity_0zx4x3v" />
+    <bpmn:parallelGateway id="Gateway_0hvsk8o">
+      <bpmn:incoming>Flow_1bor05q</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ckqo0b</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1f8ry31</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1f8ry31" sourceRef="Gateway_0hvsk8o" targetRef="Activity_0nlwh84" />
+    <bpmn:sequenceFlow id="Flow_0qkoenr" sourceRef="Activity_0nlwh84" targetRef="Gateway_10xwox8" />
+    <bpmn:sequenceFlow id="Flow_1ubnid2" sourceRef="Activity_0zx4x3v" targetRef="Gateway_10xwox8" />
+    <bpmn:endEvent id="Event_1nyg8hg">
+      <bpmn:incoming>Flow_1cgwtk4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1cgwtk4" sourceRef="Gateway_10xwox8" targetRef="Event_1nyg8hg" />
+    <bpmn:parallelGateway id="Gateway_10xwox8">
+      <bpmn:incoming>Flow_0qkoenr</bpmn:incoming>
+      <bpmn:incoming>Flow_1ubnid2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cgwtk4</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="Activity_0zx4x3v" name="Zeebe_user_task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:assignmentDefinition assignee="demo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ckqo0b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ubnid2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Activity_0nlwh84" name="JobWorker_user_task">
+      <bpmn:incoming>Flow_1f8ry31</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qkoenr</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="zeebe_and_job_worker_process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1l42suk_di" bpmnElement="Gateway_0hvsk8o">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nyg8hg_di" bpmnElement="Event_1nyg8hg">
+        <dc:Bounds x="652" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jrzc0c_di" bpmnElement="Gateway_10xwox8">
+        <dc:Bounds x="535" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c0eu7r_di" bpmnElement="Activity_0zx4x3v">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c4q0bq_di" bpmnElement="Activity_0nlwh84">
+        <dc:Bounds x="370" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1bor05q_di" bpmnElement="Flow_1bor05q">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ckqo0b_di" bpmnElement="Flow_0ckqo0b">
+        <di:waypoint x="315" y="117" />
+        <di:waypoint x="370" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f8ry31_di" bpmnElement="Flow_1f8ry31">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="230" />
+        <di:waypoint x="370" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qkoenr_di" bpmnElement="Flow_0qkoenr">
+        <di:waypoint x="470" y="230" />
+        <di:waypoint x="560" y="230" />
+        <di:waypoint x="560" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ubnid2_di" bpmnElement="Flow_1ubnid2">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="535" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cgwtk4_di" bpmnElement="Flow_1cgwtk4">
+        <di:waypoint x="585" y="117" />
+        <di:waypoint x="652" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/user_process.bpmn',
+    './resources/processWithStartNodeFormDeployed.bpmn',
+    './resources/create_invoice.form',
+  ]);
+  await sleep(2000);
+});
+
+test.describe('process page', () => {
+  test.beforeEach(async ({page, taskListLoginPage, taskPanelPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await taskListLoginPage.login('demo', 'demo');
+    await expect(taskPanelPage.taskListPageBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('process page navigation', async ({
+    tasklistHeader,
+    page,
+    tasklistProcessesPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await expect(page.getByText('Start your process on demand')).toBeVisible();
+    await tasklistProcessesPage.cancelButton.click();
+    await expect(page.getByText('Welcome to Tasklist')).toBeVisible();
+
+    await tasklistHeader.clickProcessesTab();
+    await tasklistProcessesPage.continueButton.click();
+    await expect(page.getByText('Search processes')).toBeVisible();
+  });
+
+  test('process searching', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    await tasklistProcessesPage.searchForProcess('fake_process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeVisible();
+
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeHidden();
+
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1);
+    await expect(tasklistProcessesPage.processTile).toContainText(
+      'User_Process',
+    );
+  });
+
+  test('start process instance', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+    taskDetailsPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1);
+
+    await tasklistProcessesPage.startProcessButton.click();
+    await expect(page.getByText('Process has started')).toBeVisible();
+    await expect(tasklistProcessesPage.startProcessButton).toBeHidden();
+    await expect(page.getByText('Waiting for tasks...')).toBeVisible();
+    await expect(taskDetailsPage.assignToMeButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test('complete task started by process instance', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1);
+
+    await tasklistProcessesPage.startProcessButton.click();
+    await tasklistHeader.clickTasksTab();
+
+    await taskPanelPage.openTask('User_Task');
+
+    await taskDetailsPage.clickAssignToMeButton();
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(page.getByText('Task completed')).toBeVisible();
+  });
+
+  test('complete process with start node having deployed form', async ({
+    page,
+    tasklistHeader,
+    taskDetailsPage,
+    tasklistProcessesPage,
+    taskPanelPage,
+  }) => {
+    test.slow();
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    await tasklistProcessesPage.searchForProcess(
+      'processWithStartNodeFormDeployed',
+    );
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
+      timeout: 30000,
+    });
+
+    await tasklistProcessesPage.clickStartProcessButton(
+      'processWithStartNodeFormDeployed',
+    );
+    await taskDetailsPage.fillTextInput('Client Name*', 'Jon');
+    await taskDetailsPage.fillTextInput('Client Address*', 'Earth');
+    await taskDetailsPage.fillDatetimeField('Invoice Date', '1/1/3000');
+    await taskDetailsPage.fillDatetimeField('Due Date', '1/2/3000');
+    await taskDetailsPage.selectDropdownOption(
+      'USD - United States Dollar',
+      'EUR - Euro',
+    );
+    await taskDetailsPage.fillTextInput('Invoice Number*', '123');
+    await taskDetailsPage.addDynamicListRow();
+
+    await taskDetailsPage.fillDynamicList('Item Name*', 'Laptop');
+    await taskDetailsPage.fillDynamicList('Unit Price*', '1');
+    await taskDetailsPage.fillDynamicList('Quantity*', '2');
+
+    await expect(page.getByText('EUR 231')).toBeVisible();
+    await expect(page.getByText('EUR 264')).toBeVisible();
+    await expect(page.getByText('Total: EUR 544.5')).toBeVisible();
+    await tasklistProcessesPage.clickStartProcessSubButton();
+
+    await tasklistHeader.clickTasksTab();
+    await taskPanelPage.openTask('processStartedByForm_user_task');
+    await expect(
+      page.getByText('{"name":"jon","address":"earth"}'),
+    ).toBeVisible();
+    await expect(page.getByText('EUR')).toBeVisible();
+    await expect(page.getByText('3000-01-01')).toBeVisible();
+    await expect(page.getByText('3000-01-02')).toBeVisible();
+    await expect(page.getByText('123')).toBeVisible();
+    await expect(
+      page.getByText(
+        '[{"itemName":"laptop1","unitPrice":11,"quantity":21},{"itemName":"laptop2","unitPrice":12,"quantity":22}]',
+      ),
+    ).toBeVisible();
+    await taskDetailsPage.clickAssignToMeButton();
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+  });
+});

--- a/qa/core-application-e2e-test-suite/utils/waitForAssertion.ts
+++ b/qa/core-application-e2e-test-suite/utils/waitForAssertion.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+async function waitForAssertion(options: {
+  assertion: () => Promise<void>;
+  onFailure: () => Promise<void>;
+  maxRetries?: number;
+}) {
+  const {assertion, onFailure: fallback, maxRetries = 3} = options;
+  let retries = 1;
+
+  while (retries < maxRetries) {
+    try {
+      await assertion();
+      break;
+    } catch (error) {
+      if (retries === maxRetries) {
+        throw error;
+      }
+      console.log(
+        `Assertion failed, retrying (attempt ${retries}/${maxRetries})`,
+      );
+      await fallback();
+      retries++;
+    }
+  }
+}
+
+export {waitForAssertion};


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR mainly migrates `processPage.spec` to 8.7 core application test suite,  It also includes adding all resources that will be used for all test

🧪 Successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/15038293774)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to https://github.com/camunda/camunda/issues/30910

