### PR TITLE
fix: prevent diagram from breaking on migrated instance version

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -227,13 +227,13 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
         value={flowNodeInstance.id}
         aria-label={nodeName}
         renderIcon={() => {
-          return businessObject !== undefined ? (
+          return (
             <FlowNodeIcon
               flowNodeInstanceType={flowNodeInstance.type}
               diagramBusinessObject={businessObject}
               hasLeftMargin={!hasChildren}
             />
-          ) : undefined;
+          );
         }}
         onSelect={() => {
           if (

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/index.tsx
@@ -21,82 +21,85 @@ import {MultiIncidents} from './MultiIncidents';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
+  diagramCanvasRef?: React.RefObject<Element>;
 };
 
-const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
-  const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
-  const {metaData} = flowNodeMetaDataStore.state;
+const MetadataPopover: React.FC<Props> = observer(
+  ({selectedFlowNodeRef, diagramCanvasRef}) => {
+    const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
+    const {metaData} = flowNodeMetaDataStore.state;
 
-  if (flowNodeId === undefined || metaData === null) {
-    return null;
-  }
+    if (flowNodeId === undefined || metaData === null) {
+      return null;
+    }
 
-  const {instanceMetadata, incident, incidentCount} = metaData;
+    const {instanceMetadata, incident, incidentCount} = metaData;
 
-  return (
-    <Popover
-      referenceElement={selectedFlowNodeRef}
-      middlewareOptions={[
-        offset(10),
-        flip({
-          fallbackPlacements: ['top', 'right', 'left'],
-        }),
-      ]}
-      variant="arrow"
-    >
-      <Stack gap={3}>
-        {metaData.instanceCount !== null && metaData.instanceCount > 1 && (
-          <>
-            <Header
-              title={`This Flow Node triggered ${metaData.instanceCount} times`}
-            />
-            <Content>
-              To view details for any of these, select one Instance in the
-              Instance History.
-            </Content>
-          </>
-        )}
+    return (
+      <Popover
+        referenceElement={selectedFlowNodeRef ?? diagramCanvasRef?.current}
+        middlewareOptions={[
+          offset(10),
+          flip({
+            fallbackPlacements: ['top', 'right', 'left'],
+          }),
+        ]}
+        variant="arrow"
+      >
+        <Stack gap={3}>
+          {metaData.instanceCount !== null && metaData.instanceCount > 1 && (
+            <>
+              <Header
+                title={`This Flow Node triggered ${metaData.instanceCount} times`}
+              />
+              <Content>
+                To view details for any of these, select one Instance in the
+                Instance History.
+              </Content>
+            </>
+          )}
 
-        {instanceMetadata !== null && (
-          <>
-            <Details metaData={metaData} flowNodeId={flowNodeId} />
-            {incident !== null && (
-              <>
-                <Divider />
-                <Incident
-                  processInstanceId={
-                    processInstanceDetailsStore.state.processInstance?.id
-                  }
-                  incident={incident}
-                  onButtonClick={() => {
-                    incidentsStore.clearSelection();
-                    incidentsStore.toggleFlowNodeSelection(flowNodeId);
-                    incidentsStore.toggleErrorTypeSelection(
-                      incident.errorType.id,
-                    );
-                    incidentsStore.setIncidentBarOpen(true);
-                  }}
-                />
-              </>
-            )}
-          </>
-        )}
-        {incidentCount > 1 && (
-          <>
-            <Divider />
-            <MultiIncidents
-              count={incidentCount}
-              onButtonClick={() => {
-                incidentsStore.clearSelection();
-                incidentsStore.toggleFlowNodeSelection(flowNodeId);
-                incidentsStore.setIncidentBarOpen(true);
-              }}
-            />
-          </>
-        )}
-      </Stack>
-    </Popover>
-  );
-});
+          {instanceMetadata !== null && (
+            <>
+              <Details metaData={metaData} flowNodeId={flowNodeId} />
+              {incident !== null && (
+                <>
+                  <Divider />
+                  <Incident
+                    processInstanceId={
+                      processInstanceDetailsStore.state.processInstance?.id
+                    }
+                    incident={incident}
+                    onButtonClick={() => {
+                      incidentsStore.clearSelection();
+                      incidentsStore.toggleFlowNodeSelection(flowNodeId);
+                      incidentsStore.toggleErrorTypeSelection(
+                        incident.errorType.id,
+                      );
+                      incidentsStore.setIncidentBarOpen(true);
+                    }}
+                  />
+                </>
+              )}
+            </>
+          )}
+          {incidentCount > 1 && (
+            <>
+              <Divider />
+              <MultiIncidents
+                count={incidentCount}
+                onButtonClick={() => {
+                  incidentsStore.clearSelection();
+                  incidentsStore.toggleFlowNodeSelection(flowNodeId);
+                  incidentsStore.setIncidentBarOpen(true);
+                }}
+              />
+            </>
+          )}
+        </Stack>
+      </Popover>
+    );
+  },
+);
 
 export {MetadataPopover};

