### PR TITLE
[Backport stable/8.6] refactor: move default objectMapper to test setup

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaAutoConfiguration.java
@@ -15,10 +15,6 @@
  */
 package io.camunda.zeebe.spring.client.configuration;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.event.ZeebeLifecycleEventProducer;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
@@ -41,11 +37,6 @@ import org.springframework.context.annotation.Configuration;
 })
 @AutoConfigureAfter(JacksonAutoConfiguration.class)
 public class CamundaAutoConfiguration {
-
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
-      new ObjectMapper()
-          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
 
   @Bean
   @ConditionalOnMissingBean(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
@@ -15,7 +15,8 @@
  */
 package io.camunda.process.test.impl.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -35,6 +36,8 @@ public class CamundaProcessTestDefaultConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public ObjectMapper objectMapper() {
-    return DEFAULT_OBJECT_MAPPER;
+    return new ObjectMapper()
+        .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
   }
 }


### PR DESCRIPTION
# Description
Backport of #32108 to `stable/8.6`.

relates to 