### PR TITLE
fix(renovate): remove redundant repositoryURL

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -300,6 +300,18 @@
       "addLabels": [
         "automerge"
       ]
+    },
+    {
+      "matchDatasources": [
+        "maven"
+      ],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2",
+        "https://artifacts.camunda.com/artifactory/zeebe-io/",
+        "https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/",
+        "https://artifacts.camunda.com/artifactory/camunda-identity/",
+        "https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/"
+      ]
     }
   ],
   "dockerfile": {

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ c8run/*.class
 
 /camunda.mv.db
 /camunda.trace.db
+
+renovate_cache/

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -100,7 +100,7 @@
       </snapshots>
       <id>central</id>
       <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
     </repository>
 

--- a/cmd/renovate/README.md
+++ b/cmd/renovate/README.md
@@ -1,0 +1,12 @@
+## Local Renovate Tests
+
+If you want to tweak the [renovate config](../../.github/renovate.json), it's a good idea to test this locally.
+You can make use of the script [renovate-local.sh](./renovate-local.sh) to do so.
+
+First, [create a Github PAT](https://github.com/settings/tokens/new) with repo scope and assign it to a variable:
+
+```shell
+GITHUB_TOKEN=<yourPAT>
+```
+
+After that you can just execute `./renovate-local.sh` and it will take the LOCAL `.github/renovate.json` config as source of truth and execute a full dry run.

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-LOCAL_RENOVATE_CONFIG="./.github/renovate.json"
+set -euo pipefail
+
+LOCAL_RENOVATE_CONFIG="../.././.github/renovate.json"
 REPO_NAME="camunda/camunda"
 LOCAL_CACHE_DIR="$(pwd)/renovate_cache"
 
 if [ ! -f "$LOCAL_RENOVATE_CONFIG" ]; then
-    echo "Error: Local Renovate global config file '$LOCAL_RENOVATE_CONFIG' not found."
+    echo "Error: Local Renovate config file '$LOCAL_RENOVATE_CONFIG' not found."
     exit 1
 fi
 mkdir -p "${LOCAL_CACHE_DIR}"
 
 echo "Processing repository: ${REPO_NAME}"
-echo "Using Renovate global configuration from: ${LOCAL_RENOVATE_CONFIG}"
+echo "Using Renovate configuration from: ${LOCAL_RENOVATE_CONFIG}"
 echo "Using local Renovate cache at: ${LOCAL_CACHE_DIR}"
 
 start_time=$(date +%s)
@@ -26,8 +28,8 @@ docker run --rm \
   -e RENOVATE_PLATFORM="github" \
   -e RENOVATE_TOKEN="${GITHUB_TOKEN}" \
   -e RENOVATE_REPOSITORIES="${REPO_NAME}" \
-  -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-global-config.json" \
-  -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-global-config.json:ro" \
+  -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-config.json" \
+  -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-config.json:ro" \
   -e RENOVATE_CACHE_DIR="/cache/renovate" \
   -v "${LOCAL_CACHE_DIR}:/cache/renovate" \
   \

--- a/renovate-local.sh
+++ b/renovate-local.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+LOCAL_RENOVATE_CONFIG="./.github/renovate.json"
+REPO_NAME="camunda/camunda"
+LOCAL_CACHE_DIR="$(pwd)/renovate_cache"
+
+if [ ! -f "$LOCAL_RENOVATE_CONFIG" ]; then
+    echo "Error: Local Renovate global config file '$LOCAL_RENOVATE_CONFIG' not found."
+    exit 1
+fi
+mkdir -p "${LOCAL_CACHE_DIR}"
+
+echo "Processing repository: ${REPO_NAME}"
+echo "Using Renovate global configuration from: ${LOCAL_RENOVATE_CONFIG}"
+echo "Using local Renovate cache at: ${LOCAL_CACHE_DIR}"
+
+start_time=$(date +%s)
+echo "Renovate run started at: $(date)"
+
+# run renovate
+docker run --rm \
+  -u "$(id -u):$(id -g)" \
+  -e LOG_LEVEL="debug" \
+  -e RENOVATE_DRY_RUN="full" \
+  -e RENOVATE_LOG_FORMAT="json" \
+  -e RENOVATE_PLATFORM="github" \
+  -e RENOVATE_TOKEN="${GITHUB_TOKEN}" \
+  -e RENOVATE_REPOSITORIES="${REPO_NAME}" \
+  -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-global-config.json" \
+  -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-global-config.json:ro" \
+  -e RENOVATE_CACHE_DIR="/cache/renovate" \
+  -v "${LOCAL_CACHE_DIR}:/cache/renovate" \
+  \
+  renovate/renovate | tee "/tmp/camunda_$(date +%Y%m%d_%H%M%S).txt"
+
+end_time=$(date +%s)
+echo "Renovate run finished at: $(date)"
+duration=$((end_time - start_time))
+echo "Total runtime: ${duration} seconds"
+minutes=$((duration / 60))
+seconds=$((duration % 60))
+echo "Total runtime: ${minutes} minutes and ${seconds} seconds"

--- a/tasklist/.idea/jarRepositories.xml
+++ b/tasklist/.idea/jarRepositories.xml
@@ -2,11 +2,6 @@
 <project version="4">
   <component name="RemoteRepositoriesConfiguration">
     <remote-repository>
-      <option name="id" value="central" />
-      <option name="name" value="Maven Central" />
-      <option name="url" value="https://repo1.maven.org/maven2" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="camunda-identity" />
       <option name="name" value="Camunda Identity Repository" />
       <option name="url" value="https://artifacts.camunda.com/artifactory/camunda-identity/" />
@@ -30,11 +25,6 @@
       <option name="id" value="camunda-bpm-nexus-ee" />
       <option name="name" value="Camunda Enterprise Maven Repository" />
       <option name="url" value="https://artifacts.camunda.com/artifactory/private/" />
-    </remote-repository>
-    <remote-repository>
-      <option name="id" value="central" />
-      <option name="name" value="Maven Central repository" />
-      <option name="url" value="https://repo1.maven.org/maven2" />
     </remote-repository>
     <remote-repository>
       <option name="id" value="jboss.community" />


### PR DESCRIPTION
## Description

### :zap:  Problem
According to @maxdanilov 's findings in how renovate assembles the repository list to be traversed, he figured out that renovate uses a RepositoryStrategy called "merge". 
This means renovate traverses ALL repositorURLs found in the repository's pom files, even if it already found matching artifact data in one of them. 

This is an implicit mechanism of renovate which can be overriden by providing an explicit `repositoryURLs` list in the packageRules of the renovate config.

### :dart:  Solution
As a first iteration and quickfix we only provide an explicit list of all repos being traversed at the moment with on tweak:
We removed a redundant entry `"https://repo1.maven.org/maven2"` (which is basically a duplicate of `"https://repo.maven.apache.org/maven2"`). This might already be enough to let renovate runs avoid hitting the current 30min job timeout (reduction of 6 to 5 repositories for x6 branches).

### :alembic:  Testing
To test if this change takes effect I also created a test script to execute a full dry-run of the changed config locally. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

- camunda/team-infrastructure#847
