### PR TITLE
refactor: relocate NoopSearchClientsProxy to search-client module

### DIFF
--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients;
 
+import io.camunda.search.clients.impl.NoopSearchClientsProxy;
 import io.camunda.security.auth.SecurityContext;
 
 public interface SearchClientsProxy
@@ -32,4 +33,12 @@ public interface SearchClientsProxy
 
   @Override
   SearchClientsProxy withSecurityContext(SecurityContext securityContext);
+
+  /**
+   * Creates a no-op search client proxy. For usage in test environments where search is not
+   * available.
+   */
+  static SearchClientsProxy noop() {
+    return new NoopSearchClientsProxy();
+  }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.search;
+package io.camunda.search.clients.impl;
 
 import static java.util.Collections.emptyList;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.perf;
 
-import io.camunda.search.clients.impl.NoopSearchClientsProxy;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -86,7 +86,7 @@ public final class TestEngine {
                             interPartitionCommandSender,
                             featureFlags,
                             JobStreamer.noop(),
-                            new NoopSearchClientsProxy())
+                            SearchClientsProxy.noop())
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.engine.perf;
 
+import io.camunda.search.clients.impl.NoopSearchClientsProxy;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
-import io.camunda.zeebe.engine.search.NoopSearchClientsProxy;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.util.ProcessingExporterTransistor;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.engine.processing.processinstance.migration.Migra
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+import io.camunda.search.clients.impl.NoopSearchClientsProxy;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCancelProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCreateProcessor;
@@ -46,7 +47,6 @@ import io.camunda.zeebe.engine.processing.tenant.TenantUpdateProcessor;
 import io.camunda.zeebe.engine.processing.user.UserCreateProcessor;
 import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
 import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
-import io.camunda.zeebe.engine.search.NoopSearchClientsProxy;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
 import io.camunda.zeebe.model.bpmn.Bpmn;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.engine.processing.processinstance.migration.Migra
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import io.camunda.search.clients.impl.NoopSearchClientsProxy;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCancelProcessor;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationCreateProcessor;
@@ -119,7 +119,7 @@ public class CommandDistributionIdempotencyTest {
   public static final EngineRule ENGINE =
       EngineRule.multiplePartition(2)
           .withEngineConfig(c -> c.setBatchOperationSchedulerInterval(Duration.ofDays(1)))
-          .withSearchClientsProxy(new NoopSearchClientsProxy());
+          .withSearchClientsProxy(SearchClientsProxy.noop());
 
   private static final Set<Class<?>> DISTRIBUTING_PROCESSORS =
       new HashSet<>(


### PR DESCRIPTION
## Description

It is useful to have a default noop implementation to use by dependants like zeebe-process-test, instead of having to adapt a local duplicated NoopClient to changes.

For context see
https://camunda.slack.com/archives/C05DH1F5TAR/p1742990662728819
and https://camunda.slack.com/archives/C089U9BSWEM/p1746769623789769

Needs follow-up on https://github.com/camunda/zeebe-process-test once merged to make use of the client impl.
