### PR TITLE
[Backport stable/operate-8.5] fix: Operate Opensearch importer throws IllegalFormatConversionException

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchBatchRequest.java
@@ -79,9 +79,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                     op.index(
                         idx ->
                             idx.index(index).id(entity.getId()).document(entity).routing(routing))),
-        String.format(
-            "Error preparing the query to index [%s] of entity type [%s] with routing",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to index [%s] of entity type [%s] with routing",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -106,9 +107,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                 op ->
                     op.update(
                         upd -> upd.index(index).id(id).upsert(entity).document(updateFields))),
-        String.format(
-            "Error preparing the query to upsert [%s] of entity type [%s]",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to upsert [%s] of entity type [%s]",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -140,9 +142,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .upsert(entity)
                                 .document(updateFields)
                                 .routing(routing))),
-        String.format(
-            "Error preparing the query to upsert [%s] of entity type [%s] with routing",
-            entity.getClass().getName(), entity));
+        () ->
+            String.format(
+                "Error preparing the query to upsert [%s] of entity type [%s] with routing",
+                entity, entity.getClass().getName()));
 
     return this;
   }
@@ -173,12 +176,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .upsert(entity)
                                 .script(script(script, parameters))
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
+        () ->
             String.format(
                 "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-                entity.getClass().getName(), entity),
-            index,
-            id));
+                entity, entity.getClass().getName()));
     return this;
   }
 
@@ -211,12 +212,10 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .script(script(script, parameters))
                                 .routing(routing)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
+        () ->
             String.format(
                 "Error preparing the query to upsert [%s] of entity type [%s] with script and routing",
-                entity.getClass().getName(), entity),
-            index,
-            id));
+                entity, entity.getClass().getName()));
     return this;
   }
 
@@ -237,8 +236,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .document(updateFields)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }
@@ -256,8 +256,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .document(entity)
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }
@@ -281,8 +282,9 @@ public class OpensearchBatchRequest implements BatchRequest {
                                 .id(id)
                                 .script(script(script, parameters))
                                 .retryOnConflict(UPDATE_RETRY_COUNT))),
-        String.format(
-            "Error preparing the query to update index [%s] document with id [%s]", index, id));
+        () ->
+            String.format(
+                "Error preparing the query to update index [%s] document with id [%s]", index, id));
 
     return this;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/util/ExceptionHelper.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ExceptionHelper.java
@@ -23,37 +23,38 @@ import java.util.function.Supplier;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 
 public interface ExceptionHelper {
-  static <R> R withPersistenceException(Supplier<R> supplier) throws PersistenceException {
+  static <R> R withPersistenceException(final Supplier<R> supplier) throws PersistenceException {
     try {
       return supplier.get();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new PersistenceException(e.getMessage(), e.getCause());
     }
   }
 
-  static <R> R withPersistenceException(Supplier<R> supplier, String errorMessage)
+  static <R> R withPersistenceException(
+      final Supplier<R> supplier, final Supplier<String> errorMessageSupplier)
       throws PersistenceException {
     try {
       return supplier.get();
-    } catch (Exception e) {
-      throw new PersistenceException(errorMessage, e);
+    } catch (final Exception e) {
+      throw new PersistenceException(errorMessageSupplier.get(), e);
     }
   }
 
-  static <R> R withOperateRuntimeException(ExceptionSupplier<R> supplier) {
+  static <R> R withOperateRuntimeException(final ExceptionSupplier<R> supplier) {
     try {
       return supplier.get();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new OperateRuntimeException(e.getMessage(), e.getCause());
     }
   }
 
-  public static <R> R withIOException(ExceptionSupplier<R> supplier) throws IOException {
+  public static <R> R withIOException(final ExceptionSupplier<R> supplier) throws IOException {
     try {
       return supplier.get();
-    } catch (OpenSearchException e) {
+    } catch (final OpenSearchException e) {
       throw e;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new IOException(e.getMessage(), e.getCause());
     }
   }


### PR DESCRIPTION
# Description
Backport of #32123 to `stable/operate-8.5`.

relates to camunda/camunda#32122