### PR TITLE
feat: introduce onSuccess,onError callbacks implemented with onComplete

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -188,6 +189,8 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @param <U> the type of the new future
    */
   <U> ActorFuture<U> andThen(Function<V, ActorFuture<U>> next, Executor executor);
+
+  <U> ActorFuture<U> andThen(BiFunction<V, Throwable, ActorFuture<U>> next, Executor executor);
 
   /**
    * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -67,6 +68,68 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @param executor the executor on which the callback will be executed
    */
   void onComplete(BiConsumer<V, Throwable> consumer, Executor executor);
+
+  /**
+   * Runs a callback when the future terminates successfully If the caller is not * an actor, the
+   * consumer is executed in the actor which completes this future. If the caller is * not an actor,
+   * it is recommended to use {@link ActorFuture#onComplete(BiConsumer, Executor)} * instead.
+   *
+   * @param handler to run
+   */
+  default void onSuccess(final Consumer<V> handler) {
+    onComplete(
+        (v, error) -> {
+          if (error == null) {
+            handler.accept(v);
+          }
+        });
+  }
+
+  /**
+   * Runs a callback when the future terminates successfully
+   *
+   * @param handler to run
+   */
+  default void onSuccess(final Consumer<V> handler, final Executor executor) {
+    onComplete(
+        (v, error) -> {
+          if (error == null) {
+            handler.accept(v);
+          }
+        },
+        executor);
+  }
+
+  /**
+   * Runs a callback when the future terminates exceptionally If the caller is not * an actor, the
+   * consumer is executed in the actor which completes this future. If the caller is * not an actor,
+   * it is recommended to use {@link ActorFuture#onComplete(BiConsumer, Executor)} * instead.
+   *
+   * @param handler to run
+   */
+  default void onError(final Consumer<Throwable> handler) {
+    onComplete(
+        (v, error) -> {
+          if (error != null) {
+            handler.accept(error);
+          }
+        });
+  }
+
+  /**
+   * Runs a callback when the future terminates exceptionally
+   *
+   * @param handler to run when
+   */
+  default void onError(final Consumer<Throwable> handler, final Executor executor) {
+    onComplete(
+        (v, error) -> {
+          if (error != null) {
+            handler.accept(error);
+          }
+        },
+        executor);
+  }
 
   boolean isCompletedExceptionally();
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -71,9 +71,9 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
   void onComplete(BiConsumer<V, Throwable> consumer, Executor executor);
 
   /**
-   * Runs a callback when the future terminates successfully If the caller is not * an actor, the
-   * consumer is executed in the actor which completes this future. If the caller is * not an actor,
-   * it is recommended to use {@link ActorFuture#onComplete(BiConsumer, Executor)} * instead.
+   * Runs a callback when the future terminates successfully If the caller is not an actor, the
+   * consumer is executed in the actor which completes this future. If the caller is not an actor,
+   * it is recommended to use {@link ActorFuture#onSuccess(Consumer, Executor)} instead.
    *
    * @param handler to run
    */
@@ -102,9 +102,9 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
   }
 
   /**
-   * Runs a callback when the future terminates exceptionally If the caller is not * an actor, the
-   * consumer is executed in the actor which completes this future. If the caller is * not an actor,
-   * it is recommended to use {@link ActorFuture#onComplete(BiConsumer, Executor)} * instead.
+   * Runs a callback when the future terminates exceptionally If the caller is not an actor, the
+   * consumer is executed in the actor which completes this future. If the caller is not an actor,
+   * it is recommended to use {@link ActorFuture#onError(Consumer, Executor)} instead.
    *
    * @param handler to run
    */
@@ -190,6 +190,18 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    */
   <U> ActorFuture<U> andThen(Function<V, ActorFuture<U>> next, Executor executor);
 
