### PR TITLE
ci: improve renovate performance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,15 @@
   },
   "packageRules": [
     {
+      "matchDatasources": [
+        "maven"
+      ],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2",
+        "https://artifacts.camunda.com/artifactory/public/"
+      ]
+    },
+    {
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,
       "matchBaseBranches": [

--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,4 @@ c8run/*.class
 /camunda.mv.db
 /camunda.trace.db
 
-renovate_cache/
+cmd/renovate/renovate*/

--- a/cmd/renovate/renovate-local.sh
+++ b/cmd/renovate/renovate-local.sh
@@ -14,12 +14,14 @@ fi
 LOCAL_RENOVATE_CONFIG="../.././.github/renovate.json"
 REPO_NAME="camunda/camunda"
 LOCAL_CACHE_DIR="$(pwd)/renovate_cache"
+LOCAL_BASE_DIR="$(pwd)/renovate"
 
 if [ ! -f "$LOCAL_RENOVATE_CONFIG" ]; then
     echo "Error: Local Renovate config file '$LOCAL_RENOVATE_CONFIG' not found."
     exit 1
 fi
 mkdir -p "${LOCAL_CACHE_DIR}"
+mkdir -p "${LOCAL_BASE_DIR}"
 
 echo "Processing repository: ${REPO_NAME}"
 echo "Using Renovate configuration from: ${LOCAL_RENOVATE_CONFIG}"
@@ -37,8 +39,11 @@ docker run --rm \
   -e RENOVATE_PLATFORM="github" \
   -e RENOVATE_TOKEN="${GITHUB_TOKEN}" \
   -e RENOVATE_REPOSITORIES="${REPO_NAME}" \
+  -e RENOVATE_REQUIRE_CONFIG="ignored" \
   -e RENOVATE_CONFIG_FILE="/usr/src/app/mounted-renovate-config.json" \
   -v "$(pwd)/${LOCAL_RENOVATE_CONFIG}:/usr/src/app/mounted-renovate-config.json:ro" \
+  -e RENOVATE_BASE_DIR="/tmp/renovate" \
+  -v "${LOCAL_BASE_DIR}:/tmp/renovate" \
   -e RENOVATE_CACHE_DIR="/cache/renovate" \
   -v "${LOCAL_CACHE_DIR}:/cache/renovate" \
   renovate/renovate | tee "/tmp/${REPO_NAME//\//_}_$(date +%Y%m%d_%H%M%S).txt"


### PR DESCRIPTION
## Description

This is a sibling to https://github.com/camunda/camunda/pull/32179 where we test approaches to improve renovate's performance on this issue.

This permutation doesn't modify the poms but rather only sets an effective list of possible maven repositories.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

* camunda/team-infrastructure#847
