### PR TITLE
feat: Add API endpoint for fetching incidents by processInstanceKey

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -122,12 +122,14 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
-      final SequenceFlowSearchClient sequenceFlowSearchClient) {
+      final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final IncidentSearchClient incidentSearchClient) {
     return new ProcessInstanceServices(
         brokerClient,
         securityContextProvider,
         processInstanceSearchClient,
         sequenceFlowSearchClient,
+        incidentSearchClient,
         null);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.prefix;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.BPMN_PROCESS_ID;
@@ -57,7 +58,7 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
     final var flowNodeInstanceKeyQuery = getFlowNodeInstanceKeyQuery(filter.flowNodeInstanceKeys());
     final var creationTimeQuery = getCreationTimeQuery(filter.creationTime());
     final var stateQuery = getStateQuery(filter.states());
-    final var treePathQuery = getTreePathQuery(filter.treePaths());
+    final var treePathQuery = getTreePathQuery(filter.treePath());
     final var jobKeyQuery = getJobKeyQuery(filter.jobKeys());
     final var tenantIdQuery = getTenantIdQuery(filter.tenantIds());
     final var errorMessageHashesQuery = getErrorMessageHashesQuery(filter.errorMessageHashes());
@@ -91,8 +92,11 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
     return stringTerms("state", states != null ? states.stream().map(Enum::name).toList() : null);
   }
 
-  private SearchQuery getTreePathQuery(final List<String> treePaths) {
-    return stringTerms("treePath", treePaths);
+  private SearchQuery getTreePathQuery(final String treePath) {
+    if (treePath == null) {
+      return null;
+    }
+    return prefix("treePath", treePath);
   }
 
   private SearchQuery getCreationTimeQuery(final DateValueFilter filter) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
@@ -92,7 +92,7 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
   }
 
   private SearchQuery getTreePathQuery(final List<String> treePaths) {
-    return stringTerms("treePath", treePaths); // TODO: Change literal to const?
+    return stringTerms("treePath", treePaths);
   }
 
   private SearchQuery getCreationTimeQuery(final DateValueFilter filter) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
@@ -57,6 +57,7 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
     final var flowNodeInstanceKeyQuery = getFlowNodeInstanceKeyQuery(filter.flowNodeInstanceKeys());
     final var creationTimeQuery = getCreationTimeQuery(filter.creationTime());
     final var stateQuery = getStateQuery(filter.states());
+    final var treePathQuery = getTreePathQuery(filter.treePaths());
     final var jobKeyQuery = getJobKeyQuery(filter.jobKeys());
     final var tenantIdQuery = getTenantIdQuery(filter.tenantIds());
     final var errorMessageHashesQuery = getErrorMessageHashesQuery(filter.errorMessageHashes());
@@ -72,6 +73,7 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
         flowNodeInstanceKeyQuery,
         creationTimeQuery,
         stateQuery,
+        treePathQuery,
         jobKeyQuery,
         tenantIdQuery,
         errorMessageHashesQuery);
@@ -87,6 +89,10 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
 
   private SearchQuery getStateQuery(final List<IncidentState> states) {
     return stringTerms("state", states != null ? states.stream().map(Enum::name).toList() : null);
+  }
+
+  private SearchQuery getTreePathQuery(final List<String> treePaths) {
+    return stringTerms("treePath", treePaths); // TODO: Change literal to const?
   }
 
   private SearchQuery getCreationTimeQuery(final DateValueFilter filter) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
