### PR TITLE
feat: endpoint to search for clients that are member of a tenant

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -336,6 +336,12 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
+  public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
+    return getSearchExecutor()
+        .search(filter, io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity.class);
+  }
+
+  @Override
   public List<TenantEntity> findAllTenants(final TenantQuery query) {
     return getSearchExecutor()
         .findAll(query, io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.index.TenantIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.TenantIndex.MEMBER_ID;
 import static io.camunda.webapps.schema.descriptors.index.TenantIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.TenantIndex.TENANT_ID;
 
@@ -19,6 +20,7 @@ public class TenantFieldSortingTransformer implements FieldSortingTransformer {
       case "key" -> KEY;
       case "tenantId" -> TENANT_ID;
       case "name" -> NAME;
+      case "memberId" -> MEMBER_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -273,6 +274,11 @@ public class RdbmsSearchClient implements SearchClientsProxy {
     LOG.debug("[RDBMS Search Client] Search for tenants: {}", query);
 
     return rdbmsService.getTenantReader().search(query);
+  }
+
+  @Override
+  public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
+    throw new UnsupportedOperationException("Tenant member search not implemented on RDBMS");
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.SecurityContext;
@@ -15,6 +16,8 @@ import java.util.List;
 
 public interface TenantSearchClient {
   SearchQueryResult<TenantEntity> searchTenants(TenantQuery filter);
+
+  SearchQueryResult<TenantMemberEntity> searchTenantMembers(TenantQuery filter);
 
   List<TenantEntity> findAllTenants(TenantQuery query);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -29,6 +29,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -182,6 +183,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<TenantMemberEntity> searchTenantMembers(final TenantQuery filter) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -26,6 +26,17 @@ public record TenantFilter(
     return builderFunction.apply(new Builder()).build();
   }
 
+  public Builder toBuilder() {
+    return new Builder()
+        .key(key)
+        .tenantId(tenantId)
+        .name(name)
+        .joinParentId(joinParentId)
+        .memberType(entityType)
+        .memberIds(memberIds)
+        .childMemberType(childMemberType);
+  }
+
   public static final class Builder implements ObjectBuilder<TenantFilter> {
 
     private Long key;

--- a/search/search-domain/src/main/java/io/camunda/search/query/TenantQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/TenantQuery.java
@@ -23,6 +23,10 @@ public record TenantQuery(TenantFilter filter, TenantSort sort, SearchQueryPage 
     return fn.apply(new TenantQuery.Builder()).build();
   }
 
+  public Builder toBuilder() {
+    return new Builder().filter(filter).sort(sort).page(page);
+  }
+
   public static final class Builder
       extends SearchQueryBase.AbstractQueryBuilder<TenantQuery.Builder>
       implements TypedSearchQueryBuilder<

--- a/search/search-domain/src/main/java/io/camunda/search/sort/TenantSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/TenantSort.java
@@ -40,6 +40,11 @@ public record TenantSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public Builder memberId() {
+      currentOrdering = new FieldSorting("memberId", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.SearchQueryResult;
@@ -51,6 +52,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.tenant().read())))
         .searchTenants(query);
+  }
+
+  public SearchQueryResult<TenantMemberEntity> searchMembers(final TenantQuery query) {
+    return tenantSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.tenant().read())))
+        .searchTenantMembers(query);
   }
 
   public List<TenantEntity> findAll(final TenantQuery query) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -167,6 +167,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     setupRecord.addRole(new RoleRecord().setRoleId(connectorsRoleId).setName("Connectors"));
     setupRecord.addAuthorization(
         new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .setResourceId(WILDCARD_PERMISSION)
@@ -176,6 +177,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
                     PermissionType.UPDATE_PROCESS_INSTANCE)));
     setupRecord.addAuthorization(
         new AuthorizationRecord()
+            .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(connectorsRoleId)
             .setResourceType(AuthorizationResourceType.MESSAGE)
             .setResourceId(WILDCARD_PERMISSION)

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7166,7 +7166,7 @@ components:
         - $ref: "#/components/schemas/SearchQueryResponse"
       properties:
         items:
-          description: The matching clients.
+          description: The matching members.
           type: array
           items:
             $ref: "#/components/schemas/TenantMemberResult"

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -563,6 +563,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserSearchResult"
+  /tenants/{tenantId}/clients/search:
+    post:
+      tags:
+        - Tenant
+      operationId: searchClientsForTenant
+      summary: Search clients for tenant
+      description: Retrieves a filtered and sorted list of clients for a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantMemberSearchQueryRequest"
+      responses:
+        "200":
+          description: The search result of users for the tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantMemberSearchResult"
   /tenants/{tenantId}/groups/search:
     post:
       tags:
@@ -7127,6 +7154,44 @@ components:
         email:
           description: The email of the user.
           type: "string"
+    TenantMemberResult:
+      type: object
+      properties:
+        memberId:
+          description: The ID of the member.
+          type: string
+    TenantMemberSearchResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching clients.
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantMemberResult"
+    TenantMemberSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantMemberSearchQuerySortRequest"
+    TenantMemberSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - memberId
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
     RoleCreateRequest:
       type: "object"
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -582,14 +582,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TenantMemberSearchQueryRequest"
+              $ref: "#/components/schemas/TenantClientSearchQueryRequest"
       responses:
         "200":
           description: The search result of users for the tenant.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantMemberSearchResult"
+                $ref: "#/components/schemas/TenantClientSearchResult"
   /tenants/{tenantId}/groups/search:
     post:
       tags:
@@ -7154,23 +7154,23 @@ components:
         email:
           description: The email of the user.
           type: "string"
-    TenantMemberResult:
+    TenantClientResult:
       type: object
       properties:
-        memberId:
-          description: The ID of the member.
+        clientId:
+          description: The ID of the client.
           type: string
-    TenantMemberSearchResult:
+    TenantClientSearchResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
       properties:
         items:
-          description: The matching members.
+          description: The matching clients.
           type: array
           items:
-            $ref: "#/components/schemas/TenantMemberResult"
-    TenantMemberSearchQueryRequest:
+            $ref: "#/components/schemas/TenantClientResult"
+    TenantClientSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
       type: object
@@ -7179,15 +7179,15 @@ components:
           description: Sort field criteria.
           type: array
           items:
-            $ref: "#/components/schemas/TenantMemberSearchQuerySortRequest"
-    TenantMemberSearchQuerySortRequest:
+            $ref: "#/components/schemas/TenantClientSearchQuerySortRequest"
+    TenantClientSearchQuerySortRequest:
       type: object
       properties:
         field:
           description: The field to sort by.
           type: string
           enum:
-            - memberId
+            - clientId
         order:
           $ref: "#/components/schemas/SortOrderEnum"
       required:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -350,16 +350,16 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, TenantQuery> toTenantQuery(
-      final TenantMemberSearchQueryRequest request) {
+      final TenantClientSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.tenantSearchQuery().build());
     }
     final var page = toSearchQueryPage(request.getPage());
     final var sort =
         toSearchQuerySort(
-            SearchQuerySortRequestMapper.fromTenantMemberSearchQuerySortRequest(request.getSort()),
+            SearchQuerySortRequestMapper.fromTenantClientSearchQuerySortRequest(request.getSort()),
             SortOptionBuilders::tenant,
-            SearchQueryRequestMapper::applyTenantMemberSortField);
+            SearchQueryRequestMapper::applyTenantClientSortField);
     final var filter = FilterBuilders.tenant().build();
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::tenantSearchQuery);
   }
