### PR TITLE
Support roles in Operate and Tasklist V1 API

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.testcontainers.Testcontainers;
@@ -249,7 +248,6 @@ public class PrefixMigrationIT {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/30126")
   void shouldReindexDocumentsDuringPrefixMigration() throws IOException {
     // given
     final var camunda87 = createCamundaContainer();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.operate;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
+import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.client.api.search.enums.ResourceType.ROLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.Profile;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.User;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.Strings;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class OperateInternalApiRolePermissionsIT {
+
+  public static final String REQUEST_BODY =
+      """
+      {
+        "query": {
+          "bpmnProcessId": "%s",
+          "running": true,
+          "active": true
+        }
+      }""";
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withAuthorizationsEnabled()
+          .withBasicAuth()
+          .withAdditionalProfile(Profile.OPERATE);
+
+  private static final String BASE_PATH = "api/process-instances";
+  private static final String PROCESS_ID = "processId";
+  private static final String ADMIN_USERNAME = "admin";
+  private static final String AUTHORIZED_USERNAME = "authorized";
+  private static final String UNAUTHORIZED_USERNAME = "unauthorized";
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @UserDefinition
+  private static final User ADMIN =
+      new User(
+          ADMIN_USERNAME,
+          ADMIN_USERNAME,
+          List.of(
+              new Permissions(ROLE, CREATE, List.of("*")),
+              new Permissions(ROLE, UPDATE, List.of("*")),
+              new Permissions(AUTHORIZATION, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+
+  @UserDefinition
+  private static final User AUTHORIZED_USER =
+      new User(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
+  @UserDefinition
+  private static final User UNAUTHORIZED_USER =
+      new User(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
+  @BeforeAll
+  public static void beforeAll(
+      @Authenticated(ADMIN_USERNAME) final CamundaClient adminClient,
+      @Authenticated(AUTHORIZED_USERNAME) final CamundaClient authorizedClient,
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient unauthorizedClient)
+      throws Exception {
+    final var roleId = Strings.newRandomValidIdentityId();
+    adminClient.newCreateRoleCommand().roleId(roleId).name("role name").send().join();
+    adminClient
+        .newCreateAuthorizationCommand()
+        .ownerId(roleId)
+        .ownerType(OwnerType.ROLE)
+        .resourceId("*")
+        .resourceType(PROCESS_DEFINITION)
+        .permissionTypes(PermissionType.READ_PROCESS_INSTANCE)
+        .send()
+        .join();
+    addUserToRole(adminClient.getConfiguration().getRestAddress(), roleId, AUTHORIZED_USERNAME);
+
+    adminClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done(),
+            "process.bpmn")
+        .send()
+        .join();
+    final var processInstanceKey =
+        adminClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(f -> f.processInstanceKey(processInstanceKey))
+                            .send()
+                            .join()
+                            .items())
+                    .describedAs("Wait until the process instance is exported")
+                    .hasSize(1));
+  }
+
+  @Test
+  void shouldBePermittedToSearchUsingInternalApi(
+      @Authenticated(AUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
+    final var count = searchRunningProcessInstances(client, AUTHORIZED_USERNAME);
+    assertThat(count.totalCount).describedAs("Has retrieved the running instance").isEqualTo(1);
+  }
+
+  @Test
+  void shouldBeUnauthorizedToSearchUsingInternalApi(
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
+    final var count = searchRunningProcessInstances(client, UNAUTHORIZED_USERNAME);
+    // Searching when unauthorized results in no instances returned, not an unauthorized error
+    assertThat(count.totalCount).describedAs("Has not retrieved any instances").isEqualTo(0);
+  }
+
+  private static void addUserToRole(final URI url, final String roleId, final String username)
+      throws Exception {
+    final var uri = URI.create(url + "v2/roles/%s/users/%s".formatted(roleId, username));
+    final var encodedCredentials =
+        Base64.getEncoder()
+            .encodeToString("%s:%s".formatted(ADMIN_USERNAME, ADMIN_USERNAME).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(uri)
+            .PUT(HttpRequest.BodyPublishers.noBody())
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .header("Content-Type", "application/json")
+            .build();
+    HTTP_CLIENT.send(request, BodyHandlers.ofString());
+  }
+
+  private ResponseCount searchRunningProcessInstances(
+      final CamundaClient client, final String username)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url = client.getConfiguration().getRestAddress() + BASE_PATH;
+
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted(username, username).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI(url))
+            .POST(HttpRequest.BodyPublishers.ofString(REQUEST_BODY.formatted(PROCESS_ID)))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .header("Content-Type", "application/json")
+            .build();
+
+    // Send the request and get the response
+    final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), ResponseCount.class);
+  }
+
+  private record ResponseCount(int totalCount) {}
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.tasklist.v1.roles;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE;
+import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.client.api.search.enums.ResourceType.ROLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.User;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.Strings;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.springframework.http.HttpStatus;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class TasklistV1ApiRolePermissionsIT {
+
+  @MultiDbTestApplication
+  static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication().withAuthorizationsEnabled().withBasicAuth();
+
+  private static final String PROCESS_ID = "processId";
+  private static final String ADMIN_USERNAME = "admin";
+  private static final String AUTHORIZED_USERNAME = "authorized";
+  private static final String UNAUTHORIZED_USERNAME = "unauthorized";
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @UserDefinition
+  private static final User ADMIN =
+      new User(
+          ADMIN_USERNAME,
+          ADMIN_USERNAME,
+          List.of(
+              new Permissions(ROLE, CREATE, List.of("*")),
+              new Permissions(ROLE, UPDATE, List.of("*")),
+              new Permissions(AUTHORIZATION, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*"))));
+
+  @UserDefinition
+  private static final User AUTHORIZED_USER =
+      new User(AUTHORIZED_USERNAME, AUTHORIZED_USERNAME, List.of());
+
+  @UserDefinition
+  private static final User UNAUTHORIZED_USER =
+      new User(UNAUTHORIZED_USERNAME, UNAUTHORIZED_USERNAME, List.of());
+
+  private static long processDefinitionKey;
+  private static long taskKey;
+
+  @BeforeAll
+  public static void beforeAll(
+      @Authenticated(ADMIN_USERNAME) final CamundaClient adminClient,
+      @Authenticated(AUTHORIZED_USERNAME) final CamundaClient authorizedClient,
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient unauthorizedClient)
+      throws Exception {
+    final var roleId = Strings.newRandomValidIdentityId();
+    adminClient.newCreateRoleCommand().roleId(roleId).name("role name").send().join();
+    adminClient
+        .newCreateAuthorizationCommand()
+        .ownerId(roleId)
+        .ownerType(OwnerType.ROLE)
+        .resourceId("*")
+        .resourceType(PROCESS_DEFINITION)
+        .permissionTypes(PermissionType.READ_PROCESS_DEFINITION, PermissionType.UPDATE_USER_TASK)
+        .send()
+        .join();
+    addUserToRole(adminClient.getConfiguration().getRestAddress(), roleId, AUTHORIZED_USERNAME);
+
+    adminClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask()
+                .zeebeUserTask()
+                .endEvent()
+                .done(),
+            "process.bpmn")
+        .send()
+        .join();
+    final var processInstanceEvent =
+        adminClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join();
+    processDefinitionKey = processInstanceEvent.getProcessDefinitionKey();
+    await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var tasks =
+                  adminClient
+                      .newUserTaskSearchRequest()
+                      .filter(
+                          t -> t.processInstanceKey(processInstanceEvent.getProcessInstanceKey()))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(tasks).describedAs("Wait until the task exists").hasSize(1);
+              taskKey = tasks.getFirst().getUserTaskKey();
+            });
+  }
+
+  @Test
+  void shouldBePermittedToGetProcess(@Authenticated(AUTHORIZED_USERNAME) final CamundaClient client)
+      throws Exception {
+    final var statusCode =
+        getRunningProcessInstance(client, AUTHORIZED_USERNAME, processDefinitionKey);
+    assertThat(statusCode)
+        .describedAs("Is authorized to get the process")
+        .isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  void shouldBeUnauthorizedToGetProcess(
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
+    final var statusCode =
+        getRunningProcessInstance(client, UNAUTHORIZED_USERNAME, processDefinitionKey);
+    assertThat(statusCode)
+        .describedAs("Is unauthorized to get the process")
+        .isEqualTo(HttpStatus.FORBIDDEN.value());
+  }
+
+  @Test
+  void shouldBePermittedToAssignTask(@Authenticated(AUTHORIZED_USERNAME) final CamundaClient client)
+      throws Exception {
+    final var statusCode = assignTask(client, AUTHORIZED_USERNAME, taskKey);
+    assertThat(statusCode)
+        .describedAs("Is authorized to assign the task")
+        .isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  void shouldBeUnauthorizedToAssignTask(
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
+    final var statusCode = assignTask(client, UNAUTHORIZED_USERNAME, taskKey);
+    assertThat(statusCode)
+        .describedAs("Is unauthorized to assign the task")
+        .isEqualTo(HttpStatus.FORBIDDEN.value());
+  }
+
+  private static void addUserToRole(final URI url, final String roleId, final String username)
+      throws Exception {
+    final var uri = URI.create(url + "v2/roles/%s/users/%s".formatted(roleId, username));
+    final var encodedCredentials =
+        Base64.getEncoder()
+            .encodeToString("%s:%s".formatted(ADMIN_USERNAME, ADMIN_USERNAME).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(uri)
+            .PUT(BodyPublishers.noBody())
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .header("Content-Type", "application/json")
+            .build();
+    HTTP_CLIENT.send(request, BodyHandlers.ofString());
+  }
+
+  private int getRunningProcessInstance(
+      final CamundaClient client, final String username, final long processDefinitionKey)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url =
+        client.getConfiguration().getRestAddress()
+            + "v1/internal/processes/"
+            + processDefinitionKey;
+
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted(username, username).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI(url))
+            .GET()
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    // Send the request and get the response
+    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+  }
+
+  private int assignTask(final CamundaClient client, final String username, final long taskId)
+      throws URISyntaxException, IOException, InterruptedException {
+    final String url =
+        client.getConfiguration().getRestAddress() + "v1/tasks/" + taskId + "/assign";
+
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString("%s:%s".formatted(username, username).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI(url))
+            .method(
+                "PATCH",
+                BodyPublishers.ofString(
+                    """
+                          {
+                            "assignee": "%s",
+                            "allowOverrideAssignment": true
+                          }
+                          """
+                        .formatted(username)))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    // Send the request and get the response
+    return HTTP_CLIENT.send(request, BodyHandlers.ofString()).statusCode();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds tests to verify roles are taken into account when making requests to the internal API of Operate and the V1 API of Tasklist.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to #28507
