### PR TITLE
fix: remove elastic.co Maven repository

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -175,18 +175,6 @@
       <name>Camunda BPM Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
-
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>elasticsearch</id>
-      <name>Elasticsearch Repository</name>
-      <url>https://artifacts.elastic.co/maven/</url>
-    </repository>
   </repositories>
 
   <build>

--- a/tasklist/.idea/jarRepositories.xml
+++ b/tasklist/.idea/jarRepositories.xml
@@ -12,11 +12,6 @@
       <option name="url" value="https://repo.maven.apache.org/maven2" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="elasticsearch" />
-      <option name="name" value="Elasticsearch Repository" />
-      <option name="url" value="https://artifacts.elastic.co/maven/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="camunda-identity-snapshot" />
       <option name="name" value="Camunda Identity Snapshot Repository" />
       <option name="url" value="https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/" />


### PR DESCRIPTION
## Description

fix: remove elastic.co Maven repository

https://elastic.co/maven does not works anymore, and all calls to it return 404.
Due to how it works, Renovate tries to search dependencies in this registry, just because it's declared (`merge` strategy)

Turning it off saves time on Renovate job runtime.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
