### PR TITLE
fix: resolve flakiness

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/roles/TasklistV1ApiRolePermissionsIT.java
@@ -141,41 +141,65 @@ public class TasklistV1ApiRolePermissionsIT {
   }
 
   @Test
-  void shouldBePermittedToGetProcess(@Authenticated(AUTHORIZED_USERNAME) final CamundaClient client)
-      throws Exception {
-    final var statusCode =
-        getRunningProcessInstance(client, AUTHORIZED_USERNAME, processDefinitionKey);
-    assertThat(statusCode)
-        .describedAs("Is authorized to get the process")
-        .isEqualTo(HttpStatus.OK.value());
+  void shouldBePermittedToGetProcess(
+      @Authenticated(AUTHORIZED_USERNAME) final CamundaClient client) {
+    await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var statusCode =
+                  getRunningProcessInstance(client, AUTHORIZED_USERNAME, processDefinitionKey);
+              assertThat(statusCode)
+                  .describedAs("Is authorized to get the process")
+                  .isEqualTo(HttpStatus.OK.value());
+            });
   }
 
   @Test
   void shouldBeUnauthorizedToGetProcess(
-      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
-    final var statusCode =
-        getRunningProcessInstance(client, UNAUTHORIZED_USERNAME, processDefinitionKey);
-    assertThat(statusCode)
-        .describedAs("Is unauthorized to get the process")
-        .isEqualTo(HttpStatus.FORBIDDEN.value());
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) {
+    await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var statusCode =
+                  getRunningProcessInstance(client, UNAUTHORIZED_USERNAME, processDefinitionKey);
+              assertThat(statusCode)
+                  .describedAs("Is unauthorized to get the process")
+                  .isEqualTo(HttpStatus.FORBIDDEN.value());
+            });
   }
 
   @Test
-  void shouldBePermittedToAssignTask(@Authenticated(AUTHORIZED_USERNAME) final CamundaClient client)
-      throws Exception {
-    final var statusCode = assignTask(client, AUTHORIZED_USERNAME, taskKey);
-    assertThat(statusCode)
-        .describedAs("Is authorized to assign the task")
-        .isEqualTo(HttpStatus.OK.value());
+  void shouldBePermittedToAssignTask(
+      @Authenticated(AUTHORIZED_USERNAME) final CamundaClient client) {
+    await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var statusCode = assignTask(client, AUTHORIZED_USERNAME, taskKey);
+              assertThat(statusCode)
+                  .describedAs("Is authorized to assign the task")
+                  .isEqualTo(HttpStatus.OK.value());
+            });
   }
 
   @Test
   void shouldBeUnauthorizedToAssignTask(
-      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) throws Exception {
-    final var statusCode = assignTask(client, UNAUTHORIZED_USERNAME, taskKey);
-    assertThat(statusCode)
-        .describedAs("Is unauthorized to assign the task")
-        .isEqualTo(HttpStatus.FORBIDDEN.value());
+      @Authenticated(UNAUTHORIZED_USERNAME) final CamundaClient client) {
+    await()
+        .atMost(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var statusCode = assignTask(client, UNAUTHORIZED_USERNAME, taskKey);
+              assertThat(statusCode)
+                  .describedAs("Is unauthorized to assign the task")
+                  .isEqualTo(HttpStatus.FORBIDDEN.value());
+            });
   }
 
   private static void addUserToRole(final URI url, final String roleId, final String username)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The index that's queried in the before all doesn't guarantee the indices that are queried in the test cases are populated. By wrapping the assertions with awaitility we prevent running into 404s.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
