### PR TITLE
fix: do not initialize SDK if client is disabled

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaActuatorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaActuatorConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.spring.client.configuration;
 import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.actuator.CamundaClientHealthIndicator;
 import io.camunda.spring.client.actuator.MicrometerMetricsRecorder;
+import io.camunda.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 
 @AutoConfigureBefore(MetricsDefaultConfiguration.class)
+@ConditionalOnCamundaClientEnabled
 @ConditionalOnClass({
   EndpointAutoConfiguration.class,
   MeterRegistry.class

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaAutoConfiguration.java
@@ -20,6 +20,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.spring.client.event.CamundaLifecycleEventProducer;
 import io.camunda.spring.client.testsupport.CamundaSpringProcessTestContext;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
@@ -33,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
 
 /** Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients */
 @Configuration
+@ConditionalOnCamundaClientEnabled
 @ImportAutoConfiguration({
   CamundaClientProdAutoConfiguration.class,
   CamundaClientAllAutoConfiguration.class,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
@@ -21,6 +21,7 @@ import static java.util.Optional.ofNullable;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.spring.client.annotation.customizer.JobWorkerValueCustomizer;
+import io.camunda.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.spring.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
@@ -37,16 +38,11 @@ import io.camunda.spring.client.properties.PropertyBasedJobWorkerValueCustomizer
 import io.camunda.zeebe.client.ZeebeClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-@ConditionalOnProperty(
-    prefix = "camunda.client",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnCamundaClientEnabled
 @Import({
   AnnotationProcessorConfiguration.class,
   JsonMapperConfiguration.class,

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientEnabledTest.java
@@ -18,7 +18,7 @@ package io.camunda.spring.client.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.spring.client.configuration.CamundaClientProdAutoConfiguration;
+import io.camunda.spring.client.configuration.CamundaAutoConfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ public class CamundaClientEnabledTest {
 
   @Nested
   @SpringBootTest(
-      classes = CamundaClientProdAutoConfiguration.class,
+      classes = CamundaAutoConfiguration.class,
       properties = {"camunda.client.enabled=false"})
   class CurrentConfiguration {
     @Autowired(required = false)
@@ -42,7 +42,7 @@ public class CamundaClientEnabledTest {
 
   @Nested
   @SpringBootTest(
-      classes = CamundaClientProdAutoConfiguration.class,
+      classes = CamundaAutoConfiguration.class,
       properties = {"camunda.client.zeebe.enabled=false"})
   class ZeebeClientConfiguration {
     @Autowired(required = false)
@@ -56,7 +56,7 @@ public class CamundaClientEnabledTest {
 
   @Nested
   @SpringBootTest(
-      classes = CamundaClientProdAutoConfiguration.class,
+      classes = CamundaAutoConfiguration.class,
       properties = {"zeebe.client.enabled=false"})
   class LegacyConfiguration {
     @Autowired(required = false)
@@ -69,7 +69,7 @@ public class CamundaClientEnabledTest {
   }
 
   @Nested
-  @SpringBootTest(classes = CamundaClientProdAutoConfiguration.class)
+  @SpringBootTest(classes = CamundaAutoConfiguration.class)
   class DefaultTest {
     @Autowired(required = false)
     CamundaClient camundaClient;


### PR DESCRIPTION


## Description

Otherwise, the spring bean setup fails unexpectedly. This adds the client.enabled condition to specific config classes that depend on the client or that create client classes. Additionally the condition is added to the CamundaAutoConfiguration class, as right now without the client the SDK is not serving any functionality.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32104
