### PR TITLE
deps: bump c8run core version to 8.8.0-alpha4.1

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,6 +1,6 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha4
+CAMUNDA_VERSION=8.8.0-alpha4.1
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.8.0-alpha4.1
 # version of docker compose artifact (used for --docker option)


### PR DESCRIPTION
## Description

Bump c8run core version to 8.8.0-alpha4.1

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Ad-hoc release, May 2025.
