### PR TITLE
feat: reworked logout security flow

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -200,6 +200,11 @@
       <artifactId>zeebe-broker-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -546,10 +545,7 @@ public class WebSecurityConfig {
         final OAuth2AuthorizedClientService authorizedClientService,
         final SecurityConfiguration securityConfiguration) {
       return new OidcSecurityContextLogoutHandler(
-          clientRegistrationRepository,
-          authorizedClientService,
-          securityConfiguration,
-          new RestTemplateBuilder().build());
+          clientRegistrationRepository, authorizedClientService, securityConfiguration);
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/handler/OidcLogoutSuccessHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/OidcLogoutSuccessHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+public class OidcLogoutSuccessHandler implements LogoutSuccessHandler {
+
+  public static final String LOGOUT_SUCCESS_REDIRECT_URL_PROPERTY = "camunda.logout.redirect.url";
+
+  @Override
+  public void onLogoutSuccess(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Authentication authentication)
+      throws IOException {
+    final String oidcLogoutUrl =
+        (String) request.getAttribute(LOGOUT_SUCCESS_REDIRECT_URL_PROPERTY);
+    response.sendRedirect(Objects.requireNonNullElse(oidcLogoutUrl, "/"));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/handler/OidcSecurityContextLogoutHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/OidcSecurityContextLogoutHandler.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import io.camunda.authentication.config.OidcClientRegistration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class OidcSecurityContextLogoutHandler implements LogoutHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OidcSecurityContextLogoutHandler.class);
+
+  private final ClientRegistrationRepository clientRegistrationRepository;
+  private final OAuth2AuthorizedClientService authorizedClientService;
+  private final SecurityConfiguration securityConfiguration;
+  private final RestTemplate restTemplate;
+
+  public OidcSecurityContextLogoutHandler(
+      final ClientRegistrationRepository clientRegistrationRepository,
+      final OAuth2AuthorizedClientService authorizedClientService,
+      final SecurityConfiguration securityConfiguration,
+      final RestTemplate restTemplate) {
+    this.clientRegistrationRepository = clientRegistrationRepository;
+    this.authorizedClientService = authorizedClientService;
+    this.securityConfiguration = securityConfiguration;
+    this.restTemplate = restTemplate;
+  }
+
+  @Override
+  public void logout(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Authentication authentication) {
+
+    if (authentication == null) {
+      return;
+    }
+
+    try {
+      // execute OIDC logout
+      performOidcLogout(authentication);
+
+      // prepare redirect URL if logout was successful
+      storeLogoutRedirectUrl(request, authentication);
+
+    } catch (final Exception e) {
+      LOG.error(e.getMessage(), e);
+    } finally {
+      // remove authorized client
+      clearAuthorizedClients(authentication);
+
+      // clear session
+      final HttpSession session = request.getSession(false);
+      if (session != null) {
+        session.invalidate();
+      }
+      // clear context
+      SecurityContextHolder.clearContext();
+    }
+  }
+
+  private void clearAuthorizedClients(final Authentication authentication) {
+    if (authentication instanceof OAuth2AuthenticationToken) {
+      final OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
+      final String registrationId = oauth2Token.getAuthorizedClientRegistrationId();
+      final String principalName = authentication.getName();
+      authorizedClientService.removeAuthorizedClient(registrationId, principalName);
+    }
+  }
+
+  private void performOidcLogout(final Authentication authentication) {
+    if (!(authentication instanceof OAuth2AuthenticationToken)) {
+      LOG.warn(
+          "Authentication object is not of type OAuth2AuthenticationToken, skipping OIDC logout.");
+      return;
+    }
+
+    final OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
+    final String registrationId = oauth2Token.getAuthorizedClientRegistrationId();
+
+    final OAuth2AuthorizedClient authorizedClient =
+        authorizedClientService.loadAuthorizedClient(registrationId, authentication.getName());
+
+    if (authorizedClient != null) {
+      revokeTokensForProvider(authorizedClient);
+    }
+  }
+
+  private void revokeTokensForProvider(final OAuth2AuthorizedClient authorizedClient) {
+    final ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+
+    try {
+      // revoke refresh token first
+      final OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+      if (refreshToken != null) {
+        revokeToken(
+            clientRegistration, refreshToken.getTokenValue(), OAuth2ParameterNames.REFRESH_TOKEN);
+      }
+
+      // now access token
+      final OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+      if (accessToken != null) {
+        revokeToken(
+            clientRegistration, accessToken.getTokenValue(), OAuth2ParameterNames.ACCESS_TOKEN);
+      }
+
+    } catch (final Exception e) {
+      // not critical but still a warning
+      LOG.warn("Could not revoke token for client: {}", clientRegistration.getClientId(), e);
+    }
+  }
+
+  private void revokeToken(
+      final ClientRegistration clientRegistration, final String token, final String tokenType) {
+    final String revokeEndpoint =
+        securityConfiguration.getAuthentication().getOidc().getRevokeTokenUri();
+    if (revokeEndpoint == null) {
+      LOG.warn(
+          "Revoke endpoint was not set. Skipping token revocation for token type: {}", tokenType);
+      return;
+    }
+
+    try {
+      final HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+      headers.setBasicAuth(clientRegistration.getClientId(), clientRegistration.getClientSecret());
+
+      final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+      params.add(OAuth2ParameterNames.TOKEN, token);
+      params.add(OAuth2ParameterNames.TOKEN_TYPE_HINT, tokenType);
+
+      final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+      final ResponseEntity<String> response =
+          restTemplate.postForEntity(revokeEndpoint, request, String.class);
+
+      if (!response.getStatusCode().is2xxSuccessful()) {
+        LOG.warn("Token revocation failed with status: {}", response.getStatusCode());
+      }
+
+    } catch (final Exception e) {
+      LOG.warn("Error revoking {}", tokenType, e);
+    }
+  }
+
+  private void storeLogoutRedirectUrl(
+      final HttpServletRequest request, final Authentication authentication) {
+    final String logoutRedirectUrl = buildOidcLogoutUrl();
+    if (logoutRedirectUrl != null) {
+      // store in request attribute for LogoutSuccessHandler
+      request.setAttribute(
+          OidcLogoutSuccessHandler.LOGOUT_SUCCESS_REDIRECT_URL_PROPERTY, logoutRedirectUrl);
+    }
+  }
+
+  private String buildOidcLogoutUrl() {
+    try {
+      final ClientRegistration clientRegistration =
+          clientRegistrationRepository.findByRegistrationId(OidcClientRegistration.REGISTRATION_ID);
+
+      if (clientRegistration == null) {
+        return null;
+      }
+
+      final String endSessionEndpoint =
+          securityConfiguration.getAuthentication().getOidc().getSessionLogoutUrl();
+
+      if (endSessionEndpoint == null) {
+        return null;
+      }
+
+      final UriComponentsBuilder logoutUriBuilder =
+          UriComponentsBuilder.fromUriString(endSessionEndpoint)
+              .queryParam(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
+
+      return logoutUriBuilder.build().toString();
+
+    } catch (final Exception e) {
+      LOG.warn("Error building OIDC logout url", e);
+      return null;
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/handler/OidcSecurityContextLogoutHandlerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/handler/OidcSecurityContextLogoutHandlerTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.handler;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.config.OidcClientRegistration;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OidcSecurityContextLogoutHandlerTest {
+
+  @Mock private ClientRegistrationRepository clientRegistrationRepository;
+  @Mock private OAuth2AuthorizedClientService authorizedClientService;
+  @Mock private SecurityConfiguration securityConfiguration;
+  @Mock private AuthenticationConfiguration authenticationConfig;
+  @Mock private OidcAuthenticationConfiguration oidcConfig;
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private HttpSession session;
+  @Mock private OAuth2AuthenticationToken oauth2AuthenticationToken;
+  @Mock private OAuth2AuthorizedClient authorizedClient;
+  @Mock private ClientRegistration clientRegistration;
+  @Mock private OAuth2AccessToken accessToken;
+  @Mock private OAuth2RefreshToken refreshToken;
+  @Mock private RestTemplate restTemplate;
+
+  private OidcSecurityContextLogoutHandler logoutHandler;
+
+  @BeforeEach
+  void setUp() {
+    logoutHandler =
+        new OidcSecurityContextLogoutHandler(
+            clientRegistrationRepository,
+            authorizedClientService,
+            securityConfiguration,
+            restTemplate);
+
+    when(securityConfiguration.getAuthentication()).thenReturn(authenticationConfig);
+    when(authenticationConfig.getOidc()).thenReturn(oidcConfig);
+  }
+
+  @Test
+  void shouldDoNothingWhenAuthenticationIsNull() {
+    // Given
+    when(request.getSession(false)).thenReturn(session);
+
+    // When
+    logoutHandler.logout(request, response, null);
+
+    // Then
+    verifyNoInteractions(session);
+    verifyNoInteractions(authorizedClientService);
+  }
+
+  @Test
+  void shouldPerformNormalLogoutWithOAuth2Authentication() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+    final String accessTokenValue = "access-token-123";
+    final String refreshTokenValue = "refresh-token-456";
+    final String revokeUri = "https://provider.com/revoke";
+    final String logoutUri = "https://provider.com/logout";
+    final String clientId = "test-client-id";
+    final String clientSecret = "test-client-secret";
+
+    final OAuth2User oauth2User =
+        new DefaultOAuth2User(Set.of(), java.util.Map.of("sub", principalName), "sub");
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(oauth2AuthenticationToken.getPrincipal()).thenReturn(oauth2User);
+
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(authorizedClient);
+
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getRefreshToken()).thenReturn(refreshToken);
+
+    when(clientRegistration.getClientId()).thenReturn(clientId);
+    when(clientRegistration.getClientSecret()).thenReturn(clientSecret);
+
+    when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
+    when(refreshToken.getTokenValue()).thenReturn(refreshTokenValue);
+
+    when(oidcConfig.getRevokeTokenUri()).thenReturn(revokeUri);
+    when(oidcConfig.getSessionLogoutUrl()).thenReturn(logoutUri);
+
+    when(clientRegistrationRepository.findByRegistrationId(OidcClientRegistration.REGISTRATION_ID))
+        .thenReturn(clientRegistration);
+
+    when(restTemplate.postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(new ResponseEntity<>("", HttpStatus.OK));
+
+    when(request.getSession(false)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(authorizedClientService).removeAuthorizedClient(registrationId, principalName);
+      verify(restTemplate, times(2))
+          .postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class));
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+      verify(request)
+          .setAttribute(
+              eq(OidcLogoutSuccessHandler.LOGOUT_SUCCESS_REDIRECT_URL_PROPERTY),
+              contains(logoutUri));
+    }
+  }
+
+  @Test
+  void shouldOnlyClearContextAndSessionWithNonOAuth2Authentication() {
+    // Given
+    final Authentication regularAuth = mock(Authentication.class);
+    when(request.getSession(false)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, regularAuth);
+
+      // Then
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+      verifyNoInteractions(authorizedClientService);
+      verifyNoInteractions(restTemplate);
+    }
+  }
+
+  @Test
+  void shouldStillClearContextAndSessionWithNoAuthorizedClient() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(null);
+    when(request.getSession(false)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(authorizedClientService).removeAuthorizedClient(registrationId, principalName);
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+      verifyNoInteractions(restTemplate);
+    }
+  }
+
+  @Test
+  void shouldContinueWithLogoutWithTokenRevocationFailure() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+    final String revokeUri = "https://provider.com/revoke";
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getRefreshToken()).thenReturn(refreshToken);
+    when(clientRegistration.getClientId()).thenReturn("client-id");
+    when(clientRegistration.getClientSecret()).thenReturn("client-secret");
+    when(accessToken.getTokenValue()).thenReturn("access-token");
+    when(refreshToken.getTokenValue()).thenReturn("refresh-token");
+    when(oidcConfig.getRevokeTokenUri()).thenReturn(revokeUri);
+    when(request.getSession(false)).thenReturn(session);
+
+    when(restTemplate.postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class)))
+        .thenThrow(new RestClientException("Network error"));
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(authorizedClientService).removeAuthorizedClient(registrationId, principalName);
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+    }
+  }
+
+  @Test
+  void shouldNotThrowExceptionWithNoSession() {
+    // Given
+    when(request.getSession(false)).thenReturn(null);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      assertDoesNotThrow(() -> logoutHandler.logout(request, response, oauth2AuthenticationToken));
+
+      // Then
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+    }
+  }
+
+  @Test
+  void shouldRevokeOnlyAccessTokenWithOnlyAccessToken() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+    final String accessTokenValue = "access-token-123";
+    final String revokeUri = "https://provider.com/revoke";
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getRefreshToken()).thenReturn(null); // No refresh token
+    when(clientRegistration.getClientId()).thenReturn("client-id");
+    when(clientRegistration.getClientSecret()).thenReturn("client-secret");
+    when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
+    when(oidcConfig.getRevokeTokenUri()).thenReturn(revokeUri);
+    when(request.getSession(false)).thenReturn(session);
+
+    when(restTemplate.postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(new ResponseEntity<>("", HttpStatus.OK));
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then - should only revoke access token
+      verify(restTemplate, times(1))
+          .postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class));
+    }
+  }
+
+  @Test
+  void shouldSkipTokenRevocationWithNullRevokeUri() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(oidcConfig.getRevokeTokenUri()).thenReturn(null); // No revoke URI configured
+    when(request.getSession(false)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(authorizedClientService).removeAuthorizedClient(registrationId, principalName);
+      verifyNoInteractions(restTemplate);
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+    }
+  }
+
+  @Test
+  void shouldContinueWithHttpErrorResponse() {
+    // Given
+    final String registrationId = "test-registration";
+    final String principalName = "test-user";
+    final String revokeUri = "https://provider.com/revoke";
+
+    when(oauth2AuthenticationToken.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+    when(oauth2AuthenticationToken.getName()).thenReturn(principalName);
+    when(authorizedClientService.loadAuthorizedClient(registrationId, principalName))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(clientRegistration.getClientId()).thenReturn("client-id");
+    when(clientRegistration.getClientSecret()).thenReturn("client-secret");
+    when(accessToken.getTokenValue()).thenReturn("access-token");
+    when(oidcConfig.getRevokeTokenUri()).thenReturn(revokeUri);
+    when(request.getSession(false)).thenReturn(session);
+
+    when(restTemplate.postForEntity(eq(revokeUri), any(HttpEntity.class), eq(String.class)))
+        .thenReturn(new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST));
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(authorizedClientService).removeAuthorizedClient(registrationId, principalName);
+      verify(session).invalidate();
+      mockedSecurityContext.verify(SecurityContextHolder::clearContext);
+    }
+  }
+
+  @Test
+  void shouldCreateCorrectUrlWithValidConfiguration() {
+    // Given
+    final String logoutUri = "https://provider.com/logout";
+    final String clientId = "test-client-id";
+
+    when(clientRegistrationRepository.findByRegistrationId(OidcClientRegistration.REGISTRATION_ID))
+        .thenReturn(clientRegistration);
+    when(clientRegistration.getClientId()).thenReturn(clientId);
+    when(oidcConfig.getSessionLogoutUrl()).thenReturn(logoutUri);
+    when(request.getSession(false)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mockedSecurityContext =
+        mockStatic(SecurityContextHolder.class)) {
+
+      // When
+      logoutHandler.logout(request, response, oauth2AuthenticationToken);
+
+      // Then
+      verify(request)
+          .setAttribute(
+              eq(OidcLogoutSuccessHandler.LOGOUT_SUCCESS_REDIRECT_URL_PROPERTY),
+              eq(logoutUri + "?client_id=" + clientId));
+    }
+  }
+}

