### PR TITLE
[Backport stable/8.6] Remove invalid maven combine.children usage

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2423,7 +2423,7 @@
               </goals>
               <!-- not bound by default since it would execute in places where we don't want SBE generation -->
               <phase>none</phase>
-              <configuration combine.children="override">
+              <configuration>
                 <!--
                   we have to use the goal exec with the java executable as otherwise the process
                   will not fork, and this can cause thread safety issues in a parallel multi-module


### PR DESCRIPTION
# Description
Backport of #32124 to `stable/8.6`.

relates to 