### PR TITLE
ci: migrate testRail reporter to a new test suite

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -141,9 +141,10 @@ jobs:
         run: |
           pip install trcli
           trcli -y -h $TESTRAIL_HOST \
-            --project 'Core Application' \
+            --project 'C8' \
             --username $TESTRAIL_USERNAME \
             --key $TESTRAIL_KEY \
-            parse_junit --title "Nightly Core Application Run Test Results - $BRANCH_NAME - $(date '+%Y-%m-%d %H:%M:%S')" \
+            parse_junit --suite-id 17050 \ 
+            --title "Nightly Core Application Run Test Results - $BRANCH_NAME - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
             -f $JUNIT_RESULTS_FILE

--- a/.github/workflows/core-application-e2e-tests-on-demand.yml
+++ b/.github/workflows/core-application-e2e-tests-on-demand.yml
@@ -156,10 +156,11 @@ jobs:
         run: |
           pip install trcli
           trcli -y -h $TESTRAIL_HOST \
-            --project 'Core Application' \
+            --project 'C8' \
             --username $TESTRAIL_USERNAME \
             --key $TESTRAIL_KEY \
-            parse_junit --title "On Demand Core Application Test Run Results -  ${{ github.event.inputs.branch }}" \
+            parse_junit --suite-id 17050 \
+            --title "On Demand Core Application Test Run Results -  ${{ github.event.inputs.branch }}" \
             --close-run \
             -f $JUNIT_RESULTS_FILE
 


### PR DESCRIPTION
## Description

This PR migrates the TestRail reporter to the [new test suite](https://camunda.testrail.com/index.php?/suites/view/17050).

🧪 Successful test Run [here](https://github.com/camunda/camunda/actions/runs/15066943989/job/42353824236)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