@@ -1205,11 +1205,11 @@ public final class SearchQueryRequestMapper {
     return validationErrors;
   }
 
-  private static List<String> applyTenantMemberSortField(
-      final TenantMemberSearchQuerySortRequest.FieldEnum field, final TenantSort.Builder builder) {
+  private static List<String> applyTenantClientSortField(
+      final TenantClientSearchQuerySortRequest.FieldEnum field, final TenantSort.Builder builder) {
     return switch (field) {
       case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
-      case MEMBER_ID -> {
+      case CLIENT_ID -> {
         builder.memberId();
         yield List.of();
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -349,6 +349,21 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::tenantSearchQuery);
   }
 
+  public static Either<ProblemDetail, TenantQuery> toTenantQuery(
+      final TenantMemberSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.tenantSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromTenantMemberSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::tenant,
+            SearchQueryRequestMapper::applyTenantMemberSortField);
+    final var filter = FilterBuilders.tenant().build();
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::tenantSearchQuery);
+  }
+
   public static Either<ProblemDetail, MappingQuery> toMappingQuery(
       final MappingSearchQueryRequest request) {
     if (request == null) {
@@ -1188,6 +1203,17 @@ public final class SearchQueryRequestMapper {
       }
     }
     return validationErrors;
+  }
+
+  private static List<String> applyTenantMemberSortField(
+      final TenantMemberSearchQuerySortRequest.FieldEnum field, final TenantSort.Builder builder) {
+    return switch (field) {
+      case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+      case MEMBER_ID -> {
+        builder.memberId();
+        yield List.of();
+      }
+    };
   }
 
   private static List<String> applyMappingSortField(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -35,6 +35,7 @@ import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
 import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.TenantMemberEntity;
 import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
@@ -93,6 +94,8 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUserResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
+import io.camunda.zeebe.gateway.protocol.rest.TenantMemberResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
@@ -253,6 +256,16 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toTenants)
+                .orElseGet(List::of));
+  }
+
+  public static TenantMemberSearchResult toTenantMemberSearchQueryResponse(
+      final SearchQueryResult<TenantMemberEntity> result) {
+    return new TenantMemberSearchResult()
+        .page(toSearchQueryPageResponse(result))
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toTenantMembers)
                 .orElseGet(List::of));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -94,8 +94,8 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUserResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
-import io.camunda.zeebe.gateway.protocol.rest.TenantMemberResult;
-import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantClientResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantClientSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
@@ -259,13 +259,13 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(List::of));
   }
 
