### PR TITLE
[Backport stable/operate-8.5] fix: remove elastic.co Maven repository

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -1147,17 +1147,5 @@
       </snapshots>
     </repository>
 
-    <repository>
-      <id>elasticsearch</id>
-      <name>Elasticsearch Repository</name>
-      <url>https://artifacts.elastic.co/maven/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
   </repositories>
 </project>


### PR DESCRIPTION
# Description
Backport of #32161 to `stable/operate-8.5`.

relates to 