### PR TITLE
Remove role key from API response, role filtering and role sorting

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateRoleResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateRoleResponse.java
@@ -18,13 +18,6 @@ package io.camunda.client.api.response;
 public interface CreateRoleResponse {
 
   /**
-   * Returns the key of the created role.
-   *
-   * @return the key of the created role.
-   */
-  long getRoleKey();
-
-  /**
    * Returns the ID of the created role.
    *
    * @return the ID of the created role.

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateRoleResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateRoleResponse.java
@@ -16,12 +16,6 @@
 package io.camunda.client.api.response;
 
 public interface UpdateRoleResponse {
-  /**
-   * Returns the key of the updated role.
-   *
-   * @return the key of the updated role.
-   */
-  long getRoleKey();
 
   /**
    * Returns the ID of the updated role.

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Role.java
@@ -17,8 +17,6 @@ package io.camunda.client.api.search.response;
 
 public interface Role {
 
-  Long getRoleKey();
-
   String getRoleId();
 
   String getName();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
@@ -19,15 +19,9 @@ import io.camunda.client.api.response.CreateRoleResponse;
 import io.camunda.client.protocol.rest.RoleCreateResult;
 
 public class CreateRoleResponseImpl implements CreateRoleResponse {
-  private long roleKey;
   private String roleId;
   private String name;
   private String description;
-
-  @Override
-  public long getRoleKey() {
-    return roleKey;
-  }
 
   @Override
   public String getRoleId() {
@@ -45,7 +39,6 @@ public class CreateRoleResponseImpl implements CreateRoleResponse {
   }
 
   public CreateRoleResponseImpl setResponse(final RoleCreateResult response) {
-    roleKey = Long.parseLong(response.getRoleKey());
     roleId = response.getRoleId();
     name = response.getName();
     description = response.getDescription();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateRoleResponseImpl.java
@@ -19,15 +19,9 @@ import io.camunda.client.api.response.UpdateRoleResponse;
 import io.camunda.client.protocol.rest.RoleUpdateResult;
 
 public class UpdateRoleResponseImpl implements UpdateRoleResponse {
-  private long roleKey;
   private String roleId;
   private String name;
   private String description;
-
-  @Override
-  public long getRoleKey() {
-    return roleKey;
-  }
 
   @Override
   public String getRoleId() {
@@ -45,7 +39,6 @@ public class UpdateRoleResponseImpl implements UpdateRoleResponse {
   }
 
   public UpdateRoleResponseImpl setResponse(final RoleUpdateResult roleUpdateResult) {
-    roleKey = Long.parseLong(roleUpdateResult.getRoleKey());
     roleId = roleUpdateResult.getRoleId();
     name = roleUpdateResult.getName();
     description = roleUpdateResult.getDescription();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/RoleImpl.java
@@ -19,22 +19,14 @@ import io.camunda.client.api.search.response.Role;
 
 public class RoleImpl implements Role {
 
-  private final long roleKey;
   private final String roleId;
   private final String name;
   private final String description;
 
-  public RoleImpl(
-      final long roleKey, final String roleId, final String name, final String description) {
-    this.roleKey = roleKey;
+  public RoleImpl(final String roleId, final String name, final String description) {
     this.roleId = roleId;
     this.name = name;
     this.description = description;
-  }
-
-  @Override
-  public Long getRoleKey() {
-    return roleKey;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -170,11 +170,7 @@ public final class SearchResponseMapper {
   }
 
   public static Role toRoleResponse(final RoleResult response) {
-    return new RoleImpl(
-        ParseUtil.parseLongOrNull(response.getRoleKey()),
-        response.getRoleId(),
-        response.getName(),
-        response.getDescription());
+    return new RoleImpl(response.getRoleId(), response.getName(), response.getDescription());
   }
 
   public static SearchResponse<Role> toRolesResponse(final RoleSearchQueryResult response) {

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -50,7 +50,6 @@
 
   <sql id="searchFilter">
     WHERE 1 = 1
-    <if test="filter.roleKey != null">AND r.ROLE_KEY = #{filter.roleKey}</if>
     <if test="filter.roleId != null">AND r.ROLE_ID = #{filter.roleId}</if>
     <if test="filter.name != null">AND r.NAME = #{filter.name}</if>
     <if test="filter.memberIds != null">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -347,7 +347,6 @@ public class RoleIntegrationTest {
               assertThat(role.getRoleId()).isEqualTo(roleId);
               assertThat(role.getName()).isEqualTo(roleName);
               assertThat(role.getDescription()).isEqualTo(description);
-              assertThat(role.getRoleKey()).isPositive();
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByGroupIntegrationTest.java
@@ -55,7 +55,6 @@ public class RolesByGroupIntegrationTest {
               assertThat(role.getRoleId()).isEqualTo(EXISTING_ROLE_ID);
               assertThat(role.getName()).isEqualTo("ARoleName");
               assertThat(role.getDescription()).isEqualTo("description");
-              assertThat(role.getRoleKey()).isPositive();
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
@@ -53,7 +53,6 @@ public class RolesByMappingIntegrationTest {
               assertThat(role.getRoleId()).isEqualTo(EXISTING_ROLE_ID);
               assertThat(role.getName()).isEqualTo("ARoleName");
               assertThat(role.getDescription()).isEqualTo("description");
-              assertThat(role.getRoleKey()).isPositive();
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -146,13 +146,13 @@ public class RoleIT {
     final var searchResult =
         roleReader.search(
             new RoleQuery(
-                new RoleFilter.Builder().roleKey(role.roleKey()).name(role.name()).build(),
+                new RoleFilter.Builder().roleId(role.roleId()).name(role.name()).build(),
                 RoleSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().roleKey()).isEqualTo(role.roleKey());
+    assertThat(searchResult.items().getFirst().roleId()).isEqualTo(role.roleId());
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
@@ -36,19 +36,19 @@ public class RoleSortIT {
   public static final Long PARTITION_ID = 0L;
 
   @TestTemplate
-  public void shouldSortByRoleKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSortByRoleIdAsc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
-        b -> b.roleKey().asc(),
-        Comparator.comparing(RoleEntity::roleKey));
+        b -> b.roleId().asc(),
+        Comparator.comparing(RoleEntity::roleId));
   }
 
   @TestTemplate
-  public void shouldSortByRoleKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSortByRoleIdDesc(final CamundaRdbmsTestApplication testApplication) {
     testSorting(
         testApplication.getRdbmsService(),
-        b -> b.roleKey().desc(),
-        Comparator.comparing(RoleEntity::roleKey).reversed());
+        b -> b.roleId().desc(),
+        Comparator.comparing(RoleEntity::roleId).reversed());
   }
 
   private void testSorting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -158,7 +158,6 @@ public class RoleSpecificFilterIT {
   static List<RoleFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new RoleFilter.Builder().roleId(ROLE_ID).build(),
-        new RoleFilter.Builder().roleKey(ROLE_KEY).build(),
         new RoleFilter.Builder().name(ROLE_NAME).build(),
         new RoleFilter.Builder().memberId(ENTITY_ID).childMemberType(ENTITY_TYPE).build());
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -28,7 +28,6 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
   @Override
   public SearchQuery toSearchQuery(final RoleFilter filter) {
     return and(
-        filter.roleKey() == null ? null : term(RoleIndex.KEY, filter.roleKey()),
         filter.roleId() == null ? null : term(RoleIndex.ROLE_ID, filter.roleId()),
         filter.name() == null ? null : term(RoleIndex.NAME, filter.name()),
         filter.description() == null ? null : term(RoleIndex.DESCRIPTION, filter.description()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/RoleFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/RoleFieldSortingTransformer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
-import static io.camunda.webapps.schema.descriptors.index.RoleIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.RoleIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.RoleIndex.ROLE_ID;
 
@@ -16,7 +15,6 @@ public class RoleFieldSortingTransformer implements FieldSortingTransformer {
   @Override
   public String apply(final String domainField) {
     return switch (domainField) {
-      case "roleKey" -> KEY;
       case "name" -> NAME;
       case "roleId" -> ROLE_ID;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleQueryTransformerTest.java
@@ -18,23 +18,6 @@ import org.junit.jupiter.api.Test;
 public class RoleQueryTransformerTest extends AbstractTransformerTest {
 
   @Test
-  public void shouldQueryByRoleKey() {
-    // given
-    final var filter = FilterBuilders.role((f) -> f.roleKey(12345L));
-
-    // when
-    final var query = (SearchBoolQuery) transformQuery(filter).queryOption();
-
-    // then
-    assertThat(query.filter()).isEmpty();
-    assertThat(query.should()).isEmpty();
-    assertThat(query.must())
-        .containsExactlyInAnyOrder(
-            SearchQuery.of(q1 -> q1.term(t -> t.field("key").value(12345L))),
-            SearchQuery.of(q1 -> q1.term(t -> t.field("join").value("role"))));
-  }
-
-  @Test
   void shouldQueryByRoleId() {
     // given
     final var filter = FilterBuilders.role((f) -> f.roleId("role1"));
@@ -138,8 +121,7 @@ public class RoleQueryTransformerTest extends AbstractTransformerTest {
   @Test
   void shouldQueryByMultipleRoleFields() {
     // given
-    final var filter =
-        FilterBuilders.role((f) -> f.roleKey(12345L).roleId("role1").name("TestRole"));
+    final var filter = FilterBuilders.role((f) -> f.roleId("role1").name("TestRole"));
 
     // when
     final var query = (SearchBoolQuery) transformQuery(filter).queryOption();
@@ -149,7 +131,6 @@ public class RoleQueryTransformerTest extends AbstractTransformerTest {
     assertThat(query.should()).isEmpty();
     assertThat(query.must())
         .containsExactlyInAnyOrder(
-            SearchQuery.of(q -> q.term(t -> t.field("key").value(12345L))),
             SearchQuery.of(q -> q.term(t -> t.field("roleId").value("role1"))),
             SearchQuery.of(q -> q.term(t -> t.field("name").value("TestRole"))),
             SearchQuery.of(q -> q.term(t -> t.field("join").value("role"))));

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 
 public record RoleFilter(
-    Long roleKey,
     String roleId,
     String name,
     String description,
@@ -25,7 +24,6 @@ public record RoleFilter(
     implements FilterBase {
   public Builder toBuilder() {
     return new Builder()
-        .roleKey(roleKey)
         .roleId(roleId)
         .name(name)
         .description(description)
@@ -37,7 +35,6 @@ public record RoleFilter(
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
-    private Long roleKey;
     private String roleId;
     private String name;
     private String description;
@@ -47,11 +44,6 @@ public record RoleFilter(
     private Set<String> roleIds;
     private EntityType childMemberType;
     private String tenantId;
-
-    public Builder roleKey(final Long value) {
-      roleKey = value;
-      return this;
-    }
 
     public Builder roleId(final String value) {
       roleId = value;
@@ -108,7 +100,6 @@ public record RoleFilter(
         throw new IllegalArgumentException("If memberIds is set, childMemberType must be set too");
       }
       return new RoleFilter(
-          roleKey,
           roleId,
           name,
           description,

--- a/search/search-domain/src/main/java/io/camunda/search/sort/RoleSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/RoleSort.java
@@ -25,11 +25,6 @@ public record RoleSort(List<FieldSorting> orderings) implements SortOption {
   public static final class Builder extends AbstractBuilder<Builder>
       implements ObjectBuilder<RoleSort> {
 
-    public Builder roleKey() {
-      currentOrdering = new FieldSorting("roleKey", null);
-      return this;
-    }
-
     public Builder name() {
       currentOrdering = new FieldSorting("name", null);
       return this;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -17,7 +17,6 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "role";
   public static final String INDEX_VERSION = "8.8.0";
 
-  public static final String KEY = "key";
   public static final String ROLE_ID = "roleId";
   public static final String NAME = "name";
   public static final String DESCRIPTION = "description";

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7103,9 +7103,6 @@ components:
     RoleCreateResult:
       type: object
       properties:
-        roleKey:
-          description: The key of the created role.
-          type: string
         roleId:
           description: The ID of the created role.
           type: string
@@ -7130,9 +7127,6 @@ components:
     RoleUpdateResult:
       type: object
       properties:
-        roleKey:
-          type: string
-          description: The key of the updated role.
         name:
           type: string
           description: The display name of the updated role.
@@ -7149,9 +7143,6 @@ components:
         name:
           type: string
           description: The role name.
-        roleKey:
-          type: string
-          description: The role key.
         roleId:
           type: string
           description: The role id.
@@ -7165,7 +7156,6 @@ components:
           description: The field to sort by.
           type: string
           enum:
-            - roleKey
             - name
             - roleId
         order:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -519,7 +519,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toRoleCreateResponse(final RoleRecord roleRecord) {
     final var response =
         new RoleCreateResult()
-            .roleKey(KeyUtil.keyToString(roleRecord.getRoleKey()))
             .roleId(roleRecord.getRoleId())
             .name(roleRecord.getName())
             .description(roleRecord.getDescription());
@@ -529,7 +528,6 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toRoleUpdateResponse(final RoleRecord roleRecord) {
     final var response =
         new RoleUpdateResult()
-            .roleKey(KeyUtil.keyToString(roleRecord.getRoleKey()))
             .roleId(roleRecord.getRoleId())
             .description(roleRecord.getDescription())
             .name(roleRecord.getName());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1073,7 +1073,6 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case ROLE_KEY -> builder.roleKey();
         case NAME -> builder.name();
         case ROLE_ID -> builder.roleId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -428,7 +428,6 @@ public final class SearchQueryResponseMapper {
 
   public static RoleResult toRole(final RoleEntity roleEntity) {
     return new RoleResult()
-        .roleKey(KeyUtil.keyToString(roleEntity.roleKey()))
         .roleId(roleEntity.roleId())
         .description(roleEntity.description())
         .name(roleEntity.name());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -189,13 +189,11 @@ public class TenantQueryControllerTest extends RestControllerTest {
       {
          "items": [
            {
-             "roleKey": %s,
              "name": "%s",
              "description": "%s",
              "roleId": "%s"
            },
            {
-             "roleKey": %s,
              "name": "%s",
              "description": "%s",
              "roleId": "%s"
@@ -211,11 +209,9 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   private static final String EXPECTED_ROLE_RESPONSE =
       ROLE_RESPONSE.formatted(
-          "\"%s\"".formatted(ROLE_ENTITIES.get(0).roleKey()),
           ROLE_ENTITIES.get(0).name(),
           ROLE_ENTITIES.get(0).description(),
           ROLE_ENTITIES.get(0).roleId(),
-          "\"%s\"".formatted(ROLE_ENTITIES.get(1).roleKey()),
           ROLE_ENTITIES.get(1).name(),
           ROLE_ENTITIES.get(1).description(),
           ROLE_ENTITIES.get(1).roleId(),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -127,19 +127,16 @@ public class GroupQueryControllerTest extends RestControllerTest {
       {
         "items":[
           {
-            "roleKey":"1",
             "roleId":"%s",
             "name":"role1",
             "description":"role1 description"
           },
           {
-            "roleKey":"2",
             "roleId":"%s",
             "name":"role2",
             "description":"role2 description"
           },
           {
-            "roleKey":"3",
             "roleId":"%s",
             "name":"role3",
             "description":"role3 description"

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -273,13 +273,12 @@ public class RoleControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "roleKey": "%d",
               "roleId": "%s",
               "name": "%s",
               "description": "%s"
             }
             """
-                .formatted(roleKey, roleId, roleName, description));
+                .formatted(roleId, roleName, description));
 
     // then
     verify(roleServices, times(1)).updateRole(request);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -71,7 +71,6 @@ public class RoleQueryControllerTest extends RestControllerTest {
             """
             {
               "name": "Role Name",
-              "roleKey": "100",
               "roleId": "roleId",
               "description": "description"
             }""");
@@ -147,19 +146,16 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "roleKey": "100",
                  "name": "Role 1",
                  "roleId": "role1",
                  "description": "description 1"
                },
                {
-                 "roleKey": "200",
                  "name": "Role 2",
                  "roleId": "role2",
                  "description": "description 2"
                },
                {
-                 "roleKey": "300",
                  "name": "Role 12",
                  "roleId": "role12",
                  "description": "description 12"
@@ -247,19 +243,16 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "userKey": "100",
                  "username": "user1",
                  "name": "User 1",
                  "email": "user1@example.com"
                },
                {
-                 "userKey": "200",
                  "username": "user2",
                  "name": "User 2",
                  "email": "user2@example.com"
                },
                {
-                 "userKey": "300",
                  "username": "user3",
                  "name": "User 3",
                  "email": "user3@example.com"

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateRoleTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateRoleTest.java
@@ -53,7 +53,6 @@ class CreateRoleTest {
             .join();
 
     // then
-    assertThat(response.getRoleKey()).isGreaterThan(0);
     assertThat(response.getRoleId()).isEqualTo(ROLE_ID);
     assertThat(response.getName()).isEqualTo(ROLE_NAME);
     assertThat(response.getDescription()).isEqualTo(ROLE_DESCRIPTION);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Removes the role key from the API responses, the filters and the sorting

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32175 
