### PR TITLE
feat: new StandaloneCamunda default profiles

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -29,7 +29,13 @@ public class StandaloneCamunda {
 
   private static final String SPRING_PROFILES_ACTIVE_PROPERTY = ACTIVE_PROFILES_PROPERTY_NAME;
   private static final String DEFAULT_CAMUNDA_PROFILES =
-      String.join(",", Profile.OPERATE.getId(), Profile.TASKLIST.getId(), Profile.BROKER.getId());
+      String.join(
+          ",",
+          Profile.OPERATE.getId(),
+          Profile.TASKLIST.getId(),
+          Profile.BROKER.getId(),
+          Profile.IDENTITY.getId(),
+          Profile.CONSOLIDATED_AUTH.getId());
 
   public static void main(final String[] args) {
     MainSupport.setDefaultGlobalConfiguration();


### PR DESCRIPTION
## Description

This adds identity to the defaults as well as consolidated-auth. The latter will switch the default to the new central spring security setup coming with 8.8.

Context https://camunda.slack.com/archives/C08MRKHJ0CD/p1747326650269769

Note:
Running the default profiles will still not allow you to login until https://github.com/camunda/camunda/issues/28819 is resolved. Till then the following minimal exporter config is required still
```
ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter
ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200
ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS=false
```