--- a/operate/client/src/modules/api/logout.ts
+++ b/operate/client/src/modules/api/logout.ts
@@ -6,13 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {requestAndParse} from 'modules/request';
+import { authenticationStore } from 'modules/stores/authentication';
 
 const logout = async () => {
-  return requestAndParse({
-    url: '/logout',
-    method: 'POST',
-  });
+  try {
+    console.log('DEBUG ONLY');
+    authenticationStore.expireSession();
+
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/logout';
+    form.style.display = 'none';
+
+    // Add CSRF token if needed
+    const csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content');
+    if (csrfToken) {
+      const csrfInput = document.createElement('input');
+      csrfInput.type = 'hidden';
+      csrfInput.name = '_csrf';
+      csrfInput.value = csrfToken;
+      form.appendChild(csrfInput);
+    }
+
+    document.body.appendChild(form);
+    form.submit();
+
+  } catch (error) {
+    console.error('Error during logout:', error);
+    window.location.href = '/login';
+  }
 };
 
-export {logout};
+export { logout };

--- a/operate/client/src/modules/stores/authentication.ts
+++ b/operate/client/src/modules/stores/authentication.ts
@@ -184,9 +184,9 @@ class Authentication {
   handleLogout = async () => {
     const response = await logout();
 
-    if (!response.isSuccess) {
-      return new Error('Could not logout');
-    }
+    // if (!response.isSuccess) {
+    //   return new Error('Could not logout');
+    // }
 
     this.disableSession();
   };

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -14,8 +14,7 @@ import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
   private String issuerUri;
-  private String revokeTokenUri;
-  private String sessionLogoutUrl;
+  private String issuerLogoutUrl;
   private String clientId;
   private String clientSecret;
   private String grantType = "authorization_code";
@@ -38,20 +37,12 @@ public class OidcAuthenticationConfiguration {
     this.issuerUri = issuerUri;
   }
 
-  public String getRevokeTokenUri() {
-    return revokeTokenUri;
+  public String getIssuerLogoutUrl() {
+    return issuerLogoutUrl;
   }
 
-  public void setRevokeTokenUri(final String revokeTokenUri) {
-    this.revokeTokenUri = revokeTokenUri;
-  }
-
-  public String getSessionLogoutUrl() {
-    return sessionLogoutUrl;
-  }
-
-  public void setSessionLogoutUrl(final String sessionLogoutUrl) {
-    this.sessionLogoutUrl = sessionLogoutUrl;
+  public void setIssuerLogoutUrl(final String issuerLogoutUrl) {
+    this.issuerLogoutUrl = issuerLogoutUrl;
   }
 
   public String getClientId() {
@@ -114,7 +105,7 @@ public class OidcAuthenticationConfiguration {
     return tokenUri;
   }
 
-  public void setTokenUri(String tokenUri) {
+  public void setTokenUri(final String tokenUri) {
     this.tokenUri = tokenUri;
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -14,6 +14,8 @@ import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
   private String issuerUri;
+  private String revokeTokenUri;
+  private String sessionLogoutUrl;
   private String clientId;
   private String clientSecret;
   private String grantType = "authorization_code";
@@ -34,6 +36,22 @@ public class OidcAuthenticationConfiguration {
 
   public void setIssuerUri(final String issuerUri) {
     this.issuerUri = issuerUri;
+  }
+
+  public String getRevokeTokenUri() {
+    return revokeTokenUri;
+  }
+
+  public void setRevokeTokenUri(final String revokeTokenUri) {
+    this.revokeTokenUri = revokeTokenUri;
+  }
+
+  public String getSessionLogoutUrl() {
+    return sessionLogoutUrl;
+  }
+
+  public void setSessionLogoutUrl(final String sessionLogoutUrl) {
+    this.sessionLogoutUrl = sessionLogoutUrl;
   }
 
   public String getClientId() {


### PR DESCRIPTION
## About this PR

This PR will be dismissed shortly. This code implements Relying Party (RP)-based logout. The 8.8 is not ready to onboard full-scale RP-based logout due to several concerns: (1) inconsistent logout: logging out from Operate may not automatically lead to Modeler logout which might bring even more confusion; (2) IdP customization: every IdP may require its own implementation (e.g. Keycloak has token invalidation but Entra does not - and these cases need to be handled gracefully); (3) effort is quite high to have high confidence feature being implemented before 8.8 release.

Therefore, [we decided](https://docs.google.com/document/d/13bKQ0YeZa0MBSx7mA4UX9zwqNfZqXADeCWbW3NgFkOY/edit?tab=t.0) to keep existing logout functionality as-is, and implement IdP logout beyond 8.8 via https://github.com/camunda/product-hub/issues/2991.

## Description

feat: reworked logout security flow

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to: https://github.com/camunda/camunda/issues/26802, https://github.com/camunda/camunda/issues/32382
