### PR TITLE
feat: reject mixed pagination in API

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1343,6 +1343,9 @@ public final class SearchQueryRequestMapper {
     if (searchAfter != null && searchBefore != null) {
       return Either.left(List.of(ERROR_SEARCH_BEFORE_AND_AFTER));
     }
+    if (requestedPage.getFrom() != null && (searchAfter != null || searchBefore != null)) {
+      return Either.left(List.of(ERROR_SEARCH_BEFORE_AND_AFTER_AND_FROM));
+    }
 
     return Either.right(
         SearchQueryPage.of(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -16,14 +16,14 @@ public final class ErrorMessages {
       No update data provided. Provide at least an "action" or a non-null value \
       for a supported attribute in the "changeset\"""";
   public static final String ERROR_MESSAGE_EMPTY_ATTRIBUTE = "No %s provided";
-  public static final String ERROR_MESSAGE_EMPTY_NESTED_ATTRIBUTE = "No %s provided in '%s'";
   public static final String ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE =
       "The value for %s is '%s' but must be %s";
   public static final String ERROR_SORT_FIELD_MUST_NOT_BE_NULL = "Sort field must not be null";
   public static final String ERROR_UNKNOWN_SORT_BY = "Unknown sortBy: %s";
-  public static final String ERROR_UNKNOWN_SORT_ORDER = "Unknown sortOrder: %s";
   public static final String ERROR_SEARCH_BEFORE_AND_AFTER =
       "Both searchAfter and searchBefore cannot be set at the same time";
+  public static final String ERROR_SEARCH_BEFORE_AND_AFTER_AND_FROM =
+      "Both searchAfter/searchBefore and from cannot be set at the same time";
   public static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD = "At least one of %s is required";
   public static final String ERROR_MESSAGE_INVALID_TENANT =
       "Expected to handle request %s with tenant identifier '%s', but %s";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -327,6 +327,46 @@ public class VariablesQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldInvalidateVariableSearchQueryWithConflictingPaginationTypes() {
+    // given
+    final var request =
+        """
+            {
+                "page": {
+                    "searchAfter": ["a"],
+                    "from": 4
+                }
+            }""";
+    final var expectedResponse =
+        String.format(
+            """
+                {
+                  "type": "about:blank",
+                  "title": "INVALID_ARGUMENT",
+                  "status": 400,
+                  "detail": "Both searchAfter/searchBefore and from cannot be set at the same time.",
+                  "instance": "%s"
+                }""",
+            VARIABLE_TASKS_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(VARIABLE_TASKS_SEARCH_URL)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse);
+
+    verify(variableServices, never()).search(any(VariableQuery.class));
+  }
+
+  @Test
   void shouldGetVariableByKey() {
     // when / then
     webClient


### PR DESCRIPTION
## Description

The V2 API supports offset and keyset pagination. Those types cannot be mixed, so we need to reject such requests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to https://github.com/camunda/camunda/issues/23722