-  public static TenantMemberSearchResult toTenantMemberSearchQueryResponse(
+  public static TenantClientSearchResult toTenantClientSearchQueryResponse(
       final SearchQueryResult<TenantMemberEntity> result) {
-    return new TenantMemberSearchResult()
+    return new TenantClientSearchResult()
         .page(toSearchQueryPageResponse(result))
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toTenantMembers)
+                .map(SearchQueryResponseMapper::toTenantClients)
                 .orElseGet(List::of));
   }
 
@@ -514,6 +514,14 @@ public final class SearchQueryResponseMapper {
         .name(tenantEntity.name())
         .description(tenantEntity.description())
         .tenantId(tenantEntity.tenantId());
+  }
+
+  public static List<TenantClientResult> toTenantClients(final List<TenantMemberEntity> members) {
+    return members.stream().map(SearchQueryResponseMapper::toTenantClient).toList();
+  }
+
+  public static TenantClientResult toTenantClient(final TenantMemberEntity tenantMember) {
+    return new TenantClientResult().clientId(tenantMember.id());
   }
 
   private static List<RoleUserResult> toRoleUsers(final List<RoleMemberEntity> members) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -54,6 +54,12 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<TenantMemberSearchQuerySortRequest.FieldEnum>>
+      fromTenantMemberSearchQuerySortRequest(
+          final List<TenantMemberSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   public static List<SearchQuerySortRequest<MappingSearchQuerySortRequest.FieldEnum>>
       fromMappingSearchQuerySortRequest(final List<MappingSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -54,9 +54,9 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
-  public static List<SearchQuerySortRequest<TenantMemberSearchQuerySortRequest.FieldEnum>>
-      fromTenantMemberSearchQuerySortRequest(
-          final List<TenantMemberSearchQuerySortRequest> requests) {
+  public static List<SearchQuerySortRequest<TenantClientSearchQuerySortRequest.FieldEnum>>
+      fromTenantClientSearchQuerySortRequest(
+          final List<TenantClientSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -27,9 +27,9 @@ import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantClientSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.TenantClientSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
@@ -230,9 +230,9 @@ public class TenantController {
   }
 
   @CamundaPostMapping(path = "/{tenantId}/clients/search")
-  public ResponseEntity<TenantMemberSearchResult> searchClientsInTenant(
+  public ResponseEntity<TenantClientSearchResult> searchClientsInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final TenantMemberSearchQueryRequest query) {
+      @RequestBody(required = false) final TenantClientSearchQueryRequest query) {
     return SearchQueryRequestMapper.toTenantQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
@@ -276,14 +276,14 @@ public class TenantController {
     }
   }
 
-  private ResponseEntity<TenantMemberSearchResult> searchMembersInTenant(
+  private ResponseEntity<TenantClientSearchResult> searchMembersInTenant(
       final String tenantId, final EntityType memberType, final TenantQuery query) {
     try {
       final var result =
           tenantServices
               .withAuthentication(RequestMapper.getAuthentication())
               .searchMembers(buildTenantMemberQuery(tenantId, memberType, query));
-      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantMemberSearchQueryResponse(result));
+      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantClientSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.TenantMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
@@ -227,6 +229,16 @@ public class TenantController {
             roleQuery -> searchRolesInTenant(tenantId, roleQuery));
   }
 
+  @CamundaPostMapping(path = "/{tenantId}/clients/search")
+  public ResponseEntity<TenantMemberSearchResult> searchClientsInTenant(
+      @PathVariable final String tenantId,
+      @RequestBody(required = false) final TenantMemberSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toTenantQuery(query)
+        .fold(
+            RestErrorMapper::mapProblemToResponse,
+            tenantQuery -> searchMembersInTenant(tenantId, EntityType.CLIENT, tenantQuery));
+  }
+
   private CompletableFuture<ResponseEntity<Object>> createTenant(final TenantDTO tenantDTO) {
     return RequestMapper.executeServiceMethod(
         () ->
@@ -259,6 +271,19 @@ public class TenantController {
       final var result =
           tenantServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private ResponseEntity<TenantMemberSearchResult> searchMembersInTenant(
+      final String tenantId, final EntityType memberType, final TenantQuery query) {
+    try {
+      final var result =
+          tenantServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .searchMembers(buildTenantMemberQuery(tenantId, memberType, query));
+      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantMemberSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -318,6 +343,13 @@ public class TenantController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private TenantQuery buildTenantMemberQuery(
+      final String tenantId, final EntityType memberType, final TenantQuery query) {
+    return query.toBuilder()
+        .filter(query.filter().toBuilder().joinParentId(tenantId).memberType(memberType).build())
+        .build();
   }
 
   private MappingQuery buildMappingQuery(final String tenantId, final MappingQuery mappingQuery) {


### PR DESCRIPTION
This adds the endpoint to search for all clients that are member of a specific tenant. The request supports sorting by member id and pagination but no filters.

closes #31873