--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -99,14 +99,39 @@ class BpmnJS {
     const {
       container,
       xml,
-      selectableFlowNodes = [],
-      selectedFlowNodeIds,
+      selectableFlowNodes: unfilteredSelectableFlowNodes = [],
+      selectedFlowNodeIds: unfilteredSelectedFlowNodeIds,
       overlaysData = [],
       highlightedSequenceFlows = [],
-      highlightedFlowNodeIds = [],
+      highlightedFlowNodeIds: unfilteredHighlightedFlowNodeIds = [],
       nonSelectableNodeTooltipText,
       hasOuterBorderOnSelection,
     } = options;
+
+    const selectedFlowNodeIds = unfilteredSelectedFlowNodeIds?.filter(
+      (flowNodeId) => {
+        const element = this.#navigatedViewer
+          ?.get('elementRegistry')
+          .get(flowNodeId);
+        return element !== undefined;
+      },
+    );
+    const highlightedFlowNodeIds = unfilteredHighlightedFlowNodeIds?.filter(
+      (flowNodeId) => {
+        const element = this.#navigatedViewer
+          ?.get('elementRegistry')
+          .get(flowNodeId);
+        return element !== undefined;
+      },
+    );
+    const selectableFlowNodes = unfilteredSelectableFlowNodes?.filter(
+      (flowNodeId) => {
+        const element = this.#navigatedViewer
+          ?.get('elementRegistry')
+          .get(flowNodeId);
+        return element !== undefined;
+      },
+    );
 
     if (this.#navigatedViewer === null) {
       this.#createViewer(container);

--- a/operate/client/src/modules/components/Diagram/index.tsx
+++ b/operate/client/src/modules/components/Diagram/index.tsx
@@ -143,12 +143,12 @@ const Diagram: React.FC<Props> = observer(
             {children}
           </>
         )}
-        {!isViewboxChanging &&
-          React.isValidElement(selectedFlowNodeOverlay) &&
-          React.cloneElement(selectedFlowNodeOverlay, {
-            selectedFlowNodeRef: viewer.selectedFlowNode,
-            diagramCanvasRef,
-          })}
+        {!isViewboxChanging && React.isValidElement(selectedFlowNodeOverlay)
+          ? React.cloneElement(selectedFlowNodeOverlay, {
+              selectedFlowNodeRef: viewer.selectedFlowNode,
+              diagramCanvasRef,
+            })
+          : null}
       </StyledDiagram>
     );
   },

--- a/operate/client/src/modules/components/Diagram/v2/index.tsx
+++ b/operate/client/src/modules/components/Diagram/v2/index.tsx
@@ -148,12 +148,12 @@ const Diagram: React.FC<Props> = observer(
             {children}
           </>
         )}
-        {!isViewboxChanging &&
-          React.isValidElement(selectedFlowNodeOverlay) &&
-          React.cloneElement(selectedFlowNodeOverlay, {
-            selectedFlowNodeRef: viewer.selectedFlowNode,
-            diagramCanvasRef,
-          })}
+        {!isViewboxChanging && React.isValidElement(selectedFlowNodeOverlay)
+          ? React.cloneElement(selectedFlowNodeOverlay, {
+              selectedFlowNodeRef: viewer.selectedFlowNode,
+              diagramCanvasRef,
+            })
+          : null}
       </StyledDiagram>
     );
   },

--- a/operate/client/src/modules/components/FlowNodeIcon/index.test.tsx
+++ b/operate/client/src/modules/components/FlowNodeIcon/index.test.tsx
@@ -27,6 +27,19 @@ describe('FlowNodeIcon', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render default icon for deleted flow node', () => {
+    render(
+      <FlowNodeIcon
+        flowNodeInstanceType=""
+        diagramBusinessObject={undefined}
+      />,
+    );
+
+    expect(
+      screen.getByText('flow-node-task-undefined.svg'),
+    ).toBeInTheDocument();
+  });
+
   it('should render parallel multi instance body', () => {
     render(
       <FlowNodeIcon

--- a/operate/client/src/modules/components/FlowNodeIcon/index.tsx
+++ b/operate/client/src/modules/components/FlowNodeIcon/index.tsx
@@ -92,9 +92,13 @@ import {ReactComponent as FlowNodeEventCompensationIntermediateThrow} from 'modu
 import {ReactComponent as FlowNodeEventCompensationBoundary} from 'modules/components/Icon/flow-node-compensation-boundary-event.svg';
 
 const getSVGComponent = (
-  businessObject: BusinessObject,
+  businessObject: BusinessObject | undefined,
   isMultiInstanceBody: boolean,
 ) => {
+  if (businessObject === undefined) {
+    return FlowNodeTask;
+  }
+
   if (isMultiInstanceBody) {
     switch (getMultiInstanceType(businessObject)) {
       case 'parallel':
@@ -277,7 +281,7 @@ const getSVGComponent = (
 
 type Props = {
   flowNodeInstanceType: FlowNodeInstance['type'];
-  diagramBusinessObject: BusinessObject;
+  diagramBusinessObject: BusinessObject | undefined;
   className?: string;
   hasLeftMargin?: boolean;
 };
@@ -296,9 +300,12 @@ const FlowNodeIcon: React.FC<Props> = ({
   return (
     <SVGIcon
       SVGComponent={SVGComponent}
-      $isGateway={['bpmn:ParallelGateway', 'bpmn:ExclusiveGateway'].includes(
-        diagramBusinessObject.$type,
-      )}
+      $isGateway={
+        diagramBusinessObject !== undefined &&
+        ['bpmn:ParallelGateway', 'bpmn:ExclusiveGateway'].includes(
+          diagramBusinessObject.$type,
+        )
+      }
       className={className}
       $hasLeftMargin={hasLeftMargin}
     />


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When we migrate a process instance there's a chance some node are deleted on the diagram. In that case the nodes would still be present on the flow node instance history but wouldn't exist in the new diagram version.
When this happened this would break the process instance page and wouldn't show the active token.

It also breaks the metadata popover of the deleted nodes

I also fixed the icon for the deleted flow nodes in the history, now we're just showing a generic icon.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31985