@@ -29,7 +29,7 @@ public record IncidentFilter(
     List<Long> flowNodeInstanceKeys,
     DateValueFilter creationTime,
     List<IncidentState> states,
-    List<String> treePaths,
+    String treePath,
     List<Long> jobKeys,
     List<String> tenantIds)
     implements FilterBase {
@@ -47,7 +47,7 @@ public record IncidentFilter(
     private List<Long> flowNodeInstanceKeys;
     private DateValueFilter creationTimeFilter;
     private List<IncidentState> states;
-    private List<String> treePaths;
+    private String treePath;
     private List<Long> jobKeys;
     private List<String> tenantIds;
 
@@ -146,12 +146,8 @@ public record IncidentFilter(
       return this;
     }
 
-    public Builder treePaths(final String value, final String... values) {
-      return treePaths(collectValues(value, values));
-    }
-
-    public Builder treePaths(final List<String> values) {
-      treePaths = addValuesToList(treePaths, values);
+    public Builder treePath(final String value) {
+      treePath = value;
       return this;
     }
 
@@ -187,7 +183,7 @@ public record IncidentFilter(
           Objects.requireNonNullElse(flowNodeInstanceKeys, Collections.emptyList()),
           creationTimeFilter,
           Objects.requireNonNullElse(states, Collections.emptyList()),
-          Objects.requireNonNullElse(treePaths, Collections.emptyList()),
+          treePath,
           Objects.requireNonNullElse(jobKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
@@ -29,6 +29,7 @@ public record IncidentFilter(
     List<Long> flowNodeInstanceKeys,
     DateValueFilter creationTime,
     List<IncidentState> states,
+    List<String> treePaths,
     List<Long> jobKeys,
     List<String> tenantIds)
     implements FilterBase {
@@ -46,6 +47,7 @@ public record IncidentFilter(
     private List<Long> flowNodeInstanceKeys;
     private DateValueFilter creationTimeFilter;
     private List<IncidentState> states;
+    private List<String> treePaths;
     private List<Long> jobKeys;
     private List<String> tenantIds;
 
@@ -144,6 +146,15 @@ public record IncidentFilter(
       return this;
     }
 
+    public Builder treePaths(final String value, final String... values) {
+      return treePaths(collectValues(value, values));
+    }
+
+    public Builder treePaths(final List<String> values) {
+      treePaths = addValuesToList(treePaths, values);
+      return this;
+    }
+
     public Builder jobKeys(final Long value, final Long... values) {
       return jobKeys(collectValues(value, values));
     }
@@ -176,6 +187,7 @@ public record IncidentFilter(
           Objects.requireNonNullElse(flowNodeInstanceKeys, Collections.emptyList()),
           creationTimeFilter,
           Objects.requireNonNullElse(states, Collections.emptyList()),
+          Objects.requireNonNullElse(treePaths, Collections.emptyList()),
           Objects.requireNonNullElse(jobKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -301,21 +301,19 @@ public final class ProcessInstanceServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public List<IncidentEntity> incidents(final Long processInstanceKey) {
+  public List<IncidentEntity> incidents(final long processInstanceKey) {
     final var processInstance = getByKey(processInstanceKey);
     final var treePath = processInstance.treePath();
 
-    if (treePath == null || treePath.isBlank()) {
-      return List.of();
-    }
-
-    final var result =
-        incidentSearchClient.searchIncidents(
+    return incidentSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
+        .searchIncidents(
             new IncidentQuery.Builder()
                 .filter(new IncidentFilter.Builder().treePaths(treePath).build())
-                .build());
-
-    return result.items();
+                .build())
+        .items();
   }
 
   public record ProcessInstanceCreateRequest(

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -301,7 +301,8 @@ public final class ProcessInstanceServices
     return sendBrokerRequest(brokerRequest);
   }
 
-  public List<IncidentEntity> incidents(final long processInstanceKey) {
+  public SearchQueryResult<IncidentEntity> searchIncidents(
+      final long processInstanceKey, final IncidentQuery query) {
     final var processInstance = getByKey(processInstanceKey);
     final var treePath = processInstance.treePath();
 
@@ -311,9 +312,10 @@ public final class ProcessInstanceServices
                 authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .searchIncidents(
             new IncidentQuery.Builder()
-                .filter(new IncidentFilter.Builder().treePaths(treePath).build())
-                .build())
-        .items();
+                .filter(new IncidentFilter.Builder().treePath(treePath).build())
+                .page(query.page())
+                .sort(query.sort())
+                .build());
   }
 
   public record ProcessInstanceCreateRequest(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -12,11 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
+import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
@@ -52,31 +54,33 @@ import org.mockito.ArgumentCaptor;
 public final class ProcessInstanceServiceTest {
 
   private ProcessInstanceServices services;
-  private ProcessInstanceSearchClient client;
+  private ProcessInstanceSearchClient processInstanceSearchClient;
   private SequenceFlowSearchClient sequenceFlowSearchClient;
-  private IncidentSearchClient incidentClient;
+  private IncidentSearchClient incidentSearchClient;
   private SecurityContextProvider securityContextProvider;
   private Authentication authentication;
   private BrokerClient brokerClient;
 
   @BeforeEach
   public void before() {
-    client = mock(ProcessInstanceSearchClient.class);
+    processInstanceSearchClient = mock(ProcessInstanceSearchClient.class);
     sequenceFlowSearchClient = mock(SequenceFlowSearchClient.class);
     authentication = Authentication.none();
-    incidentClient = mock(IncidentSearchClient.class);
+    incidentSearchClient = mock(IncidentSearchClient.class);
     authentication = mock(Authentication.class);
-    when(client.withSecurityContext(any())).thenReturn(client);
+    when(processInstanceSearchClient.withSecurityContext(any()))
+        .thenReturn(processInstanceSearchClient);
     when(sequenceFlowSearchClient.withSecurityContext(any())).thenReturn(sequenceFlowSearchClient);
+    when(incidentSearchClient.withSecurityContext(any())).thenReturn(incidentSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
     brokerClient = mock(BrokerClient.class);
     services =
         new ProcessInstanceServices(
             brokerClient,
             securityContextProvider,
-            client,
+            processInstanceSearchClient,
             sequenceFlowSearchClient,
-            incidentClient,
+            incidentSearchClient,
             authentication);
   }
 
@@ -84,7 +88,7 @@ public final class ProcessInstanceServiceTest {
   public void shouldReturnProcessInstance() {
     // given
     final var result = mock(SearchQueryResult.class);
-    when(client.searchProcessInstances(any())).thenReturn(result);
+    when(processInstanceSearchClient.searchProcessInstances(any())).thenReturn(result);
 
     final ProcessInstanceQuery searchQuery =
         SearchQueryBuilders.processInstanceSearchQuery().build();
@@ -121,7 +125,7 @@ public final class ProcessInstanceServiceTest {
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processInstanceKey()).thenReturn(key);
     when(entity.processDefinitionId()).thenReturn("processId");
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
     authorizeProcessReadInstance(true, "processId");
 
@@ -136,7 +140,7 @@ public final class ProcessInstanceServiceTest {
   public void shouldThrownExceptionIfNotFoundByKey() {
     // given
     final var key = 100L;
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
 
     // when / then
@@ -152,7 +156,7 @@ public final class ProcessInstanceServiceTest {
     final var key = 200L;
     final var entity1 = mock(ProcessInstanceEntity.class);
     final var entity2 = mock(ProcessInstanceEntity.class);
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(2, List.of(entity1, entity2), null, null));
 
     // when / then
@@ -167,7 +171,7 @@ public final class ProcessInstanceServiceTest {
     // given
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processDefinitionId()).thenReturn("processId");
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     authorizeProcessReadInstance(false, "processId");
     // when
@@ -225,7 +229,7 @@ public final class ProcessInstanceServiceTest {
     when(parentProcess.processDefinitionId()).thenReturn("parent_process_id");
     authorizeProcessReadInstance(true, "parent_process_id");
 
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(childProcess, parentProcess), null, null));
 
     // when
@@ -246,7 +250,7 @@ public final class ProcessInstanceServiceTest {
     authorizeProcessReadInstance(true, "root_process_id");
     when(rootInstance.treePath()).thenReturn(null); // No treePath
 
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
 
     // when
@@ -265,7 +269,7 @@ public final class ProcessInstanceServiceTest {
     authorizeProcessReadInstance(true, "root_process_id");
     when(rootInstance.treePath()).thenReturn("PI_123"); // Root treePath
 
-    when(client.searchProcessInstances(any()))
+    when(processInstanceSearchClient.searchProcessInstances(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
 
     // when
@@ -413,5 +417,58 @@ public final class ProcessInstanceServiceTest {
             authentication,
             Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .thenReturn(authorize);
+  }
+
+  @Test
+  void shouldReturnIncidentsForProcessInstanceKey() {
+    // given
+    final var processInstanceKey = 123L;
+
+    final var processInstance = mock(ProcessInstanceEntity.class);
+    when(processInstance.treePath()).thenReturn("PI_123/FN_A/FNI_456/PI_789/FN_B/FNI_654");
+    when(processInstance.processInstanceKey()).thenReturn(processInstanceKey);
+    when(processInstance.processDefinitionId()).thenReturn("processId");
+    when(processInstanceSearchClient.searchProcessInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(processInstance), null, null));
+    authorizeProcessReadInstance(true, processInstance.processDefinitionId());
+
+    final var incidentEntity = mock(IncidentEntity.class);
+    when(incidentSearchClient.searchIncidents(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(incidentEntity), null, null));
+    Authorization.of(a -> a.processDefinition().readProcessInstance());
+
+    // when
+    final var result = services.incidents(processInstanceKey);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst()).isEqualTo(incidentEntity);
+    verify(incidentSearchClient)
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication,
+                Authorization.of(a -> a.processDefinition().readProcessInstance())));
+  }
+
+  @Test
+  void incidentsShouldThrowForbiddenExceptionIfNotAuthorizedToReadProcessInstance() {
+    // given
+    final var processInstanceKey = 123L;
+
+    final var processInstance = mock(ProcessInstanceEntity.class);
+    when(processInstance.processDefinitionId()).thenReturn("processId");
+    when(processInstanceSearchClient.searchProcessInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(processInstance), null, null));
+    authorizeProcessReadInstance(false, processInstance.processDefinitionId());
+
+    // when
+    final Executable executeGetByKey = () -> services.incidents(processInstanceKey);
+
+    // then
+    final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
+    verifyNoInteractions(incidentSearchClient);
   }
 }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -53,6 +54,7 @@ public final class ProcessInstanceServiceTest {
   private ProcessInstanceServices services;
   private ProcessInstanceSearchClient client;
   private SequenceFlowSearchClient sequenceFlowSearchClient;
+  private IncidentSearchClient incidentClient;
   private SecurityContextProvider securityContextProvider;
   private Authentication authentication;
   private BrokerClient brokerClient;
@@ -62,6 +64,8 @@ public final class ProcessInstanceServiceTest {
     client = mock(ProcessInstanceSearchClient.class);
     sequenceFlowSearchClient = mock(SequenceFlowSearchClient.class);
     authentication = Authentication.none();
+    incidentClient = mock(IncidentSearchClient.class);
+    authentication = mock(Authentication.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     when(sequenceFlowSearchClient.withSecurityContext(any())).thenReturn(sequenceFlowSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
@@ -72,6 +76,7 @@ public final class ProcessInstanceServiceTest {
             securityContextProvider,
             client,
             sequenceFlowSearchClient,
+            incidentClient,
             authentication);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1731,6 +1731,45 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /process-instances/{processInstanceKey}/incidents:
+    get:
+      tags:
+        - Process instance
+      operationId: getProcessInstanceIncidents
+      summary: Get process instance incidents
+      description: |
+        Get incidents caused by the process instance or its called process instances.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The assigned key of the process instance, which acts as a unique identifier for this process instance.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The array of incidents.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IncidentResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The process instance with the given key was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /process-instances/{processInstanceKey}/statistics/element-instances:
     get:
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1731,45 +1731,6 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /process-instances/{processInstanceKey}/incidents:
-    get:
-      tags:
-        - Process instance
-      operationId: getProcessInstanceIncidents
-      summary: Get process instance incidents
-      description: |
-        Get incidents caused by the process instance or its called process instances.
-      parameters:
-        - name: processInstanceKey
-          in: path
-          required: true
-          description: The assigned key of the process instance, which acts as a unique identifier for this process instance.
-          schema:
-            type: string
-      responses:
-        "200":
-          description: The array of incidents.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/IncidentResult"
-        "400":
-          $ref: "#/components/responses/InvalidData"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          description: The process instance with the given key was not found.
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
   /process-instances/{processInstanceKey}/statistics/element-instances:
     get:
       tags:
@@ -1828,6 +1789,49 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /process-instances/{processInstanceKey}/incidents/search:
+    post:
+      tags:
+        - Process instance
+      operationId: searchProcessInstanceIncidents
+      summary: Search for incidents associated with a process instance
+      description: |
+        Search for incidents caused by the process instance or any of its called process or decision instances.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The assigned key of the process instance, which acts as a unique identifier for this process instance.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessInstanceIncidentSearchQuery"
+      responses:
+        "200":
+          description: The process instance search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IncidentSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The process instance with the given key was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -5755,6 +5759,16 @@ components:
           description: The process instance search filters.
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceFilter"
+    ProcessInstanceIncidentSearchQuery:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/IncidentSearchQuerySortRequest"
     AdvancedIntegerFilter:
       title: Advanced filter
       description: Advanced integer (int32) filter.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -663,6 +663,21 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::incidentSearchQuery);
   }
 
+  public static Either<ProblemDetail, IncidentQuery> toIncidentQuery(
+      final ProcessInstanceIncidentSearchQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.incidentSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromIncidentSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::incident,
+            SearchQueryRequestMapper::applyIncidentSortField);
+    return buildSearchQuery(
+        toIncidentFilter(null), sort, page, SearchQueryBuilders::incidentSearchQuery);
+  }
+
   public static Either<ProblemDetail, BatchOperationQuery> toBatchOperationQuery(
       final BatchOperationSearchQuery request) {
     if (request == null) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -686,7 +686,7 @@ public final class SearchQueryResponseMapper {
         .toList();
   }
 
-  private static List<IncidentResult> toIncidents(final List<IncidentEntity> incidents) {
+  public static List<IncidentResult> toIncidents(final List<IncidentEntity> incidents) {
     return incidents.stream().map(SearchQueryResponseMapper::toIncident).toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -195,7 +195,7 @@ public class ProcessInstanceController {
 
   @CamundaGetMapping(path = "/{processInstanceKey}/incidents")
   public ResponseEntity<Object> getIncidents(
-      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+      @PathVariable("processInstanceKey") final long processInstanceKey) {
     try {
       return ResponseEntity.ok()
           .body(
@@ -203,7 +203,6 @@ public class ProcessInstanceController {
                   processInstanceServices
                       .withAuthentication(RequestMapper.getAuthentication())
                       .incidents(processInstanceKey)));
-
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -193,6 +193,22 @@ public class ProcessInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationModify);
   }
 
+  @CamundaGetMapping(path = "/{processInstanceKey}/incidents")
+  public ResponseEntity<Object> getIncidents(
+      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+    try {
+      return ResponseEntity.ok()
+          .body(
+              SearchQueryResponseMapper.toIncidents(
+                  processInstanceServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .incidents(processInstanceKey)));
+
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
   private ResponseEntity<ProcessInstanceSearchQueryResult> search(
       final ProcessInstanceQuery query) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
+import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
@@ -19,8 +20,10 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.rest.IncidentSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCreationInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceIncidentSearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
@@ -193,19 +196,14 @@ public class ProcessInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::batchOperationModify);
   }
 
-  @CamundaGetMapping(path = "/{processInstanceKey}/incidents")
-  public ResponseEntity<Object> getIncidents(
-      @PathVariable("processInstanceKey") final long processInstanceKey) {
-    try {
-      return ResponseEntity.ok()
-          .body(
-              SearchQueryResponseMapper.toIncidents(
-                  processInstanceServices
-                      .withAuthentication(RequestMapper.getAuthentication())
-                      .incidents(processInstanceKey)));
-    } catch (final Exception e) {
-      return mapErrorToResponse(e);
-    }
+  @CamundaPostMapping(path = "/{processInstanceKey}/incidents/search")
+  public ResponseEntity<IncidentSearchQueryResult> searchIncidents(
+      @PathVariable("processInstanceKey") final long processInstanceKey,
+      @RequestBody(required = false) final ProcessInstanceIncidentSearchQuery query) {
+    return SearchQueryRequestMapper.toIncidentQuery(query)
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            incidentQuery -> searchIncidents(processInstanceKey, incidentQuery));
   }
 
   private ResponseEntity<ProcessInstanceSearchQueryResult> search(
@@ -217,6 +215,19 @@ public class ProcessInstanceController {
               .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<IncidentSearchQueryResult> searchIncidents(
+      final long processInstanceKey, final IncidentQuery query) {
+    try {
+      final var result =
+          processInstanceServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .searchIncidents(processInstanceKey, query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }


### PR DESCRIPTION
## Description

This PR introduces a new POST endpoint (a search endpoint) that given a `processInstanceKey` and `page` and `sort` information it returns the incidents caused by the process instance or its descendants (called process instances).

In this PR I am providing:
* The API documentation in `rest-api.yaml`
* The Controller implementation
* Unit tests

In the next PR I am planning to introduce:
* The changes to the Java client
* Integration tests (it is my understanding those require the Java client)

## Testing

In the following hierarchy of process instances with the given processInstanceKeys
```
2251799814751242
- 2251799814751247
-- 2251799814751251
--- 2251799814751255 <- causes incident
```
all the following calls return the incident caused by `2251799814751255`
```
POST /v2/process-instances/2251799814751242/incidents/search
POST /v2/process-instances/2251799814751247/incidents/search
POST /v2/process-instances/2251799814751251/incidents/search
POST /v2/process-instances/2251799814751255/incidents/search
---
...
    {
        "processDefinitionId": "activity_3",
        "errorType": "FORM_NOT_FOUND",
        "errorMessage": "Expected to find a form with id 'bad_form_id', but no form with this id is found, at least a form with this id should be available. To resolve the Incident please deploy a form with the same id",
        "elementId": "Activity_07rrek1",
        "creationTime": "2025-05-23T17:41:24.406Z",
        "state": "PENDING",
        "tenantId": "<default>",
        "incidentKey": "2251799814751259",
        "processDefinitionKey": "2251799814751221",
        "processInstanceKey": "2251799814751255",
        "elementInstanceKey": "2251799814751258"
    }
...
```

## Checklist

-

## Related issues

relates to #27327
