### PR TITLE
fix: role member search returns username only

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2746,14 +2746,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RoleMemberSearchQueryRequest"
+              $ref: "#/components/schemas/RoleUserSearchQueryRequest"
       responses:
         "200":
           description: The users assigned to the role.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoleMemberSearchResult"
+                $ref: "#/components/schemas/RoleUserSearchResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -7240,6 +7240,44 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RoleResult"
+    RoleUserResult:
+      type: object
+      properties:
+        username:
+          description: The username of the user.
+          type: string
+    RoleUserSearchResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching users.
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleUserResult"
+    RoleUserSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleUserSearchQuerySortRequest"
+    RoleUserSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - username
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
     RoleClientResult:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2746,14 +2746,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserSearchQueryRequest"
+              $ref: "#/components/schemas/RoleMemberSearchQueryRequest"
       responses:
         "200":
           description: The users assigned to the role.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserSearchResult"
+                $ref: "#/components/schemas/RoleMemberSearchResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -275,6 +275,21 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, RoleQuery> toRoleQuery(
+      final RoleUserSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.roleSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromRoleUserSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::role,
+            SearchQueryRequestMapper::applyRoleUserSortField);
+    final var filter = FilterBuilders.role().build();
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::roleSearchQuery);
+  }
+
+  public static Either<ProblemDetail, RoleQuery> toRoleQuery(
       final RoleClientSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.roleSearchQuery().build());
@@ -1094,6 +1109,17 @@ public final class SearchQueryRequestMapper {
       }
     }
     return validationErrors;
