### PR TITLE
ci: send update-identity notification to release Slack channel

### DIFF
--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -1,4 +1,7 @@
 name: Update Identity Version
+
+# owner: @camunda/monorepo-devops-team
+
 on:
   workflow_dispatch:
     inputs:
@@ -19,18 +22,21 @@ on:
         type: boolean
         default: true
 
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
 jobs:
   update-identity:
-    name: "Update the identity version to ${{ inputs.identityVersion }}"
-    timeout-minutes: 20
+    name: "Update Identity version to ${{ inputs.identityVersion }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
-        id: checkout
         with:
           ref: ${{ inputs.targetBranch }}
       - name: Git User Setup
-        id: git-setup
         run: |
           git config --global user.email "github-actions[update-identity]"
           git config --global user.name "github-actions[update-identity]@users.noreply.github.com"
@@ -40,8 +46,7 @@ jobs:
         with:
           xml-file: './parent/pom.xml'
           xpath: '//*[local-name()="version.identity"]'
-      - name: Setup Zeebe Build Tooling
-        uses: ./.github/actions/setup-build
+      - uses: ./.github/actions/setup-build
         if: ${{ steps.get-current-identity-version.outputs.info != inputs.identityVersion }}
         with:
           maven-cache-key-modifier: identity-update
@@ -57,17 +62,40 @@ jobs:
       - name: Push Changes to the target branch
         if: ${{ steps.update-identity-version.outcome == 'success' && inputs.dryRun == false }}
         run: git push origin "${{ inputs.targetBranch }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   notify:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
-    needs: [ update-identity ]
+    needs: [update-identity]
     if: ${{ failure() && inputs.dryRun == false }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
-      - id: slack-notify-failure
-        name: Send failure slack notification
-        uses: slackapi/slack-github-action@v2.0.0
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
@@ -77,15 +105,25 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: *Updating the identity version* on `${{ inputs.targetBranch }}` failed! :alarm:\n ${{ inputs.userSlackId != '' && format('\\cc <@{0}>', inputs.userSlackId) || '' }}"
+                    "text": ":alarm: *Updating Identity version* to ${{ inputs.identityVersion }} on `${{ inputs.targetBranch }}` failed!\n"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                    "text": "${{ inputs.userSlackId != '' && format('<@{0}>', inputs.userSlackId) || '' }} Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
                   }
                 }
               ]
             }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

This PR adjusts `update-identity.yml` which is only used by our [release process automation](https://github.com/camunda/camunda/actions/workflows/update-identity.yml) to notify us in a Slack channel that is related to coordinating releases.

I also adjusted the workflow to follow our CI best practices. This change should be backported to 8.7 and 8.6, but not below since 8.5 and earlier are Zeebe-specific.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
