### PR TITLE
fix: Operate Opensearch importer throws IllegalFormatConversionException

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
@@ -70,9 +70,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                     op.index(
                         idx ->
                             idx.index(index).id(entity.getId()).document(entity).routing(routing))),
-        String.format(
-            "Error preparing the query to index [%s] of entity type [%s] with routing",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to index [%s] of entity type [%s] with routing",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -97,9 +98,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                 op ->
                     op.update(
                         upd -> upd.index(index).id(id).upsert(entity).document(updateFields))),
-        String.format(
-            "Error preparing the query to upsert [%s] of entity type [%s]",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to upsert [%s] of entity type [%s]",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -131,9 +133,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .upsert(entity)
                                 .document(updateFields)
                                 .routing(routing))),
-        String.format(
-            "Error preparing the query to upsert [%s] of entity type [%s] with routing",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to upsert [%s] of entity type [%s] with routing",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -164,12 +167,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .upsert(entity)
                                 .script(script(script, parameters))
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
+        () ->
             String.format(
                 "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-                entity.getClass().getName(), entity),
-            index,
-            id));
+                entity, entity.getClass().getName()));
     return this;
   }
 
@@ -202,12 +203,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .script(script(script, parameters))
                                 .routing(routing)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
+        () ->
             String.format(
                 "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-                entity.getClass().getName(), entity),
-            index,
-            id));
+                entity, entity.getClass().getName()));
     return this;
   }
 
@@ -228,8 +227,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .document(updateFields)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }
@@ -247,8 +247,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .document(entity)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }
@@ -272,8 +273,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .script(script(script, parameters))
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/util/ExceptionHelper.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ExceptionHelper.java
@@ -14,37 +14,38 @@ import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 
 public interface ExceptionHelper {
-  static <R> R withPersistenceException(Supplier<R> supplier) throws PersistenceException {
+  static <R> R withPersistenceException(final Supplier<R> supplier) throws PersistenceException {
     try {
       return supplier.get();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new PersistenceException(e.getMessage(), e.getCause());
     }
   }
 
-  static <R> R withPersistenceException(Supplier<R> supplier, String errorMessage)
+  static <R> R withPersistenceException(
+      final Supplier<R> supplier, final Supplier<String> errorMessageSupplier)
       throws PersistenceException {
     try {
       return supplier.get();
-    } catch (Exception e) {
-      throw new PersistenceException(errorMessage, e);
+    } catch (final Exception e) {
+      throw new PersistenceException(errorMessageSupplier.get(), e);
     }
   }
 
-  static <R> R withOperateRuntimeException(ExceptionSupplier<R> supplier) {
+  static <R> R withOperateRuntimeException(final ExceptionSupplier<R> supplier) {
     try {
       return supplier.get();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new OperateRuntimeException(e.getMessage(), e.getCause());
     }
   }
 
-  public static <R> R withIOException(ExceptionSupplier<R> supplier) throws IOException {
+  public static <R> R withIOException(final ExceptionSupplier<R> supplier) throws IOException {
     try {
       return supplier.get();
-    } catch (OpenSearchException e) {
+    } catch (final OpenSearchException e) {
       throw e;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new IOException(e.getMessage(), e.getCause());
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

* Fix the double String formatting (`String.format(String.format("...")`), most likely it was a typo done with copy pasting => this is the main root cause of the issue
* Correct the order of the formatted arguments
*  Use lazy formatting to be done only when an exception is thrown


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/32122
