### PR TITLE
[Backport stable/8.7] fix: do not initialize SDK if client is disabled

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaAutoConfiguration.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.spring.client.configuration;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.zeebe.spring.client.event.ZeebeLifecycleEventProducer;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 
 /** Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients */
 @Configuration
+@ConditionalOnCamundaClientEnabled
 @ImportAutoConfiguration({
   ZeebeClientProdAutoConfiguration.class,
   ZeebeClientAllAutoConfiguration.class,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.spring.client.configuration;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.actuator.MicrometerMetricsRecorder;
 import io.camunda.zeebe.spring.client.actuator.ZeebeClientHealthIndicator;
+import io.camunda.zeebe.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 
 @AutoConfigureBefore(MetricsDefaultConfiguration.class)
+@ConditionalOnCamundaClientEnabled
 @ConditionalOnClass({
   EndpointAutoConfiguration.class,
   MeterRegistry.class

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -21,6 +21,7 @@ import static java.util.Optional.ofNullable;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
+import io.camunda.zeebe.spring.client.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
@@ -33,16 +34,11 @@ import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.PropertyBasedZeebeWorkerValueCustomizer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-@ConditionalOnProperty(
-    prefix = "camunda.client.zeebe",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true)
+@ConditionalOnCamundaClientEnabled
 @Import({AnnotationProcessorConfiguration.class, JsonMapperConfiguration.class})
 @EnableConfigurationProperties({CamundaClientProperties.class})
 public class ZeebeClientAllAutoConfiguration {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -35,18 +35,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 /*
  * All configurations that will only be used in production code - meaning NO TEST cases
  */
-@ConditionalOnProperty(
-    prefix = "camunda.client.zeebe",
-    name = "enabled",
-    havingValue = "true",
-    matchIfMissing = true)
 @ConditionalOnCamundaClientEnabled
 @ConditionalOnMissingBean(SpringZeebeTestContext.class)
 @ImportAutoConfiguration({

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientEnabledTest.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.spring.client.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ public class ZeebeClientEnabledTest {
 
   @Nested
   @SpringBootTest(
-      classes = ZeebeClientProdAutoConfiguration.class,
+      classes = CamundaAutoConfiguration.class,
       properties = {"camunda.client.zeebe.enabled=false"})
   class CurrentConfiguration {
     @Autowired(required = false)
@@ -42,7 +42,7 @@ public class ZeebeClientEnabledTest {
 
   @Nested
   @SpringBootTest(
-      classes = ZeebeClientProdAutoConfiguration.class,
+      classes = CamundaAutoConfiguration.class,
       properties = {"zeebe.client.enabled=false"})
   class LegacyConfiguration {
     @Autowired(required = false)
@@ -55,7 +55,7 @@ public class ZeebeClientEnabledTest {
   }
 
   @Nested
-  @SpringBootTest(classes = ZeebeClientProdAutoConfiguration.class)
+  @SpringBootTest(classes = CamundaAutoConfiguration.class)
   class DefaultTest {
     @Autowired(required = false)
     ZeebeClient camundaClient;


### PR DESCRIPTION
# Description
Backport of #32107 to `stable/8.7`.

relates to #32104