### PR TITLE
test: generic local renovate tests

### DIFF
--- a/cmd/renovate/README.md
+++ b/cmd/renovate/README.md
@@ -3,10 +3,27 @@
 If you want to tweak the [renovate config](../../.github/renovate.json), it's a good idea to test this locally.
 You can make use of the script [renovate-local.sh](./renovate-local.sh) to do so.
 
-First, [create a Github PAT](https://github.com/settings/tokens/new) with repo scope and assign it to a variable:
+> [!IMPORTANT]
+> Make sure you've installed [GitHub CLI](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) locally.
+
+## Usage in this repo
+
+You can just execute `./cmd/renovate/renovate-local.sh`.
+
+## Usage in other repos
+
+If you want to use this script in other repositories, you can simply execute the following one-liner:
 
 ```shell
-GITHUB_TOKEN=<yourPAT>
+# make sure your terminal location is at the root of the current repository
+curl https://raw.githubusercontent.com/camunda/camunda/refs/heads/main/cmd/renovate/renovate-local.sh | bash
 ```
 
-After that you can just execute `./renovate-local.sh` and it will take the LOCAL `.github/renovate.json` config as source of truth and execute a full dry run.
+## Options
+
+The script itself will automatically login to Github.
+It detects the name of the current repository and the renovate config (located in the project's root or under `.github`) within this repository.
+This is why you need to be located in the repositories root with your terminal session.
+You can however set the following environment variables to override default behavior:
+- `LOCAL_RENOVATE_CONFIG` - filename (with full path) of the local renovate config to use
+- `REPO_NAME` - Github repository name (e.g. `camunda/camunda`)


### PR DESCRIPTION
## Description

To avoid code duplication we made the local renovate test script so generic, that it can easily be used from any other repository as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

* camunda/team-infrastructure#847
