### PR TITLE
feat: added CSRF enforcement

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -20,6 +20,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.session</groupId>
       <artifactId>spring-session-core</artifactId>
     </dependency>
@@ -38,6 +43,14 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -165,11 +178,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -8,14 +8,11 @@
 package io.camunda.authentication.csrf;
 
 import io.camunda.authentication.config.WebSecurityConfig;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -72,26 +69,11 @@ public class CsrfProtectionRequestMatcher implements RequestMatcher {
       return false;
     }
 
-    // we don't need CSRF protection if authorized with Authorization header
-    if (authZHeaderPresent(request)) {
-      return false;
-    }
-
     return apiCallComingFromBrowser(request);
   }
 
   private boolean apiCallComingFromBrowser(final HttpServletRequest request) {
-    return Optional.ofNullable(request.getCookies())
-        .map(Arrays::stream)
-        .orElse(Arrays.stream(new Cookie[] {}))
-        .anyMatch(cookie -> WebSecurityConfig.SESSION_COOKIE.equals(cookie.getName()));
-  }
-
-  private boolean authZHeaderPresent(final HttpServletRequest request) {
-    // If is authenticated from as API user using Bearer token or Basic auth
-    final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-    return authorizationHeader != null
-        && (authorizationHeader.startsWith("Bearer ") || authorizationHeader.startsWith("Basic "));
+    return request.getSession(false) != null;
   }
 
   private Pattern allowedPathsToPattern(final Set<String> paths) {

--- a/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
+++ b/authentication/src/main/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcher.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.csrf;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+public class CsrfProtectionRequestMatcher implements RequestMatcher {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CsrfProtectionRequestMatcher.class);
+
+  // CSRF-safe methods
+  private static final Pattern ALLOWED_METHODS = Pattern.compile("^(GET|HEAD|TRACE|OPTIONS)$");
+
+  private final Pattern allowedPathsPattern;
+
+  public CsrfProtectionRequestMatcher() {
+    final Set<String> allowedPaths = new HashSet<>();
+    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_PATHS);
+    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_API_PATHS);
+    allowedPaths.add(WebSecurityConfig.LOGIN_URL);
+    allowedPaths.add(WebSecurityConfig.LOGOUT_URL);
+    allowedPathsPattern = allowedPathsToPattern(allowedPaths);
+    LOG.info("CSRF protection configuration - allowed paths pattern: {}", allowedPathsPattern);
+  }
+
+  @Override
+  public boolean matches(final HttpServletRequest request) {
+    // These methods are CSRF-safe
+    if (ALLOWED_METHODS.matcher(request.getMethod()).matches()) {
+      return false;
+    }
+
+    if (allowedPathsPattern.matcher(request.getServletPath()).matches()) {
+      return false;
+    }
+
+    // If request coming from Swagger UI
+    final String referer = request.getHeader(HttpHeaders.REFERER);
+    final String baseRequestUrl;
+    try {
+      final URL requestUrl = URI.create(request.getRequestURL().toString()).toURL();
+      baseRequestUrl =
+          requestUrl.getProtocol()
+              + "://"
+              + requestUrl.getHost()
+              + (requestUrl.getPort() > 0 ? ":" + requestUrl.getPort() : "");
+    } catch (final MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (referer != null && referer.matches(baseRequestUrl + "/swagger-ui.*")) {
+      return false;
+    }
+
+    // we don't need CSRF protection if authorized with Authorization header
+    if (authZHeaderPresent(request)) {
+      return false;
+    }
+
+    return apiCallComingFromBrowser(request);
+  }
+
+  private boolean apiCallComingFromBrowser(final HttpServletRequest request) {
+    return Optional.ofNullable(request.getCookies())
+        .map(Arrays::stream)
+        .orElse(Arrays.stream(new Cookie[] {}))
+        .anyMatch(cookie -> WebSecurityConfig.SESSION_COOKIE.equals(cookie.getName()));
+  }
+
+  private boolean authZHeaderPresent(final HttpServletRequest request) {
+    // If is authenticated from as API user using Bearer token or Basic auth
+    final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    return authorizationHeader != null
+        && (authorizationHeader.startsWith("Bearer ") || authorizationHeader.startsWith("Basic "));
+  }
+
+  private Pattern allowedPathsToPattern(final Set<String> paths) {
+    final String patternAsString =
+        paths.stream()
+            .map(path -> path.replace("**", ".*")) // Replace wildcard with regex equivalent
+            .collect(Collectors.joining("|", "^(", ")$")); // Combine paths into regex
+    return Pattern.compile(patternAsString);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/AbstractWebSecurityConfigTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
@@ -102,5 +103,14 @@ public class AbstractWebSecurityConfigTest {
                 PERMISSIONS_POLICY,
                 List.of(PermissionsPolicyConfig.DEFAULT_PERMISSIONS_POLICY_VALUE)))
         .doesNotContainKeys(CONTENT_SECURITY_POLICY_REPORT_ONLY);
+  }
+
+  protected void assertMissingCsrfToken(final MvcTestResult response) {
+    assertThat(response)
+        .hasStatus(HttpStatus.UNAUTHORIZED)
+        .bodyJson()
+        .extractingPath("detail")
+        .isEqualTo(
+            "Could not verify the provided CSRF token because no token was found to compare.");
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthCsrfFilteringDisabledTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthCsrfFilteringDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityConfig.class,
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=basic",
+      "camunda.security.csrf.enabled=false"
+    })
+public class BasicAuthCsrfFilteringDisabledTest extends AbstractWebSecurityConfigTest {
+
+  @Test
+  public void shouldNotRequireCsrfTokenWithSessionAuthentication() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigTest.java
@@ -8,14 +8,19 @@
 package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
+import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 @SpringBootTest(
@@ -40,6 +45,61 @@ public class BasicAuthWebSecurityConfigTest extends AbstractWebSecurityConfigTes
     // then
     assertThat(testResult).hasStatusOk();
     assertDefaultSecurityHeaders(testResult);
+  }
+
+  @Test
+  public void shouldRequireCsrfTokenWithSessionAuthentication() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertMissingCsrfToken(result);
+  }
+
+  @Test
+  public void shouldNotRequireCsrfTokenWithGetEndpoint() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
+  }
+
+  @Test
+  public void shouldSucceedWithCsrfTokenAndSessionAuthentication() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .with(csrf())
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
   }
 
   protected static HttpHeaders basicAuthDemo() {

--- a/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
@@ -8,11 +8,16 @@
 package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
+import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 @SpringBootTest(
@@ -31,5 +36,60 @@ public class UnprotectedWebSecurityConfigTest extends AbstractWebSecurityConfigT
     // then
     assertThat(testResult).hasStatusOk();
     assertDefaultSecurityHeaders(testResult);
+  }
+
+  @Test
+  public void shouldRequireCsrfTokenWithSessionAuthentication() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertMissingCsrfToken(result);
+  }
+
+  @Test
+  public void shouldNotRequireCsrfTokenWithGetEndpoint() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
+  }
+
+  @Test
+  public void shouldSucceedWithCsrfTokenAndSessionAuthentication() {
+    // given
+    final MockHttpSession mockHttpSession = new MockHttpSession();
+
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .session(mockHttpSession)
+            .with(user("demo"))
+            .with(csrf())
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -8,12 +8,14 @@
 package io.camunda.authentication.config.controllers;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 public class TestApiController {
 
+  public static final String DEFAULT_RESPONSE = "I am dummy endpoint";
   public static final String DUMMY_OPERATE_INTERNAL_API_ENDPOINT = "/api/foo";
   public static final String DUMMY_V1_API_ENDPOINT = "/v1/foo";
   public static final String DUMMY_V2_API_ENDPOINT = "/v2/foo";
@@ -22,26 +24,31 @@ public class TestApiController {
 
   @RequestMapping(DUMMY_OPERATE_INTERNAL_API_ENDPOINT)
   public @ResponseBody String dummyOperateInternalApiEndpoint() {
-    return "I am dummy endpoint";
+    return DEFAULT_RESPONSE;
   }
 
   @RequestMapping(DUMMY_V1_API_ENDPOINT)
   public @ResponseBody String dummyV1ApiEndpoint() {
-    return "I am dummy endpoint";
+    return DEFAULT_RESPONSE;
   }
 
   @RequestMapping(DUMMY_V2_API_ENDPOINT)
   public @ResponseBody String dummyV2ApiEndpoint() {
-    return "I am dummy endpoint";
+    return DEFAULT_RESPONSE;
   }
 
   @RequestMapping(DUMMY_WEBAPP_ENDPOINT)
   public @ResponseBody String dummyWebappEndpoint() {
-    return "I am dummy endpoint";
+    return DEFAULT_RESPONSE;
   }
 
   @RequestMapping(DUMMY_UNPROTECTED_ENDPOINT)
   public @ResponseBody String dummyUnprotectedEndpoint() {
-    return "I am dummy endpoint";
+    return DEFAULT_RESPONSE;
+  }
+
+  @PostMapping(DUMMY_V2_API_ENDPOINT)
+  public @ResponseBody String dummyV2ApiPostEndpoint() {
+    return DEFAULT_RESPONSE;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.security.configuration.AuthenticationConfiguration;
-import jakarta.servlet.http.Cookie;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -49,7 +48,7 @@ class CsrfProtectionRequestMatcherTest {
   @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
   void whenUnprotectedApiIsOffAndApiCalledFromBrowser(final String method) {
     final var request = prepareMockRequest();
-    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.getSession(true);
     request.setMethod(method);
     assertTrue(matcher.matches(request));
   }
@@ -75,7 +74,7 @@ class CsrfProtectionRequestMatcherTest {
     authConfig.setUnprotectedApi(true);
     final var unprotectedApiMatcher = new CsrfProtectionRequestMatcher();
     final var request = prepareMockRequest();
-    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.getSession(true);
     request.setServletPath(protectedUrls);
     assertTrue(unprotectedApiMatcher.matches(request));
   }
@@ -98,7 +97,7 @@ class CsrfProtectionRequestMatcherTest {
   void swaggerReferrerDoesNotMatchForCsrf() {
     final var request = prepareMockRequest();
     request.addHeader(REFERER, "http://localhost/swagger-ui/index.html");
-    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.getSession(true);
     assertFalse(matcher.matches(request));
   }
 
@@ -106,7 +105,7 @@ class CsrfProtectionRequestMatcherTest {
   void arbitraryReferrerMatchesForCsrf() {
     final var request = prepareMockRequest();
     request.addHeader(REFERER, "http://localhost/fake-swagger/index.html");
-    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.getSession(true);
     assertTrue(matcher.matches(request));
   }
 
@@ -136,7 +135,7 @@ class CsrfProtectionRequestMatcherTest {
   @MethodSource("protectedPaths")
   void protectedPathsMatchForCsrfFromBrowser(final String path) {
     final var request = prepareMockRequest();
-    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.getSession(true);
     request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
     assertTrue(matcher.matches(request));
   }

--- a/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/csrf/CsrfProtectionRequestMatcherTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.csrf;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.REFERER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import jakarta.servlet.http.Cookie;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class CsrfProtectionRequestMatcherTest {
+
+  private CsrfProtectionRequestMatcher matcher;
+
+  @BeforeEach
+  void beforeEach() {
+    final var authConfig = new AuthenticationConfiguration();
+    authConfig.setUnprotectedApi(false);
+    matcher = new CsrfProtectionRequestMatcher();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"GET", "HEAD", "TRACE", "OPTIONS"})
+  void safeMethodsDoNotMatchForCsrf(final String method) {
+    final var request = prepareMockRequest();
+    request.setMethod(method);
+    assertFalse(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
+  void whenUnprotectedApiIsOffAndApiCalledFromBrowser(final String method) {
+    final var request = prepareMockRequest();
+    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.setMethod(method);
+    assertTrue(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
+  void whenUnprotectedApiIsOffAndApiCalledFromNonBrowser(final String method) {
+    final var request = prepareMockRequest();
+    request.setMethod(method);
+    assertFalse(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/v2/operate/processes",
+        "/v2/process-instances/search",
+        "/v1/flownode-instances/search",
+        "/api/process-instances/123/sequence-flows"
+      })
+  void whenUnprotectedApiIsOnAndApiCalledFromBrowser(final String protectedUrls) {
+    final var authConfig = new AuthenticationConfiguration();
+    authConfig.setUnprotectedApi(true);
+    final var unprotectedApiMatcher = new CsrfProtectionRequestMatcher();
+    final var request = prepareMockRequest();
+    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.setServletPath(protectedUrls);
+    assertTrue(unprotectedApiMatcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/v2/operate/processes",
+        "/v2/process-instances/search",
+        "/v1/flownode-instances/search",
+        "/api/process-instances/123/sequence-flows"
+      })
+  void whenUnprotectedApiIsOnAndApiCalledFromNonBrowser(final String protectedUrls) {
+    final var request = prepareMockRequest();
+    request.setServletPath(protectedUrls);
+    assertFalse(matcher.matches(request));
+  }
+
+  @Test
+  void swaggerReferrerDoesNotMatchForCsrf() {
+    final var request = prepareMockRequest();
+    request.addHeader(REFERER, "http://localhost/swagger-ui/index.html");
+    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    assertFalse(matcher.matches(request));
+  }
+
+  @Test
+  void arbitraryReferrerMatchesForCsrf() {
+    final var request = prepareMockRequest();
+    request.addHeader(REFERER, "http://localhost/fake-swagger/index.html");
+    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    assertTrue(matcher.matches(request));
+  }
+
+  @Test
+  void bearerAuthorizedDoesNotMatchForCsrf() {
+    final var request = prepareMockRequest();
+    request.addHeader(AUTHORIZATION, "Bearer some-token");
+    assertFalse(matcher.matches(request));
+  }
+
+  @Test
+  void basicAuthorizedDoesNotMatchForCsrf() {
+    final var request = prepareMockRequest();
+    request.addHeader(AUTHORIZATION, "Basic some-creds");
+    assertFalse(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @MethodSource("unprotectedPaths")
+  void unprotectedPathsDoNotMatchForCsrf(final String path) {
+    final var request = prepareMockRequest();
+    request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
+    assertFalse(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @MethodSource("protectedPaths")
+  void protectedPathsMatchForCsrfFromBrowser(final String path) {
+    final var request = prepareMockRequest();
+    request.setCookies(new Cookie(WebSecurityConfig.SESSION_COOKIE, "ABCDEF"));
+    request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
+    assertTrue(matcher.matches(request));
+  }
+
+  @ParameterizedTest
+  @MethodSource("protectedPaths")
+  void protectedPathsDontMatchForCsrfFromBrowser(final String path) {
+    final var request = prepareMockRequest();
+    request.setServletPath(path.replace("**", "/some/path").replace("*", "/some-path"));
+    assertFalse(matcher.matches(request));
+  }
+
+  private static Stream<Arguments> unprotectedPaths() {
+    final Set<String> allowedPaths = new HashSet<>();
+    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_PATHS);
+    allowedPaths.addAll(WebSecurityConfig.UNPROTECTED_API_PATHS);
+    allowedPaths.add(WebSecurityConfig.LOGIN_URL);
+    allowedPaths.add(WebSecurityConfig.LOGOUT_URL);
+    return Stream.of(allowedPaths.stream().map(Arguments::of).toArray(Arguments[]::new));
+  }
+
+  private static Stream<Arguments> protectedPaths() {
+    final Set<String> protectedPaths = new HashSet<>(WebSecurityConfig.API_PATHS);
+    return Stream.of(protectedPaths.stream().map(Arguments::of).toArray(Arguments[]::new));
+  }
+
+  private MockHttpServletRequest prepareMockRequest() {
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("POST"); // POST by default will apply CSRF
+    request.setServletPath("/v2/operate/processes");
+    return request;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/csrf/CsrfTokenIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.csrf;
+
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_PASSWORD;
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.configuration.CsrfConfiguration;
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class CsrfTokenIT {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA_APPLICATION =
+      new TestCamundaApplication()
+          .withAuthenticatedAccess()
+          .withSecurityConfig(
+              sc -> {
+                final var csrfConfig = new CsrfConfiguration();
+                csrfConfig.setEnabled(true);
+                sc.setCsrf(csrfConfig);
+              })
+          .withAdditionalProfile("consolidated-auth");
+
+  // Test endpoints
+  private static final List<String> PROTECTED_ENDPOINTS =
+      List.of("api/processes/grouped", "v2/process-instances/search", "v1/tasks/search");
+
+  @Test
+  public void visitProtectedEndpointSuccessfulWhenCsrfTokenPresent()
+      throws URISyntaxException, IOException, InterruptedException {
+
+    final var testContext = setupTestContext();
+
+    // Test all protected endpoints with CSRF token
+    for (final String endpoint : PROTECTED_ENDPOINTS) {
+      final var response = sendRequestWithCsrfToken(testContext, endpoint);
+      assertThat(response.statusCode())
+          .as("Endpoint %s should return OK when CSRF token is present", endpoint)
+          .isEqualTo(HttpStatus.OK.value());
+    }
+  }
+
+  @Test
+  public void visitProtectedEndpointSuccessfulWhenBasicAuthWithoutCsrfToken()
+      throws URISyntaxException, IOException, InterruptedException {
+
+    final var testContext = setupTestContext();
+
+    // Test all protected endpoints with CSRF token
+    for (final String endpoint : PROTECTED_ENDPOINTS) {
+      final var response = sendRequestWithoutCsrfTokenWithBasicAuth(testContext, endpoint);
+      assertThat(response.statusCode())
+          .as("Endpoint %s should return OK when CSRF token is present", endpoint)
+          .isEqualTo(HttpStatus.OK.value());
+    }
+  }
+
+  @Test
+  public void visitProtectedEndpointNotAuthorizedWhenCsrfTokenAbsent()
+      throws URISyntaxException, IOException, InterruptedException {
+
+    final var testContext = setupTestContext();
+
+    // Test all protected endpoints without CSRF token
+    for (final String endpoint : PROTECTED_ENDPOINTS) {
+      final var response = sendRequestWithoutCsrfToken(testContext, endpoint);
+      assertThat(response.statusCode())
+          .as("Endpoint %s should return UNAUTHORIZED when CSRF token is absent", endpoint)
+          .isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+  }
+
+  private TestContext setupTestContext()
+      throws URISyntaxException, IOException, InterruptedException {
+
+    final var operateClient = CAMUNDA_APPLICATION.newOperateClient();
+    final var uri = operateClient.getEndpoint();
+    final var cookieHandler = new CookieManager();
+    final var httpClient = HttpClient.newBuilder().cookieHandler(cookieHandler).build();
+
+    final var csrfToken = loginWithCamundaService(httpClient, uri);
+    final var cookies = extractCookies(cookieHandler);
+
+    return new TestContext(uri, csrfToken, cookies.sessionCookie, cookies.csrfCookie);
+  }
+
+  private CookieContext extractCookies(final CookieManager cookieHandler) {
+    final var cookies = cookieHandler.getCookieStore().getCookies();
+
+    assertThat(cookies.stream().map(HttpCookie::getName))
+        .hasSize(2)
+        .contains(WebSecurityConfig.X_CSRF_TOKEN, WebSecurityConfig.SESSION_COOKIE);
+
+    final var sessionCookie = findCookie(cookies, WebSecurityConfig.SESSION_COOKIE);
+    final var csrfCookie = findCookie(cookies, WebSecurityConfig.X_CSRF_TOKEN);
+
+    return new CookieContext(sessionCookie, csrfCookie);
+  }
+
+  private HttpCookie findCookie(final List<HttpCookie> cookies, final String cookieName) {
+    return cookies.stream()
+        .filter(c -> cookieName.equals(c.getName()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Cookie not found: " + cookieName));
+  }
+
+  private HttpResponse<String> sendRequestWithCsrfToken(
+      final TestContext context, final String endpoint)
+      throws URISyntaxException, IOException, InterruptedException {
+    return sendRequest(context, endpoint, true, false);
+  }
+
+  private HttpResponse<String> sendRequestWithoutCsrfToken(
+      final TestContext context, final String endpoint)
+      throws URISyntaxException, IOException, InterruptedException {
+    return sendRequest(context, endpoint, false, false);
+  }
+
+  private HttpResponse<String> sendRequestWithoutCsrfTokenWithBasicAuth(
+      final TestContext context, final String endpoint)
+      throws URISyntaxException, IOException, InterruptedException {
+    return sendRequest(context, endpoint, false, true);
+  }
+
+  private HttpResponse<String> sendRequest(
+      final TestContext context,
+      final String endpoint,
+      final boolean includeCsrfToken,
+      final boolean useBasicAuth)
+      throws URISyntaxException, IOException, InterruptedException {
+
+    final var httpClient = HttpClient.newBuilder().build();
+    final var requestBuilder =
+        HttpRequest.newBuilder()
+            .uri(new URI(context.uri + endpoint))
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .POST(BodyPublishers.ofString("{}"));
+
+    if (useBasicAuth) {
+      requestBuilder.header(
+          HttpHeaders.AUTHORIZATION,
+          "Basic "
+              + Base64.getEncoder()
+                  .encodeToString(
+                      (DEFAULT_USER_USERNAME + ":" + DEFAULT_USER_PASSWORD).getBytes()));
+    } else {
+      requestBuilder.header(HttpHeaders.COOKIE, context.sessionCookie.toString());
+    }
+
+    if (includeCsrfToken) {
+      requestBuilder.header(WebSecurityConfig.X_CSRF_TOKEN, context.csrfToken);
+      requestBuilder.header(HttpHeaders.COOKIE, context.csrfCookie.toString());
+    }
+
+    return httpClient.send(requestBuilder.build(), BodyHandlers.ofString());
+  }
+
+  private String loginWithCamundaService(final HttpClient httpClient, final URI uri)
+      throws IOException, InterruptedException, URISyntaxException {
+
+    final var authRequest =
+        HttpRequest.newBuilder()
+            .uri(new URI(uri.toString() + "login"))
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED.toString())
+            .POST(
+                HttpRequest.BodyPublishers.ofString(
+                    "username=" + DEFAULT_USER_USERNAME + "&password=" + DEFAULT_USER_PASSWORD))
+            .build();
+
+    // Test public API
+    final var response = httpClient.send(authRequest, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+    final var rootServletRequest =
+        httpClient.send(
+            HttpRequest.newBuilder().uri(new URI(uri.toString())).GET().build(),
+            BodyHandlers.ofString());
+
+    return rootServletRequest.headers().firstValue(WebSecurityConfig.X_CSRF_TOKEN).orElse(null);
+  }
+
+  // Helper classes to organize test data
+  private static class TestContext {
+    final URI uri;
+    final String csrfToken;
+    final HttpCookie sessionCookie;
+    final HttpCookie csrfCookie;
+
+    TestContext(
+        final URI uri,
+        final String csrfToken,
+        final HttpCookie sessionCookie,
+        final HttpCookie csrfCookie) {
+      this.uri = uri;
+      this.csrfToken = csrfToken;
+      this.sessionCookie = sessionCookie;
+      this.csrfCookie = csrfCookie;
+    }
+  }
+
+  private static class CookieContext {
+    final HttpCookie sessionCookie;
+    final HttpCookie csrfCookie;
+
+    CookieContext(final HttpCookie sessionCookie, final HttpCookie csrfCookie) {
+      this.sessionCookie = sessionCookie;
+      this.csrfCookie = csrfCookie;
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestOperateClient.java
@@ -254,6 +254,10 @@ public class TestRestOperateClient implements AutoCloseable {
     return createInternalGetProcessDefinitionByKeyRequest(key).flatMap(this::sendRequest);
   }
 
+  public URI getEndpoint() {
+    return endpoint;
+  }
+
   @Override
   public void close() {
     httpClient.close();

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestTasklistClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestTasklistClient.java
@@ -145,6 +145,10 @@ public class TestRestTasklistClient implements CloseableSilently {
     return Base64.getEncoder().encodeToString(basicAuth.getBytes());
   }
 
+  public URI getEndpoint() {
+    return endpoint;
+  }
+
   @Override
   public void close() {
     httpClient.close();

--- a/security/security-core/src/main/java/io/camunda/security/configuration/CsrfConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/CsrfConfiguration.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class CsrfConfiguration {
+  private boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -15,6 +15,7 @@ public class SecurityConfiguration {
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
   private InitializationConfiguration initialization = new InitializationConfiguration();
   private MultiTenancyConfiguration multiTenancy = new MultiTenancyConfiguration();
+  private CsrfConfiguration csrf = new CsrfConfiguration();
   private HeaderConfiguration httpHeaders = new HeaderConfiguration();
   private SaasConfiguration saas = new SaasConfiguration();
 
@@ -68,5 +69,13 @@ public class SecurityConfiguration {
 
   public void setHttpHeaders(final HeaderConfiguration httpHeaders) {
     this.httpHeaders = httpHeaders;
+  }
+
+  public CsrfConfiguration getCsrf() {
+    return csrf;
+  }
+
+  public void setCsrf(final CsrfConfiguration csrf) {
+    this.csrf = csrf;
   }
 }

--- a/tasklist/client/src/common/api/useCurrentUser.query.tsx
+++ b/tasklist/client/src/common/api/useCurrentUser.query.tsx
@@ -6,28 +6,30 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, queryOptions} from '@tanstack/react-query';
 import {commonApi} from 'common/api';
-import {type RequestError, request} from 'common/api/request';
+import {request} from 'common/api/request';
 import type {CurrentUser} from '@vzeta/camunda-api-zod-schemas/8.8';
 
+const currentUserQueryOptions = queryOptions({
+  queryKey: ['currentUser'],
+  queryFn: async () => {
+    const {response, error} = await request(commonApi.getCurrentUser());
+
+    if (response !== null) {
+      return response.json() as Promise<CurrentUser>;
+    }
+
+    throw error;
+  },
+  gcTime: Infinity,
+  staleTime: Infinity,
+  refetchIntervalInBackground: false,
+  refetchOnWindowFocus: false,
+});
+
 function useCurrentUser() {
-  return useQuery<CurrentUser, RequestError | Error>({
-    queryKey: ['currentUser'],
-    queryFn: async () => {
-      const {response, error} = await request(commonApi.getCurrentUser());
-
-      if (response !== null) {
-        return response.json();
-      }
-
-      throw error ?? new Error('Could not fetch current user');
-    },
-    gcTime: Infinity,
-    staleTime: Infinity,
-    refetchIntervalInBackground: false,
-    refetchOnWindowFocus: false,
-  });
+  return useQuery(currentUserQueryOptions);
 }
 
-export {useCurrentUser};
+export {useCurrentUser, currentUserQueryOptions};

--- a/tasklist/client/src/common/auth/Login/index.test.tsx
+++ b/tasklist/client/src/common/auth/Login/index.test.tsx
@@ -18,6 +18,7 @@ import {Component} from './index';
 import {authenticationStore} from 'common/auth/authentication';
 import {nodeMockServer} from 'common/testing/nodeMockServer';
 import {LocationLog} from 'common/testing/LocationLog';
+import {currentUser} from 'common/mocks/current-user';
 
 function createWrapper(
   initialEntries: React.ComponentProps<
@@ -66,6 +67,9 @@ describe('<Login />', () => {
           once: true,
         },
       ),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
     );
 
     const {user} = render(<Component />, {
@@ -98,6 +102,9 @@ describe('<Login />', () => {
           once: true,
         },
       ),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
     );
     const {user} = render(<Component />, {
       wrapper: createWrapper(),
@@ -194,6 +201,9 @@ describe('<Login />', () => {
           once: true,
         },
       ),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
     );
 
     const {user} = render(<Component />, {
@@ -209,6 +219,10 @@ describe('<Login />', () => {
         name: 'Logging in',
       }),
     ).toBeDisabled();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent(/^\/$/i),
+    );
   });
 
   it('should have the correct copyright notice', () => {
@@ -238,6 +252,9 @@ describe('<Login />', () => {
           once: true,
         },
       ),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
       http.post(
         '/login',
         () => {
@@ -247,6 +264,9 @@ describe('<Login />', () => {
           once: true,
         },
       ),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
     );
 
     const {user} = render(<Component />, {

--- a/tasklist/client/src/common/auth/authentication.test.tsx
+++ b/tasklist/client/src/common/auth/authentication.test.tsx
@@ -11,6 +11,7 @@ import {authenticationStore} from './authentication';
 import {nodeMockServer} from 'common/testing/nodeMockServer';
 import {getStateLocally} from 'common/local-storage';
 import {getClientConfig} from 'common/config/getClientConfig';
+import {currentUser} from 'common/mocks/current-user';
 
 vi.mock('common/config/getClientConfig', async (importOriginal) => {
   const actual =
@@ -38,6 +39,9 @@ describe('authentication store', () => {
   it('should login', async () => {
     nodeMockServer.use(
       http.post('/login', () => new HttpResponse(''), {once: true}),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
     );
 
     authenticationStore.disableSession();
@@ -80,6 +84,9 @@ describe('authentication store', () => {
 
     nodeMockServer.use(
       http.post('/login', () => new HttpResponse(''), {once: true}),
+      http.get('/v2/authentication/me', () => HttpResponse.json(currentUser), {
+        once: true,
+      }),
       http.post('/logout', () => new HttpResponse(''), {once: true}),
     );
 
@@ -195,8 +202,18 @@ describe('authentication store', () => {
 
       nodeMockServer.use(
         http.post('/login', () => new HttpResponse(''), {once: true}),
+        http.get(
+          '/v2/authentication/me',
+          () => HttpResponse.json(currentUser),
+          {once: true},
+        ),
         http.post('/logout', () => new HttpResponse(''), {once: true}),
         http.post('/login', () => new HttpResponse(''), {once: true}),
+        http.get(
+          '/v2/authentication/me',
+          () => HttpResponse.json(currentUser),
+          {once: true},
+        ),
       );
 
       await authenticationStore.handleLogin('demo', 'demo');

--- a/tasklist/client/src/common/auth/authentication.tsx
+++ b/tasklist/client/src/common/auth/authentication.tsx
@@ -12,6 +12,7 @@ import {getClientConfig} from 'common/config/getClientConfig';
 import {reactQueryClient} from 'common/react-query/reactQueryClient';
 import {request} from 'common/api/request';
 import {getStateLocally, storeStateLocally} from 'common/local-storage';
+import {currentUserQueryOptions} from 'common/api/useCurrentUser.query';
 
 type Status =
   | 'initial'
@@ -44,6 +45,7 @@ class Authentication {
 
     if (error === null) {
       this.activateSession();
+      await reactQueryClient.ensureQueryData(currentUserQueryOptions);
     }
 
     return {response, error};

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -137,7 +137,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         .withReadTimeout(DEFAULT_READINESS_TIMEOUT);
   }
 
-  private static boolean isPartitionReady(String response) {
+  private static boolean isPartitionReady(final String response) {
     return response.matches(".*\"partitionId\"\\s*:\\s*1.*")
         && response.matches(".*\"role\"\\s*:\\s*\"leader\".*")
         && response.matches(".*\"health\"\\s*:\\s*\"healthy\".*");


### PR DESCRIPTION
## Description

feat: added CSRF enforcement

Changes:

- - [x] Add CSRF protection feature toggle (done via `io.camunda.security.configuration.CsrfConfiguration`)
- - [x] (? - maybe not needed) Register CSRF via all `SecurityFilterChain` for unprotected API
- - [x] Register CSRF via all `SecurityFilterChain` basic auth API / webapp
- - [x] Register CSRF via all `SecurityFilterChain` for OIDC API / webapp
- - [x] Configure the `CookieCsrfTokenRepository`: should be forced to have httpOnly=true and secure=true
- - [x] Configure the CSRF protection matcher: similr to one from the [Tasklist](https://github.com/camunda/camunda/blob/main/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/CsrfRequireMatcher.java) or Operate
- - [x] The new CSRF protection matcher must allow all new unprotected paths ([1](https://github.com/camunda/camunda/blob/6f0e07ffd5a2435b9e6a21f464006884dbe0b4f1/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java#L89), [2](https://github.com/camunda/camunda/blob/6f0e07ffd5a2435b9e6a21f464006884dbe0b4f1/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java#L105))
- - [x] The new CSRF protection matcher should allow APIs authorized with `Basic ` auth
- - [x] Decision not to include because `Authorization` header covers that use-case already ~The new CSRF protection matcher should allow `camunda-client-java/XXX` user agent~
- - [x] Add new CSRF once-per-request filter that adds CSRF header when required, similar to Tasklist/Operate
- - [x] Add a toggle config property to be able to turn the once-per-request filter that adds CSRF header off when necessarry
- - [x] Pass the CSRF token from the Identity UI via header when calling backend
- - [x] Clean up cookie on logout

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to: https://github.com/camunda/camunda/issues/26802
