### PR TITLE
feat: integration with BE part-2

### DIFF
--- a/operate/client/e2e-playwright/a11y/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/processInstance.spec.ts
@@ -29,6 +29,8 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -74,8 +76,10 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
-          statisticsV2: runningInstance.statisticsV2,
+          statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
           sequenceFlowsV2: instanceWithIncident.sequenceFlowsV2,
           variables: instanceWithIncident.variables,
@@ -141,6 +145,8 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/delete-finished-instances.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/delete-finished-instances.spec.ts
@@ -162,6 +162,8 @@ test.describe('delete finished instances', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: completedOrderProcessInstance.detail,
+        processInstanceDetailV2: completedOrderProcessInstance.detailV2,
+        callHierarchy: completedOrderProcessInstance.callHierarchy,
         flowNodeInstances: completedOrderProcessInstance.flowNodeInstances,
         statisticsV2: completedOrderProcessInstance.statisticsV2,
         sequenceFlows: completedOrderProcessInstance.sequenceFlows,
@@ -202,6 +204,16 @@ test.describe('delete finished instances', () => {
 
     await page.route(URL_API_PATTERN, (route) => {
       if (route.request().url().includes('/api/process-instances/')) {
+        return route.fulfill({
+          status: 404,
+          body: JSON.stringify(''),
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      }
+
+      if (route.request().url().includes('/v2/process-instances/')) {
         return route.fulfill({
           status: 404,
           body: JSON.stringify(''),

--- a/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
@@ -118,6 +118,8 @@ test.describe('get familiar with operate', () => {
       URL_API_PATTERN,
       mockProcessInstanceDetailResponses({
         processInstanceDetail: runningOrderProcessInstance.detail,
+        processInstanceDetailV2: runningOrderProcessInstance.detailV2,
+        callHierarchy: runningOrderProcessInstance.callHierarchy,
         flowNodeInstances: runningOrderProcessInstance.flowNodeInstances,
         statisticsV2: runningOrderProcessInstance.statisticsV2,
         sequenceFlows: runningOrderProcessInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
@@ -30,6 +30,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -132,6 +134,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -250,6 +254,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -392,6 +398,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
@@ -106,6 +106,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.incidentState.detail,
+        processInstanceDetailV2: orderProcessInstance.incidentState.detailV2,
+        callHierarchy: orderProcessInstance.incidentState.callHierarchy,
         flowNodeInstances: orderProcessInstance.incidentState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentState.statisticsV2,
         sequenceFlows: orderProcessInstance.incidentState.sequenceFlows,
@@ -186,6 +188,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.incidentState.detail,
+        processInstanceDetailV2: orderProcessInstance.incidentState.detailV2,
+        callHierarchy: orderProcessInstance.incidentState.callHierarchy,
         flowNodeInstances: orderProcessInstance.incidentState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentState.statisticsV2,
         sequenceFlows: orderProcessInstance.incidentState.sequenceFlows,
@@ -247,6 +251,9 @@ test.describe('variables and incidents', () => {
       mockProcessDetailResponses({
         processInstanceDetail:
           orderProcessInstance.incidentResolvedState.detail,
+        processInstanceDetailV2:
+          orderProcessInstance.incidentResolvedState.detailV2,
+        callHierarchy: orderProcessInstance.incidentResolvedState.callHierarchy,
         flowNodeInstances:
           orderProcessInstance.incidentResolvedState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentResolvedState.statisticsV2,
@@ -273,6 +280,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.completedState.detail,
+        processInstanceDetailV2: orderProcessInstance.completedState.detailV2,
+        callHierarchy: orderProcessInstance.completedState.callHierarchy,
         flowNodeInstances:
           orderProcessInstance.completedState.flowNodeInstances,
         statisticsV2: orderProcessInstance.completedState.statisticsV2,

--- a/operate/client/e2e-playwright/mocks/processInstance/compensationProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/compensationProcessInstance.mocks.ts
@@ -39,6 +39,7 @@ const compensationProcessInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: false,
   },
+  callHierarchy: [],
   flowNodeInstances: {
     '9007199254744341': {
       children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/completedInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/completedInstance.mocks.ts
@@ -38,6 +38,7 @@ const completedInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: false,
   },
+  callHierarchy: [],
   flowNodeInstances: {
     '2551799813954282': {
       children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/completedOrderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/completedOrderProcessInstance.mocks.ts
@@ -26,6 +26,7 @@ const completedOrderProcessInstance: InstanceMock = {
     processDefinitionVersion: 1,
     processDefinitionId: 'orderProcess',
   },
+  callHierarchy: [],
   xml: open('orderProcess.bpmn'),
   statisticsV2: {
     items: [

--- a/operate/client/e2e-playwright/mocks/processInstance/eventBasedGatewayProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/eventBasedGatewayProcessInstance.mocks.ts
@@ -38,6 +38,7 @@ const eventBasedGatewayProcessInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: true,
   },
+  callHierarchy: [],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_13jk2qx" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.5.0">
       <bpmn:process id="eventBasedGatewayProcess" name="Event based gateway with timer start" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/index.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/index.ts
@@ -9,6 +9,7 @@
 import {Route} from '@playwright/test';
 import {
   GetProcessDefinitionStatisticsResponseBody,
+  GetProcessInstanceCallHierarchyResponseBody,
   GetProcessSequenceFlowsResponseBody,
   ProcessInstance,
 } from '@vzeta/camunda-api-zod-schemas/operate';
@@ -24,6 +25,7 @@ type InstanceMock = {
   xml: string;
   detail: ProcessInstanceEntity;
   detailV2: ProcessInstance;
+  callHierarchy: GetProcessInstanceCallHierarchyResponseBody;
   flowNodeInstances: FlowNodeInstancesDto<FlowNodeInstanceDto>;
   statisticsV2: GetProcessDefinitionStatisticsResponseBody;
   sequenceFlows: SequenceFlowsDto;
@@ -36,6 +38,7 @@ type InstanceMock = {
 function mockResponses({
   processInstanceDetail,
   processInstanceDetailV2,
+  callHierarchy,
   flowNodeInstances,
   statisticsV2,
   sequenceFlows,
@@ -47,6 +50,7 @@ function mockResponses({
 }: {
   processInstanceDetail?: ProcessInstanceEntity;
   processInstanceDetailV2?: ProcessInstance;
+  callHierarchy?: GetProcessInstanceCallHierarchyResponseBody;
   flowNodeInstances?: FlowNodeInstancesDto<FlowNodeInstanceDto>;
   statisticsV2?: GetProcessDefinitionStatisticsResponseBody;
   sequenceFlows?: SequenceFlowsDto;
@@ -163,6 +167,16 @@ function mockResponses({
       return route.fulfill({
         status: metaData === undefined ? 400 : 200,
         body: JSON.stringify(metaData),
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    if (route.request().url().includes('call-hierarchy')) {
+      return route.fulfill({
+        status: callHierarchy === undefined ? 400 : 200,
+        body: JSON.stringify(callHierarchy),
         headers: {
           'content-type': 'application/json',
         },

--- a/operate/client/e2e-playwright/mocks/processInstance/instanceWithIncident.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/instanceWithIncident.mocks.ts
@@ -50,12 +50,30 @@ const instanceWithIncident: InstanceMock = {
     processDefinitionKey: '2251799813687188',
     processDefinitionName: 'Order process',
     processDefinitionVersion: 2,
+    parentProcessInstanceKey: '6755399441062817',
     startDate: '2023-08-14T05:47:07.376+0000',
     state: 'ACTIVE',
     processDefinitionId: 'orderProcess',
     tenantId: '',
     hasIncident: true,
   },
+  callHierarchy: [
+    {
+      processInstanceKey: '6755399441062811',
+      processDefinitionName: 'Call Activity Process',
+      processDefinitionKey: '2251799813686145',
+    },
+    {
+      processInstanceKey: '6755399441062817',
+      processDefinitionName: 'called-process',
+      processDefinitionKey: '2251799813687891',
+    },
+    {
+      processInstanceKey: '6755399441062827',
+      processDefinitionName: 'Order process',
+      processDefinitionKey: '2251799813687188',
+    },
+  ],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
   <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
     <bpmn:process id="orderProcess" name="Order process" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/orderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/orderProcessInstance.mocks.ts
@@ -189,6 +189,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: true,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [
@@ -417,6 +418,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: false,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [
@@ -637,6 +639,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: false,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/runningInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/runningInstance.mocks.ts
@@ -38,6 +38,7 @@ const runningInstance: InstanceMock = {
     tenantId: '',
     hasIncident: false,
   },
+  callHierarchy: [],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w68912" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
       <bpmn:process id="signalEventProcess" name="Signal event" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/runningOrderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/runningOrderProcessInstance.mocks.ts
@@ -24,6 +24,7 @@ const runningOrderProcessInstance: InstanceMock = {
     processDefinitionName: 'Order process',
     processDefinitionId: 'orderProcess',
   },
+  callHierarchy: [],
   xml: open('orderProcess.bpmn'),
   statisticsV2: {
     items: [

--- a/operate/client/e2e-playwright/visual/modifications.spec.ts
+++ b/operate/client/e2e-playwright/visual/modifications.spec.ts
@@ -41,6 +41,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -77,6 +79,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -121,6 +125,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
@@ -189,6 +195,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,

--- a/operate/client/e2e-playwright/visual/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstance.spec.ts
@@ -43,6 +43,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           xml: runningInstance.xml,
         }),
       );
@@ -68,6 +70,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -98,6 +102,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -129,6 +135,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -165,6 +173,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
@@ -181,6 +191,12 @@ test.describe('process instance page', () => {
           waitUntil: 'networkidle',
         },
       });
+
+      await page
+        .getByRole('button', {
+          name: /reset diagram zoom/i,
+        })
+        .click();
 
       await page
         .getByRole('button', {
@@ -202,6 +218,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: completedInstance.detail,
+          processInstanceDetailV2: completedInstance.detailV2,
+          callHierarchy: completedInstance.callHierarchy,
           flowNodeInstances: completedInstance.flowNodeInstances,
           statisticsV2: completedInstance.statisticsV2,
           sequenceFlows: completedInstance.sequenceFlows,
@@ -237,6 +255,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: compensationProcessInstance.detail,
+          processInstanceDetailV2: compensationProcessInstance.detailV2,
+          callHierarchy: compensationProcessInstance.callHierarchy,
           flowNodeInstances: compensationProcessInstance.flowNodeInstances,
           statisticsV2: compensationProcessInstance.statisticsV2,
           sequenceFlows: compensationProcessInstance.sequenceFlows,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -7,12 +7,7 @@
  */
 
 import {VariablePanel} from './index';
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -192,12 +187,10 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
-    );
-
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: /add variable/i}),
+      await screen.findByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([]);
@@ -219,11 +212,11 @@ describe('VariablePanel', () => {
       cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
-    await waitFor(() =>
+    await waitFor(async () => {
       expect(
-        screen.getByText('The Flow Node has no Variables'),
-      ).toBeInTheDocument(),
-    );
+        await screen.findByText('The Flow Node has no Variables'),
+      ).toBeInTheDocument();
+    });
 
     // add a new token
     act(() => {
@@ -359,9 +352,8 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       await screen.findByRole('button', {name: /add variable/i}),
@@ -539,17 +531,15 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
-    );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+
     mockFetchVariables().withSuccess([]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -43,7 +43,6 @@ import {
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
   IS_PROCESS_INSTANCE_V2_ENABLED: true,
 }));
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -186,7 +186,9 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
     expect(
       await screen.findByRole('button', {name: /add variable/i}),
@@ -351,7 +353,9 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -530,7 +534,9 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/FlowNodeStates.test.tsx
@@ -7,7 +7,12 @@
  */
 
 import {VariablePanel} from './index';
-import {render, screen, waitFor} from 'modules/testing-library';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -96,7 +101,7 @@ const mockProcessInstance: ProcessInstance = {
   hasIncident: false,
 };
 
-describe.skip('VariablePanel', () => {
+describe('VariablePanel', () => {
   beforeEach(() => {
     const mockProcessInstanceDeprecated = createInstance();
 
@@ -187,13 +192,15 @@ describe.skip('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
 
+    mockFetchVariables().withSuccess([]);
     mockFetchVariables().withSuccess([]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
 
@@ -208,20 +215,15 @@ describe.skip('VariablePanel', () => {
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
 
     // initial state
-    expect(
-      await screen.findByText('The Flow Node has no Variables'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: /add variable/i}),
-    ).toBeInTheDocument();
-
     act(() => {
       cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
     });
 
-    expect(
-      screen.getByText('The Flow Node has no Variables'),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText('The Flow Node has no Variables'),
+      ).toBeInTheDocument(),
+    );
 
     // add a new token
     act(() => {
@@ -357,7 +359,9 @@ describe.skip('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       await screen.findByRole('button', {name: /add variable/i}),
@@ -530,18 +534,22 @@ describe.skip('VariablePanel', () => {
         endDate: '2022-09-08T12:44:45.406+0000',
       },
     });
+    mockFetchVariables().withSuccess([createVariable()]);
 
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
-
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
     mockFetchVariables().withSuccess([]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
@@ -7,13 +7,7 @@
  */
 
 import {VariablePanel} from './index';
-import {
-  render,
-  screen,
-  UserEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, UserEvent, waitFor} from 'modules/testing-library';
 
 import {LastModification} from 'App/ProcessInstance/LastModification';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
@@ -37,6 +31,11 @@ import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas/operate';
 import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstances/fetchProcessInstanceListeners';
 import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
+}));
 
 const editNameFromTextfieldAndBlur = async (user: UserEvent, value: string) => {
   const [nameField] = screen.getAllByTestId('new-variable-name');
@@ -157,9 +156,6 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.getByTestId('variables-skeleton'),
-    );
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -185,8 +181,6 @@ describe('New Variable Modifications', () => {
       modificationsStore.enableModificationMode();
 
       const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
       await waitFor(() => {
         expect(
           screen.getByRole('button', {name: /add variable/i}),
@@ -226,8 +220,6 @@ describe('New Variable Modifications', () => {
       mockFetchVariables().withSuccess([createVariable()]);
 
       const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
       await waitFor(() => {
         expect(
           screen.getByRole('button', {name: /add variable/i}),
@@ -318,8 +310,6 @@ describe('New Variable Modifications', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
     await waitFor(() => {
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
     });
@@ -359,8 +349,6 @@ describe('New Variable Modifications', () => {
         </>,
         {wrapper: getWrapper()},
       );
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
       await waitFor(() => {
         expect(
           screen.getByRole('button', {name: /add variable/i}),
@@ -542,7 +530,6 @@ describe('New Variable Modifications', () => {
       modificationsStore.enableModificationMode();
 
       const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
       await waitFor(() => {
         expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/NewVariableModifications.test.tsx
@@ -582,7 +582,7 @@ describe('New Variable Modifications', () => {
     },
   );
 
-  it.skip('should be able to remove the first added variable modification after switching between flow node instances', async () => {
+  it('should be able to remove the first added variable modification after switching between flow node instances', async () => {
     jest.useFakeTimers();
     modificationsStore.enableModificationMode();
 
@@ -640,7 +640,7 @@ describe('New Variable Modifications', () => {
 
     act(() => {
       selectFlowNode(
-        {},
+        {flowNodeInstanceId: 'instance_id', isMultiInstance: false},
         {
           flowNodeInstanceId: 'instance_id',
           isMultiInstance: false,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -177,7 +177,9 @@ describe('VariablePanel', () => {
 
     render(<VariablePanel />, {wrapper: getWrapper()});
 
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
   });
 
@@ -595,8 +597,9 @@ describe('VariablePanel', () => {
     mockFetchVariables().withSuccess([createVariable()]);
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
-
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([createVariable({name: 'test2'})]);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -168,11 +168,14 @@ describe('VariablePanel', () => {
   });
 
   it('should render variables', async () => {
+    mockFetchVariables().withSuccess([createVariable()]);
+
     render(<VariablePanel />, {wrapper: getWrapper()});
 
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
   });
 
   it('should add new variable', async () => {
@@ -589,10 +592,10 @@ describe('VariablePanel', () => {
     mockFetchVariables().withSuccess([createVariable()]);
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([createVariable({name: 'test2'})]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -50,6 +50,11 @@ import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'mo
 
 const getOperationSpy = jest.spyOn(operationApi, 'getOperation');
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
+}));
+
 jest.mock('modules/stores/notifications', () => ({
   notificationsStore: {
     displayNotification: jest.fn(() => () => {}),
@@ -172,9 +177,7 @@ describe('VariablePanel', () => {
 
     render(<VariablePanel />, {wrapper: getWrapper()});
 
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
   });
 
@@ -592,9 +595,8 @@ describe('VariablePanel', () => {
     mockFetchVariables().withSuccess([createVariable()]);
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchVariables().withSuccess([createVariable({name: 'test2'})]);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/index.test.tsx
@@ -87,7 +87,7 @@ const getWrapper = (
   return Wrapper;
 };
 
-describe.skip('VariablePanel', () => {
+describe('VariablePanel', () => {
   const mockProcessInstance: ProcessInstance = {
     processInstanceKey: 'instance_id',
     state: 'ACTIVE',
@@ -170,7 +170,9 @@ describe.skip('VariablePanel', () => {
   it('should render variables', async () => {
     render(<VariablePanel />, {wrapper: getWrapper()});
 
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
   });
 
   it('should add new variable', async () => {
@@ -388,6 +390,8 @@ describe.skip('VariablePanel', () => {
   });
 
   it('should display validation error if backend validation fails while adding variable', async () => {
+    mockFetchVariables().withSuccess([createVariable()]);
+
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
@@ -582,10 +586,13 @@ describe.skip('VariablePanel', () => {
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: statistics,
     });
+    mockFetchVariables().withSuccess([createVariable()]);
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     mockFetchVariables().withSuccess([createVariable({name: 'test2'})]);
     mockFetchProcessInstanceListeners().withSuccess(noListeners);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
@@ -52,7 +52,6 @@ const getOperationSpy = jest.spyOn(operationApi, 'getOperation');
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
   IS_PROCESS_INSTANCE_V2_ENABLED: true,
 }));
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/notification.test.tsx
@@ -93,7 +93,7 @@ const getWrapper = (
   return Wrapper;
 };
 
-describe.skip('VariablePanel', () => {
+describe('VariablePanel', () => {
   beforeEach(() => {
     const mockProcessInstance: ProcessInstance = {
       processInstanceKey: 'instance_id',
@@ -164,7 +164,9 @@ describe.skip('VariablePanel', () => {
     jest.clearAllTimers();
   });
 
-  it.only('should display error notification if add variable operation could not be created', async () => {
+  it('should display error notification if add variable operation could not be created', async () => {
+    mockFetchVariables().withSuccess([createVariable()]);
+
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitFor(() =>
       expect(
@@ -251,6 +253,7 @@ describe.skip('VariablePanel', () => {
       },
     ];
 
+    mockFetchVariables().withSuccess([createVariable()]);
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: statistics,
     });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/placeholder.test.tsx
@@ -38,7 +38,7 @@ import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'mo
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
 }));
 
 jest.mock('modules/stores/notifications', () => ({

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -7,12 +7,7 @@
  */
 
 import {VariablePanel} from './index';
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -48,7 +43,7 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
 }));
 
 jest.mock('modules/stores/notifications', () => ({
@@ -208,9 +203,7 @@ describe('VariablePanel', () => {
     render(<VariablePanel />, {
       wrapper: getWrapper([Paths.processInstance('processInstanceId123')]),
     });
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -267,9 +260,7 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -360,9 +351,7 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -463,9 +452,7 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -526,9 +513,7 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -203,7 +203,9 @@ describe('VariablePanel', () => {
     render(<VariablePanel />, {
       wrapper: getWrapper([Paths.processInstance('processInstanceId123')]),
     });
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -260,7 +262,9 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -351,7 +355,9 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -452,7 +458,9 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
@@ -513,7 +521,9 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -41,10 +41,7 @@ import {mockFetchProcessInstanceListeners} from 'modules/mocks/api/processInstan
 import {noListeners} from 'modules/mocks/mockProcessInstanceListeners';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {init as initFlowNodeMetadata} from 'modules/utils/flowNodeMetadata';
-import {
-  init as initFlowNodeSelection,
-  selectFlowNode,
-} from 'modules/utils/flowNodeSelection';
+import {selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {cancelAllTokens} from 'modules/utils/modifications';
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
@@ -211,16 +208,18 @@ describe('VariablePanel', () => {
     render(<VariablePanel />, {
       wrapper: getWrapper([Paths.processInstance('processInstanceId123')]),
     });
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument(),
-    );
+
+    expect(
+      await screen.findByTestId('edit-variable-value'),
+    ).toBeInTheDocument();
 
     act(() => {
       cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
@@ -268,10 +267,10 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -361,10 +360,10 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -464,10 +463,10 @@ describe('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -527,10 +526,10 @@ describe('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/readonly.test.tsx
@@ -7,7 +7,12 @@
  */
 
 import {VariablePanel} from './index';
-import {render, screen, waitFor} from 'modules/testing-library';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -86,7 +91,7 @@ const getWrapper = (
   return Wrapper;
 };
 
-describe.skip('VariablePanel', () => {
+describe('VariablePanel', () => {
   beforeEach(() => {
     const mockProcessInstance: ProcessInstance = {
       processInstanceKey: 'instance_id',
@@ -105,6 +110,10 @@ describe.skip('VariablePanel', () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstanceDeprecated().withSuccess(
+      mockProcessInstanceDeprecated,
+    );
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockProcessInstanceDeprecated,
     );
@@ -139,14 +148,15 @@ describe.skip('VariablePanel', () => {
     });
 
     mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchVariables().withSuccess([createVariable()]);
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
 
-    initFlowNodeMetadata('instance_id', statistics);
-    initFlowNodeSelection(null, 'instance_id');
+    initFlowNodeMetadata('process-instance', statistics);
+    flowNodeSelectionStore.init();
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
         id: 'instance_id',
@@ -201,13 +211,16 @@ describe.skip('VariablePanel', () => {
     render(<VariablePanel />, {
       wrapper: getWrapper([Paths.processInstance('processInstanceId123')]),
     });
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
-    expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId('edit-variable-value')).toBeInTheDocument(),
+    );
 
     act(() => {
       cancelAllTokens('Activity_0qtp1k6', 1, 1, {});
@@ -255,7 +268,10 @@ describe.skip('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -345,7 +361,10 @@ describe.skip('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -445,7 +464,10 @@ describe.skip('VariablePanel', () => {
     });
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -505,7 +527,10 @@ describe.skip('VariablePanel', () => {
     modificationsStore.enableModificationMode();
 
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -42,7 +42,7 @@ import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'mo
 
 jest.mock('modules/feature-flags', () => ({
   ...jest.requireActual('modules/feature-flags'),
-  IS_FLOWNODE_INSTANCE_STATISTICS_V2_ENABLED: true,
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
 }));
 
 jest.mock('modules/stores/notifications', () => ({
@@ -166,10 +166,7 @@ describe('VariablePanel spinner', () => {
 
   it('should display spinner for variables tab when switching between tabs', async () => {
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
@@ -196,8 +193,7 @@ describe('VariablePanel spinner', () => {
 
   it('should display spinner on second variable fetch', async () => {
     render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     mockFetchVariables().withDelay([createVariable()]);
 
     act(() => {
@@ -219,9 +215,7 @@ describe('VariablePanel spinner', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -10,6 +10,7 @@ import {VariablePanel} from './index';
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
@@ -82,7 +83,7 @@ const getWrapper = (
   return Wrapper;
 };
 
-describe.skip('VariablePanel spinner', () => {
+describe('VariablePanel spinner', () => {
   beforeEach(() => {
     const mockProcessInstance: ProcessInstance = {
       processInstanceKey: 'instance_id',
@@ -140,6 +141,8 @@ describe.skip('VariablePanel spinner', () => {
     });
 
     mockFetchVariables().withSuccess([createVariable()]);
+    mockFetchVariables().withSuccess([createVariable()]);
+
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
@@ -165,7 +168,9 @@ describe.skip('VariablePanel spinner', () => {
   it('should display spinner for variables tab when switching between tabs', async () => {
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withDelay([createVariable({name: 'test2'})]);
@@ -216,7 +221,9 @@ describe.skip('VariablePanel spinner', () => {
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
-    expect(screen.getByText('testVariableName')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    );
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     act(() => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -10,7 +10,6 @@ import {VariablePanel} from './index';
 import {
   render,
   screen,
-  waitFor,
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
@@ -168,9 +167,10 @@ describe('VariablePanel spinner', () => {
   it('should display spinner for variables tab when switching between tabs', async () => {
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     mockFetchVariables().withDelay([createVariable({name: 'test2'})]);
@@ -219,11 +219,10 @@ describe('VariablePanel spinner', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
-    await waitFor(() =>
-      expect(screen.getByText('testVariableName')).toBeInTheDocument(),
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('variables-skeleton'),
     );
+    expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
     act(() => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/spinner.test.tsx
@@ -10,6 +10,7 @@ import {VariablePanel} from './index';
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
 } from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
@@ -166,7 +167,9 @@ describe('VariablePanel spinner', () => {
 
   it('should display spinner for variables tab when switching between tabs', async () => {
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);
@@ -193,7 +196,9 @@ describe('VariablePanel spinner', () => {
 
   it('should display spinner on second variable fetch', async () => {
     render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     mockFetchVariables().withDelay([createVariable()]);
 
     act(() => {
@@ -215,7 +220,9 @@ describe('VariablePanel spinner', () => {
     modificationsStore.enableModificationMode();
 
     const {user} = render(<VariablePanel />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
     expect(await screen.findByText('testVariableName')).toBeInTheDocument();
 
     mockFetchProcessInstanceListeners().withSuccess(noListeners);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/VariablesTable.tsx
@@ -22,9 +22,9 @@ import {useProcessInstancePageParams} from '../../../useProcessInstancePageParam
 import {Edit} from '@carbon/react/icons';
 import {VariableFormValues} from 'modules/types/variables';
 import {EditButtons} from '../EditButtons';
-import {ExistingVariableValue} from '../ExistingVariableValue';
-import {Name} from '../NewVariableModification/Name';
-import {Value} from '../NewVariableModification/Value';
+import {ExistingVariableValue} from './ExistingVariableValue';
+import {Name} from '../NewVariableModification/v2/Name';
+import {Value} from '../NewVariableModification/v2/Value';
 import {Operation as OperationV2} from '../NewVariableModification/v2/Operation';
 import {ViewFullVariableButton} from '../ViewFullVariableButton';
 import {MAX_VARIABLES_STORED} from 'modules/constants/variables';

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -34,11 +34,11 @@ describe('Add variable', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
-    jest.clearAllTimers();
     await new Promise(process.nextTick);
   });
 
   it('should show/hide add variable inputs', async () => {
+    jest.useFakeTimers();
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchVariables().withSuccess(mockVariables);
@@ -66,9 +66,7 @@ describe('Add variable', () => {
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
     expect(
-      screen.getByRole('textbox', {
-        name: /name/i,
-      }),
+      await screen.findByRole('textbox', {name: /name/i}),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', {
@@ -87,9 +85,13 @@ describe('Add variable', () => {
         name: /value/i,
       }),
     ).not.toBeInTheDocument();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should not allow empty value', async () => {
+    jest.useFakeTimers();
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
@@ -106,7 +108,11 @@ describe('Add variable', () => {
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
-    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {name: /save variable/i}),
+      ).toBeDisabled(),
+    );
 
     await user.type(
       screen.getByRole('textbox', {
@@ -126,9 +132,13 @@ describe('Add variable', () => {
     expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
     expect(screen.queryByTitle('Value has to be JSON')).not.toBeInTheDocument();
     expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should not allow empty characters in variable name', async () => {
+    jest.useFakeTimers();
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
@@ -225,6 +235,9 @@ describe('Add variable', () => {
 
     expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
     expect(screen.getByText('Name is invalid')).toBeInTheDocument();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should not allow to add duplicate variables', async () => {
@@ -504,6 +517,9 @@ describe('Add variable', () => {
     const {user} = render(<Variables />, {wrapper: getWrapper()});
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
+    expect(
+      await screen.findByRole('button', {name: /add variable/i}),
+    ).toBeInTheDocument();
     await user.click(screen.getByRole('button', {name: /add variable/i}));
     await user.click(
       screen.getByRole('button', {name: /open json editor modal/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -29,6 +29,7 @@ describe('Add variable', () => {
   beforeEach(() => {
     mockFetchProcessInstanceDeprecated().withSuccess(createInstance());
     mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
   });
 
   it('should show/hide add variable inputs', async () => {
@@ -121,7 +122,7 @@ describe('Add variable', () => {
     expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
   });
 
-  it.skip('should not allow empty characters in variable name', async () => {
+  it('should not allow empty characters in variable name', async () => {
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
@@ -400,7 +401,7 @@ describe('Add variable', () => {
     ).not.toBeInTheDocument();
   });
 
-  it.skip('should not exit add variable state when user presses Enter', async () => {
+  it('should not exit add variable state when user presses Enter', async () => {
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -34,7 +34,6 @@ describe('Add variable', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
-    await new Promise(process.nextTick);
   });
 
   it('should show/hide add variable inputs', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -32,6 +32,12 @@ describe('Add variable', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
   });
 
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    await new Promise(process.nextTick);
+  });
+
   it('should show/hide add variable inputs', async () => {
     processInstanceDetailsStore.setProcessInstance(instanceMock);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
@@ -38,7 +38,6 @@ const instanceMock = createInstance({id: '1'});
 describe('Footer', () => {
   afterEach(async () => {
     jest.clearAllMocks();
-    jest.clearAllTimers();
     await new Promise(process.nextTick);
   });
 
@@ -175,6 +174,7 @@ describe('Footer', () => {
   });
 
   it('should hide/disable add variable button if add/edit variable button is clicked', async () => {
+    jest.useFakeTimers();
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockProcessInstanceDeprecated().withSuccess(instanceMock);
     processInstanceDetailsStore.setProcessInstance(instanceMock);
@@ -194,9 +194,11 @@ describe('Footer', () => {
     await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
-    expect(
-      screen.queryByRole('button', {name: /add variable/i}),
-    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', {name: /add variable/i}),
+      ).not.toBeInTheDocument(),
+    );
 
     await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
@@ -210,5 +212,8 @@ describe('Footer', () => {
 
     await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
@@ -36,6 +36,89 @@ import {mockFetchProcessInstance as mockProcessInstanceDeprecated} from 'modules
 const instanceMock = createInstance({id: '1'});
 
 describe('Footer', () => {
+  it('should disable add variable button when selected flow node is not running', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: 'start',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+        {
+          elementId: 'neverFails',
+          active: 0,
+          canceled: 0,
+          incidents: 0,
+          completed: 1,
+        },
+      ],
+    });
+    mockFetchProcessDefinitionXml().withSuccess(
+      mockProcessWithInputOutputMappingsXML,
+    );
+    mockFetchVariables().withSuccess([]);
+
+    init('process-instance', []);
+    processInstanceDetailsStore.setProcessInstance(instanceMock);
+    variablesStore.fetchVariables({
+      fetchType: 'initial',
+      instanceId: '1',
+      payload: {pageSize: 10, scopeId: '1'},
+    });
+
+    mockFetchFlowNodeMetadata().withSuccess({
+      ...singleInstanceMetadata,
+      instanceMetadata: {
+        ...singleInstanceMetadata.instanceMetadata!,
+        endDate: null,
+      },
+    });
+
+    act(() =>
+      flowNodeSelectionStore.setSelection({
+        flowNodeId: 'start',
+        flowNodeInstanceId: '2',
+        isMultiInstance: false,
+      }),
+    );
+
+    render(<Variables />, {wrapper: getWrapper()});
+    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+
+    await waitFor(() =>
+      expect(
+        flowNodeMetaDataStore.state.metaData?.instanceMetadata?.endDate,
+      ).toEqual(null),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
+    );
+
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+
+    act(() =>
+      flowNodeSelectionStore.setSelection({
+        flowNodeId: 'neverFails',
+        flowNodeInstanceId: '3',
+        isMultiInstance: false,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        flowNodeMetaDataStore.state.metaData?.instanceMetadata?.endDate,
+      ).toEqual(MOCK_TIMESTAMP),
+    );
+
+    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
+
+    flowNodeMetaDataStore.reset();
+  });
   it('should disable add variable button when loading', async () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     processInstanceDetailsStore.setProcessInstance(instanceMock);
@@ -85,7 +168,7 @@ describe('Footer', () => {
     );
   });
 
-  it.skip('should hide/disable add variable button if add/edit variable button is clicked', async () => {
+  it('should hide/disable add variable button if add/edit variable button is clicked', async () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockProcessInstanceDeprecated().withSuccess(instanceMock);
     processInstanceDetailsStore.setProcessInstance(instanceMock);
@@ -121,93 +204,5 @@ describe('Footer', () => {
 
     await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
-  });
-
-  it.skip('should disable add variable button when selected flow node is not running', async () => {
-    mockFetchProcessInstance().withSuccess(mockProcessInstance);
-    mockProcessInstanceDeprecated().withSuccess(instanceMock);
-    mockFetchFlownodeInstancesStatistics().withSuccess({
-      items: [
-        {
-          elementId: 'start',
-          active: 0,
-          canceled: 0,
-          incidents: 0,
-          completed: 1,
-        },
-        {
-          elementId: 'neverFails',
-          active: 0,
-          canceled: 0,
-          incidents: 0,
-          completed: 1,
-        },
-      ],
-    });
-    mockFetchProcessDefinitionXml().withSuccess(
-      mockProcessWithInputOutputMappingsXML,
-    );
-    mockFetchVariables().withSuccess([]);
-
-    init('process-instance', []);
-    processInstanceDetailsStore.setProcessInstance(instanceMock);
-    variablesStore.fetchVariables({
-      fetchType: 'initial',
-      instanceId: '1',
-      payload: {pageSize: 10, scopeId: '1'},
-    });
-
-    render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
-
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
-    );
-
-    mockFetchFlowNodeMetadata().withSuccess({
-      ...singleInstanceMetadata,
-      instanceMetadata: {
-        ...singleInstanceMetadata.instanceMetadata!,
-        endDate: null,
-      },
-    });
-
-    act(() =>
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'start',
-        flowNodeInstanceId: '2',
-        isMultiInstance: false,
-      }),
-    );
-
-    await waitFor(() =>
-      expect(
-        flowNodeMetaDataStore.state.metaData?.instanceMetadata?.endDate,
-      ).toEqual(null),
-    );
-
-    await waitFor(() =>
-      expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
-    );
-
-    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
-
-    act(() =>
-      flowNodeSelectionStore.setSelection({
-        flowNodeId: 'neverFails',
-        flowNodeInstanceId: '3',
-        isMultiInstance: false,
-      }),
-    );
-
-    await waitFor(() =>
-      expect(
-        flowNodeMetaDataStore.state.metaData?.instanceMetadata?.endDate,
-      ).toEqual(MOCK_TIMESTAMP),
-    );
-
-    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
-
-    flowNodeMetaDataStore.reset();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
@@ -36,6 +36,12 @@ import {mockFetchProcessInstance as mockProcessInstanceDeprecated} from 'modules
 const instanceMock = createInstance({id: '1'});
 
 describe('Footer', () => {
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    await new Promise(process.nextTick);
+  });
+
   it('should disable add variable button when selected flow node is not running', async () => {
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockProcessInstanceDeprecated().withSuccess(instanceMock);

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -47,7 +47,7 @@ const mockProcessInstance: ProcessInstance = {
   processDefinitionId: 'processName',
   tenantId: '<default>',
   processDefinitionName: 'Multi-Instance Process',
-  hasIncident: true,
+  hasIncident: false,
 };
 const mockDeprecatedProcessInstance = createInstance({
   id: '1',

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -212,10 +212,8 @@ describe('FlowNodeInstanceLog', () => {
       0,
     );
 
-    await waitFor(() =>
-      expect(
-        screen.getByText('Migrated 2018-12-12 00:00:00'),
-      ).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText('Migrated 2018-12-12 00:00:00'),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -49,6 +49,19 @@ const mockProcessInstance: ProcessInstance = {
   processDefinitionName: 'Multi-Instance Process',
   hasIncident: true,
 };
+const mockDeprecatedProcessInstance = createInstance({
+  id: '1',
+  state: 'ACTIVE',
+  processName: 'processName',
+  bpmnProcessId: 'processName',
+  operations: [
+    createOperation({
+      state: 'COMPLETED',
+      type: 'MIGRATE_PROCESS_INSTANCE',
+      completedDate: MOCK_TIMESTAMP,
+    }),
+  ],
+});
 
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
   useEffect(() => {
@@ -74,19 +87,7 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
 describe('FlowNodeInstanceLog', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDeprecated().withSuccess(
-      createInstance({
-        id: '1',
-        state: 'ACTIVE',
-        processName: 'processName',
-        bpmnProcessId: 'processName',
-        operations: [
-          createOperation({
-            state: 'COMPLETED',
-            type: 'MIGRATE_PROCESS_INSTANCE',
-            completedDate: MOCK_TIMESTAMP,
-          }),
-        ],
-      }),
+      mockDeprecatedProcessInstance,
     );
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
 
@@ -197,7 +198,10 @@ describe('FlowNodeInstanceLog', () => {
     jest.useRealTimers();
   });
 
-  it.skip('should render flow node instances tree', async () => {
+  it('should render flow node instances tree', async () => {
+    mockFetchProcessInstanceDeprecated().withSuccess(
+      mockDeprecatedProcessInstance,
+    );
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
     mockFetchProcessDefinitionXml().withSuccess('');
     init(mockProcessInstance);
@@ -208,8 +212,10 @@ describe('FlowNodeInstanceLog', () => {
       0,
     );
 
-    expect(
-      screen.getByText('Migrated 2018-12-12 00:00:00'),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText('Migrated 2018-12-12 00:00:00'),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -94,6 +94,10 @@ describe('FlowNodeInstanceLog', () => {
     processInstanceDetailsStore.init({id: '1'});
   });
 
+  afterEach(async () => {
+    await new Promise(process.nextTick);
+  });
+
   it('should render skeleton when instance tree is not loaded', async () => {
     mockFetchFlowNodeInstances().withSuccess(processInstancesMock.level1);
     mockFetchProcessDefinitionXml().withSuccess('');
@@ -199,6 +203,7 @@ describe('FlowNodeInstanceLog', () => {
   });
 
   it('should render flow node instances tree', async () => {
+    jest.useFakeTimers();
     mockFetchProcessInstanceDeprecated().withSuccess(
       mockDeprecatedProcessInstance,
     );
@@ -215,5 +220,7 @@ describe('FlowNodeInstanceLog', () => {
     expect(
       await screen.findByText('Migrated 2018-12-12 00:00:00'),
     ).toBeInTheDocument();
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/v2/eventSubprocess.test.tsx
@@ -16,8 +16,8 @@ import {
   mockFlowNodeInstance,
   processInstanceId,
   Wrapper,
-  mockEventSubprocessInstance,
   eventSubprocessProcessInstance,
+  mockEventSubprocessInstance,
 } from './mocks';
 import {eventSubProcess} from 'modules/testUtils';
 import {createRef} from 'react';

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
@@ -238,7 +238,7 @@ describe('InstanceHeader', () => {
     jest.useRealTimers();
   });
 
-  it.skip('should show spinner when operation is applied', async () => {
+  it('should show spinner when operation is applied', async () => {
     mockFetchCallHierarchy().withSuccess([]);
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
@@ -263,6 +263,7 @@ describe('InstanceHeader', () => {
     expect(screen.queryByTestId('operation-spinner')).not.toBeInTheDocument();
 
     mockFetchProcessInstance().withSuccess(mockInstanceWithActiveOperation);
+    mockFetchProcessInstance().withSuccess(mockInstanceWithActiveOperation);
     await user.click(screen.getByRole('button', {name: /Cancel Instance/}));
     await user.click(screen.getByRole('button', {name: 'Apply'}));
 
@@ -276,7 +277,7 @@ describe('InstanceHeader', () => {
     jest.useRealTimers();
   });
 
-  it.skip('should show spinner when variables is added', async () => {
+  it('should show spinner when variables is added', async () => {
     jest.useFakeTimers();
     const mockVariable = createVariable();
 
@@ -329,7 +330,7 @@ describe('InstanceHeader', () => {
     jest.useRealTimers();
   });
 
-  it.skip('should remove spinner when operation fails', async () => {
+  it('should remove spinner when operation fails', async () => {
     mockFetchCallHierarchy().withSuccess([]);
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
@@ -344,6 +345,9 @@ describe('InstanceHeader', () => {
       />,
       {wrapper: Wrapper},
     );
+
+    jest.useFakeTimers();
+
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
     );
@@ -359,6 +363,9 @@ describe('InstanceHeader', () => {
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     await waitForElementToBeRemoved(screen.getByTestId('operation-spinner'));
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
   });
 
   it('should display error notification when operation fails', async () => {

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -204,7 +204,7 @@ const ProcessInstance: React.FC = observer(() => {
             breadcrumb={
               isBreadcrumbVisible && callHierarchy ? (
                 <Breadcrumb
-                  callHierarchy={callHierarchy}
+                  callHierarchy={callHierarchy.slice(0, -1)}
                   processInstance={processInstance}
                 />
               ) : undefined

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -51,6 +51,9 @@ import {
   useIsRootNodeSelected,
   useRootNode,
 } from 'modules/hooks/flowNodeSelection';
+import {notificationsStore} from 'modules/stores/notifications';
+import {useNavigate} from 'react-router-dom';
+import {Locations} from 'modules/Routes';
 
 const startPolling = (processInstance?: ProcessInstanceT) => {
   startPollingVariables(processInstance, {runImmediately: true});
@@ -74,11 +77,29 @@ const ProcessInstance: React.FC = observer(() => {
   const {data: processInstanceData} = useProcessInstance();
   const isRootNodeSelected = useIsRootNodeSelected();
   const rootNode = useRootNode();
+  const navigate = useNavigate();
 
   const {isNavigationInterrupted, confirmNavigation, cancelNavigation} =
     useCallbackPrompt({
       shouldInterrupt: modificationsStore.isModificationModeEnabled,
     });
+
+  useEffect(() => {
+    if (error?.response?.status === 404 && processInstanceId) {
+      notificationsStore.displayNotification({
+        kind: 'error',
+        title: `Instance ${processInstanceId} could not be found`,
+        isDismissable: true,
+      });
+      navigate(
+        Locations.processes({
+          active: true,
+          incidents: true,
+        }),
+        {replace: true},
+      );
+    }
+  }, [error, processInstanceId, navigate]);
 
   useEffect(() => {
     const disposer = reaction(

--- a/operate/client/src/modules/hooks/flowNodeInstance.ts
+++ b/operate/client/src/modules/hooks/flowNodeInstance.ts
@@ -34,7 +34,7 @@ const useInstanceExecutionHistory = (): FlowNodeInstance | null => {
   return {
     id: processInstance.processInstanceKey,
     type: 'PROCESS',
-    state: processInstance.state,
+    state: processInstance.hasIncident ? 'INCIDENT' : processInstance.state,
     treePath: processInstance.processInstanceKey,
     endDate: null,
     startDate: '',

--- a/operate/client/src/modules/queries/processInstance/deprecated/useProcessInstanceDeprecated.ts
+++ b/operate/client/src/modules/queries/processInstance/deprecated/useProcessInstanceDeprecated.ts
@@ -37,6 +37,7 @@ const useProcessInstanceDeprecated = <T = ProcessInstanceEntity>(
         }
       : skipToken,
     select,
+    refetchInterval: 5000,
   });
 };
 

--- a/operate/client/src/modules/utils/flowNodeInstance.ts
+++ b/operate/client/src/modules/utils/flowNodeInstance.ts
@@ -82,8 +82,6 @@ const startPolling = (
   processInstance?: ProcessInstance,
   options: {runImmediately?: boolean} = {runImmediately: false},
 ) => {
-  console.log('startPolling');
-
   if (
     document.visibilityState === 'hidden' ||
     (processInstance && !isInstanceRunning(processInstance)) ||

--- a/operate/client/src/modules/utils/flowNodeInstance.ts
+++ b/operate/client/src/modules/utils/flowNodeInstance.ts
@@ -82,6 +82,8 @@ const startPolling = (
   processInstance?: ProcessInstance,
   options: {runImmediately?: boolean} = {runImmediately: false},
 ) => {
+  console.log('startPolling');
+
   if (
     document.visibilityState === 'hidden' ||
     (processInstance && !isInstanceRunning(processInstance)) ||


### PR DESCRIPTION
## Description

In this PR, I am :
- fixing mocks/asserts on breaking tests (see explanations below)
- fixing bugs in the components
- added better test isolation for 2 flaky test suites
- added a redirect handler as shown below

Here is a screen recording of a auto-redirect which replicates to v1 behavior. I didn't have to configure anything on the query itself because by default TanStack applies 3 retries with 1s delay. It is possible and easy to define a retry to exponential backoff if we want in the future.
https://github.com/user-attachments/assets/9cc867ee-a8d0-4101-b319-e9fdaf0e9e3a

## Related issues

related to #31203
