### PR TITLE
Renovate unification

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,32 +33,7 @@
       "automerge"
     ]
   },
-  "hostRules": [
-    {
-      "matchHost": "https://artifacts.camunda.com/artifactory/zeebe-io/",
-      "enabled": false
-    },
-    {
-      "matchHost": "https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/",
-      "enabled": false
-    },
-    {
-      "matchHost": "https://artifacts.camunda.com/artifactory/camunda-identity/",
-      "enabled": false
-    },
-    {
-      "matchHost": "https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/",
-      "enabled": false
-    }
-  ],
   "packageRules": [
-    {
-      "matchDatasources": ["maven"],
-      "registryUrls": [
-        "https://repo.maven.apache.org/maven2/",
-        "https://artifacts.camunda.com/artifactory/public/"
-        ]
-    },
     {
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,9 +6,7 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranches": [
-    "/^stable\\/8\\..*/",
-    "stable/operate-8.5",
-    "main"
+    "renovate-unification"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,
@@ -35,6 +33,24 @@
       "automerge"
     ]
   },
+  "hostRules": [
+    {
+      "matchHost": "https://artifacts.camunda.com/artifactory/zeebe-io/",
+      "enabled": false
+    },
+    {
+      "matchHost": "https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/",
+      "enabled": false
+    },
+    {
+      "matchHost": "https://artifacts.camunda.com/artifactory/camunda-identity/",
+      "enabled": false
+    },
+    {
+      "matchHost": "https://artifacts.camunda.com/artifactory/camunda-identity-snapshots/",
+      "enabled": false
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": ["maven"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,13 @@
   },
   "packageRules": [
     {
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2/",
+        "https://artifacts.camunda.com/artifactory/public/"
+        ]
+    },
+    {
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,
       "matchBaseBranches": [

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -109,6 +109,18 @@
         <enabled>true</enabled>
       </releases>
       <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>public</id>
+      <name>Public Maven Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
+    </repository>
+
+    <!-- <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
         <enabled>false</enabled>
       </snapshots>
       <id>zeebe</id>
@@ -174,7 +186,7 @@
       <id>camunda-bpm-snapshots</id>
       <name>Camunda BPM Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/camunda-bpm-snapshots/</url>
-    </repository>
+    </repository> -->
   </repositories>
 
   <build>

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -37,6 +37,7 @@ docker run --rm \
   -e RENOVATE_PLATFORM="github" \
   -e RENOVATE_TOKEN="${GITHUB_TOKEN}" \
   -e RENOVATE_REPOSITORIES="${REPO_NAME}" \
+  -e RENOVATE_REQUIRE_CONFIG="ignored" \
   -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-config.json" \
   -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-config.json:ro" \
   -e RENOVATE_CACHE_DIR="/cache/renovate" \

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -473,13 +473,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
+  <!-- <repositories>
     <repository>
       <id>maven_central</id>
       <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
-  </repositories>
+  </repositories> -->
 
   <build>
     <plugins>

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -129,7 +129,7 @@
     </dependency>
   </dependencies>
 
-  <repositories>
+  <!-- <repositories>
     <repository>
       <releases>
         <enabled>true</enabled>
@@ -153,7 +153,7 @@
       <name>Zeebe Snapshot Repository</name>
       <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
     </repository>
-  </repositories>
+  </repositories> -->
 
   <build>
     <plugins>


### PR DESCRIPTION
## Description

This change alters the `bom/pom.xml` so it doesn't list all artifactory repositories separately but only the virtual repository `public`. This speeds up the renovate lookup process for each branch analyzed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

* camunda/team-infrastructure#847

## :alembic: Testing 

Tested with the script `cmd/renovate/renovate-local.sh` only for this feature branch.

