### PR TITLE
Retrive only usernames when querying for a group's users

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2114,7 +2114,6 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * camundaClient
    *  .newUsersByGroupSearchRequest(groupId)
-   *  .filter((f) -> f.username(username))
    *  .sort((s) -> s.username().asc())
    *  .page((p) -> p.limit(100))
    *  .send();

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupUserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupUserFilter.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.fetch;
+package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
-import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.TypedSearchRequest;
-import io.camunda.client.api.search.response.GroupUser;
-import io.camunda.client.api.search.sort.GroupUserSort;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
 
-public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, UsersByGroupSearchRequest>,
-        FinalSearchRequestStep<GroupUser> {}
+public interface GroupUserFilter extends SearchRequestFilter {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestBuilders.java
@@ -40,6 +40,7 @@ import io.camunda.client.api.search.sort.DecisionInstanceSort;
 import io.camunda.client.api.search.sort.DecisionRequirementsSort;
 import io.camunda.client.api.search.sort.ElementInstanceSort;
 import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.api.search.sort.IncidentSort;
 import io.camunda.client.api.search.sort.MappingSort;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
@@ -75,6 +76,7 @@ import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
 import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
 import io.camunda.client.impl.search.sort.ElementInstanceSortImpl;
 import io.camunda.client.impl.search.sort.GroupSortImpl;
+import io.camunda.client.impl.search.sort.GroupUserSortImpl;
 import io.camunda.client.impl.search.sort.IncidentSortImpl;
 import io.camunda.client.impl.search.sort.MappingSortImpl;
 import io.camunda.client.impl.search.sort.ProcessDefinitionSortImpl;
@@ -260,6 +262,12 @@ public final class SearchRequestBuilders {
 
   public static UserSort userSort(final Consumer<UserSort> fn) {
     final UserSort sort = new UserSortImpl();
+    fn.accept(sort);
+    return sort;
+  }
+
+  public static GroupUserSort groupUserSort(final Consumer<GroupUserSort> fn) {
+    final GroupUserSort sort = new GroupUserSortImpl();
     fn.accept(sort);
     return sort;
   }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/GroupUser.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/GroupUser.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.fetch;
+package io.camunda.client.api.search.response;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
-import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.TypedSearchRequest;
-import io.camunda.client.api.search.response.GroupUser;
-import io.camunda.client.api.search.sort.GroupUserSort;
-
-public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, UsersByGroupSearchRequest>,
-        FinalSearchRequestStep<GroupUser> {}
+public interface GroupUser {
+  String getUsername();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupUserSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupUserSort.java
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.fetch;
+package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
-import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.TypedSearchRequest;
-import io.camunda.client.api.search.response.GroupUser;
-import io.camunda.client.api.search.sort.GroupUserSort;
+import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
 
-public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, UsersByGroupSearchRequest>,
-        FinalSearchRequestStep<GroupUser> {}
+public interface GroupUserSort extends SearchRequestSort<GroupUserSort> {
+  GroupUserSort username();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestSortMapper.java
@@ -329,6 +329,19 @@ public class SearchRequestSortMapper {
         .collect(Collectors.toList());
   }
 
+  public static List<GroupUserSearchQuerySortRequest> toGroupUserSearchQuerySortRequest(
+      final List<SearchRequestSort> requests) {
+    return requests.stream()
+        .map(
+            r -> {
+              final GroupUserSearchQuerySortRequest request = new GroupUserSearchQuerySortRequest();
+              request.setField(GroupUserSearchQuerySortRequest.FieldEnum.fromValue(r.getField()));
+              request.setOrder(r.getOrder());
+              return request;
+            })
+        .collect(Collectors.toList());
+  }
+
   public static List<IncidentSearchQuerySortRequest> toIncidentSearchQuerySortRequest(
       final List<SearchRequestSort> requests) {
     return requests.stream()

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/UsersByGroupSearchRequestImpl.java
@@ -15,35 +15,34 @@
  */
 package io.camunda.client.impl.search.request;
 
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupUserSort;
 import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
-import static io.camunda.client.api.search.request.SearchRequestBuilders.userFilter;
-import static io.camunda.client.api.search.request.SearchRequestBuilders.userSort;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.fetch.UsersByGroupSearchRequest;
-import io.camunda.client.api.search.filter.UserFilter;
+import io.camunda.client.api.search.filter.GroupUserFilter;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
 import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.client.api.search.response.User;
-import io.camunda.client.api.search.sort.UserSort;
+import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.impl.command.ArgumentUtil;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.SearchResponseMapper;
-import io.camunda.client.protocol.rest.UserSearchQueryRequest;
-import io.camunda.client.protocol.rest.UserSearchResult;
+import io.camunda.client.protocol.rest.GroupUserSearchQueryRequest;
+import io.camunda.client.protocol.rest.GroupUserSearchResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public class UsersByGroupSearchRequestImpl
-    extends TypedSearchRequestPropertyProvider<UserSearchQueryRequest>
+    extends TypedSearchRequestPropertyProvider<GroupUserSearchQueryRequest>
     implements UsersByGroupSearchRequest {
 
-  private final UserSearchQueryRequest request;
+  private final GroupUserSearchQueryRequest request;
   private final String groupId;
   private final HttpClient httpClient;
   private final JsonMapper jsonMapper;
@@ -55,50 +54,52 @@ public class UsersByGroupSearchRequestImpl
     this.jsonMapper = jsonMapper;
     this.groupId = groupId;
     httpRequestConfig = httpClient.newRequestConfig();
-    request = new UserSearchQueryRequest();
+    request = new GroupUserSearchQueryRequest();
   }
 
   @Override
-  public FinalSearchRequestStep<User> requestTimeout(final Duration requestTimeout) {
+  public FinalSearchRequestStep<GroupUser> requestTimeout(final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public CamundaFuture<SearchResponse<User>> send() {
+  public CamundaFuture<SearchResponse<GroupUser>> send() {
     ArgumentUtil.ensureNotNullNorEmpty("groupId", groupId);
-    final HttpCamundaFuture<SearchResponse<User>> result = new HttpCamundaFuture<>();
+    final HttpCamundaFuture<SearchResponse<GroupUser>> result = new HttpCamundaFuture<>();
     httpClient.post(
         String.format("/groups/%s/users/search", groupId),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        UserSearchResult.class,
-        SearchResponseMapper::toUsersResponse,
+        GroupUserSearchResult.class,
+        SearchResponseMapper::toGroupUsersResponse,
         result);
     return result;
   }
 
   @Override
-  public UsersByGroupSearchRequest filter(final UserFilter value) {
-    request.setFilter(provideSearchRequestProperty(value));
+  public UsersByGroupSearchRequest filter(final GroupUserFilter value) {
+    // This command doesn't support filtering
     return this;
   }
 
   @Override
-  public UsersByGroupSearchRequest filter(final Consumer<UserFilter> fn) {
-    return filter(userFilter(fn));
+  public UsersByGroupSearchRequest filter(final Consumer<GroupUserFilter> fn) {
+    // This command doesn't support filtering
+    return this;
   }
 
   @Override
-  public UsersByGroupSearchRequest sort(final UserSort value) {
+  public UsersByGroupSearchRequest sort(final GroupUserSort value) {
     request.setSort(
-        SearchRequestSortMapper.toUserSearchQuerySortRequest(provideSearchRequestProperty(value)));
+        SearchRequestSortMapper.toGroupUserSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
     return this;
   }
 
   @Override
-  public UsersByGroupSearchRequest sort(final Consumer<UserSort> fn) {
-    return sort(userSort(fn));
+  public UsersByGroupSearchRequest sort(final Consumer<GroupUserSort> fn) {
+    return sort(groupUserSort((fn)));
   }
 
   @Override
@@ -113,7 +114,7 @@ public class UsersByGroupSearchRequestImpl
   }
 
   @Override
-  protected UserSearchQueryRequest getSearchRequestProperty() {
+  protected GroupUserSearchQueryRequest getSearchRequestProperty() {
     return request;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupUserImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/GroupUserImpl.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.fetch;
+package io.camunda.client.impl.search.response;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
-import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.TypedSearchRequest;
 import io.camunda.client.api.search.response.GroupUser;
-import io.camunda.client.api.search.sort.GroupUserSort;
 
-public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, UsersByGroupSearchRequest>,
-        FinalSearchRequestStep<GroupUser> {}
+public class GroupUserImpl implements GroupUser {
+
+  private final String username;
+
+  public GroupUserImpl(final String username) {
+    this.username = username;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.Mapping;
 import io.camunda.client.api.search.response.ProcessDefinition;
@@ -190,6 +191,18 @@ public final class SearchResponseMapper {
         response.getUsername(),
         response.getName(),
         response.getEmail());
+  }
+
+  public static SearchResponse<GroupUser> toGroupUsersResponse(
+      final GroupUserSearchResult response) {
+    final SearchResponsePage page = toSearchResponsePage(response.getPage());
+    final List<GroupUser> instances =
+        toSearchResponseInstances(response.getItems(), SearchResponseMapper::toGroupUser);
+    return new SearchResponseImpl<>(instances, page);
+  }
+
+  public static GroupUser toGroupUser(final GroupUserResult response) {
+    return new GroupUserImpl(response.getUsername());
   }
 
   public static Mapping toMappingResponse(final MappingResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/GroupUserSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/GroupUserSortImpl.java
@@ -13,14 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.fetch;
+package io.camunda.client.impl.search.sort;
 
-import io.camunda.client.api.search.filter.GroupUserFilter;
-import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.TypedSearchRequest;
-import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.client.api.search.sort.GroupUserSort;
+import io.camunda.client.impl.search.request.SearchRequestSortBase;
 
-public interface UsersByGroupSearchRequest
-    extends TypedSearchRequest<GroupUserFilter, GroupUserSort, UsersByGroupSearchRequest>,
-        FinalSearchRequestStep<GroupUser> {}
+public class GroupUserSortImpl extends SearchRequestSortBase<GroupUserSort>
+    implements GroupUserSort {
+
+  @Override
+  public GroupUserSort username() {
+    return field("username");
+  }
+
+  @Override
+  protected GroupUserSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/GroupSearchTest.java
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.api.search.sort.GroupUserSort;
 import io.camunda.client.api.search.sort.MappingSort;
 import io.camunda.client.api.search.sort.RoleSort;
-import io.camunda.client.api.search.sort.UserSort;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -63,8 +63,7 @@ public class GroupSearchTest extends ClientRestTest {
     final String groupId = "groupId";
     client
         .newUsersByGroupSearchRequest(groupId)
-        .filter(fn -> fn.username("username"))
-        .sort(UserSort::name)
+        .sort(GroupUserSort::username)
         .page(fn -> fn.limit(5))
         .send()
         .join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.response.User;
+import io.camunda.client.api.search.response.GroupUser;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
@@ -49,21 +49,8 @@ public class UsersByGroupSearchTest {
 
     assertThat(users.items().size()).isEqualTo(2);
     assertThat(users.items())
-        .extracting(User::getUsername)
+        .extracting(GroupUser::getUsername)
         .containsExactly(USER_USERNAME_1, USER_USERNAME_2);
-  }
-
-  @Test
-  void shouldReturnUsersByGroupFiltered() {
-    final var users =
-        camundaClient
-            .newUsersByGroupSearchRequest(GROUP_ID)
-            .filter(fn -> fn.username(USER_USERNAME_1))
-            .send()
-            .join();
-
-    assertThat(users.items().size()).isEqualTo(1);
-    assertThat(users.items()).extracting(User::getUsername).containsExactly(USER_USERNAME_1);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
@@ -18,8 +18,10 @@ import io.camunda.zeebe.test.util.Strings;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class UsersByGroupSearchTest {
 
   private static CamundaClient camundaClient;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -346,6 +346,12 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery filter) {
+    return getSearchExecutor()
+        .search(filter, io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity.class);
+  }
+
+  @Override
   public List<GroupEntity> findAllGroups(final GroupQuery query) {
     return getSearchExecutor()
         .findAll(query, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -346,9 +346,9 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
   }
 
   @Override
-  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery filter) {
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
     return getSearchExecutor()
-        .search(filter, io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity.class);
+        .search(query, io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GroupFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/GroupFieldSortingTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.sort;
 
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.GROUP_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.GroupIndex.MEMBER_ID;
 import static io.camunda.webapps.schema.descriptors.index.GroupIndex.NAME;
 
 public class GroupFieldSortingTransformer implements FieldSortingTransformer {
@@ -19,6 +20,7 @@ public class GroupFieldSortingTransformer implements FieldSortingTransformer {
       case "groupKey" -> KEY;
       case "groupId" -> GROUP_ID;
       case "name" -> NAME;
+      case "memberId" -> MEMBER_ID;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -18,6 +18,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -211,6 +212,11 @@ public class RdbmsSearchClient implements SearchClientsProxy {
     LOG.debug("[RDBMS Search Client] Search for groups: {}", query);
 
     return rdbmsService.getGroupReader().search(query);
+  }
+
+  @Override
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
+    throw new UnsupportedOperationException("Group member search not implemented on RDBMS");
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -18,7 +18,7 @@ public interface GroupSearchClient {
 
   SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query);
 
-  SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupQuery filter);
+  SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupQuery query);
 
   List<GroupEntity> findAllGroups(final GroupQuery query);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
@@ -16,6 +17,8 @@ import java.util.List;
 public interface GroupSearchClient {
 
   SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query);
+
+  SearchQueryResult<GroupMemberEntity> searchGroupMembers(GroupQuery filter);
 
   List<GroupEntity> findAllGroups(final GroupQuery query);
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -19,6 +19,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -111,6 +112,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery filter) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -116,7 +116,7 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   }
 
   @Override
-  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery filter) {
+  public SearchQueryResult<GroupMemberEntity> searchGroupMembers(final GroupQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
@@ -39,6 +39,11 @@ public record GroupSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public Builder memberId() {
+      currentOrdering = new FieldSorting("memberId", null);
+      return this;
+    }
+
     @Override
     protected Builder self() {
       return this;

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.GroupQuery;
@@ -143,6 +144,14 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
         BrokerGroupMemberRequest.createRemoveRequest(groupMemberDTO.groupId)
             .setMemberId(groupMemberDTO.memberId)
             .setMemberType(groupMemberDTO.memberType));
+  }
+
+  public SearchQueryResult<GroupMemberEntity> searchMembers(final GroupQuery query) {
+    return groupSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.group().read())))
+        .searchGroupMembers(query);
   }
 
   public record GroupDTO(String groupId, String name, String description) {}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3300,14 +3300,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserSearchQueryRequest"
+              $ref: "#/components/schemas/GroupMemberSearchQueryRequest"
       responses:
         "200":
           description: The users assigned to the group.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserSearchResult"
+                $ref: "#/components/schemas/GroupMemberSearchResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -7312,6 +7312,44 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/GroupResult"
+    GroupMemberResult:
+      type: object
+      properties:
+        memberId:
+          description: The ID of the member.
+          type: string
+    GroupMemberSearchResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching members.
+          type: array
+          items:
+            $ref: "#/components/schemas/GroupMemberResult"
+    GroupMemberSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/GroupMemberSearchQuerySortRequest"
+    GroupMemberSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - memberId
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+        - field
     MappingRuleCreateUpdateRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3300,14 +3300,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/GroupMemberSearchQueryRequest"
+              $ref: "#/components/schemas/GroupUserSearchQueryRequest"
       responses:
         "200":
           description: The users assigned to the group.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupMemberSearchResult"
+                $ref: "#/components/schemas/GroupUserSearchResult"
         "400":
           $ref: "#/components/responses/InvalidData"
         "401":
@@ -7312,13 +7312,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/GroupResult"
-    GroupMemberResult:
+    GroupUserResult:
       type: object
       properties:
-        memberId:
-          description: The ID of the member.
+        username:
+          description: The username of the user.
           type: string
-    GroupMemberSearchResult:
+    GroupUserSearchResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -7327,8 +7327,8 @@ components:
           description: The matching members.
           type: array
           items:
-            $ref: "#/components/schemas/GroupMemberResult"
-    GroupMemberSearchQueryRequest:
+            $ref: "#/components/schemas/GroupUserResult"
+    GroupUserSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
       type: object
@@ -7337,15 +7337,15 @@ components:
           description: Sort field criteria.
           type: array
           items:
-            $ref: "#/components/schemas/GroupMemberSearchQuerySortRequest"
-    GroupMemberSearchQuerySortRequest:
+            $ref: "#/components/schemas/GroupUserSearchQuerySortRequest"
+    GroupUserSearchQuerySortRequest:
       type: object
       properties:
         field:
           description: The field to sort by.
           type: string
           enum:
-            - memberId
+            - username
         order:
           $ref: "#/components/schemas/SortOrderEnum"
       required:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -290,16 +290,16 @@ public final class SearchQueryRequestMapper {
   }
 
   public static Either<ProblemDetail, GroupQuery> toGroupQuery(
-      final GroupMemberSearchQueryRequest request) {
+      final GroupUserSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.groupSearchQuery().build());
     }
     final var page = toSearchQueryPage(request.getPage());
     final var sort =
         toSearchQuerySort(
-            SearchQuerySortRequestMapper.fromGroupMemberSearchQuerySortRequest(request.getSort()),
+            SearchQuerySortRequestMapper.fromGroupUserSearchQuerySortRequest(request.getSort()),
             SortOptionBuilders::group,
-            SearchQueryRequestMapper::applyGroupMemberSortField);
+            SearchQueryRequestMapper::applyGroupUserSortField);
     final var filter = FilterBuilders.group().build();
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::groupSearchQuery);
   }
@@ -1111,11 +1111,11 @@ public final class SearchQueryRequestMapper {
     return validationErrors;
   }
 
-  private static List<String> applyGroupMemberSortField(
-      final GroupMemberSearchQuerySortRequest.FieldEnum field, final GroupSort.Builder builder) {
+  private static List<String> applyGroupUserSortField(
+      final GroupUserSearchQuerySortRequest.FieldEnum field, final GroupSort.Builder builder) {
     return switch (field) {
       case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
-      case MEMBER_ID -> {
+      case USERNAME -> {
         builder.memberId();
         yield List.of();
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -289,6 +289,21 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::groupSearchQuery);
   }
 
+  public static Either<ProblemDetail, GroupQuery> toGroupQuery(
+      final GroupMemberSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.groupSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromGroupMemberSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::group,
+            SearchQueryRequestMapper::applyGroupMemberSortField);
+    final var filter = FilterBuilders.group().build();
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::groupSearchQuery);
+  }
+
   public static Either<ProblemDetail, TenantQuery> toTenantQuery(
       final TenantSearchQueryRequest request) {
     if (request == null) {
@@ -1094,6 +1109,17 @@ public final class SearchQueryRequestMapper {
       }
     }
     return validationErrors;
+  }
+
+  private static List<String> applyGroupMemberSortField(
+      final GroupMemberSearchQuerySortRequest.FieldEnum field, final GroupSort.Builder builder) {
+    return switch (field) {
+      case null -> List.of(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+      case MEMBER_ID -> {
+        builder.memberId();
+        yield List.of();
+      }
+    };
   }
 
   private static List<String> applyTenantSortField(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -25,6 +25,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -61,6 +62,8 @@ import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionInputItem;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.zeebe.gateway.protocol.rest.FormResult;
+import io.camunda.zeebe.gateway.protocol.rest.GroupMemberResult;
+import io.camunda.zeebe.gateway.protocol.rest.GroupMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.IncidentResult;
@@ -203,6 +206,17 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toGroups)
+                .orElseGet(List::of));
+  }
+
+  public static GroupMemberSearchResult toGroupMemberSearchQueryResponse(
+      final SearchQueryResult<GroupMemberEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new GroupMemberSearchResult()
+        .page(toSearchQueryPageResponse(result))
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toGroupMembers)
                 .orElseGet(List::of));
   }
 
@@ -442,6 +456,15 @@ public final class SearchQueryResponseMapper {
         .groupId(groupEntity.groupId())
         .name(groupEntity.name())
         .description(groupEntity.description());
+  }
+
+  private static List<GroupMemberResult> toGroupMembers(
+      final List<GroupMemberEntity> groupMembers) {
+    return groupMembers.stream().map(SearchQueryResponseMapper::toGroupMember).toList();
+  }
+
+  private static GroupMemberResult toGroupMember(final GroupMemberEntity groupMember) {
+    return new GroupMemberResult().memberId(groupMember.id());
   }
 
   private static List<TenantResult> toTenants(final List<TenantEntity> tenants) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -62,10 +62,10 @@ import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionInputItem;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.zeebe.gateway.protocol.rest.FormResult;
-import io.camunda.zeebe.gateway.protocol.rest.GroupMemberResult;
-import io.camunda.zeebe.gateway.protocol.rest.GroupMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.GroupUserResult;
+import io.camunda.zeebe.gateway.protocol.rest.GroupUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.IncidentResult;
 import io.camunda.zeebe.gateway.protocol.rest.IncidentSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingResult;
@@ -209,14 +209,14 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(List::of));
   }
 
-  public static GroupMemberSearchResult toGroupMemberSearchQueryResponse(
+  public static GroupUserSearchResult toGroupUserSearchQueryResponse(
       final SearchQueryResult<GroupMemberEntity> result) {
     final var page = toSearchQueryPageResponse(result);
-    return new GroupMemberSearchResult()
+    return new GroupUserSearchResult()
         .page(toSearchQueryPageResponse(result))
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toGroupMembers)
+                .map(SearchQueryResponseMapper::toGroupUsers)
                 .orElseGet(List::of));
   }
 
@@ -458,13 +458,12 @@ public final class SearchQueryResponseMapper {
         .description(groupEntity.description());
   }
 
-  private static List<GroupMemberResult> toGroupMembers(
-      final List<GroupMemberEntity> groupMembers) {
-    return groupMembers.stream().map(SearchQueryResponseMapper::toGroupMember).toList();
+  private static List<GroupUserResult> toGroupUsers(final List<GroupMemberEntity> groupMembers) {
+    return groupMembers.stream().map(SearchQueryResponseMapper::toGroupUser).toList();
   }
 
-  private static GroupMemberResult toGroupMember(final GroupMemberEntity groupMember) {
-    return new GroupMemberResult().memberId(groupMember.id());
+  private static GroupUserResult toGroupUser(final GroupMemberEntity groupMember) {
+    return new GroupUserResult().username(groupMember.id());
   }
 
   private static List<TenantResult> toTenants(final List<TenantEntity> tenants) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -213,7 +213,7 @@ public final class SearchQueryResponseMapper {
       final SearchQueryResult<GroupMemberEntity> result) {
     final var page = toSearchQueryPageResponse(result);
     return new GroupUserSearchResult()
-        .page(toSearchQueryPageResponse(result))
+        .page(page)
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toGroupUsers)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -34,6 +34,12 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<GroupMemberSearchQuerySortRequest.FieldEnum>>
+      fromGroupMemberSearchQuerySortRequest(
+          final List<GroupMemberSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   public static List<SearchQuerySortRequest<TenantSearchQuerySortRequest.FieldEnum>>
       fromTenantSearchQuerySortRequest(final List<TenantSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -34,9 +34,8 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
-  public static List<SearchQuerySortRequest<GroupMemberSearchQuerySortRequest.FieldEnum>>
-      fromGroupMemberSearchQuerySortRequest(
-          final List<GroupMemberSearchQuerySortRequest> requests) {
+  public static List<SearchQuerySortRequest<GroupUserSearchQuerySortRequest.FieldEnum>>
+      fromGroupUserSearchQuerySortRequest(final List<GroupUserSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -18,7 +18,6 @@ import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
-import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.protocol.rest.GroupCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
@@ -51,17 +50,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class GroupController {
 
   private final GroupServices groupServices;
-  private final UserServices userServices;
   private final MappingServices mappingServices;
   private final RoleServices roleServices;
 
   public GroupController(
       final GroupServices groupServices,
-      final UserServices userServices,
       final MappingServices mappingServices,
       final RoleServices roleServices) {
     this.groupServices = groupServices;
-    this.userServices = userServices;
     this.mappingServices = mappingServices;
     this.roleServices = roleServices;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -20,11 +20,11 @@ import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.protocol.rest.GroupCreateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.GroupMemberSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.GroupMemberSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.GroupSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupUpdateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.GroupUserSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.GroupUserSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MappingSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
@@ -141,13 +141,13 @@ public class GroupController {
   }
 
   @CamundaPostMapping(path = "/{groupId}/users/search")
-  public ResponseEntity<GroupMemberSearchResult> usersByGroup(
+  public ResponseEntity<GroupUserSearchResult> usersByGroup(
       @PathVariable final String groupId,
-      @RequestBody(required = false) final GroupMemberSearchQueryRequest query) {
+      @RequestBody(required = false) final GroupUserSearchQueryRequest query) {
     return SearchQueryRequestMapper.toGroupQuery(query)
         .fold(
             RestErrorMapper::mapProblemToResponse,
-            groupQuery -> searchMembersInGroup(groupId, EntityType.USER, groupQuery));
+            groupQuery -> searchUsersInGroup(groupId, groupQuery));
   }
 
   @CamundaPostMapping(path = "/{groupId}/mapping-rules/search")
@@ -230,14 +230,14 @@ public class GroupController {
                 .assignMember(request));
   }
 
-  private ResponseEntity<GroupMemberSearchResult> searchMembersInGroup(
-      final String groupId, final EntityType memberType, final GroupQuery groupQuery) {
+  private ResponseEntity<GroupUserSearchResult> searchUsersInGroup(
+      final String groupId, final GroupQuery groupQuery) {
     try {
       final var result =
           groupServices
               .withAuthentication(RequestMapper.getAuthentication())
-              .searchMembers(buildGroupMemberQuery(groupId, memberType, groupQuery));
-      return ResponseEntity.ok(SearchQueryResponseMapper.toGroupMemberSearchQueryResponse(result));
+              .searchMembers(buildGroupMemberQuery(groupId, EntityType.USER, groupQuery));
+      return ResponseEntity.ok(SearchQueryResponseMapper.toGroupUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -14,23 +14,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.entities.UserEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
-import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
 import java.util.stream.Stream;
@@ -76,36 +75,24 @@ public class GroupQueryControllerTest extends RestControllerTest {
   private static final String GROUP_BASE_URL = "/v2/groups";
   private static final String GROUP_SEARCH_URL = GROUP_BASE_URL + "/search";
 
-  private static final List<UserEntity> USER_ENTITIES =
+  private static final List<GroupMemberEntity> GROUP_MEMBER_ENTITIES =
       List.of(
-          new UserEntity(
-              1L, Strings.newRandomValidIdentityId(), "user1", "user1@email.com", "password"),
-          new UserEntity(
-              2L, Strings.newRandomValidIdentityId(), "user2", "user2@email.com", "password"),
-          new UserEntity(
-              3L, Strings.newRandomValidIdentityId(), "user3", "user3@email.com", "password"));
+          new GroupMemberEntity(Strings.newRandomValidIdentityId(), EntityType.USER),
+          new GroupMemberEntity(Strings.newRandomValidIdentityId(), EntityType.USER),
+          new GroupMemberEntity(Strings.newRandomValidIdentityId(), EntityType.USER));
 
   private static final String USER_RESPONSE =
       """
       {
         "items":[
           {
-            "userKey":"1",
-            "username":"%s",
-            "name":"user1",
-            "email":"user1@email.com"
+            "username":"%s"
           },
           {
-            "userKey":"2",
-            "username":"%s",
-            "name":"user2",
-            "email":"user2@email.com"
+            "username":"%s"
           },
           {
-            "userKey":"3",
-            "username":"%s",
-            "name":"user3",
-            "email":"user3@email.com"
+            "username":"%s"
           }
         ],
         "page":{
@@ -158,9 +145,9 @@ public class GroupQueryControllerTest extends RestControllerTest {
 
   private static final String EXPECTED_USER_RESPONSE =
       USER_RESPONSE.formatted(
-          USER_ENTITIES.get(0).username(),
-          USER_ENTITIES.get(1).username(),
-          USER_ENTITIES.get(2).username());
+          GROUP_MEMBER_ENTITIES.get(0).id(),
+          GROUP_MEMBER_ENTITIES.get(1).id(),
+          GROUP_MEMBER_ENTITIES.get(2).id());
 
   private static final List<MappingEntity> MAPPNING_ENTITIES =
       List.of(
@@ -199,14 +186,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
           MAPPNING_ENTITIES.get(0).mappingId(), MAPPNING_ENTITIES.get(1).mappingId());
 
   @MockBean private GroupServices groupServices;
-  @MockBean private UserServices userServices;
   @MockBean private MappingServices mappingServices;
   @MockBean private RoleServices roleServices;
 
   @BeforeEach
   void setup() {
     when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
-    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
     when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
     when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
   }
@@ -415,11 +400,11 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupUsersWithSorting() {
     // given
-    when(userServices.search(any(UserQuery.class)))
+    when(groupServices.searchMembers(any(GroupQuery.class)))
         .thenReturn(
-            new SearchQueryResult.Builder<UserEntity>()
-                .total(USER_ENTITIES.size())
-                .items(USER_ENTITIES)
+            new SearchQueryResult.Builder<GroupMemberEntity>()
+                .total(GROUP_MEMBER_ENTITIES.size())
+                .items(GROUP_MEMBER_ENTITIES)
                 .firstSortValues(new Object[] {"f"})
                 .lastSortValues(new Object[] {"v"})
                 .build());
@@ -448,11 +433,11 @@ public class GroupQueryControllerTest extends RestControllerTest {
   @Test
   void shouldSearchGroupUsersWithEmptyQuery() {
     // given
-    when(userServices.search(any(UserQuery.class)))
+    when(groupServices.searchMembers(any(GroupQuery.class)))
         .thenReturn(
-            new SearchQueryResult.Builder<UserEntity>()
-                .total(USER_ENTITIES.size())
-                .items(USER_ENTITIES)
+            new SearchQueryResult.Builder<GroupMemberEntity>()
+                .total(GROUP_MEMBER_ENTITIES.size())
+                .items(GROUP_MEMBER_ENTITIES)
                 .firstSortValues(new Object[] {"f"})
                 .lastSortValues(new Object[] {"v"})
                 .build());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In the case of OIDC we won't always have a full user entity, but sometimes entity-less assignment. As a result, when we search for users we should return only the username. In the case of basic auth the frontend can then query more details in a second request.

I left RDBMS out of scope of this PR. There is too much work to be done to support this for this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/30346
