### PR TITLE
fix: race condition with opening of exporter vs allowing export

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -378,8 +378,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       LangUtil.rethrowUnchecked(e);
     }
 
-    isOpened.set(true);
-
     // remove exporters from state
     // which are no longer in our configuration
     clearExporterState();
@@ -543,6 +541,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     actor.runOnCompletion(
         containerOpenFutures,
         (error) -> {
+          isOpened.set(true);
           if (state.hasExporters()) {
             final long snapshotPosition = state.getLowestPosition();
             // start reading and exporting


### PR DESCRIPTION
## Description

I suspect a race condition between the future which opens the exporter and the export starting as the `isOpened` is set to true before the exporters actually are opened.

## Related issues

closes #32009
