### PR TITLE
refactor: move default objectMapper to test setup

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaAutoConfiguration.java
@@ -15,10 +15,6 @@
  */
 package io.camunda.spring.client.configuration;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.event.CamundaLifecycleEventProducer;
 import io.camunda.spring.client.testsupport.CamundaSpringProcessTestContext;
@@ -43,11 +39,6 @@ import org.springframework.context.annotation.Configuration;
 })
 @AutoConfigureAfter(JacksonAutoConfiguration.class)
 public class CamundaAutoConfiguration {
-
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
-      new ObjectMapper()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
 
   @Bean
   @ConditionalOnMissingBean(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
@@ -15,7 +15,8 @@
  */
 package io.camunda.process.test.impl.configuration;
 
-import static io.camunda.spring.client.configuration.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.api.JsonMapper;
@@ -42,6 +43,8 @@ public class CamundaProcessTestDefaultConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public ObjectMapper objectMapper() {
-    return DEFAULT_OBJECT_MAPPER;
+    return new ObjectMapper()
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
   }
 }


### PR DESCRIPTION
## Description

It's only used there, thus no need to have it statically initialized in the production code of the SDK.