### PR TITLE
fix: apply profile annotation to legacy zeebe security classes to ensure they are only loaded when necessary

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/security/IdentityAuthenticationManager.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/security/IdentityAuthenticationManager.java
@@ -15,12 +15,14 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+@Profile("identity-auth")
 @Component
 public final class IdentityAuthenticationManager implements AuthenticationManager {
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/security/PreAuthTokenConverter.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/security/PreAuthTokenConverter.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.shared.security;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.Optional;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.stereotype.Component;
 
+@Profile("identity-auth")
 @Component
 public final class PreAuthTokenConverter implements AuthenticationConverter {
   private static final NoToken EMPTY_TOKEN = new NoToken();

--- a/dist/src/main/java/io/camunda/zeebe/shared/security/ProblemAuthFailureHandler.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/security/ProblemAuthFailureHandler.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -26,6 +27,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+@Profile("identity-auth")
 @Component
 public final class ProblemAuthFailureHandler
     implements AuthenticationFailureHandler, AccessDeniedHandler, AuthenticationEntryPoint {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

Currently when you set one of the new configuration options (audience, org id, cluster id) that triggers the initialisation of the JWT validators, upon failing a check there is a rogue legacy class `IdentityAuthenticationManager` that is loaded in and used incorrectly, the inclusion of this unexpected class results in a 500 ISE when it should really fail the authentication and return an error.

In this PR I apply I the `identity-auth` profile to these legacy classes to match their intention and let the new authentication layer correctly handle the validation/failure.

relates to https://github.com/camunda/camunda/issues/34294
