### PR TITLE
Feature/31544 assert evaluated decisions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
@@ -191,6 +192,20 @@ public class CamundaAssert {
    */
   public static DecisionInstanceAssert assertThat(final DecisionSelector decisionSelector) {
     return new DecisionInstanceAssertj(getDataSource(), decisionSelector);
+  }
+
+  /**
+   * To verify an evaluated decision response (via API).
+   *
+   * @param response the evaluated decision response to assert
+   * @return the assertion object
+   */
+  public static DecisionInstanceAssertj assertThat(final EvaluateDecisionResponse response) {
+    return new DecisionInstanceAssertj(
+        getDataSource(),
+        decisionInstance ->
+            decisionInstance.getDecisionInstanceKey() == response.getDecisionInstanceKey()
+                && decisionInstance.getDecisionDefinitionId().equals(response.getDecisionId()));
   }
 
   // ======== Internal ========

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -20,6 +20,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
 import io.camunda.process.test.api.assertions.DecisionInstanceAssert;
 import io.camunda.process.test.api.assertions.DecisionSelector;
+import io.camunda.process.test.api.assertions.DecisionSelectors;
 import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
@@ -201,11 +202,7 @@ public class CamundaAssert {
    * @return the assertion object
    */
   public static DecisionInstanceAssertj assertThat(final EvaluateDecisionResponse response) {
-    return new DecisionInstanceAssertj(
-        getDataSource(),
-        decisionInstance ->
-            decisionInstance.getDecisionInstanceKey() == response.getDecisionInstanceKey()
-                && decisionInstance.getDecisionDefinitionId().equals(response.getDecisionId()));
+    return new DecisionInstanceAssertj(getDataSource(), DecisionSelectors.byResponse(response));
   }
 
   // ======== Internal ========

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionInstanceAssert.java
@@ -37,6 +37,13 @@ public interface DecisionInstanceAssert {
   DecisionInstanceAssert hasOutput(final Object expectedOutput);
 
   /**
+   * Verifies that the decision matched nothing.
+   *
+   * @return the assertion object
+   */
+  DecisionInstanceAssert hasNoMatchedRules();
+
+  /**
    * Verifies that the decision has matched the given rule indices.
    *
    * @param expectedMatchedRuleIndexes the rule indices that should have matched

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.response.DecisionInstance;
 
@@ -65,6 +66,10 @@ public class DecisionSelectors {
    */
   public static DecisionSelector byId(final String decisionId, final long processInstanceKey) {
     return new DecisionIdSelector(decisionId, processInstanceKey);
+  }
+
+  public static DecisionSelector byResponse(final EvaluateDecisionResponse response) {
+    return new EvaluateDecisionResponseSelector(response);
   }
 
   private static final class DecisionProcessInstanceKeySelector implements DecisionSelector {
@@ -146,8 +151,8 @@ public class DecisionSelectors {
     }
 
     @Override
-    public boolean test(final DecisionInstance userTask) {
-      return decisionDefinitionName.equals(userTask.getDecisionDefinitionName());
+    public boolean test(final DecisionInstance decision) {
+      return decisionDefinitionName.equals(decision.getDecisionDefinitionName());
     }
 
     @Override
@@ -166,6 +171,37 @@ public class DecisionSelectors {
       if (processInstanceKey != null) {
         filter.processInstanceKey(processInstanceKey);
       }
+    }
+  }
+
+  private static final class EvaluateDecisionResponseSelector implements DecisionSelector {
+
+    private final EvaluateDecisionResponse response;
+
+    private EvaluateDecisionResponseSelector(final EvaluateDecisionResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public boolean test(final DecisionInstance decision) {
+      return decision.getDecisionInstanceKey() == response.getDecisionInstanceKey()
+          && decision.getDecisionDefinitionId().equals(response.getDecisionId());
+    }
+
+    @Override
+    public String describe() {
+      return String.format(
+          "%s (decisionInstanceKey: %d, decisionId: %s)",
+          response.getDecisionName(),
+          response.getDecisionInstanceKey(),
+          response.getDecisionId());
+    }
+
+    @Override
+    public void applyFilter(final DecisionInstanceFilter filter) {
+      filter
+          .decisionInstanceKey(response.getDecisionInstanceKey())
+          .decisionDefinitionId(response.getDecisionId());
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/DecisionSelectors.java
@@ -191,10 +191,7 @@ public class DecisionSelectors {
     @Override
     public String describe() {
       return String.format(
-          "%s (decisionInstanceKey: %d, decisionId: %s)",
-          response.getDecisionName(),
-          response.getDecisionInstanceKey(),
-          response.getDecisionId());
+          "%s (decisionId: %s)", response.getDecisionName(), response.getDecisionId());
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -16,7 +16,6 @@
 package io.camunda.process.test.impl.assertions;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
 import io.camunda.client.api.search.filter.IncidentFilter;
@@ -117,9 +116,5 @@ public class CamundaDataSource {
 
   public DecisionInstance getDecisionInstance(final String decisionInstanceId) {
     return client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
-  }
-
-  public JsonMapper getJsonMapper() {
-    return client.getConfiguration().getJsonMapper();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionMatchedRulesAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionMatchedRulesAssertj.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Fail.fail;
+
+import io.camunda.client.api.response.MatchedDecisionRule;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public class DecisionMatchedRulesAssertj
+    extends AbstractAssert<DecisionMatchedRulesAssertj, String> {
+
+  public DecisionMatchedRulesAssertj(final String failureMessagePrefix) {
+
+    super(failureMessagePrefix, DecisionMatchedRulesAssertj.class);
+  }
+
+  public void hasNoMatchedRules(final List<MatchedDecisionRule> matchedRules) {
+    final List<Integer> actualMatchedRuleIndices =
+        matchedRules.stream().map(MatchedDecisionRule::getRuleIndex).collect(Collectors.toList());
+
+    Assertions.assertThat(matchedRules)
+        .withFailMessage("%s to have no matches, but matched %s", actual, actualMatchedRuleIndices)
+        .isEmpty();
+  }
+
+  public void hasMatchedRules(
+      final List<MatchedDecisionRule> matchedRules, final int... expectedMatchedRuleIndexes) {
+
+    final List<Integer> expectedMatches = validateExpectedRuleIndexes(expectedMatchedRuleIndexes);
+    final List<Integer> actualMatchedRuleIndices =
+        matchedRules.stream().map(MatchedDecisionRule::getRuleIndex).collect(Collectors.toList());
+
+    Assertions.assertThat(actualMatchedRuleIndices)
+        .withFailMessage(
+            "%s to have matched rules %s, but did not. Matches:\n"
+                + "\t- matched: %s\n"
+                + "\t- missing: %s\n"
+                + "\t- unexpected: %s",
+            actual,
+            Arrays.toString(expectedMatchedRuleIndexes),
+            matchingRules(actualMatchedRuleIndices, expectedMatches),
+            missingRules(actualMatchedRuleIndices, expectedMatches),
+            unexpectedRules(actualMatchedRuleIndices, expectedMatches))
+        .containsAll(expectedMatches);
+  }
+
+  public void hasNotMatchedRules(
+      final List<MatchedDecisionRule> matchedRules, final int... expectedUnmatchedRuleIndexes) {
+
+    final List<Integer> expectedUnmatchedRuleIndexList =
+        validateExpectedRuleIndexes(expectedUnmatchedRuleIndexes);
+    final List<Integer> actualMatchedRuleIndexes =
+        matchedRules.stream().map(MatchedDecisionRule::getRuleIndex).collect(Collectors.toList());
+
+    Assertions.assertThat(actualMatchedRuleIndexes)
+        .withFailMessage(
+            "%s to not have matched rules %s, but matched %s",
+            actual,
+            Arrays.toString(expectedUnmatchedRuleIndexes),
+            matchingRules(actualMatchedRuleIndexes, expectedUnmatchedRuleIndexList))
+        .doesNotContainAnyElementsOf(expectedUnmatchedRuleIndexList);
+  }
+
+  private <T> List<T> matchingRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return expectedMatches.stream().filter(actualMatches::contains).collect(Collectors.toList());
+  }
+
+  private <T> List<T> missingRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return expectedMatches.stream()
+        .filter(e -> actualMatches.stream().noneMatch(a -> Objects.equals(a, e)))
+        .collect(Collectors.toList());
+  }
+
+  private <T> List<T> unexpectedRules(final List<T> actualMatches, final List<T> expectedMatches) {
+    return actualMatches.stream()
+        .filter(e -> expectedMatches.stream().noneMatch(a -> Objects.equals(a, e)))
+        .collect(Collectors.toList());
+  }
+
+  private List<Integer> validateExpectedRuleIndexes(final int... ruleIndexes) {
+    if (ruleIndexes.length == 0) {
+      fail("No matched rules given. Please provide at least one matched rule index.");
+    }
+
+    final List<Integer> ruleIndexList =
+        Arrays.stream(ruleIndexes).boxed().collect(Collectors.toList());
+
+    if (ruleIndexList.stream().anyMatch(i -> i <= 0)) {
+      fail("Matched rule indexes contain illegal values: %s", Arrays.toString(ruleIndexes));
+    }
+
+    return ruleIndexList;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionOutputAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/DecisionOutputAssertj.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import org.assertj.core.api.AbstractAssert;
+
+public class DecisionOutputAssertj extends AbstractAssert<DecisionOutputAssertj, String> {
+
+  private final ObjectMapper jsonMapper = new ObjectMapper();
+
+  public DecisionOutputAssertj(final String failureMessagePrefix) {
+    super(failureMessagePrefix, DecisionOutputAssertj.class);
+  }
+
+  public void hasOutput(final String decisionOutput, final Object expectedOutput) {
+    final JsonNode decisionOutputJson = readJson(decisionOutput);
+    final JsonNode expectedOutputJson = toJson(expectedOutput);
+
+    assertThat(decisionOutputJson)
+        .withFailMessage(
+            "%s to have output '%s', but was '%s'", actual, expectedOutputJson, decisionOutputJson)
+        .isEqualTo(expectedOutputJson);
+  }
+
+  private JsonNode readJson(final String value) {
+    if (value == null) {
+      return NullNode.getInstance();
+    }
+
+    try {
+      return jsonMapper.readValue(value, JsonNode.class);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(String.format("Failed to read JSON: '%s'", value), e);
+    }
+  }
+
+  private JsonNode toJson(final Object value) {
+    try {
+      return jsonMapper.convertValue(value, JsonNode.class);
+    } catch (final IllegalArgumentException e) {
+      throw new RuntimeException(
+          String.format("Failed to transform value to JSON: '%s'", value), e);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionMatchedRulesAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionMatchedRulesAssertTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.client.api.response.MatchedDecisionRule;
+import io.camunda.client.impl.response.MatchedDecisionRuleImpl;
+import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
+import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
+import io.camunda.process.test.impl.assertions.DecisionMatchedRulesAssertj;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DecisionMatchedRulesAssertTest {
+
+  private final DecisionMatchedRulesAssertj asserter =
+      new DecisionMatchedRulesAssertj("Expected EvaluatedDecision [name]");
+
+  private static Stream<Arguments> positiveMatchedRuleScenarios() {
+    return Stream.of(
+        Arguments.of(singleRule(), new int[] {1}),
+        Arguments.of(singleRule(), new int[] {1, 1, 1}),
+        Arguments.of(multiRule(), new int[] {1, 2, 3}),
+        Arguments.of(multiRule(), new int[] {3, 2, 1}),
+        Arguments.of(multiRule(), new int[] {1, 2}),
+        Arguments.of(multiRule(), new int[] {2, 3}),
+        Arguments.of(multiRule(), new int[] {1, 3}),
+        Arguments.of(multiRule(), new int[] {1}),
+        Arguments.of(multiRule(), new int[] {2}),
+        Arguments.of(multiRule(), new int[] {3}),
+        Arguments.of(multiRule(), new int[] {1, 1, 1}));
+  }
+
+  private static Stream<Arguments> positiveUnmatchedRuleScenarios() {
+    return Stream.of(
+        Arguments.of(singleRule(), new int[] {3}),
+        Arguments.of(singleRule(), new int[] {2}),
+        Arguments.of(singleRule(), new int[] {2, 2}),
+        Arguments.of(multiRule(), new int[] {4}),
+        Arguments.of(multiRule(), new int[] {4, 5, 6}));
+  }
+
+  private static List<MatchedDecisionRule> singleRule() {
+    final List<MatchedDecisionRule> matchedDecisionRuleItems = new java.util.ArrayList<>();
+    matchedDecisionRuleItems.add(
+        new MatchedDecisionRuleImpl(
+            new MatchedDecisionRuleItem()
+                .ruleId("ruleId")
+                .ruleIndex(1)
+                .addEvaluatedOutputsItem(
+                    new EvaluatedDecisionOutputItem()
+                        .outputId("outputId")
+                        .outputName("outputName")
+                        .outputValue("outputValue")),
+            null));
+    return matchedDecisionRuleItems;
+  }
+
+  private static List<MatchedDecisionRule> multiRule() {
+    final List<MatchedDecisionRule> matchedDecisionRuleItems = new java.util.ArrayList<>();
+    matchedDecisionRuleItems.add(
+        new MatchedDecisionRuleImpl(
+            new MatchedDecisionRuleItem()
+                .ruleId("ruleId")
+                .ruleIndex(1)
+                .addEvaluatedOutputsItem(
+                    new EvaluatedDecisionOutputItem()
+                        .outputId("outputId1")
+                        .outputName("outputName1")
+                        .outputValue("outputValue1")),
+            null));
+    matchedDecisionRuleItems.add(
+        new MatchedDecisionRuleImpl(
+            new MatchedDecisionRuleItem()
+                .ruleId("ruleId")
+                .ruleIndex(2)
+                .addEvaluatedOutputsItem(
+                    new EvaluatedDecisionOutputItem()
+                        .outputId("outputId2")
+                        .outputName("outputName2")
+                        .outputValue("outputValue2")),
+            null));
+    matchedDecisionRuleItems.add(
+        new MatchedDecisionRuleImpl(
+            new MatchedDecisionRuleItem()
+                .ruleId("ruleId")
+                .ruleIndex(3)
+                .addEvaluatedOutputsItem(
+                    new EvaluatedDecisionOutputItem()
+                        .outputId("outputId3")
+                        .outputName("outputName3")
+                        .outputValue("outputValue3")),
+            null));
+    return matchedDecisionRuleItems;
+  }
+
+  @Nested
+  class HasMatchedRules {
+
+    @ParameterizedTest
+    @MethodSource(
+        "io.camunda.process.test.api.DecisionMatchedRulesAssertTest#positiveMatchedRuleScenarios")
+    void hasMatchedRules(
+        final List<MatchedDecisionRule> matchedRules, final int[] expectedMatchedRules) {
+      // then
+      asserter.hasMatchedRules(matchedRules, expectedMatchedRules);
+    }
+
+    @Test
+    void hasDetailedOutputIfNoMatchesFound() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(singleRule(), 2))
+          .hasMessage(
+              "Expected EvaluatedDecision [name] to have matched rules [2], but did not. Matches:\n"
+                  + "\t- matched: []\n"
+                  + "\t- missing: [2]\n"
+                  + "\t- unexpected: [1]");
+    }
+
+    @Test
+    void hasDetailedOutputIfPartialMatchesFound() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(multiRule(), 1, 2, 4))
+          .hasMessage(
+              "Expected EvaluatedDecision [name] to have matched rules [1, 2, 4], but did not. Matches:\n"
+                  + "\t- matched: [1, 2]\n"
+                  + "\t- missing: [4]\n"
+                  + "\t- unexpected: [3]");
+    }
+  }
+
+  @Nested
+  class HasNotMatchedRules {
+
+    @ParameterizedTest
+    @MethodSource(
+        "io.camunda.process.test.api.DecisionMatchedRulesAssertTest#positiveUnmatchedRuleScenarios")
+    void hasNotMatchedRules(
+        final List<MatchedDecisionRule> matchedRules, final int[] expectedMatchedRules) {
+      // then
+      asserter.hasNotMatchedRules(matchedRules, expectedMatchedRules);
+    }
+
+    @Test
+    void hasDetailedOutputIfMatched() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasNotMatchedRules(singleRule(), 1))
+          .hasMessage(
+              "Expected EvaluatedDecision [name] to not have matched rules [1], but matched [1]");
+    }
+
+    @Test
+    void hasDetailedOutputIfPartiallyMatched() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasNotMatchedRules(multiRule(), 1, 2, 4))
+          .hasMessage(
+              "Expected EvaluatedDecision [name] to not have matched rules [1, 2, 4], but matched [1, 2]");
+    }
+  }
+
+  @Nested
+  class HasNoMatchedRules {
+
+    @Test
+    void hasNoMatchedRules() {
+      // then
+      asserter.hasNoMatchedRules(Collections.emptyList());
+    }
+
+    @Test
+    void hasMatches() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasNoMatchedRules(multiRule()))
+          .hasMessage(
+              "Expected EvaluatedDecision [name] to have no matches, but matched [1, 2, 3]");
+    }
+  }
+
+  @Nested
+  class EdgeCases {
+    @Test
+    void shouldFailIfNoMatchedRulesGiven() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(multiRule()))
+          .hasMessage("No matched rules given. Please provide at least one matched rule index.");
+
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(multiRule()))
+          .hasMessage("No matched rules given. Please provide at least one matched rule index.");
+    }
+
+    @Test
+    void shouldFailIfIllegalIndexValueGiven() {
+      // then
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(multiRule(), -1))
+          .hasMessage("Matched rule indexes contain illegal values: [-1]");
+
+      Assertions.assertThatThrownBy(() -> asserter.hasNotMatchedRules(multiRule(), -1))
+          .hasMessage("Matched rule indexes contain illegal values: [-1]");
+
+      Assertions.assertThatThrownBy(() -> asserter.hasMatchedRules(multiRule(), -1, 0))
+          .hasMessage("Matched rule indexes contain illegal values: [-1, 0]");
+
+      Assertions.assertThatThrownBy(() -> asserter.hasNotMatchedRules(multiRule(), -1, 0))
+          .hasMessage("Matched rule indexes contain illegal values: [-1, 0]");
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionOutputAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/DecisionOutputAssertTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.process.test.impl.assertions.DecisionOutputAssertj;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DecisionOutputAssertTest {
+
+  private static final String FAILURE_MESSAGE_PREFIX = "Expected DecisionInstance [name]";
+
+  private final DecisionOutputAssertj decisionOutputAssert =
+      new DecisionOutputAssertj(FAILURE_MESSAGE_PREFIX);
+
+  private static Stream<Arguments> outputScenarios() {
+    return Stream.of(
+        Arguments.of("\"output\"", "output"),
+        Arguments.of("5", 5),
+        Arguments.of("true", true),
+        Arguments.of("{\"a\":\"b\",\"v\":2}", outputMap()),
+        Arguments.of("[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]", outputList()),
+        Arguments.of("null", null),
+        Arguments.of("[1, 2, 3]", Arrays.asList(1, 2, 3)));
+  }
+
+  private static Map<String, Object> outputMap() {
+    final Map<String, Object> expected = new HashMap<>();
+    expected.put("a", "b");
+    expected.put("v", 2);
+
+    return expected;
+  }
+
+  private static List<Map<String, Object>> outputList() {
+    final Map<String, Object> firstMatch = new HashMap<>();
+    firstMatch.put("a", 1);
+    firstMatch.put("b", 2);
+    final Map<String, Object> secondMatch = new HashMap<>();
+    secondMatch.put("c", 3);
+    secondMatch.put("d", 4);
+
+    return Arrays.asList(firstMatch, secondMatch);
+  }
+
+  @ParameterizedTest
+  @MethodSource("io.camunda.process.test.api.DecisionOutputAssertTest#outputScenarios")
+  void hasOutput(String actual, Object expected) {
+    decisionOutputAssert.hasOutput(actual, expected);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -646,10 +646,7 @@ public class CamundaProcessTestContextIT {
         evaluateDecisionByDecisionId("simple_decision", variables);
 
     // Then
-    assertThat(response)
-        .isEvaluated()
-        .hasOutput(":)")
-        .hasMatchedRules(1);
+    assertThat(response).isEvaluated().hasOutput(":)").hasMatchedRules(1);
   }
 
   @Test
@@ -670,10 +667,7 @@ public class CamundaProcessTestContextIT {
         evaluateDecisionByDecisionId("decision_overall_happiness", variables);
 
     // Then
-    assertThat(response)
-        .isEvaluated()
-        .hasOutput("pretty happy")
-        .hasMatchedRules(3);
+    assertThat(response).isEvaluated().hasOutput("pretty happy").hasMatchedRules(3);
 
     assertThat(DecisionSelectors.byId("decision_color_happiness"))
         .isEvaluated()
@@ -705,7 +699,10 @@ public class CamundaProcessTestContextIT {
 
     // Then
     Assertions.assertThatThrownBy(() -> assertThat(response).isEvaluated())
-        .hasMessageStartingWith("No DecisionInstance");
+        .hasMessage(
+            "No DecisionInstance [Determine Overall Happiness "
+                + "(decisionId: decision_overall_happiness)] "
+                + "found.");
 
     Assertions.assertThatThrownBy(
             () -> assertThat(DecisionSelectors.byId("decision_overall_happiness")).isEvaluated())

--- a/testing/camunda-process-test-java/src/test/resources/dmn/complex-decision-table.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/complex-decision-table.dmn
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="definition_complex" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="1e1176c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="decision_color_happiness" name="Color Happiness">
+    <decisionTable id="DecisionTable_1esy623">
+      <input id="Input_1" label="color">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>color</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="color_happiness" name="color_happiness" typeRef="number" />
+      <rule id="DecisionRule_11bo7x9">
+        <inputEntry id="UnaryTests_0x9mhws">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hhcg0b">
+          <text>15</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0zeptnx">
+        <inputEntry id="UnaryTests_0ebiywx">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_13futrr">
+          <text>90</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_010pdj4">
+        <inputEntry id="UnaryTests_0ptat5a">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_102yfvl">
+          <text>50</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision_overall_happiness" name="Determine Overall Happiness">
+    <informationRequirement id="InformationRequirement_0182tof">
+      <requiredDecision href="#decision_color_happiness" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_1jlp6d0">
+      <requiredDecision href="#decision_language_happiness" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1fnl378">
+      <input id="InputClause_010jomw" label="color_happiness">
+        <inputExpression id="LiteralExpression_1goujyk" typeRef="number">
+          <text>decision_color_happiness</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_05qpdtw" label="language_happiness">
+        <inputExpression id="LiteralExpression_0o941m6" typeRef="number">
+          <text>decision_language_happiness</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0nxcgzf" label="overall_happiness" name="overall_happiness" typeRef="string" />
+      <rule id="DecisionRule_0utdyd7">
+        <inputEntry id="UnaryTests_1yw9taa">
+          <text>15</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w6vxab">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1tenict">
+          <text>"very unhappy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1rbszu2">
+        <inputEntry id="UnaryTests_1q6ddxa">
+          <text>15</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1idb44b">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hc5d8f">
+          <text>"kinda happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00uvg8b">
+        <inputEntry id="UnaryTests_0gsxdc8">
+          <text>90</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hr88wd">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1qybhya">
+          <text>"pretty happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_005mb3w">
+        <inputEntry id="UnaryTests_0oqira9">
+          <text>90</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y8gokf">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t5tm81">
+          <text>"overwhelmingly happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06vu0ot">
+        <inputEntry id="UnaryTests_0lyp7v7">
+          <text>50</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t266du">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ebpudg">
+          <text>"somewhat happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00wuip7">
+        <inputEntry id="UnaryTests_1k9bxo3">
+          <text>50</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10weehb">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01ztkqu">
+          <text>"extremely happy"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision_language_happiness" name="Language Happiness">
+    <decisionTable id="DecisionTable_1grwo62">
+      <input id="InputClause_15uu868" label="language">
+        <inputExpression id="LiteralExpression_1rnnaqe" typeRef="string">
+          <text>language</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_10ett6q" label="language_happinessx" name="language_happiness" typeRef="number" />
+      <rule id="DecisionRule_1h5hb7v">
+        <inputEntry id="UnaryTests_0ki87j0">
+          <text>"german"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0iigyjx">
+          <text>10</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0zfesak">
+        <inputEntry id="UnaryTests_10zcglw">
+          <text>"english"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mzaalu">
+          <text>80</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision_color_happiness">
+        <dc:Bounds height="80" width="180" x="160" y="290" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_1149owv" dmnElementRef="InformationRequirement_0182tof">
+        <di:waypoint x="250" y="290" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_00g50d4" dmnElementRef="InformationRequirement_1jlp6d0">
+        <di:waypoint x="540" y="290" />
+        <di:waypoint x="430" y="180" />
+        <di:waypoint x="430" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape id="DMNShape_1nupidt" dmnElementRef="decision_overall_happiness">
+        <dc:Bounds height="80" width="180" x="310" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_08eihc8" dmnElementRef="decision_language_happiness">
+        <dc:Bounds height="80" width="180" x="450" y="290" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/testing/camunda-process-test-java/src/test/resources/dmn/faulty-decision-table.dmn
+++ b/testing/camunda-process-test-java/src/test/resources/dmn/faulty-decision-table.dmn
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" id="definition_complex" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Web Modeler" exporterVersion="1e1176c" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <decision id="decision_color_happiness" name="Color Happiness">
+    <decisionTable id="DecisionTable_1esy623">
+      <input id="Input_1" label="color">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>color</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="color_happiness" name="color_happiness" typeRef="number" />
+      <rule id="DecisionRule_11bo7x9">
+        <inputEntry id="UnaryTests_0x9mhws">
+          <text>"red"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hhcg0b">
+          <text>15</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0zeptnx">
+        <inputEntry id="UnaryTests_0ebiywx">
+          <text>"green"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_13futrr">
+          <text>90</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_010pdj4">
+        <inputEntry id="UnaryTests_0ptat5a">
+          <text>"blue"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_102yfvl">
+          <text>50</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision_overall_happiness" name="Determine Overall Happiness">
+    <informationRequirement id="InformationRequirement_0182tof">
+      <requiredDecision href="#decision_color_happiness" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_1jlp6d0">
+      <requiredDecision href="#decision_language_happiness" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_1fnl378">
+      <input id="InputClause_010jomw" label="color_happiness">
+        <inputExpression id="LiteralExpression_1goujyk" typeRef="number">
+          <text>decision_color_happiness</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_05qpdtw" label="language_happiness">
+        <inputExpression id="LiteralExpression_0o941m6" typeRef="number">
+          <text>decision_language_happiness</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_0nxcgzf" label="overall_happiness" name="overall_happiness" typeRef="string" />
+      <rule id="DecisionRule_0utdyd7">
+        <inputEntry id="UnaryTests_1yw9taa">
+          <text>15</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0w6vxab">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1tenict">
+          <text>"very unhappy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1rbszu2">
+        <inputEntry id="UnaryTests_1q6ddxa">
+          <text>15</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1idb44b">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hc5d8f">
+          <text>"kinda happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00uvg8b">
+        <inputEntry id="UnaryTests_0gsxdc8">
+          <text>90</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0hr88wd">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1qybhya">
+          <text>"pretty happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_005mb3w">
+        <inputEntry id="UnaryTests_0oqira9">
+          <text>90</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1y8gokf">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0t5tm81">
+          <text>"overwhelmingly happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_06vu0ot">
+        <inputEntry id="UnaryTests_0lyp7v7">
+          <text>50</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0t266du">
+          <text>10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0ebpudg">
+          <text>"somewhat happy"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_00wuip7">
+        <inputEntry id="UnaryTests_1k9bxo3">
+          <text>50</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_10weehb">
+          <text>80</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01ztkqu">
+          <text>"extremely happy"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="decision_language_happiness" name="Language Happiness">
+    <decisionTable id="DecisionTable_1grwo62">
+      <input id="InputClause_15uu868" label="language">
+        <inputExpression id="LiteralExpression_1rnnaqe" typeRef="string">
+          <text>language</text>
+        </inputExpression>
+      </input>
+      <output id="OutputClause_10ett6q" label="language_happiness" name="language_happiness" typeRef="number" biodi:width="192" />
+      <rule id="DecisionRule_1h5hb7v">
+        <inputEntry id="UnaryTests_0ki87j0">
+          <text>"german"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0iigyjx">
+          <text>10</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0zfesak">
+        <inputEntry id="UnaryTests_10zcglw">
+          <text>"english"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0mzaalu">
+          <text>80</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0pr78b3">
+        <inputEntry id="UnaryTests_1xmhdgb">
+          <text>"german"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0jtjwiu">
+          <text>10</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision_color_happiness">
+        <dc:Bounds height="80" width="180" x="160" y="290" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_1149owv" dmnElementRef="InformationRequirement_0182tof">
+        <di:waypoint x="250" y="290" />
+        <di:waypoint x="370" y="180" />
+        <di:waypoint x="370" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_00g50d4" dmnElementRef="InformationRequirement_1jlp6d0">
+        <di:waypoint x="540" y="290" />
+        <di:waypoint x="430" y="180" />
+        <di:waypoint x="430" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape id="DMNShape_1nupidt" dmnElementRef="decision_overall_happiness">
+        <dc:Bounds height="80" width="180" x="310" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_08eihc8" dmnElementRef="decision_language_happiness">
+        <dc:Bounds height="80" width="180" x="450" y="290" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
## Description

Asserts decisions evaluated via Camunda API. This PR also refactors some of the repeated logic and creates custom assertion classes for MatchedRules and decision outputs. This now enables developers to test DecisionInstances, EvaluateDecisionResponse and EvaluatedDecisions.

A good showcase of the new assertions are in CamundaProcessTestContextIT.

## Related issues

closes https://github.com/camunda/camunda/issues/31544 
closes https://github.com/camunda/camunda/issues/29070
