### PR TITLE
Remove outdated instructions from Operate Readme

### DIFF
--- a/operate/README.md
+++ b/operate/README.md
@@ -7,18 +7,6 @@
 
 ## Running locally
 
-### Use maven
-
-To run the application locally without docker you can use
-
-```
-make start-backend
-```
-
-This starts elasticsearch and zeebe docker containers, then installs operate locally and starts the server.
-You can shutdown the application with Control-C.
-At the first run it takes some time to resolve all dependencies.
-
 ### Use Camunda 8 with Elasticsearch docker container
 
 To run the application locally you can use `docker`, `docker-compose` and


### PR DESCRIPTION
## Description

The make target referenced in the README file does not exist anymore.
