### PR TITLE
[Backport stable/8.5] refactor: move default objectMapper to test setup

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -15,11 +15,17 @@
  */
 package io.camunda.zeebe.spring.client;
 
+<<<<<<< HEAD:spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.configuration.JsonMapperConfiguration;
 import io.camunda.zeebe.spring.client.configuration.MetricsDefaultConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeActuatorConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientAllAutoConfiguration;
+=======
+import io.camunda.client.CamundaClient;
+import io.camunda.spring.client.event.CamundaLifecycleEventProducer;
+import io.camunda.spring.client.testsupport.CamundaSpringProcessTestContext;
+>>>>>>> e7c26b7d (refactor: move default objectMapper to test setup):clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaAutoConfiguration.java
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
 import io.camunda.zeebe.spring.client.event.ZeebeLifecycleEventProducer;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
@@ -13,7 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+<<<<<<< HEAD:spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
 package io.camunda.zeebe.spring.client.configuration;
+=======
+package io.camunda.process.test.impl.configuration;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+>>>>>>> e7c26b7d (refactor: move default objectMapper to test setup):testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.common.json.SdkObjectMapper;
@@ -44,10 +51,17 @@ public class JsonMapperConfiguration {
 
   @Bean(name = "commonJsonMapper")
   @ConditionalOnMissingBean
+<<<<<<< HEAD:spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
   public io.camunda.common.json.JsonMapper commonJsonMapper() {
     if (objectMapper == null) {
       return new SdkObjectMapper();
     }
     return new SdkObjectMapper(objectMapper.copy());
+=======
+  public ObjectMapper objectMapper() {
+    return new ObjectMapper()
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
+>>>>>>> e7c26b7d (refactor: move default objectMapper to test setup):testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
   }
 }


### PR DESCRIPTION
# Description
Backport of #32108 to `stable/8.5`.

relates to 