### PR TITLE
fix: Update core-application-e2e-tests-nightly.yml

### DIFF
--- a/.github/workflows/core-application-e2e-tests-nightly.yml
+++ b/.github/workflows/core-application-e2e-tests-nightly.yml
@@ -144,7 +144,7 @@ jobs:
             --project 'C8' \
             --username $TESTRAIL_USERNAME \
             --key $TESTRAIL_KEY \
-            parse_junit --suite-id 17050 \ 
+            parse_junit --suite-id 17050 \
             --title "Nightly Core Application Run Test Results - $BRANCH_NAME - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
             -f $JUNIT_RESULTS_FILE


### PR DESCRIPTION
## Description
The nightly E2E test workflow was failing during the `Publish test results to TestRail` step. The issue was caused by an invalid line continuation (`\ `) in the `trcli` command, which resulted in a syntax error and prevented the test results from being published to TestRail.

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
