### PR TITLE
Remove invalid maven combine.children usage

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2450,7 +2450,7 @@
               </goals>
               <!-- not bound by default since it would execute in places where we don't want SBE generation -->
               <phase>none</phase>
-              <configuration combine.children="override">
+              <configuration>
                 <!--
                   we have to use the goal exec with the java executable as otherwise the process
                   will not fork, and this can cause thread safety issues in a parallel multi-module


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Maven 4.0.0-rc-3 is strict about usage of combine.children, only allowing append and merge options. There is no option to use override.

The used override options is only for combine.self which should be used inside the inheriting child definitions. While some of the child definitions define their own configuration for the exec-maven-plugin, the only way that they can override the parent's config is by explicitly using combine.self="override".

As there is no use to defining combine.children="override", we can safely remove it. This means we can build using maven 4.0.0-rc-3 and mvnd 2.0.0-rc-3.

We can adjust the child configurations separately if needed.

## Related issues

NA
