### PR TITLE
[Backport stable/8.7] fix: remove elastic.co Maven repository

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -175,18 +175,6 @@
       <name>Camunda BPM Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
     </repository>
-
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>elasticsearch</id>
-      <name>Elasticsearch Repository</name>
-      <url>https://artifacts.elastic.co/maven/</url>
-    </repository>
   </repositories>
 
   <build>

--- a/tasklist/.idea/jarRepositories.xml
+++ b/tasklist/.idea/jarRepositories.xml
@@ -17,11 +17,6 @@
       <option name="url" value="https://repo.maven.apache.org/maven2" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="elasticsearch" />
-      <option name="name" value="Elasticsearch Repository" />
-      <option name="url" value="https://artifacts.elastic.co/maven/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="camunda-identity-snapshot" />
       <option name="name" value="Camunda Identity Snapshot Repository" />
       <option name="url" value="https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/" />


### PR DESCRIPTION
# Description
Backport of #32161 to `stable/8.7`.

relates to 