### PR TITLE
fix: tenant member search returns username only

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -555,14 +555,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserSearchQueryRequest"
+              $ref: "#/components/schemas/TenantMemberSearchQueryRequest"
       responses:
         "200":
           description: The search result of users for the tenant.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserSearchResult"
+                $ref: "#/components/schemas/TenantMemberSearchResult"
   /tenants/{tenantId}/clients/search:
     post:
       tags:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -555,14 +555,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TenantMemberSearchQueryRequest"
+              $ref: "#/components/schemas/TenantUserSearchQueryRequest"
       responses:
         "200":
           description: The search result of users for the tenant.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantMemberSearchResult"
+                $ref: "#/components/schemas/TenantUserSearchResult"
   /tenants/{tenantId}/clients/search:
     post:
       tags:
@@ -7188,6 +7188,44 @@ components:
           type: string
           enum:
             - clientId
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
+    TenantUserResult:
+      type: object
+      properties:
+        username:
+          description: The username of the user.
+          type: string
+    TenantUserSearchResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching users.
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantUserResult"
+    TenantUserSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantUserSearchQuerySortRequest"
+    TenantUserSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - username
         order:
           $ref: "#/components/schemas/SortOrderEnum"
       required:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -644,13 +644,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RoleSearchQueryResult"
-  /tenants/{tenantId}/applications/{clientId}:
+  /tenants/{tenantId}/clients/{clientId}:
     put:
       tags:
         - Tenant
-      operationId: assignApplicationToTenant
-      summary: Assign an application to a tenant
-      description: Assign an application to a specified tenant.
+      operationId: assignClientToTenant
+      summary: Assign a client to a tenant
+      description: Assign a client to a specified tenant.
       parameters:
         - name: tenantId
           in: path
@@ -682,7 +682,7 @@ paths:
     delete:
       tags:
         - Tenant
-      operationId: removeApplicationFromTenant
+      operationId: removeClientFromTenant
       summary: Remove a client from a tenant
       description: Removes a single client from a specified tenant.
       parameters:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -350,6 +350,21 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, TenantQuery> toTenantQuery(
+      final TenantUserSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.tenantSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromTenantUserSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::tenant,
+            SearchQueryRequestMapper::applyTenantUserSortField);
+    final var filter = FilterBuilders.tenant().build();
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::tenantSearchQuery);
+  }
+
+  public static Either<ProblemDetail, TenantQuery> toTenantQuery(
       final TenantClientSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.tenantSearchQuery().build());
@@ -1203,6 +1218,17 @@ public final class SearchQueryRequestMapper {
       }
     }
     return validationErrors;
+  }
+
+  private static List<String> applyTenantUserSortField(
+      final TenantUserSearchQuerySortRequest.FieldEnum field, final TenantSort.Builder builder) {
+    return switch (field) {
+      case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+      case USERNAME -> {
+        builder.memberId();
+        yield List.of();
+      }
+    };
   }
 
   private static List<String> applyTenantClientSortField(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -98,6 +98,8 @@ import io.camunda.zeebe.gateway.protocol.rest.TenantClientResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantClientSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantUserResult;
+import io.camunda.zeebe.gateway.protocol.rest.TenantUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResult;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
@@ -256,6 +258,16 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toTenants)
+                .orElseGet(List::of));
+  }
+
+  public static TenantUserSearchResult toTenantUserSearchQueryResponse(
+      final SearchQueryResult<TenantMemberEntity> result) {
+    return new TenantUserSearchResult()
+        .page(toSearchQueryPageResponse(result))
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toTenantUsers)
                 .orElseGet(List::of));
   }
 
@@ -516,11 +528,19 @@ public final class SearchQueryResponseMapper {
         .tenantId(tenantEntity.tenantId());
   }
 
-  public static List<TenantClientResult> toTenantClients(final List<TenantMemberEntity> members) {
+  private static List<TenantUserResult> toTenantUsers(final List<TenantMemberEntity> members) {
+    return members.stream().map(SearchQueryResponseMapper::toTenantUser).toList();
+  }
+
+  private static List<TenantClientResult> toTenantClients(final List<TenantMemberEntity> members) {
     return members.stream().map(SearchQueryResponseMapper::toTenantClient).toList();
   }
 
-  public static TenantClientResult toTenantClient(final TenantMemberEntity tenantMember) {
+  private static TenantUserResult toTenantUser(final TenantMemberEntity tenantMember) {
+    return new TenantUserResult().username(tenantMember.id());
+  }
+
+  private static TenantClientResult toTenantClient(final TenantMemberEntity tenantMember) {
     return new TenantClientResult().clientId(tenantMember.id());
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -54,6 +54,11 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<TenantUserSearchQuerySortRequest.FieldEnum>>
+      fromTenantUserSearchQuerySortRequest(final List<TenantUserSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   public static List<SearchQuerySortRequest<TenantClientSearchQuerySortRequest.FieldEnum>>
       fromTenantClientSearchQuerySortRequest(
           final List<TenantClientSearchQuerySortRequest> requests) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.UserSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
@@ -117,13 +116,13 @@ public class TenantController {
   }
 
   @CamundaPostMapping(path = "/{tenantId}/users/search")
-  public ResponseEntity<UserSearchResult> searchUsersInTenant(
+  public ResponseEntity<TenantMemberSearchResult> searchUsersInTenant(
       @PathVariable final String tenantId,
-      @RequestBody(required = false) final UserSearchQueryRequest query) {
-    return SearchQueryRequestMapper.toUserQuery(query)
+      @RequestBody(required = false) final TenantMemberSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toTenantQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            userQuery -> searchUsersInTenant(tenantId, userQuery));
+            tenantQuery -> searchMembersInTenant(tenantId, EntityType.USER, tenantQuery));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/clients/{clientId}")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -620,6 +620,39 @@ public class TenantQueryControllerTest extends RestControllerTest {
             """);
   }
 
+  @Test
+  void shouldListMembersOfTypeUser() {
+    // given
+    when(tenantServices.searchMembers(any(TenantQuery.class)))
+        .thenReturn(
+            new SearchQueryResult.Builder<TenantMemberEntity>()
+                .total(3)
+                .items(
+                    List.of(
+                        new TenantMemberEntity("user1", EntityType.USER),
+                        new TenantMemberEntity("user2", EntityType.USER),
+                        new TenantMemberEntity("user3", EntityType.USER)))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/%s/users/search".formatted(TENANT_BASE_URL, "tenantId"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            // language=json
+            """
+                {"items":[{"username":"user1"},{"username":"user2"},{"username":"user3"}],"page":{"totalItems":3,"firstSortValues":[],"lastSortValues":[]}}
+            """);
+  }
+
   public static Stream<Arguments> invalidTenantSearchQueries() {
     return Stream.of(
         Arguments.of(


### PR DESCRIPTION
## Description

This reuses the new tenant membership support built for #32140 to only return usernames assigned to a tenant. Other details are not available under simple mappings.

## Related issues

depends on #32140
relates to #30346
