### PR TITLE
Refactor: migrate task panel page tests to stable 8.6 core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy, createInstances} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+
+test.beforeAll(async ({resetData}) => {
+  await resetData();
+  await deploy([
+    './resources/usertask_to_be_assigned.bpmn',
+    './resources/usertask_for_scrolling_1.bpmn',
+    './resources/usertask_for_scrolling_2.bpmn',
+    './resources/usertask_for_scrolling_3.bpmn',
+  ]);
+  await sleep(100);
+
+  await createInstances('usertask_for_scrolling_3', 1, 1);
+  await createInstances('usertask_for_scrolling_2', 1, 50);
+  await createInstances('usertask_for_scrolling_2', 1, 50);
+  await createInstances('usertask_for_scrolling_2', 1, 50);
+  await createInstances('usertask_for_scrolling_2', 1, 50);
+  await createInstances('usertask_for_scrolling_1', 1, 1);
+  await createInstances('usertask_to_be_assigned', 1, 1); // this task will be seen on top since it is created last
+
+  await sleep(500);
+});
+
+test.describe('task panel page', () => {
+  test.beforeEach(async ({page, taskListLoginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await taskListLoginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('filter selection', async ({taskPanelPage}) => {
+    test.slow();
+    await expect(
+      taskPanelPage.availableTasks.getByText('Some user activity'),
+    ).toHaveCount(50);
+
+    await taskPanelPage.filterBy('Assigned to me');
+    await expect(taskPanelPage.availableTasks).toContainText('No tasks found');
+
+    await taskPanelPage.filterBy('All open tasks');
+    await expect(
+      taskPanelPage.availableTasks.getByText('Some user activity'),
+    ).toHaveCount(50);
+    await expect(
+      taskPanelPage.availableTasks.getByText('No tasks found'),
+    ).toHaveCount(0);
+  });
+
+  test('update task list according to user actions', async ({
+    page,
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('usertask_to_be_assigned');
+
+    await expect(taskDetailsPage.emptyTaskMessage).toBeVisible();
+    await taskDetailsPage.clickAssignToMeButton();
+    await expect(taskDetailsPage.unassignButton).toBeVisible();
+    await page.reload();
+
+    await expect(async () => {
+      await expect(
+        taskPanelPage.availableTasks.getByText('usertask_to_be_assigned'),
+      ).toHaveCount(0);
+    }).toPass({timeout: 5000});
+
+    await taskPanelPage.filterBy('Assigned to me');
+    await taskPanelPage.openTask('usertask_to_be_assigned');
+
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
+    await taskDetailsPage.clickCompleteTaskButton();
+
+    await expect(async () => {
+      await expect(taskPanelPage.availableTasks.getByText('user')).toHaveCount(
+        0,
+      );
+    }).toPass({timeout: 5000});
+
+    await taskPanelPage.filterBy('Completed');
+
+    await expect(async () => {
+      await expect(
+        taskPanelPage.availableTasks.getByText(/some text/),
+      ).not.toHaveCount(50);
+    }).toPass({timeout: 5000});
+  });
+
+  test('scrolling', async ({page, taskPanelPage}) => {
+    test.slow();
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+
+    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(99);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+
+    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(149);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+
+    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+
+    await taskPanelPage.scrollToLastTask('usertask_for_scrolling_2');
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(0);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(1);
+
+    await taskPanelPage.scrollToFirstTask('usertask_for_scrolling_2');
+
+    await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
+    await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(199);
+    await expect(page.getByText('usertask_for_scrolling_3')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR migrates `task-panel.spec` to `8.6` core application test suite 

🧪 successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/15039118968)
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
related to https://github.com/camunda/camunda/issues/30910