### PR TITLE
refactor(renovate): no need for registry override

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -300,18 +300,6 @@
       "addLabels": [
         "automerge"
       ]
-    },
-    {
-      "matchDatasources": [
-        "maven"
-      ],
-      "registryUrls": [
-        "https://repo.maven.apache.org/maven2",
-        "https://artifacts.camunda.com/artifactory/zeebe-io/",
-        "https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/",
-        "https://artifacts.camunda.com/artifactory/camunda-identity/",
-        "https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/"
-      ]
     }
   ],
   "dockerfile": {

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+# Ensure these environment variables are set before running the script:
+# export GITHUB_TOKEN="your_github_token"
+
+# Check if required environment variables are set
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "Error: GITHUB_TOKEN environment variable is not set."
+    exit 1
+fi
+
 LOCAL_RENOVATE_CONFIG="../.././.github/renovate.json"
 REPO_NAME="camunda/camunda"
 LOCAL_CACHE_DIR="$(pwd)/renovate_cache"
@@ -19,7 +28,7 @@ echo "Using local Renovate cache at: ${LOCAL_CACHE_DIR}"
 start_time=$(date +%s)
 echo "Renovate run started at: $(date)"
 
-# run renovate
+# Run renovate
 docker run --rm \
   -u "$(id -u):$(id -g)" \
   -e LOG_LEVEL="debug" \
@@ -32,8 +41,7 @@ docker run --rm \
   -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-config.json:ro" \
   -e RENOVATE_CACHE_DIR="/cache/renovate" \
   -v "${LOCAL_CACHE_DIR}:/cache/renovate" \
-  \
-  renovate/renovate | tee "/tmp/camunda_$(date +%Y%m%d_%H%M%S).txt"
+  renovate/renovate | tee "/tmp/${REPO_NAME//\//_}_$(date +%Y%m%d_%H%M%S).txt"
 
 end_time=$(date +%s)
 echo "Renovate run finished at: $(date)"


### PR DESCRIPTION
## Description

Removed unnecessary registryUrls from renovate config.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
