### PR TITLE
add `initializeFromSnapshot` field in `PartitionBootstrapOperation` & `PartitionStartupContext`

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -35,6 +35,7 @@ public final class PartitionStartupContext {
   private final ZeebePartitionFactory zeebePartitionFactory;
   private final BrokerCfg brokerConfig;
   private final DynamicPartitionConfig initialPartitionConfig;
+  private final boolean initializeFromSnapshot;
   private final MeterRegistry brokerMeterRegistry;
 
   private Path partitionDirectory;
@@ -56,6 +57,7 @@ public final class PartitionStartupContext {
       final ZeebePartitionFactory zeebePartitionFactory,
       final BrokerCfg brokerConfig,
       final DynamicPartitionConfig initialPartitionConfig,
+      final boolean initializeFromSnapshot,
       final MeterRegistry brokerMeterRegistry) {
     this.schedulingService = schedulingService;
     this.topologyManager = topologyManager;
@@ -68,6 +70,7 @@ public final class PartitionStartupContext {
     this.zeebePartitionFactory = zeebePartitionFactory;
     this.brokerConfig = brokerConfig;
     this.initialPartitionConfig = initialPartitionConfig;
+    this.initializeFromSnapshot = initializeFromSnapshot;
     this.brokerMeterRegistry = brokerMeterRegistry;
   }
 
@@ -168,5 +171,9 @@ public final class PartitionStartupContext {
 
   public MeterRegistry brokerMeterRegistry() {
     return brokerMeterRegistry;
+  }
+
+  public boolean isInitializeFromSnapshot() {
+    return initializeFromSnapshot;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -174,7 +174,8 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var primary =
         newMetadata.getPrimary().orElse(newMetadata.members().stream().findAny().orElseThrow());
     operations.add(
-        new PartitionBootstrapOperation(primary, partitionId, newMetadata.getPriority(primary)));
+        new PartitionBootstrapOperation(
+            primary, partitionId, newMetadata.getPriority(primary), true));
 
     // Join each remaining members to the partition
     for (final MemberId member : newMetadata.members()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -104,7 +104,8 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
                 memberId,
                 partitionId,
                 partitionState.priority(),
-                Optional.of(partitionState.config())));
+                Optional.of(partitionState.config()),
+                false));
       }
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -90,12 +90,7 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               enableExporterOperation.initializeFrom(),
               partitionChangeExecutor);
       case final PartitionBootstrapOperation bootstrapOperation ->
-          new PartitionBootstrapApplier(
-              bootstrapOperation.partitionId(),
-              bootstrapOperation.priority(),
-              bootstrapOperation.memberId(),
-              bootstrapOperation.config(),
-              partitionChangeExecutor);
+          new PartitionBootstrapApplier(bootstrapOperation, partitionChangeExecutor);
       case final DeleteHistoryOperation deleteHistoryOperation ->
           new DeleteHistoryApplier(deleteHistoryOperation.memberId(), clusterChangeExecutor);
       case final ScaleUpOperation scaleUpOperation ->

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -31,7 +31,10 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
 
   @Override
   public ActorFuture<Void> bootstrap(
-      final int partitionId, final int priority, final DynamicPartitionConfig partitionConfig) {
+      final int partitionId,
+      final int priority,
+      final DynamicPartitionConfig partitionConfig,
+      final boolean initializeFromSnapshot) {
     return CompletableActorFuture.completed(null);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -57,7 +57,10 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the partition is bootstrapped
    */
   ActorFuture<Void> bootstrap(
-      int partitionId, int priority, DynamicPartitionConfig partitionConfig);
+      int partitionId,
+      int priority,
+      DynamicPartitionConfig partitionConfig,
+      boolean initializeFromConfig);
 
   /**
    * Updates the priority of the member used for raft priority election for the given partition.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -456,7 +456,8 @@ public class ProtoBufSerializer
     final var builder =
         Topology.PartitionBootstrapOperation.newBuilder()
             .setPartitionId(bootstrapOperation.partitionId())
-            .setPriority(bootstrapOperation.priority());
+            .setPriority(bootstrapOperation.priority())
+            .setInitializeFromConfig(bootstrapOperation.initializeFromSnapshot());
     bootstrapOperation
         .config()
         .ifPresent(config -> builder.setConfig(encodePartitionConfig(config)));
@@ -651,7 +652,8 @@ public class ProtoBufSerializer
           memberId,
           bootstrapOperation.getPartitionId(),
           bootstrapOperation.getPriority(),
-          partitionConfig);
+          partitionConfig,
+          bootstrapOperation.getInitializeFromConfig());
     } else if (topologyChangeOperation.hasInitiateScaleUpPartitions()) {
       return new StartPartitionScaleUp(
           memberId,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -158,12 +158,19 @@ public sealed interface ClusterConfigurationChangeOperation {
      *     config from partition 1 is used.
      */
     record PartitionBootstrapOperation(
-        MemberId memberId, int partitionId, int priority, Optional<DynamicPartitionConfig> config)
+        MemberId memberId,
+        int partitionId,
+        int priority,
+        Optional<DynamicPartitionConfig> config,
+        boolean initializeFromSnapshot)
         implements PartitionChangeOperation {
 
       public PartitionBootstrapOperation(
-          final MemberId memberId, final int partitionId, final int priority) {
-        this(memberId, partitionId, priority, Optional.empty());
+          final MemberId memberId,
+          final int partitionId,
+          final int priority,
+          final boolean initializeFromSnapshot) {
+        this(memberId, partitionId, priority, Optional.empty(), initializeFromSnapshot);
       }
     }
   }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -140,6 +140,7 @@ message PartitionBootstrapOperation {
   int32 partitionId = 1;
   int32 priority = 2;
   optional PartitionConfig config = 3;
+  bool initializeFromConfig = 4;
 }
 
 message StartPartitionScaleUpOperation { int32 desiredPartitionCount = 2; }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -371,7 +371,7 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),