+  }
+
+  private static List<String> applyRoleUserSortField(
+      final RoleUserSearchQuerySortRequest.FieldEnum field, final RoleSort.Builder builder) {
+    return switch (field) {
+      case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+      case USERNAME -> {
+        builder.memberId();
+        yield List.of();
+      }
+    };
   }
 
   private static List<String> applyRoleClientSortField(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -87,6 +87,8 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleClientResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleClientSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUserResult;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
@@ -196,6 +198,16 @@ public final class SearchQueryResponseMapper {
         .page(page)
         .items(
             ofNullable(result.items()).map(SearchQueryResponseMapper::toRoles).orElseGet(List::of));
+  }
+
+  public static RoleUserSearchResult toRoleUserSearchQueryResponse(
+      final SearchQueryResult<RoleMemberEntity> result) {
+    return new RoleUserSearchResult()
+        .page(toSearchQueryPageResponse(result))
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toRoleUsers)
+                .orElseGet(List::of));
   }
 
   public static RoleClientSearchResult toRoleClientSearchQueryResponse(
@@ -469,8 +481,16 @@ public final class SearchQueryResponseMapper {
         .tenantId(tenantEntity.tenantId());
   }
 
+  private static List<RoleUserResult> toRoleUsers(final List<RoleMemberEntity> members) {
+    return members.stream().map(SearchQueryResponseMapper::toRoleUser).toList();
+  }
+
   private static List<RoleClientResult> toRoleClients(final List<RoleMemberEntity> members) {
     return members.stream().map(SearchQueryResponseMapper::toRoleClient).toList();
+  }
+
+  private static RoleUserResult toRoleUser(final RoleMemberEntity roleMember) {
+    return new RoleUserResult().username(roleMember.id());
   }
 
   private static RoleClientResult toRoleClient(final RoleMemberEntity roleMember) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -29,6 +29,11 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<RoleUserSearchQuerySortRequest.FieldEnum>>
+      fromRoleUserSearchQuerySortRequest(final List<RoleUserSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   public static List<SearchQuerySortRequest<RoleClientSearchQuerySortRequest.FieldEnum>>
       fromRoleClientSearchQuerySortRequest(final List<RoleClientSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -143,12 +143,12 @@ public class RoleController {
   }
 
   private ResponseEntity<RoleUserSearchResult> searchUsersInRole(
-      final String tenantId, final RoleQuery query) {
+      final String roleId, final RoleQuery query) {
     try {
       final var result =
           roleServices
               .withAuthentication(RequestMapper.getAuthentication())
-              .searchMembers(buildRoleMemberQuery(tenantId, EntityType.USER, query));
+              .searchMembers(buildRoleMemberQuery(roleId, EntityType.USER, query));
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
-import io.camunda.search.query.UserQuery;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
@@ -26,7 +25,8 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUserSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUserSearchResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
@@ -133,33 +133,26 @@ public class RoleController {
   }
 
   @CamundaPostMapping(path = "/{roleId}/users/search")
-  public ResponseEntity<RoleMemberSearchResult> searchUsersByRole(
+  public ResponseEntity<RoleUserSearchResult> searchUsersByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final RoleMemberSearchQueryRequest query) {
+      @RequestBody(required = false) final RoleUserSearchQueryRequest query) {
     return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            userQuery -> searchMembersInRole(roleId, EntityType.USER, userQuery));
+            userQuery -> searchUsersInRole(roleId, userQuery));
   }
 
-  private ResponseEntity<UserSearchResult> searchUsersInRole(
-      final String roleId, final UserQuery userQuery) {
+  private ResponseEntity<RoleUserSearchResult> searchUsersInRole(
+      final String tenantId, final RoleQuery query) {
     try {
-      final var composedUserQuery = buildUserQuery(roleId, userQuery);
       final var result =
-          userServices
+          roleServices
               .withAuthentication(RequestMapper.getAuthentication())
-              .search(composedUserQuery);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
+              .searchMembers(buildRoleMemberQuery(tenantId, EntityType.USER, query));
+      return ResponseEntity.ok(SearchQueryResponseMapper.toRoleUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
-  }
-
-  private UserQuery buildUserQuery(final String roleId, final UserQuery userQuery) {
-    return userQuery.toBuilder()
-        .filter(userQuery.filter().toBuilder().roleId(roleId).build())
-        .build();
   }
 
   @CamundaPostMapping(path = "/{roleId}/clients/search")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.UserSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
@@ -134,13 +133,13 @@ public class RoleController {
   }
 
   @CamundaPostMapping(path = "/{roleId}/users/search")
-  public ResponseEntity<UserSearchResult> searchUsersByRole(
+  public ResponseEntity<RoleMemberSearchResult> searchUsersByRole(
       @PathVariable final String roleId,
-      @RequestBody(required = false) final UserSearchQueryRequest query) {
-    return SearchQueryRequestMapper.toUserQuery(query)
+      @RequestBody(required = false) final RoleMemberSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toRoleQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            userQuery -> searchUsersInRole(roleId, userQuery));
+            userQuery -> searchMembersInRole(roleId, EntityType.USER, userQuery));
   }
 
   private ResponseEntity<UserSearchResult> searchUsersInRole(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -15,13 +15,11 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.RoleMemberEntity;
-import io.camunda.search.entities.UserEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.RoleSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.MappingServices;
@@ -30,7 +28,6 @@ import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -216,15 +213,15 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void shouldSearchUsersByRole() {
     // given
     final var roleId = "roleId";
-    when(userServices.search(any(UserQuery.class)))
+    when(roleServices.searchMembers(any(RoleQuery.class)))
         .thenReturn(
-            new SearchQueryResult.Builder<UserEntity>()
+            new SearchQueryResult.Builder<RoleMemberEntity>()
                 .total(3)
                 .items(
                     List.of(
-                        new UserEntity(100L, "user1", "User 1", "user1@example.com", "password1"),
-                        new UserEntity(200L, "user2", "User 2", "user2@example.com", "password2"),
-                        new UserEntity(300L, "user3", "User 3", "user3@example.com", "password3")))
+                        new RoleMemberEntity("user1", EntityType.USER),
+                        new RoleMemberEntity("user2", EntityType.USER),
+                        new RoleMemberEntity("user3", EntityType.USER)))
                 .build());
 
     // when /then
@@ -245,19 +242,13 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "username": "user1",
-                 "name": "User 1",
-                 "email": "user1@example.com"
+                 "memberId": "user1"
                },
                {
-                 "username": "user2",
-                 "name": "User 2",
-                 "email": "user2@example.com"
+                 "memberId": "user2"
                },
                {
-                 "username": "user3",
-                 "name": "User 3",
-                 "email": "user3@example.com"
+                 "memberId": "user3"
                }
              ],
              "page": {
@@ -267,10 +258,10 @@ public class RoleQueryControllerTest extends RestControllerTest {
              }
            }""");
 
-    verify(userServices)
-        .search(
-            new UserQuery.Builder()
-                .filter(f -> f.roleId(roleId).usernames(Collections.emptySet()))
+    verify(roleServices)
+        .searchMembers(
+            new RoleQuery.Builder()
+                .filter(f -> f.memberType(EntityType.USER).joinParentId(roleId))
                 .build());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -242,13 +242,13 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "memberId": "user1"
+                 "username": "user1"
                },
                {
-                 "memberId": "user2"
+                 "username": "user2"
                },
                {
-                 "memberId": "user3"
+                 "username": "user3"
                }
              ],
              "page": {


### PR DESCRIPTION
This reduces the data we expose in the role-user membership search endpoint to just the username.

depends on #32207
relates to #30346
