### PR TITLE
add new snapshot-api to transfer snapshots outside of raft

### DIFF
--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -483,6 +483,7 @@
             <configuration>
               <arguments>
                 <argument>${project.build.resources[0].directory}/broker-protocol.xml</argument>
+                <argument>${project.build.resources[0].directory}/transfer-snapshot-schema.xml</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zeebe/broker/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/broker/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<FindBugsFilter
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+
+  <Match>
+    <Class name="io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord"/>
+    <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
+  </Match>
+</FindBugsFilter>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/GetSnapshotChunk.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/GetSnapshotChunk.java
@@ -7,40 +7,12 @@
  */
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
 
-import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.GetSnapshotChunkSerializer;
-import io.camunda.zeebe.transport.ClientRequest;
-import io.camunda.zeebe.transport.RequestType;
 import java.util.Optional;
 import java.util.UUID;
-import org.agrona.MutableDirectBuffer;
 
 public record GetSnapshotChunk(
     int partitionId, UUID transferId, Optional<String> snapshotId, Optional<String> lastChunkName) {
-
-  ClientRequest clientRequest() {
-    return new ClientRequest() {
-      int length = 0;
-
-      @Override
-      public int getPartitionId() {
-        return partitionId;
-      }
-
-      @Override
-      public RequestType getRequestType() {
-        return RequestType.SNAPSHOT;
-      }
-
-      @Override
-      public int getLength() {
-        return 0;
-      }
-
-      @Override
-      public void write(final MutableDirectBuffer buffer, final int offset) {
-        final var serializer = new GetSnapshotChunkSerializer();
-        length = serializer.serialize(GetSnapshotChunk.this, buffer, offset);
-      }
-    };
+  public GetSnapshotChunk withPartitionId(final int partitionId) {
+    return new GetSnapshotChunk(partitionId, transferId, snapshotId, lastChunkName);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/GetSnapshotChunk.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/GetSnapshotChunk.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.GetSnapshotChunkSerializer;
+import io.camunda.zeebe.transport.ClientRequest;
+import io.camunda.zeebe.transport.RequestType;
+import java.util.Optional;
+import java.util.UUID;
+import org.agrona.MutableDirectBuffer;
+
+public record GetSnapshotChunk(
+    int partitionId, UUID transferId, Optional<String> snapshotId, Optional<String> lastChunkName) {
+
+  ClientRequest clientRequest() {
+    return new ClientRequest() {
+      int length = 0;
+
+      @Override
+      public int getPartitionId() {
+        return partitionId;
+      }
+
+      @Override
+      public RequestType getRequestType() {
+        return RequestType.SNAPSHOT;
+      }
+
+      @Override
+      public int getLength() {
+        return 0;
+      }
+
+      @Override
+      public void write(final MutableDirectBuffer buffer, final int offset) {
+        final var serializer = new GetSnapshotChunkSerializer();
+        length = serializer.serialize(GetSnapshotChunk.this, buffer, offset);
+      }
+    };
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkRecord.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkRecord.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
+
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.util.Arrays;
+import java.util.Objects;
+
+public record SnapshotChunkRecord(
+    String snapshotId,
+    int totalCount,
+    String chunkName,
+    long checksum,
+    byte[] content,
+    long fileBlockPosition,
+    long totalFileSize)
+    implements SnapshotChunk {
+
+  @Override
+  public String getSnapshotId() {
+    return snapshotId;
+  }
+
+  @Override
+  public int getTotalCount() {
+    return totalCount;
+  }
+
+  @Override
+  public String getChunkName() {
+    return chunkName;
+  }
+
+  @Override
+  public long getChecksum() {
+    return checksum;
+  }
+
+  @Override
+  public byte[] getContent() {
+    return content;
+  }
+
+  @Override
+  public long getFileBlockPosition() {
+    return fileBlockPosition;
+  }
+
+  @Override
+  public long getTotalFileSize() {
+    return totalFileSize;
+  }
+
+  // Overridden otherwise array equals is reference equality for content
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SnapshotChunkRecord that = (SnapshotChunkRecord) o;
+    return checksum == that.checksum
+        && totalCount == that.totalCount
+        && totalFileSize == that.totalFileSize
+        && fileBlockPosition == that.fileBlockPosition
+        && Objects.deepEquals(content, that.content)
+        && Objects.equals(chunkName, that.chunkName)
+        && Objects.equals(snapshotId, that.snapshotId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        snapshotId,
+        totalCount,
+        chunkName,
+        checksum,
+        Arrays.hashCode(content),
+        fileBlockPosition,
+        totalFileSize);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkRecord.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkRecord.java
@@ -21,6 +21,13 @@ public record SnapshotChunkRecord(
     long totalFileSize)
     implements SnapshotChunk {
 
+  private static final SnapshotChunkRecord EMPTY =
+      new SnapshotChunkRecord("", 0, "", 0, new byte[0], 0, 0);
+
+  public static SnapshotChunkRecord empty() {
+    return EMPTY;
+  }
+
   @Override
   public String getSnapshotId() {
     return snapshotId;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkResponse.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkResponse.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
+
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.util.UUID;
+
+public record SnapshotChunkResponse(UUID transferId, SnapshotChunk chunk) {}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkResponse.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotChunkResponse.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
 
 import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.util.Optional;
 import java.util.UUID;
 
-public record SnapshotChunkResponse(UUID transferId, SnapshotChunk chunk) {}
+public record SnapshotChunkResponse(UUID transferId, Optional<SnapshotChunk> chunk) {}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
 
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.transport.snapshotapi.GetSnapshotChunkBrokerRequest;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -59,7 +60,7 @@ public class SnapshotTransferServiceClient implements SnapshotTransferService {
               } else {
                 if (response.isRejection()) {
                   return CompletableFuture.failedFuture(
-                      new RuntimeException(response.getRejection().toString()));
+                      new BrokerRejectionException(response.getRejection()));
                 } else {
                   return CompletableFuture.failedFuture(
                       new RuntimeException("Unexpected response: " + response));

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot;
+
+import io.camunda.zeebe.broker.transport.snapshotapi.GetSnapshotChunkBrokerRequest;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
+import io.camunda.zeebe.transport.ClientTransport;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+public class SnapshotTransferServiceClient implements SnapshotTransferService {
+
+  private final ClientTransport client;
+  private final Function<Integer, String> nodeAddressProvider;
+  private final ConcurrencyControl concurrencyControl;
+
+  public SnapshotTransferServiceClient(
+      final ClientTransport client,
+      final Function<Integer, String> nodeAddressProvider,
+      final ConcurrencyControl concurrencyControl) {
+    this.client = client;
+    this.nodeAddressProvider = nodeAddressProvider;
+    this.concurrencyControl = concurrencyControl;
+  }
+
+  @Override
+  public ActorFuture<SnapshotChunk> getLatestSnapshot(final int partition, final UUID transferId) {
+    return sendRequest(partition, Optional.empty(), Optional.empty(), transferId);
+  }
+
+  @Override
+  public ActorFuture<SnapshotChunk> getNextChunk(
+      final int partition,
+      final String snapshotId,
+      final String previousChunkName,
+      final UUID transferId) {
+    return sendRequest(
+        partition, Optional.of(snapshotId), Optional.of(previousChunkName), transferId);
+  }
+
+  private ActorFuture<SnapshotChunk> sendRequest(
+      final int partition,
+      final Optional<String> snapshotId,
+      final Optional<String> previousChunkName,
+      final UUID transferId) {
+    final var request = new GetSnapshotChunk(partition, transferId, snapshotId, previousChunkName);
+    final var brokerRequest = new GetSnapshotChunkBrokerRequest(request);
+    return client
+        .sendRequest(
+            () -> nodeAddressProvider.apply(request.partitionId()),
+            brokerRequest,
+            Duration.ofSeconds(30))
+        .thenApply(brokerRequest::getResponse, concurrencyControl)
+        .andThen(
+            response -> {
+              if (response.isResponse()) {
+                return CompletableActorFuture.completed(
+                    response.getResponse().chunk().orElse(null));
+              } else {
+                if (response.isRejection()) {
+                  return CompletableActorFuture.completedExceptionally(
+                      new RuntimeException(response.getRejection().toString()));
+                } else {
+                  return CompletableActorFuture.completedExceptionally(
+                      new RuntimeException("Unexpected response: " + response));
+                }
+              }
+            },
+            concurrencyControl);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkDeserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import java.util.Optional;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+public class GetSnapshotChunkDeserializer {
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final GetSnapshotChunkDecoder decoder = new GetSnapshotChunkDecoder();
+
+  public GetSnapshotChunk deserialize(
+      final DirectBuffer buffer, final int offset, final int capacity) {
+    decoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    return new GetSnapshotChunk(
+        decoder.partition(),
+        new UUID(decoder.transferId().high(), decoder.transferId().low()),
+        asOptional(decoder.snapshotIdLength(), decoder.snapshotId()),
+        asOptional(decoder.lastChunkNameLength(), decoder.lastChunkName()));
+  }
+
+  private Optional<String> asOptional(final int length, final String string) {
+    return length > 0 ? Optional.of(string) : Optional.empty();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
-import org.agrona.BitUtil;
 import org.agrona.MutableDirectBuffer;
 
 public class GetSnapshotChunkSerializer {
@@ -19,7 +18,7 @@ public class GetSnapshotChunkSerializer {
   public int size(final GetSnapshotChunk response) {
     return MessageHeaderEncoder.ENCODED_LENGTH
         + encoder.sbeBlockLength()
-        + 2 * (BitUtil.SIZE_OF_INT)
+        + 2 * (Integer.BYTES)
         + response.snapshotId().map(String::length).orElse(0)
         + response.lastChunkName().map(String::length).orElse(0);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
@@ -8,12 +8,21 @@
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import org.agrona.BitUtil;
 import org.agrona.MutableDirectBuffer;
 
 public class GetSnapshotChunkSerializer {
 
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final GetSnapshotChunkEncoder encoder = new GetSnapshotChunkEncoder();
+
+  public int size(final GetSnapshotChunk response) {
+    return MessageHeaderEncoder.ENCODED_LENGTH
+        + encoder.sbeBlockLength()
+        + 2 * (BitUtil.SIZE_OF_INT)
+        + response.snapshotId().map(String::length).orElse(0)
+        + response.lastChunkName().map(String::length).orElse(0);
+  }
 
   public int serialize(
       final GetSnapshotChunk response, final MutableDirectBuffer buffer, final int offset) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import org.agrona.MutableDirectBuffer;
+
+public class GetSnapshotChunkSerializer {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final GetSnapshotChunkEncoder encoder = new GetSnapshotChunkEncoder();
+
+  public int serialize(
+      final GetSnapshotChunk response, final MutableDirectBuffer buffer, final int offset) {
+    encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    encoder.partition(response.partitionId());
+    encoder
+        .transferId()
+        .high(response.transferId().getMostSignificantBits())
+        .low(response.transferId().getLeastSignificantBits());
+    response.snapshotId().ifPresentOrElse(encoder::snapshotId, () -> encoder.snapshotId(""));
+    response
+        .lastChunkName()
+        .ifPresentOrElse(encoder::lastChunkName, () -> encoder.lastChunkName(""));
+    return encoder.encodedLength() + headerEncoder.encodedLength();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseDeserializer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import java.util.Optional;
 import java.util.UUID;
 import org.agrona.DirectBuffer;
 
@@ -25,6 +26,9 @@ public class SnapshotChunkResponseDeserializer {
     final var checksum = decoder.checksum();
     final var fileBlockPosition = decoder.fileBlockPosition();
     final var totalFileSize = decoder.totalFileSize();
+    if (totalCount == 0 && checksum == 0 && fileBlockPosition == 0 && totalFileSize == 0) {
+      return new SnapshotChunkResponse(transferId, Optional.empty());
+    }
     final var snapshotId = decoder.snapshotId();
     final var chunkName = decoder.chunkName();
     final var content = new byte[decoder.contentLength()];
@@ -32,6 +36,6 @@ public class SnapshotChunkResponseDeserializer {
     final var chunk =
         new SnapshotChunkRecord(
             snapshotId, totalCount, chunkName, checksum, content, fileBlockPosition, totalFileSize);
-    return new SnapshotChunkResponse(transferId, chunk);
+    return new SnapshotChunkResponse(transferId, Optional.of(chunk));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseDeserializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+
+public class SnapshotChunkResponseDeserializer {
+
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final SnapshotChunkResponseDecoder decoder = new SnapshotChunkResponseDecoder();
+
+  public SnapshotChunkResponse deserialize(
+      final DirectBuffer buffer, final int offset, final int capacity) {
+    decoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
+    final var transferId = new UUID(decoder.transferId().high(), decoder.transferId().low());
+    final var totalCount = decoder.totalCount();
+    final var checksum = decoder.checksum();
+    final var fileBlockPosition = decoder.fileBlockPosition();
+    final var totalFileSize = decoder.totalFileSize();
+    final var snapshotId = decoder.snapshotId();
+    final var chunkName = decoder.chunkName();
+    final var content = new byte[decoder.contentLength()];
+    decoder.getContent(content, 0, decoder.contentLength());
+    final var chunk =
+        new SnapshotChunkRecord(
+            snapshotId, totalCount, chunkName, checksum, content, fileBlockPosition, totalFileSize);
+    return new SnapshotChunkResponse(transferId, chunk);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
-import org.agrona.BitUtil;
 import org.agrona.MutableDirectBuffer;
 
 public class SnapshotChunkResponseSerializer {
@@ -41,7 +40,7 @@ public class SnapshotChunkResponseSerializer {
     int length =
         MessageHeaderEncoder.ENCODED_LENGTH
             + SnapshotChunkResponseEncoder.BLOCK_LENGTH
-            + BitUtil.SIZE_OF_INT * 3;
+            + Integer.BYTES * 3;
     if (snapshotChunk.chunk().isPresent()) {
       final var chunk = snapshotChunk.chunk().get();
       length +=

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
@@ -7,17 +7,20 @@
  */
 package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
 
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import org.agrona.BitUtil;
 import org.agrona.MutableDirectBuffer;
 
 public class SnapshotChunkResponseSerializer {
+
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   private final SnapshotChunkResponseEncoder encoder = new SnapshotChunkResponseEncoder();
 
   public int serialize(
       final SnapshotChunkResponse response, final MutableDirectBuffer buffer, final int offset) {
     final var transferId = response.transferId();
-    final var chunk = response.chunk();
+    final var chunk = response.chunk().orElse(SnapshotChunkRecord.empty());
     encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
     encoder
         .transferId()
@@ -32,5 +35,20 @@ public class SnapshotChunkResponseSerializer {
         .chunkName(chunk.getChunkName());
     encoder.putContent(chunk.getContent(), 0, chunk.getContent().length);
     return encoder.encodedLength() + headerEncoder.encodedLength();
+  }
+
+  public int size(final SnapshotChunkResponse snapshotChunk) {
+    int length =
+        MessageHeaderEncoder.ENCODED_LENGTH
+            + SnapshotChunkResponseEncoder.BLOCK_LENGTH
+            + BitUtil.SIZE_OF_INT * 3;
+    if (snapshotChunk.chunk().isPresent()) {
+      final var chunk = snapshotChunk.chunk().get();
+      length +=
+          chunk.getChunkName().length()
+              + chunk.getSnapshotId().length()
+              + chunk.getContent().length;
+    }
+    return length;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import org.agrona.MutableDirectBuffer;
+
+public class SnapshotChunkResponseSerializer {
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final SnapshotChunkResponseEncoder encoder = new SnapshotChunkResponseEncoder();
+
+  public int serialize(
+      final SnapshotChunkResponse response, final MutableDirectBuffer buffer, final int offset) {
+    final var transferId = response.transferId();
+    final var chunk = response.chunk();
+    encoder.wrapAndApplyHeader(buffer, offset, headerEncoder);
+    encoder
+        .transferId()
+        .high(transferId.getMostSignificantBits())
+        .low(transferId.getLeastSignificantBits());
+    encoder
+        .totalCount(chunk.getTotalCount())
+        .checksum(chunk.getChecksum())
+        .fileBlockPosition(chunk.getFileBlockPosition())
+        .totalFileSize(chunk.getTotalFileSize())
+        .snapshotId(chunk.getSnapshotId())
+        .chunkName(chunk.getChunkName());
+    encoder.putContent(chunk.getContent(), 0, chunk.getContent().length);
+    return encoder.encodedLength() + headerEncoder.encodedLength();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionStep.java
@@ -56,7 +56,7 @@ public interface PartitionTransitionStep {
 
   /**
    * This method is a hook to prepare steps for a pending transition. This method is deprecated
-   * because eventually we want ro remove it. Once removed, all steps need to take the necessary
+   * because eventually we want to remove it. Once removed, all steps need to take the necessary
    * preparatory steps as part of {@code newRaftRole(...)}.
    *
    * <p>For a time being, however, this method will be supported. Steps will be called in reverse

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/GetSnapshotChunkBrokerRequest.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/GetSnapshotChunkBrokerRequest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.GetSnapshotChunkSerializer;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.SnapshotChunkResponseDeserializer;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.SnapshotChunkResponseEncoder;
+import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class GetSnapshotChunkBrokerRequest extends BrokerRequest<SnapshotChunkResponse> {
+
+  final GetSnapshotChunkSerializer serializer = new GetSnapshotChunkSerializer();
+  final SnapshotChunkResponseDeserializer responseDeserializer =
+      new SnapshotChunkResponseDeserializer();
+  ExecuteCommandResponse response = new ExecuteCommandResponse();
+  SnapshotChunkResponse chunkResponse;
+  private GetSnapshotChunk request;
+
+  public GetSnapshotChunkBrokerRequest(final GetSnapshotChunk request) {
+    super(SnapshotChunkResponseEncoder.SCHEMA_ID, SnapshotChunkResponseEncoder.TEMPLATE_ID);
+    this.request = request;
+  }
+
+  public void setRequest(final GetSnapshotChunk request) {
+    this.request = request;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return request.partitionId();
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.SNAPSHOT;
+  }
+
+  @Override
+  public void setPartitionId(final int partitionId) {
+    request = request.withPartitionId(partitionId);
+  }
+
+  @Override
+  public boolean addressesSpecificPartition() {
+    return true;
+  }
+
+  @Override
+  public boolean requiresPartitionId() {
+    return true;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return null;
+  }
+
+  @Override
+  protected void setSerializedValue(final DirectBuffer buffer) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void wrapResponse(final DirectBuffer buffer) {
+    chunkResponse = responseDeserializer.deserialize(buffer, 0, buffer.capacity());
+  }
+
+  @Override
+  protected BrokerResponse<SnapshotChunkResponse> readResponse() {
+    if (response.getRecordType() == RecordType.COMMAND_REJECTION) {
+      final BrokerRejection brokerRejection =
+          new BrokerRejection(null, -1, response.getRejectionType(), response.getRejectionReason());
+      return new BrokerRejectionResponse<>(brokerRejection);
+    } else {
+      final var responseDto = toResponseDto(response.getValue());
+      return new BrokerResponse<>(responseDto, response.getPartitionId(), response.getKey());
+    }
+  }
+
+  @Override
+  protected SnapshotChunkResponse toResponseDto(final DirectBuffer buffer) {
+    return chunkResponse;
+  }
+
+  @Override
+  public String getType() {
+    return "Snapshot#getChunk";
+  }
+
+  @Override
+  public int getLength() {
+    return serializer.size(request);
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    serializer.serialize(request, buffer, offset);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
+import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class SnapshotApiRequestHandler
+    extends AsyncApiRequestHandler<SnapshotApiRequestReader, SnapshotApiResponseWriter> {
+
+  private final ConcurrentMap<Integer, SnapshotTransferService> transferServices =
+      new ConcurrentHashMap<>();
+  private final AtomixServerTransport serverTransport;
+
+  protected SnapshotApiRequestHandler(final AtomixServerTransport serverTransport) {
+    super(SnapshotApiRequestReader::new, SnapshotApiResponseWriter::new);
+    this.serverTransport = serverTransport;
+  }
+
+  public void addTransferService(
+      final int partitionId, final SnapshotTransferService transferService) {
+    serverTransport.subscribe(partitionId, RequestType.SNAPSHOT, this);
+    transferServices.put(partitionId, transferService);
+  }
+
+  public void removeTransferService(final int partitionId) {
+    serverTransport.unsubscribe(partitionId, RequestType.SNAPSHOT);
+    transferServices.remove(partitionId);
+  }
+
+  @Override
+  protected ActorFuture<Either<ErrorResponseWriter, SnapshotApiResponseWriter>> handleAsync(
+      final int partitionId,
+      final long requestId,
+      final SnapshotApiRequestReader requestReader,
+      final SnapshotApiResponseWriter responseWriter,
+      final ErrorResponseWriter errorWriter) {
+    final var service = transferServices.get(partitionId);
+    if (service == null) {
+      return CompletableActorFuture.completed(
+          Either.left(errorWriter.partitionUnavailable(partitionId)));
+    } else {
+      final var request = requestReader.getRequest();
+      if (request.lastChunkName().isPresent() && request.snapshotId().isPresent()) {
+        return service
+            .getNextChunk(
+                partitionId,
+                request.snapshotId().get(),
+                request.lastChunkName().get(),
+                request.transferId())
+            .thenApply(
+                chunk -> {
+                  responseWriter.setResponse(
+                      new SnapshotChunkResponse(request.transferId(), Optional.ofNullable(chunk)));
+                  return Either.right(responseWriter);
+                });
+      } else {
+        return service
+            .getLatestSnapshot(partitionId, request.transferId())
+            .thenApply(
+                chunk -> {
+                  responseWriter.setResponse(
+                      new SnapshotChunkResponse(request.transferId(), Optional.ofNullable(chunk)));
+                  return Either.right(responseWriter);
+                });
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    transferServices.forEach((partitionId, service) -> removeTransferService(partitionId));
+    super.close();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestReader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.GetSnapshotChunkDecoder;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.GetSnapshotChunkDeserializer;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
+import org.agrona.DirectBuffer;
+
+public class SnapshotApiRequestReader implements RequestReader<GetSnapshotChunkDecoder> {
+
+  GetSnapshotChunkDeserializer deserializer = new GetSnapshotChunkDeserializer();
+
+  private GetSnapshotChunk request;
+
+  SnapshotApiRequestReader() {
+    reset();
+  }
+
+  @Override
+  public void reset() {
+    request = null;
+  }
+
+  @Override
+  public GetSnapshotChunkDecoder getMessageDecoder() {
+    // who cares?
+    return null;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    request = deserializer.deserialize(buffer, offset, length);
+  }
+
+  public GetSnapshotChunk getRequest() {
+    return request;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiResponseWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe.SnapshotChunkResponseSerializer;
+import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
+import io.camunda.zeebe.transport.ServerOutput;
+import io.camunda.zeebe.transport.impl.ServerResponseImpl;
+import org.agrona.MutableDirectBuffer;
+
+public class SnapshotApiResponseWriter implements ResponseWriter {
+  private final ServerResponseImpl response = new ServerResponseImpl();
+  private SnapshotChunkResponse snapshotChunk;
+  private final SnapshotChunkResponseSerializer serializer = new SnapshotChunkResponseSerializer();
+
+  void setResponse(final SnapshotChunkResponse response) {
+    snapshotChunk = response;
+  }
+
+  @Override
+  public void tryWriteResponse(
+      final ServerOutput output, final int partitionId, final long requestId) {
+    if (snapshotChunk != null) {
+      try {
+        response.reset().writer(this).setPartitionId(partitionId).setRequestId(requestId);
+        output.sendResponse(response);
+      } finally {
+        reset();
+      }
+    }
+  }
+
+  @Override
+  public void reset() {
+    //
+  }
+
+  // Note that length must be known before serializing it
+  @Override
+  public int getLength() {
+    return serializer.size(snapshotChunk);
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    serializer.serialize(snapshotChunk, buffer, offset);
+  }
+}

--- a/zeebe/broker/src/main/resources/transfer-snapshot-schema.xml
+++ b/zeebe/broker/src/main/resources/transfer-snapshot-schema.xml
@@ -35,7 +35,7 @@
     <data name="lastChunkName" id="4" type="varDataEncoding" />
   </sbe:message>
 
-  <sbe:message name="SnapshotChunkResponse" id="3">
+  <sbe:message name="SnapshotChunkResponse" id="2">
     <field name="transferId" id="1" type="UUID"/>
     <field name="totalCount" id="2" type="int32"/>
     <field name="checksum" id="3" type="uint64"/>

--- a/zeebe/broker/src/main/resources/transfer-snapshot-schema.xml
+++ b/zeebe/broker/src/main/resources/transfer-snapshot-schema.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  package="io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe" id="11" version="1"
+  semanticVersion="0.1.0" description="Zeebe Snapshot Transfer Management Protocol"
+  byteOrder="littleEndian">
+
+  <xi:include href="../../../../protocol/src/main/resources/common-types.xml"/>
+  <types>
+    <!-- binary data -->
+    <composite name="blob">
+      <type name="length" primitiveType="uint32" maxValue="2147483647"/>
+      <type name="varData" primitiveType="uint8" length="0"/>
+    </composite>
+
+    <composite name="UUID">
+      <type name="high" primitiveType="int64"/>
+      <type name="low" primitiveType="int64"/>
+    </composite>
+  </types>
+
+
+  <sbe:message name="GetSnapshotChunk" id="1">
+    <field name="partition" id="1" type="int32"/>
+    <field name="transferId" id="2" type="UUID"/>
+    <!-- snapshotId && lastChunkNam are not set if it's the first request -->
+    <data name="snapshotId" id="3" type="varDataEncoding"/>
+    <data name="lastChunkName" id="4" type="varDataEncoding" />
+  </sbe:message>
+
+  <sbe:message name="SnapshotChunkResponse" id="3">
+    <field name="transferId" id="1" type="UUID"/>
+    <field name="totalCount" id="2" type="int32"/>
+    <field name="checksum" id="3" type="uint64"/>
+    <field name="fileBlockPosition" id="4" type="uint64" />
+    <field name="totalFileSize" id="5" type="uint64" />
+    <data name="snapshotId" id="20" type="varDataEncoding"/>
+    <data name="chunkName" id="21" type="varDataEncoding"/>
+    <data name="content" id="22" type="blob"/>
+  </sbe:message>
+
+</sbe:messageSchema>

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkEncodingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkEncodingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.GetSnapshotChunk;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class GetSnapshotChunkEncodingTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "a", "abc"})
+  public void shouldSerializeAndDeserializeGetSnapshotChunkRequest(final String lastChunkName) {
+    final Optional<String> optionalChunkName =
+        lastChunkName.isEmpty() ? Optional.empty() : Optional.of(lastChunkName);
+    final var request = new GetSnapshotChunk(23, UUID.randomUUID(), optionalChunkName);
+    final var serializer = new GetSnapshotChunkSerializer();
+    final var deserializer = new GetSnapshotChunkDeserializer();
+    final var buffer = ByteBuffer.allocate(4096);
+
+    // when
+    final var bytesWritten = serializer.serialize(request, new UnsafeBuffer(buffer), 123);
+    final var deserialized = deserializer.deserialize(new UnsafeBuffer(buffer), 123, bytesWritten);
+
+    // then
+    assertThat(deserialized).isEqualTo(request);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkEncodingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/GetSnapshotChunkEncodingTest.java
@@ -24,7 +24,8 @@ public class GetSnapshotChunkEncodingTest {
   public void shouldSerializeAndDeserializeGetSnapshotChunkRequest(final String lastChunkName) {
     final Optional<String> optionalChunkName =
         lastChunkName.isEmpty() ? Optional.empty() : Optional.of(lastChunkName);
-    final var request = new GetSnapshotChunk(23, UUID.randomUUID(), optionalChunkName);
+    final var request =
+        new GetSnapshotChunk(23, UUID.randomUUID(), optionalChunkName, optionalChunkName);
     final var serializer = new GetSnapshotChunkSerializer();
     final var deserializer = new GetSnapshotChunkDeserializer();
     final var buffer = ByteBuffer.allocate(4096);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseEncodingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseEncodingTest.java
@@ -11,20 +11,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import java.util.UUID;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SnapshotChunkResponseEncodingTest {
-  @Test
-  public void shouldEncodeAndDecodeSnapshotChunkResponse() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldEncodeAndDecodeSnapshotChunkResponse(final boolean isEmpty) {
     // given
     final var content = "this is the chunk content".getBytes();
-    final var snapshotChunkResponse =
-        new SnapshotChunkResponse(
-            UUID.randomUUID(),
-            new SnapshotChunkRecord("123123", 23, "a chunk", 23, content, 39, 129213));
+    final Optional<SnapshotChunk> chunk =
+        isEmpty
+            ? Optional.empty()
+            : Optional.of(
+                new SnapshotChunkRecord("123123", 23, "a chunk", 23, content, 39, 129213));
+    final var snapshotChunkResponse = new SnapshotChunkResponse(UUID.randomUUID(), chunk);
     final var serializer = new SnapshotChunkResponseSerializer();
     final var deserializer = new SnapshotChunkResponseDeserializer();
     final var buffer = ByteBuffer.allocate(4096);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseEncodingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/sbe/SnapshotChunkResponseEncodingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.scaling.snapshot.sbe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkRecord;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+public class SnapshotChunkResponseEncodingTest {
+  @Test
+  public void shouldEncodeAndDecodeSnapshotChunkResponse() {
+    // given
+    final var content = "this is the chunk content".getBytes();
+    final var snapshotChunkResponse =
+        new SnapshotChunkResponse(
+            UUID.randomUUID(),
+            new SnapshotChunkRecord("123123", 23, "a chunk", 23, content, 39, 129213));
+    final var serializer = new SnapshotChunkResponseSerializer();
+    final var deserializer = new SnapshotChunkResponseDeserializer();
+    final var buffer = ByteBuffer.allocate(4096);
+
+    // when
+    final var bytesWritten =
+        serializer.serialize(snapshotChunkResponse, new UnsafeBuffer(buffer), 39);
+    final var deserialized = deserializer.deserialize(new UnsafeBuffer(buffer), 39, bytesWritten);
+
+    assertThat(deserialized).isEqualTo(snapshotChunkResponse);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.utils.net.Address;
+import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotTransferServiceClient;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransfer;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransferServiceImpl;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.util.NetUtil;
+import java.nio.file.Path;
+import java.util.Map;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.SnowflakeIdGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SnapshotApiRequestHandlerTest extends SnapshotTransferUtil {
+  @AutoClose MeterRegistry registry = new SimpleMeterRegistry();
+
+  @TempDir Path temporaryFolder;
+
+  final int partitionId = 1;
+
+  ActorScheduler scheduler =
+      new ActorScheduler.ActorSchedulerBuilder()
+          .setSchedulerName(getClass().getSimpleName())
+          .build();
+
+  private AtomixClientTransportAdapter clientTransport;
+  private String serverAddress;
+  private AtomixServerTransport serverTransport;
+  private SnapshotApiRequestHandler snapshotHandler;
+  private SnapshotTransferServiceClient client;
+
+  @BeforeEach
+  void setup() {
+    final var address = SocketUtil.getNextAddress();
+
+    scheduler.start();
+    serverAddress = NetUtil.toSocketAddressString(address);
+    final var messagingService =
+        new NettyMessagingService(
+            getClass().getSimpleName() + "-server",
+            Address.from(serverAddress),
+            new MessagingConfig(),
+            registry);
+    messagingService.start().join();
+    clientTransport = new AtomixClientTransportAdapter(messagingService);
+    scheduler.submitActor(clientTransport).join();
+
+    serverTransport = new AtomixServerTransport(messagingService, new SnowflakeIdGenerator(1L));
+    scheduler.submitActor(serverTransport).join();
+
+    snapshotHandler = new SnapshotApiRequestHandler(serverTransport);
+    scheduler.submitActor(snapshotHandler).join();
+
+    // Snapshot actors:
+    final var senderDirectory = temporaryFolder.resolve("sender");
+    final var receiverDirectory = temporaryFolder.resolve("receiver");
+    senderSnapshotStore =
+        new FileBasedSnapshotStore(
+            0, partitionId, senderDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
+    scheduler.submitActor((Actor) senderSnapshotStore).join();
+
+    snapshotHandler.addTransferService(1, new SnapshotTransferServiceImpl(senderSnapshotStore, 1));
+
+    receiverSnapshotStore =
+        new FileBasedSnapshotStore(
+            0, partitionId, receiverDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
+
+    scheduler.submitActor((Actor) receiverSnapshotStore).join();
+    client =
+        new SnapshotTransferServiceClient(
+            clientTransport, (ignored) -> serverAddress, clientTransport);
+  }
+
+  @AfterEach
+  void shutdown() {
+    // Cannot use @Autoclose annotation because the order of closing is not correct.
+    CloseHelper.closeAll(
+        senderSnapshotStore,
+        receiverSnapshotStore,
+        serverTransport,
+        clientTransport,
+        snapshotHandler,
+        scheduler);
+  }
+
+  @Test
+  void shouldSendAllChunksCorrectly() {
+
+    takePersistedSnapshot();
+    final var transfer =
+        new SnapshotTransfer(client, receiverSnapshotStore, (Actor) senderSnapshotStore);
+    // when
+    final var persistedSnapshot = transfer.getLatestSnapshot(partitionId).join();
+    // then
+    assertThat(persistedSnapshot.getId())
+        .isEqualTo(senderSnapshotStore.getLatestSnapshot().get().getId());
+
+    System.out.println(persistedSnapshot);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -142,7 +142,5 @@ public class SnapshotApiRequestHandlerTest extends SnapshotTransferUtil {
     // then
     assertThat(persistedSnapshot.getId())
         .isEqualTo(senderSnapshotStore.getLatestSnapshot().get().getId());
-
-    System.out.println(persistedSnapshot);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.snapshotapi;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+public abstract class SnapshotTransferUtil {
+  protected ConstructableSnapshotStore senderSnapshotStore;
+  protected ReceivableSnapshotStore receiverSnapshotStore;
+
+  private final Map<String, String> snapshotFileContents =
+      Map.of(
+          "file1", "file1 contents",
+          "file2", "file2 contents");
+
+  protected PersistedSnapshot takePersistedSnapshot() {
+    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    transientSnapshot.take(this::writeSnapshot).join();
+    return transientSnapshot.persist().join();
+  }
+
+  protected void writeSnapshot(final Path path) {
+    try {
+      FileUtil.ensureDirectoryExists(path);
+
+      for (final var entry : snapshotFileContents.entrySet()) {
+        final var fileName = path.resolve(entry.getKey());
+        final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
+        Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
-public abstract class SnapshotTransferUtil {
+public final class SnapshotTransferUtil {
 
   public static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
       Map.of(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
-import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -22,21 +21,22 @@ import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
 public abstract class SnapshotTransferUtil {
-  protected ConstructableSnapshotStore senderSnapshotStore;
-  protected ReceivableSnapshotStore receiverSnapshotStore;
 
-  private final Map<String, String> snapshotFileContents =
+  public static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
       Map.of(
           "file1", "file1 contents",
           "file2", "file2 contents");
 
-  protected PersistedSnapshot takePersistedSnapshot() {
+  public static PersistedSnapshot takePersistedSnapshot(
+      final ConstructableSnapshotStore senderSnapshotStore,
+      final Map<String, String> snapshotFileContents) {
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
-    transientSnapshot.take(this::writeSnapshot).join();
+    transientSnapshot.take(p -> writeSnapshot(p, snapshotFileContents)).join();
     return transientSnapshot.persist().join();
   }
 
-  protected void writeSnapshot(final Path path) {
+  public static void writeSnapshot(
+      final Path path, final Map<String, String> snapshotFileContents) {
     try {
       FileUtil.ensureDirectoryExists(path);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.util.FileUtil;
@@ -27,12 +29,14 @@ public abstract class SnapshotTransferUtil {
           "file1", "file1 contents",
           "file2", "file2 contents");
 
-  public static PersistedSnapshot takePersistedSnapshot(
+  public static ActorFuture<PersistedSnapshot> takePersistedSnapshot(
       final ConstructableSnapshotStore senderSnapshotStore,
-      final Map<String, String> snapshotFileContents) {
+      final Map<String, String> snapshotFileContents,
+      final ConcurrencyControl control) {
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
-    transientSnapshot.take(p -> writeSnapshot(p, snapshotFileContents)).join();
-    return transientSnapshot.persist().join();
+    return transientSnapshot
+        .take(p -> writeSnapshot(p, snapshotFileContents))
+        .andThen(ignored -> transientSnapshot.persist(), control);
   }
 
   public static void writeSnapshot(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.transfer;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.ReceivedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.UUID;
+
+public class SnapshotTransfer {
+
+  private final SnapshotTransferService service;
+  private final ReceivableSnapshotStore snapshotStore;
+  private final ConcurrencyControl concurrency;
+
+  public SnapshotTransfer(
+      final SnapshotTransferService service,
+      final ReceivableSnapshotStore snapshotStore,
+      final ConcurrencyControl concurrency) {
+    this.service = service;
+    this.snapshotStore = snapshotStore;
+    this.concurrency = concurrency;
+  }
+
+  public ActorFuture<PersistedSnapshot> getLatestSnapshot(final int partitionId) {
+    final var transferId = UUID.randomUUID();
+    return service
+        .getLatestSnapshot(partitionId, transferId)
+        .andThen(
+            snapshot -> {
+              if (snapshot == null) {
+                return CompletableActorFuture.completedExceptionally(
+                    new IllegalArgumentException(
+                        "No initial chunk for latest snapshot in partition " + partitionId));
+              }
+              return snapshotStore
+                  .newReceivedSnapshot(snapshot.getSnapshotId())
+                  .thenApply(
+                      fbsnapshot -> {
+                        fbsnapshot.apply(snapshot);
+                        return new Tuple<>(snapshot, fbsnapshot);
+                      });
+            },
+            concurrency)
+        .andThen(
+            tuple -> {
+              final var future =
+                  receiveAllChunks(partitionId, tuple.getLeft(), tuple.getRight(), transferId);
+              future.onError(error -> tuple.getRight().abort());
+              return future;
+            },
+            concurrency);
+  }
+
+  private ActorFuture<PersistedSnapshot> receiveAllChunks(
+      final int partitionId,
+      final SnapshotChunk snapshotChunk,
+      final ReceivedSnapshot receivedSnapshot,
+      final UUID transferId) {
+    return service
+        .getNextChunk(
+            partitionId,
+            receivedSnapshot.snapshotId().getSnapshotIdAsString(),
+            snapshotChunk.getChunkName(),
+            transferId)
+        .andThen(
+            chunk -> {
+              if (chunk != null) {
+                receivedSnapshot.apply(chunk);
+                return receiveAllChunks(partitionId, chunk, receivedSnapshot, transferId);
+              } else {
+                return receivedSnapshot.persist();
+              }
+            },
+            concurrency);
+  }
+}

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
@@ -17,6 +17,13 @@ import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.UUID;
 
+/**
+ * Receive a complete snapshot from a {@link SnapshotTransferService} by repeatedly asking for the
+ * next chunk until all chunks are received. No retry is done on the futures, if you want support
+ * for retry, wrap {@param service} with retries.
+ *
+ * <p>Snapshots are received in the {@param snapshotStore}.
+ */
 public class SnapshotTransfer {
 
   private final SnapshotTransferService service;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.transfer;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.util.UUID;
+
+public interface SnapshotTransferService {
+
+  /**
+   * Initiate the transfer of the latest snapshot for a partition.
+   *
+   * @param partition the partition to get the snapshot from
+   * @return the first {@link SnapshotChunk}. It must be used in subsequent calls to {@link
+   *     SnapshotTransferService#getNextChunk}
+   */
+  ActorFuture<SnapshotChunk> getLatestSnapshot(int partition, UUID transferId);
+
+  /**
+   * Get the next chunk for the snapshot.
+   *
+   * @param partition the partition to request the snapshot from
+   * @param snapshotId the snapshotId of the snapshot being transferred
+   * @param previousChunkName the chunkName of the previous chunk, so that the next one can be
+   *     identified
+   * @return null if there is no other chunk or the SnapshotChunk after {@param previousChunkName}
+   */
+  ActorFuture<SnapshotChunk> getNextChunk(
+      int partition, String snapshotId, String previousChunkName, UUID transferId);
+}

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.transfer;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import io.camunda.zeebe.snapshots.SnapshotChunkReader;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotChunkReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class SnapshotTransferServiceImpl implements SnapshotTransferService {
+
+  private final ConstructableSnapshotStore snapshotStore;
+  private final Map<UUID, PendingTransfer> pendingTransfers = new HashMap<>();
+  private final int partitionId;
+
+  public SnapshotTransferServiceImpl(
+      final ConstructableSnapshotStore snapshotStore, final int partitionId) {
+    this.snapshotStore = snapshotStore;
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  public ActorFuture<SnapshotChunk> getLatestSnapshot(final int partition, final UUID transferId) {
+    if (partition != partitionId) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalArgumentException(
+              String.format(
+                  "[%s] Invalid partition: %d. Current partition is %d",
+                  transferId, partition, partitionId)));
+    }
+    final var lastSnapshot = snapshotStore.getLatestSnapshot();
+    if (lastSnapshot.isEmpty()) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalArgumentException(String.format("[%s] No snapshot found", transferId)));
+    }
+    final var snapshotId = lastSnapshot.get().getId();
+    try {
+      final var reader = new FileBasedSnapshotChunkReader(lastSnapshot.get().getPath());
+      final var transfer = new PendingTransfer(snapshotId, null, reader);
+      final var chunk = transfer.next();
+      if (chunk == null) {
+        return CompletableActorFuture.completedExceptionally(
+            new IllegalArgumentException(
+                String.format("[%s] No snapshot chunk found", transferId)));
+      }
+      pendingTransfers.put(transferId, transfer);
+      return CompletableActorFuture.completed(chunk);
+    } catch (final IOException e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
+  @Override
+  public ActorFuture<SnapshotChunk> getNextChunk(
+      final int partition,
+      final String snapshotId,
+      final String previousChunkName,
+      final UUID transferId) {
+    final var transfer = pendingTransfers.get(transferId);
+    if (transfer != null) {
+      if (!transfer.snapshotId.equals(snapshotId)) {
+        return CompletableActorFuture.completedExceptionally(
+            new IllegalArgumentException(
+                String.format(
+                    "[%s] Invalid snapshotId: %s. Expected: %s",
+                    transferId, snapshotId, transfer.snapshotId)));
+      }
+      if (!transfer.lastChunkName.equals(previousChunkName)) {
+        return CompletableActorFuture.completedExceptionally(
+            new IllegalArgumentException(
+                String.format(
+                    "[%s] Invalid previousChunkName: %s. Expected: %s",
+                    transferId, previousChunkName, transfer.lastChunkName)));
+      }
+      return CompletableActorFuture.completed(transfer.next());
+    } else {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalArgumentException(
+              String.format("[%s] No transfer found for snapshotId %s", transferId, snapshotId)));
+    }
+  }
+
+  private static class PendingTransfer {
+
+    private final String snapshotId;
+    private String lastChunkName;
+    private SnapshotChunkReader reader;
+
+    PendingTransfer(
+        final String snapshotId, final String lastChunkName, final SnapshotChunkReader reader) {
+      this.snapshotId = snapshotId;
+      this.lastChunkName = lastChunkName;
+      this.reader = reader;
+    }
+
+    private SnapshotChunk next() {
+      if (reader != null && reader.hasNext()) {
+        final var next = reader.next();
+        lastChunkName = next.getChunkName();
+        return next;
+      } else {
+        if (reader != null) {
+          reader.close();
+          reader = null;
+        }
+        return null;
+      }
+    }
+  }
+}

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.agrona.CloseHelper;
 
 public class SnapshotTransferServiceImpl implements SnapshotTransferService {
 
@@ -95,7 +96,7 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
 
     private final String snapshotId;
     private String lastChunkName;
-    private SnapshotChunkReader reader;
+    private final SnapshotChunkReader reader;
 
     PendingTransfer(
         final String snapshotId, final String lastChunkName, final SnapshotChunkReader reader) {
@@ -110,10 +111,7 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
         lastChunkName = next.getChunkName();
         return next;
       } else {
-        if (reader != null) {
-          reader.close();
-          reader = null;
-        }
+        CloseHelper.close(reader);
         return null;
       }
     }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -396,7 +396,11 @@ public class ReceivedSnapshotTest {
   }
 
   private PersistedSnapshot takePersistedSnapshot() {
-    return SnapshotTransferUtil.takePersistedSnapshot(
-        senderSnapshotStore, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS);
+    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    transientSnapshot
+        .take(
+            p -> SnapshotTransferUtil.writeSnapshot(p, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS))
+        .join();
+    return transientSnapshot.persist().join();
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -23,12 +23,15 @@ import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.TemporaryFolder;
 
-public class ReceivedSnapshotTest extends SnapshotTransferUtil {
+public class ReceivedSnapshotTest {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
+  @AutoClose ConstructableSnapshotStore senderSnapshotStore;
+  @AutoClose ReceivableSnapshotStore receiverSnapshotStore;
 
   @Before
   public void beforeEach() throws Exception {
@@ -390,5 +393,10 @@ public class ReceivedSnapshotTest extends SnapshotTransferUtil {
     }
 
     return receivedSnapshot;
+  }
+
+  private PersistedSnapshot takePersistedSnapshot() {
+    return SnapshotTransferUtil.takePersistedSnapshot(
+        senderSnapshotStore, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS);
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.snapshots;
 
-import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,14 +16,7 @@ import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.SnapshotWriteException;
-import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -33,18 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class ReceivedSnapshotTest {
-
-  private static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
-      Map.of(
-          "file1", "file1 contents",
-          "file2", "file2 contents");
+public class ReceivedSnapshotTest extends SnapshotTransferUtil {
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
-
-  private ConstructableSnapshotStore senderSnapshotStore;
-  private ReceivableSnapshotStore receiverSnapshotStore;
 
   @Before
   public void beforeEach() throws Exception {
@@ -406,25 +390,5 @@ public class ReceivedSnapshotTest {
     }
 
     return receivedSnapshot;
-  }
-
-  private PersistedSnapshot takePersistedSnapshot() {
-    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
-    transientSnapshot.take(this::writeSnapshot).join();
-    return transientSnapshot.persist().join();
-  }
-
-  private void writeSnapshot(final Path path) {
-    try {
-      FileUtil.ensureDirectoryExists(path);
-
-      for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {
-        final var fileName = path.resolve(entry.getKey());
-        final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
-        Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
-      }
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+
+public abstract class SnapshotTransferUtil {
+  protected ConstructableSnapshotStore senderSnapshotStore;
+  protected ReceivableSnapshotStore receiverSnapshotStore;
+
+  private final Map<String, String> snapshotFileContents =
+      Map.of(
+          "file1", "file1 contents",
+          "file2", "file2 contents");
+
+  protected PersistedSnapshot takePersistedSnapshot() {
+    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    transientSnapshot.take(this::writeSnapshot).join();
+    return transientSnapshot.persist().join();
+  }
+
+  protected void writeSnapshot(final Path path) {
+    try {
+      FileUtil.ensureDirectoryExists(path);
+
+      for (final var entry : snapshotFileContents.entrySet()) {
+        final var fileName = path.resolve(entry.getKey());
+        final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
+        Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotTransferUtil.java
@@ -18,22 +18,23 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map;
 
-public abstract class SnapshotTransferUtil {
-  protected ConstructableSnapshotStore senderSnapshotStore;
-  protected ReceivableSnapshotStore receiverSnapshotStore;
+public final class SnapshotTransferUtil {
 
-  private final Map<String, String> snapshotFileContents =
+  public static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
       Map.of(
           "file1", "file1 contents",
           "file2", "file2 contents");
 
-  protected PersistedSnapshot takePersistedSnapshot() {
+  public static PersistedSnapshot takePersistedSnapshot(
+      final ConstructableSnapshotStore senderSnapshotStore,
+      final Map<String, String> snapshotFileContents) {
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
-    transientSnapshot.take(this::writeSnapshot).join();
+    transientSnapshot.take(p -> writeSnapshot(p, snapshotFileContents)).join();
     return transientSnapshot.persist().join();
   }
 
-  protected void writeSnapshot(final Path path) {
+  public static void writeSnapshot(
+      final Path path, final Map<String, String> snapshotFileContents) {
     try {
       FileUtil.ensureDirectoryExists(path);
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -10,36 +10,30 @@ package io.camunda.zeebe.snapshots.transfer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.SnapshotTransferUtil;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 public class SnapshotTransferTest {
 
-  @AutoClose
-  static final ActorScheduler scheduler =
-      new ActorScheduler.ActorSchedulerBuilder().setIoBoundActorThreadCount(2).build();
+  @RegisterExtension
+  public final ControlledActorSchedulerExtension actorScheduler =
+      new ControlledActorSchedulerExtension();
 
   @TempDir Path temporaryFolder;
-  @AutoClose ConstructableSnapshotStore senderSnapshotStore;
-  @AutoClose ReceivableSnapshotStore receiverSnapshotStore;
-  private SnapshotTransferService transferService;
+  ConstructableSnapshotStore senderSnapshotStore;
+  ReceivableSnapshotStore receiverSnapshotStore;
   private SnapshotTransfer snapshotTransfer;
-
-  @BeforeAll
-  public static void beforeAll() {
-    scheduler.start();
-  }
 
   @BeforeEach
   public void beforeEach() throws Exception {
@@ -50,29 +44,45 @@ public class SnapshotTransferTest {
     senderSnapshotStore =
         new FileBasedSnapshotStore(
             0, partitionId, senderDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
-    scheduler.submitActor((Actor) senderSnapshotStore).join();
+    actorScheduler.submitActor((Actor) senderSnapshotStore);
+    actorScheduler.workUntilDone();
 
     receiverSnapshotStore =
         new FileBasedSnapshotStore(
             0, partitionId, receiverDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
 
-    scheduler.submitActor((Actor) receiverSnapshotStore).join();
-
-    transferService = new SnapshotTransferServiceImpl(senderSnapshotStore, 1);
+    actorScheduler.submitActor((Actor) receiverSnapshotStore);
+    actorScheduler.workUntilDone();
+    final SnapshotTransferService transferService =
+        new SnapshotTransferServiceImpl(senderSnapshotStore, 1);
     snapshotTransfer =
         new SnapshotTransfer(transferService, receiverSnapshotStore, (Actor) senderSnapshotStore);
+
+    actorScheduler.workUntilDone();
   }
 
   @Test
   public void shouldTransferSnapshot() {
     // given
     final int partitionId = 1;
-    SnapshotTransferUtil.takePersistedSnapshot(
-        senderSnapshotStore, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS);
+    final var takeSnapshotFuture =
+        SnapshotTransferUtil.takePersistedSnapshot(
+            senderSnapshotStore,
+            SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS,
+            (Actor) receiverSnapshotStore);
+    actorScheduler.workUntilDone();
+    assertThat(takeSnapshotFuture).succeedsWithin(Duration.ofSeconds(3));
     // when
-    final var persistedSnapshot = snapshotTransfer.getLatestSnapshot(partitionId).join();
+    final var persistedSnapshotFuture = snapshotTransfer.getLatestSnapshot(partitionId);
+
+    actorScheduler.workUntilDone();
+
     // then
-    assertThat(persistedSnapshot.getId())
-        .isEqualTo(senderSnapshotStore.getLatestSnapshot().get().getId());
+    assertThat(persistedSnapshotFuture)
+        .succeedsWithin(Duration.ofSeconds(30))
+        .satisfies(
+            snapshot ->
+                assertThat(snapshot.getId())
+                    .isEqualTo(senderSnapshotStore.getLatestSnapshot().get().getId()));
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.transfer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.snapshots.SnapshotTransferUtil;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SnapshotTransferTest extends SnapshotTransferUtil {
+
+  @TempDir Path temporaryFolder;
+
+  @AutoClose
+  ActorScheduler scheduler =
+      new ActorScheduler.ActorSchedulerBuilder().setIoBoundActorThreadCount(2).build();
+
+  private SnapshotTransferService transferService;
+  private SnapshotTransfer snapshotTransfer;
+
+  @BeforeEach
+  public void beforeEach() throws Exception {
+    final int partitionId = 1;
+    final var senderDirectory = temporaryFolder.resolve("sender");
+    final var receiverDirectory = temporaryFolder.resolve("receiver");
+
+    scheduler.start();
+
+    senderSnapshotStore =
+        new FileBasedSnapshotStore(
+            0, partitionId, senderDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
+    scheduler.submitActor((Actor) senderSnapshotStore).join();
+
+    receiverSnapshotStore =
+        new FileBasedSnapshotStore(
+            0, partitionId, receiverDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
+
+    final var receiverActor = scheduler.submitActor((Actor) receiverSnapshotStore).join();
+
+    transferService = new SnapshotTransferServiceImpl(senderSnapshotStore, 1);
+    snapshotTransfer =
+        new SnapshotTransfer(transferService, receiverSnapshotStore, (Actor) senderSnapshotStore);
+  }
+
+  @Test
+  public void shouldTransferSnapshot() {
+    // given
+    final int partitionId = 1;
+    takePersistedSnapshot();
+    // when
+    final var persistedSnapshot = snapshotTransfer.getLatestSnapshot(partitionId).join();
+    // then
+    assertThat(persistedSnapshot.getId())
+        .isEqualTo(senderSnapshotStore.getLatestSnapshot().get().getId());
+  }
+}

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/RequestType.java
@@ -23,6 +23,7 @@ public enum RequestType {
   ADMIN("admin"),
 
   BACKUP("backup"),
+  SNAPSHOT("snapshot"),
 
   // All other request types are considered unknown
   // This value exists mainly for testing purposes


### PR DESCRIPTION
## Description
A new snapshot-api has been added to enable transferring snapshots between two brokers outside of a raft group.
In `zeebe-snapshot`:
- `SnapshotTransferService` interface for incrementally getting the latest snapshot from a partition. One chunk at a time must be requested from the client until no more chunks are available (similar to `SnapshotChunkReader`)
  - an implementation that uses the `ConstructableSnapshotStore` is added, which can be used locally or by the "server".
  - the client will implement this interface by exchanging messages over the network.
- `SnapshotTransfer` uses a `SnapshotTransferService` to transfer a snapshot and creates a `PersistedSnapshot` from all the chunks received from the `SnapshotTransferService`.

In `zeebe-transport`:
- a new `RequestType.SNAPSHOT` has been added
- a new `RequestHandler` to handle such requests
- a new SBE schema (`transport-snapshot-schema.xml`) for serialization (inspired by raft's `snapshot-schema.xml`)

The handler implementation uses an implementation of `SnapshotTransferService` and sends over the chunks serialized via SBE.
The client provides an implementation of `SnapshotTransferService` by calling the server.

EDIT:
This PR adds an additional API to the broker, that does not send any actual command to the log/engine. I think this is an exception to how it has been done until now. 
Is it a problem? If yes, is there any alternative?
As a personal feedback, it would have been much faster to be implemented in gRPC compared to the current approach, if not we would need to "copy" some logic of `BrokerClient` to node discovery/leader discovery to this new component. 
I think it could have been ok to move it to a management endpoint, but then it would be available as an actuator route and I'm not sure if there a permissions/security risk involved with that. 


# Dependencies
- [x] #32046 
## Related issues

closes #32057