-            new PartitionBootstrapOperation(id0, 3, 1),
+            new PartitionBootstrapOperation(id0, 3, 1, true),
             new StartPartitionScaleUp(id0, 3),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
             new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));
@@ -398,7 +398,7 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),
-            new PartitionBootstrapOperation(id0, 3, 1),
+            new PartitionBootstrapOperation(id0, 3, 1, true),
             new StartPartitionScaleUp(id0, 3),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
             new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -63,8 +63,10 @@ final class ClusterPurgeRequestTransformerTest {
                       new PartitionLeaveOperation(id1, 0, 0),
                       new PartitionLeaveOperation(id1, 1, 0),
                       new DeleteHistoryOperation(id0),
-                      new PartitionBootstrapOperation(id0, 0, 2, Optional.of(partitionConfig)),
-                      new PartitionBootstrapOperation(id1, 1, 2, Optional.of(partitionConfig)),
+                      new PartitionBootstrapOperation(
+                          id0, 0, 2, Optional.of(partitionConfig), false),
+                      new PartitionBootstrapOperation(
+                          id1, 1, 2, Optional.of(partitionConfig), false),
                       new PartitionJoinOperation(id1, 0, 1),
                       new PartitionJoinOperation(id0, 1, 1));
             });
@@ -105,9 +107,12 @@ final class ClusterPurgeRequestTransformerTest {
                       new PartitionLeaveOperation(id1, 1, 0),
                       new PartitionLeaveOperation(id1, 2, 0),
                       new DeleteHistoryOperation(id0),
-                      new PartitionBootstrapOperation(id0, 0, 2, Optional.of(partitionConfig)),
-                      new PartitionBootstrapOperation(id1, 1, 2, Optional.of(partitionConfig)),
-                      new PartitionBootstrapOperation(id0, 2, 2, Optional.of(partitionConfig)),
+                      new PartitionBootstrapOperation(
+                          id0, 0, 2, Optional.of(partitionConfig), false),
+                      new PartitionBootstrapOperation(
+                          id1, 1, 2, Optional.of(partitionConfig), false),
+                      new PartitionBootstrapOperation(
+                          id0, 2, 2, Optional.of(partitionConfig), false),
                       new PartitionJoinOperation(id1, 0, 1),
                       new PartitionJoinOperation(id0, 1, 1),
                       new PartitionJoinOperation(id1, 2, 1));
@@ -144,7 +149,7 @@ final class ClusterPurgeRequestTransformerTest {
               assertThat(operations)
                   .contains(
                       new PartitionBootstrapOperation(
-                          id0, 0, 2, Optional.of(partitionConfigWithExporter)));
+                          id0, 0, 2, Optional.of(partitionConfigWithExporter), false));
             });
   }
 
@@ -183,8 +188,9 @@ final class ClusterPurgeRequestTransformerTest {
         .satisfies(
             operations -> {
               assertThat(operations)
-                  .contains(new PartitionBootstrapOperation(id0, 0, 2, Optional.of(config0)))
-                  .contains(new PartitionBootstrapOperation(id1, 1, 2, Optional.of(config1)));
+                  .contains(new PartitionBootstrapOperation(id0, 0, 2, Optional.of(config0), false))
+                  .contains(
+                      new PartitionBootstrapOperation(id1, 1, 2, Optional.of(config1), false));
             });
   }
 }


### PR DESCRIPTION
## Description
- Added a field to  `PartitionBootstrapOperation` to indicate if the partition should start from a snapshot from partition 1
- the field is then  propagated to `PartitionStartupContext` so that it can be used by `StartupStep`

## Related issues

closes #32042 