+  /**
+   * Similar to {@link ActorFuture#andThen(Function, Executor)}}, but it allows to return a future
+   * even if this future completes exceptionally.
+   *
+   * @param next the function to apply to the result of this future.
+   * @param executor the executor used to handle completion callbacks.
+   * @return a new future that completes with the result of applying the function to the result of
+   *     this future. The function is run even if this future completes exceptionally. This future
+   *     can be used for further chaining, compared to the {@link
+   *     ActorFuture#onComplete(BiConsumer)} method.
+   * @param <U> the type of the new future
+   */
   <U> ActorFuture<U> andThen(BiFunction<V, Throwable, ActorFuture<U>> next, Executor executor);
 
   /**

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
@@ -290,23 +291,25 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
   @Override
   public <U> ActorFuture<U> andThen(
       final Function<V, ActorFuture<U>> next, final Executor executor) {
+    return andThen(
+        (v, err) -> {
+          if (err != null) {
+            return CompletableActorFuture.completedExceptionally(err);
+          } else {
+            return next.apply(v);
+          }
+        },
+        executor);
+  }
+
+  @Override
+  public <U> ActorFuture<U> andThen(
+      final BiFunction<V, Throwable, ActorFuture<U>> next, final Executor executor) {
     final ActorFuture<U> nextFuture = new CompletableActorFuture<>();
     onComplete(
         (thisResult, thisError) -> {
-          if (thisError != null) {
-            nextFuture.completeExceptionally(thisError);
-          } else {
-            next.apply(thisResult)
-                .onComplete(
-                    (nextResult, nextError) -> {
-                      if (nextError != null) {
-                        nextFuture.completeExceptionally(nextError);
-                      } else {
-                        nextFuture.complete(nextResult);
-                      }
-                    },
-                    executor);
-          }
+          final var future = next.apply(thisResult, thisError);
+          future.onComplete(nextFuture, executor);
         },
         executor);
     return nextFuture;

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -532,6 +532,7 @@ final class ActorFutureTest {
     final AtomicInteger callbackInvocations = new AtomicInteger(0);
 
     future.onComplete((r, t) -> callbackInvocations.incrementAndGet());
+    future.onSuccess((r) -> callbackInvocations.incrementAndGet());
 
     final Actor completingActor =
         new Actor() {
@@ -546,7 +547,7 @@ final class ActorFutureTest {
     schedulerRule.workUntilDone();
 
     // then
-    assertThat(callbackInvocations).hasValue(1);
+    assertThat(callbackInvocations).hasValue(2);
   }
 
   @Test
@@ -563,6 +564,7 @@ final class ActorFutureTest {
         };
 
     future.onComplete((r, t) -> callbackInvocations.incrementAndGet(), decoratedExecutor);
+    future.onSuccess((r) -> callbackInvocations.incrementAndGet(), decoratedExecutor);
 
     final Actor completingActor =
         new Actor() {
@@ -577,8 +579,8 @@ final class ActorFutureTest {
     schedulerRule.workUntilDone();
 
     // then
-    assertThat(callbackInvocations).hasValue(1);
-    assertThat(executorCount).hasValue(1);
+    assertThat(callbackInvocations).hasValue(2);
+    assertThat(executorCount).hasValue(2);
   }
 
   @Test
@@ -586,8 +588,10 @@ final class ActorFutureTest {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> callBackError = new AtomicReference<>();
+    final AtomicReference<Throwable> callBackErrorOnError = new AtomicReference<>();
 
     future.onComplete((r, t) -> callBackError.set(t));
+    future.onError(callBackErrorOnError::set);
 
     final Actor completingActor =
         new Actor() {
@@ -603,6 +607,9 @@ final class ActorFutureTest {
 
     // then
     assertThat(callBackError.get())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Expected");
+    assertThat(callBackErrorOnError.get())
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Expected");
   }
@@ -612,6 +619,7 @@ final class ActorFutureTest {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> callBackError = new AtomicReference<>();
+    final AtomicReference<Throwable> callBackErrorOnError = new AtomicReference<>();
 
     final AtomicInteger executorCount = new AtomicInteger(0);
     final Executor decoratedExecutor =
@@ -621,6 +629,7 @@ final class ActorFutureTest {
         };
 
     future.onComplete((r, t) -> callBackError.set(t), decoratedExecutor);
+    future.onError(callBackErrorOnError::set, decoratedExecutor);
 
     final Actor completingActor =
         new Actor() {
@@ -638,7 +647,10 @@ final class ActorFutureTest {
     assertThat(callBackError.get())
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Expected");
-    assertThat(executorCount).hasValue(1);
+    assertThat(callBackErrorOnError.get())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Expected");
+    assertThat(executorCount).hasValue(2);
   }
 
   @Test
@@ -646,6 +658,7 @@ final class ActorFutureTest {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
     final AtomicInteger futureResult = new AtomicInteger();
+    final AtomicInteger futureResultOnSuccess = new AtomicInteger();
 
     final Actor completingActor =
         new Actor() {
@@ -667,10 +680,12 @@ final class ActorFutureTest {
         };
 
     future.onComplete((r, t) -> futureResult.set(r), decoratedExecutor);
+    future.onSuccess(futureResultOnSuccess::set, decoratedExecutor);
 
     // then
     assertThat(futureResult.get()).isOne();
-    assertThat(executorCount).hasValue(1);
+    assertThat(futureResultOnSuccess.get()).isOne();
+    assertThat(executorCount).hasValue(2);
   }
 
   @Test
@@ -678,6 +693,7 @@ final class ActorFutureTest {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> futureResult = new AtomicReference<>();
+    final AtomicReference<Throwable> futureResultOnError = new AtomicReference<>();
 
     final Actor completingActor =
         new Actor() {
@@ -700,12 +716,16 @@ final class ActorFutureTest {
         };
 
     future.onComplete((r, t) -> futureResult.set(t), decoratedExecutor);
+    future.onError(futureResultOnError::set, decoratedExecutor);
 
     // then
     assertThat(futureResult.get())
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Expected");
-    assertThat(executorCount).hasValue(1);
+    assertThat(futureResultOnError.get())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Expected");
+    assertThat(executorCount).hasValue(2);
   }
 
   @Test


### PR DESCRIPTION
## Description
Based on `onComplete` callback, it's been added:
-  `onSuccess`
-  `onError` 
callbacks that are useful when only one of the outcomes should be handled (especially error handling).
To allow for more functional-style chaining of futures a overload of `andThen` that can handle a Throwable is added. Similar to `onComplete`, but returns a future.


