### PR TITLE
[Backport stable/8.5] fix: make actuator autoconfigure and micrometer optional in spring sdk

### DIFF
--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -114,6 +114,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -124,7 +125,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -124,6 +124,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Description
Backport of #31991 to `stable/8.5`.

relates to 