### PR TITLE
feat: pass down the securitycontext from the batchoperationscheduler to the searchclients along size the filter queries

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -11,17 +11,23 @@ import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.READ;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.UPDATE_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.ResourceType.BATCH_OPERATION;
 import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
 import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
-import static io.camunda.it.util.TestHelper.startProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.getScopedVariables;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.CreateBatchOperationResponse;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
@@ -31,6 +37,7 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -42,12 +49,18 @@ import org.junit.jupiter.api.function.Executable;
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 class BatchOperationAuthorizationIT {
 
+  // Process IDs
+  public static final String SERVICE_TASKS_V_1 = "service_tasks_v1";
+  public static final String SERVICE_TASKS_V_2 = "service_tasks_v2";
+  public static final String INCIDENT_PROCESS_V_1 = "incident_process_v1";
+
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
 
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";
+  private static final String RESTRICTED_CANCEL = "restrictedCancelUser";
   private static final String RESTRICTED_READ = "restrictedReadUser";
   private static final String FORBIDDEN = "forbiddenUser";
 
@@ -58,6 +71,7 @@ class BatchOperationAuthorizationIT {
           "password",
           List.of(
               new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(
                   BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),
@@ -71,7 +85,23 @@ class BatchOperationAuthorizationIT {
           List.of(
               new Permissions(
                   BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),
-              new Permissions(BATCH_OPERATION, READ, List.of("*"))));
+              new Permissions(BATCH_OPERATION, READ, List.of("*")),
+              new Permissions(
+                  PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(SERVICE_TASKS_V_1)),
+              new Permissions(
+                  PROCESS_DEFINITION, UPDATE_PROCESS_INSTANCE, List.of(SERVICE_TASKS_V_1))));
+
+  @UserDefinition
+  private static final User RESTRICTED_CANCEL_USER =
+      new User(
+          RESTRICTED_CANCEL,
+          "password",
+          List.of(
+              new Permissions(
+                  BATCH_OPERATION, CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(BATCH_OPERATION, READ, List.of("*")),
+              new Permissions(
+                  PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(SERVICE_TASKS_V_1))));
 
   @UserDefinition
   private static final User RESTRICTED_READ_USER =
@@ -85,6 +115,8 @@ class BatchOperationAuthorizationIT {
   @UserDefinition
   private static final User FORBIDDEN_USER = new User(FORBIDDEN, "password", List.of());
 
+  private long serviceTaskV1Key;
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient camundaClient) {
     final List<String> processes =
@@ -92,49 +124,56 @@ class BatchOperationAuthorizationIT {
     processes.forEach(
         process -> deployResource(camundaClient, String.format("process/%s", process)));
     waitForProcessesToBeDeployed(camundaClient, processes.size());
+  }
 
-    startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"bar\"}");
-    startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}");
-    startProcessInstance(camundaClient, "incident_process_v1");
+  String startProcessesWithScope(final CamundaClient camundaClient) {
+    final String scopeId = UUID.randomUUID().toString();
 
-    waitForProcessInstancesToStart(camundaClient, 3);
+    serviceTaskV1Key =
+        startScopedProcessInstance(camundaClient, SERVICE_TASKS_V_1, scopeId)
+            .getProcessInstanceKey();
+    startScopedProcessInstance(camundaClient, SERVICE_TASKS_V_2, scopeId);
+    startScopedProcessInstance(camundaClient, INCIDENT_PROCESS_V_1, scopeId);
+
+    waitForScopedProcessInstancesToStart(camundaClient, scopeId, 3);
+    return scopeId;
   }
 
   @Test
-  void adminShouldStartBatchOperation(@Authenticated(ADMIN) final CamundaClient camundaClient) {
-    // when
-    final var batchOperationResponse = createProcessInstanceCancelBatchOperation(camundaClient);
+  void adminShouldStartBatchOperationWithAllItems(
+      @Authenticated(ADMIN) final CamundaClient camundaClient) {
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaClient);
+
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 3);
 
     // then
-    assertThat(batchOperationResponse).isNotNull();
-  }
-
-  @Test
-  void adminShouldReadSingleBatchOperation(
-      @Authenticated(ADMIN) final CamundaClient camundaClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
-
-    // when
-    waitForBatchOperation(camundaClient, batchOperationKey);
-
-    // when
     final var batchOperationResponse =
         camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
-
-    // then
     assertThat(batchOperationResponse).isNotNull();
+    assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(3);
   }
 
   @Test
   void adminShouldQueryBatchOperation(@Authenticated(ADMIN) final CamundaClient camundaClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaClient);
 
-    // when
-    waitForBatchOperation(camundaClient, batchOperationKey);
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 3);
 
     // when
     final var batchOperationResponse =
@@ -146,27 +185,97 @@ class BatchOperationAuthorizationIT {
 
     // then
     assertThat(batchOperationResponse).isNotNull();
+    assertThat(batchOperationResponse.items().getFirst().getOperationsTotalCount()).isEqualTo(3);
   }
 
   @Test
-  void restrictedUserShouldStartBatchOperation(
+  void restrictedUserShouldStartBatchOperationWithRestrictedItemsOnly(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
+    // given
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
+
     // when
-    final var batchOperationResponse = createProcessInstanceCancelBatchOperation(camundaClient);
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 1);
 
     // then
+    final var batchOperationResponse =
+        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
     assertThat(batchOperationResponse).isNotNull();
+    assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(1);
+
+    final List<BatchOperationItem> batchOperationItems =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .send()
+            .join()
+            .items();
+    assertThat(batchOperationItems).hasSize(1);
+    final BatchOperationItem batchOperationItem = batchOperationItems.getFirst();
+    assertThat(batchOperationItem.getProcessInstanceKey()).isEqualTo(serviceTaskV1Key);
+    assertThat(batchOperationItem.getStatus()).isEqualTo(BatchOperationItemState.COMPLETED);
+  }
+
+  @Test
+  void restrictedUserShouldStartBatchOperationAndFailOnRestrictedItem(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
+      @Authenticated(RESTRICTED_CANCEL) final CamundaClient camundaClient) {
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
+
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 1);
+
+    // then
+    final var batchOperationResponse =
+        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+    assertThat(batchOperationResponse).isNotNull();
+    assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(1);
+
+    final List<BatchOperationItem> batchOperationItems =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .send()
+            .join()
+            .items();
+    assertThat(batchOperationItems).hasSize(1);
+    final BatchOperationItem batchOperationItem = batchOperationItems.getFirst();
+    assertThat(batchOperationItem.getProcessInstanceKey()).isEqualTo(serviceTaskV1Key);
+    assertThat(batchOperationItem.getStatus()).isEqualTo(BatchOperationItemState.FAILED);
+    assertThat(batchOperationItem.getErrorMessage())
+        .isEqualTo(
+            "FORBIDDEN: Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, service_tasks_v1]'");
   }
 
   @Test
   void restrictedUserShouldReadSingleBatchOperation(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
 
-    // when
-    waitForBatchOperation(camundaClient, batchOperationKey);
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 1);
 
     // when
     final var batchOperationResponse =
@@ -178,13 +287,19 @@ class BatchOperationAuthorizationIT {
 
   @Test
   void restrictedUserShouldQueryBatchOperation(
+      @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaClient).getBatchOperationKey();
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
 
-    // when
-    waitForBatchOperation(camundaClient, batchOperationKey);
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaClient, batchOperationKey, 1);
 
     // when
     final var batchOperationResponse =
@@ -223,12 +338,17 @@ class BatchOperationAuthorizationIT {
   void shouldReturnNotFoundForUnauthorizedReadOfBatchOperation(
       @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED_READ) final CamundaClient camundaRestictedClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaRestictedClient).getBatchOperationKey();
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
 
-    // when our admin finds something
-    waitForBatchOperation(camundaAdminClient, batchOperationKey);
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaAdminClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaAdminClient, batchOperationKey, 3);
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
@@ -250,12 +370,17 @@ class BatchOperationAuthorizationIT {
   void shouldReturnEmptyForUnauthorizedQueryOfBatchOperation(
       @Authenticated(ADMIN) final CamundaClient camundaAdminClient,
       @Authenticated(RESTRICTED_READ) final CamundaClient camundaRestictedClient) {
-    // given
-    final var batchOperationKey =
-        createProcessInstanceCancelBatchOperation(camundaRestictedClient).getBatchOperationKey();
+    // given some processes with a scopeId in variables
+    final var scopeId = startProcessesWithScope(camundaAdminClient);
 
-    // when our admin finds something
-    waitForBatchOperation(camundaAdminClient, batchOperationKey);
+    // when we start the batch
+    final var batchOperationCreatedResponse =
+        createProcessInstanceCancelBatchOperation(camundaRestictedClient, scopeId);
+
+    // and we wait for it
+    assertThat(batchOperationCreatedResponse).isNotNull();
+    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
+    waitForBatchOperation(camundaAdminClient, batchOperationKey, 0);
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
@@ -290,7 +415,7 @@ class BatchOperationAuthorizationIT {
   }
 
   public static void waitForBatchOperation(
-      final CamundaClient camundaClient, final long batchOperationKey) {
+      final CamundaClient camundaClient, final long batchOperationKey, final long itemsCount) {
     Awaitility.await("should wait for started batch operation")
         .atMost(Duration.ofSeconds(15))
         .pollInterval(Duration.ofMillis(100))
@@ -300,18 +425,17 @@ class BatchOperationAuthorizationIT {
               final var batch =
                   camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
               assertThat(batch).isNotNull();
+              assertThat(batch.getOperationsTotalCount()).isEqualTo(itemsCount);
             });
   }
 
   private static CreateBatchOperationResponse createProcessInstanceCancelBatchOperation(
-      final CamundaClient camundaClient) {
-    final var batchOperationResponse =
-        camundaClient
-            .newCreateBatchOperationCommand()
-            .processInstanceCancel()
-            .filter(b -> {})
-            .send()
-            .join();
-    return batchOperationResponse;
+      final CamundaClient camundaClient, final String scopeId) {
+    return camundaClient
+        .newCreateBatchOperationCommand()
+        .processInstanceCancel()
+        .filter(b -> b.variables(getScopedVariables(scopeId)))
+        .send()
+        .join();
   }
 }

--- a/service/src/main/java/io/camunda/service/BatchOperationServices.java
+++ b/service/src/main/java/io/camunda/service/BatchOperationServices.java
@@ -18,7 +18,6 @@ import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
-import io.camunda.security.auth.Authorization.Builder;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -66,7 +65,7 @@ public final class BatchOperationServices
     return batchOperationSearchClient
         .withSecurityContext(
             securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(Builder::read)))
+                authentication, Authorization.of(a -> a.batchOperation().read())))
         .searchBatchOperationItems(query);
   }
 

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -220,7 +220,8 @@ public final class ProcessInstanceServices
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(rootInstanceFilter)
-            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE);
+            .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE)
+            .setAuthentication(authentication);
 
     return sendBrokerRequest(brokerRequest);
   }
@@ -230,7 +231,8 @@ public final class ProcessInstanceServices
     final var brokerRequest =
         new BrokerCreateBatchOperationRequest()
             .setFilter(filter)
-            .setBatchOperationType(BatchOperationType.RESOLVE_INCIDENT);
+            .setBatchOperationType(BatchOperationType.RESOLVE_INCIDENT)
+            .setAuthentication(authentication);
 
     return sendBrokerRequest(brokerRequest);
   }
@@ -245,7 +247,8 @@ public final class ProcessInstanceServices
         new BrokerCreateBatchOperationRequest()
             .setFilter(request.filter)
             .setMigrationPlan(migrationPlan)
-            .setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+            .setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE)
+            .setAuthentication(authentication);
 
     return sendBrokerRequest(brokerRequest);
   }
@@ -292,7 +295,8 @@ public final class ProcessInstanceServices
         new BrokerCreateBatchOperationRequest()
             .setModificationPlan(modificationPlan)
             .setFilter(rootInstanceFilter)
-            .setBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE);
+            .setBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE)
+            .setAuthentication(authentication);
 
     return sendBrokerRequest(brokerRequest);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -98,7 +98,7 @@ public final class BatchOperationExecuteProcessor
     final var followupCommand = new BatchOperationExecutionRecord();
     followupCommand.setBatchOperationKey(batchKey);
     commandWriter.appendFollowUpCommand(
-        command.getKey(), BatchOperationExecutionIntent.EXECUTE, followupCommand, batchKey);
+        command.getKey(), BatchOperationExecutionIntent.EXECUTE, followupCommand, batchKey, null);
   }
 
   private PersistedBatchOperation getBatchOperation(final long batchOperationKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -182,11 +182,13 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
           entityKeyProvider.fetchProcessInstanceItems(
               partitionId,
               batchOperation.getEntityFilter(ProcessInstanceFilter.class),
+              batchOperation.getAuthentication(),
               abortCondition);
       case RESOLVE_INCIDENT ->
           entityKeyProvider.fetchIncidentItems(
               partitionId,
               batchOperation.getEntityFilter(ProcessInstanceFilter.class),
+              batchOperation.getAuthentication(),
               abortCondition);
       default ->
           throw new IllegalArgumentException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -9,11 +9,16 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import com.google.common.collect.Lists;
 import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPageBuilders;
 import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.SecurityContext;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -59,16 +64,19 @@ public class BatchOperationItemProvider {
    * cause multiple queries to the secondary database.
    *
    * @param filter the filter to use
+   * @param authentication the authentication to use
    * @param shouldAbort if the process should be aborted
    * @return a set of all found process instance items
    */
   public Set<Item> fetchProcessInstanceItems(
       final int partitionId,
       final ProcessInstanceFilter filter,
+      final Authentication authentication,
       final Supplier<Boolean> shouldAbort) {
     final var processInstanceFilter = filter.toBuilder().partitionId(partitionId).build();
 
-    return fetchEntityItems(new ProcessInstancePageFetcher(), processInstanceFilter, shouldAbort);
+    return fetchEntityItems(
+        new ProcessInstancePageFetcher(), processInstanceFilter, authentication, shouldAbort);
   }
 
   /**
@@ -77,12 +85,15 @@ public class BatchOperationItemProvider {
    * queries to the secondary database.
    *
    * @param filter the filter to use
+   * @param authentication the authentication to use
    * @param shouldAbort if the process should be aborted
    * @return a set of all found process instance items
    */
   public Set<Item> fetchIncidentItems(
-      final IncidentFilter filter, final Supplier<Boolean> shouldAbort) {
-    return fetchEntityItems(new IncidentPageFetcher(), filter, shouldAbort);
+      final IncidentFilter filter,
+      final Authentication authentication,
+      final Supplier<Boolean> shouldAbort) {
+    return fetchEntityItems(new IncidentPageFetcher(), filter, authentication, shouldAbort);
   }
 
   /**
@@ -92,26 +103,30 @@ public class BatchOperationItemProvider {
    * multiple queries to the secondary database.
    *
    * @param filter the filter to use
+   * @param authentication the authentication to use
    * @param shouldAbort if the process should be aborted
    * @return a set of all found incident items
    */
   public Set<Item> fetchIncidentItems(
       final int partitionId,
       final ProcessInstanceFilter filter,
+      final Authentication authentication,
       final Supplier<Boolean> shouldAbort) {
     // first fetch all matching processInstances
     final var processInstanceKeys =
-        fetchProcessInstanceItems(partitionId, filter, shouldAbort).stream()
+        fetchProcessInstanceItems(partitionId, filter, authentication, shouldAbort).stream()
             .map(Item::processInstanceKey)
             .toList();
 
     // then fetch all incidents of the matching processInstances
-    return getIncidentItemsOfProcessInstanceKeys(new ArrayList<>(processInstanceKeys), shouldAbort);
+    return getIncidentItemsOfProcessInstanceKeys(
+        new ArrayList<>(processInstanceKeys), authentication, shouldAbort);
   }
 
   private <F extends FilterBase> Set<Item> fetchEntityItems(
       final ItemPageFetcher<F> itemPageFetcher,
       final F filter,
+      final Authentication authentication,
       final Supplier<Boolean> shouldAbort) {
     final var items = new LinkedHashSet<Item>();
 
@@ -123,7 +138,7 @@ public class BatchOperationItemProvider {
         return Set.of();
       }
 
-      final var result = itemPageFetcher.fetchItems(filter, searchValues);
+      final var result = itemPageFetcher.fetchItems(filter, searchValues, authentication);
       items.addAll(result.items);
       searchValues = result.lastSortValues();
 
@@ -136,7 +151,9 @@ public class BatchOperationItemProvider {
   }
 
   private Set<Item> getIncidentItemsOfProcessInstanceKeys(
-      final List<Long> processInstanceKeys, final Supplier<Boolean> shouldAbort) {
+      final List<Long> processInstanceKeys,
+      final Authentication authentication,
+      final Supplier<Boolean> shouldAbort) {
     final Set<Item> incidents = new LinkedHashSet<>();
 
     final List<List<Long>> processInstanceKeysBatches =
@@ -148,7 +165,7 @@ public class BatchOperationItemProvider {
       }
       final var filter =
           new IncidentFilter.Builder().processInstanceKeys(processInstanceKeysBatch).build();
-      incidents.addAll(fetchIncidentItems(filter, shouldAbort));
+      incidents.addAll(fetchIncidentItems(filter, authentication, shouldAbort));
     }
 
     return incidents;
@@ -181,12 +198,15 @@ public class BatchOperationItemProvider {
      * @param sortValues the current sortValues
      * @return the fetched items and pagination information
      */
-    ItemPage fetchItems(F filter, Object[] sortValues);
+    ItemPage fetchItems(F filter, Object[] sortValues, Authentication authentication);
   }
 
   private final class ProcessInstancePageFetcher implements ItemPageFetcher<ProcessInstanceFilter> {
     @Override
-    public ItemPage fetchItems(final ProcessInstanceFilter filter, final Object[] sortValues) {
+    public ItemPage fetchItems(
+        final ProcessInstanceFilter filter,
+        final Object[] sortValues,
+        final Authentication authentication) {
       final var page =
           SearchQueryPageBuilders.page().size(queryPageSize).searchAfter(sortValues).build();
       final var query =
@@ -195,7 +215,24 @@ public class BatchOperationItemProvider {
               .page(page)
               .resultConfig(c -> c.onlyKey(true))
               .build();
-      final var result = searchClientsProxy.searchProcessInstances(query);
+
+      final SearchQueryResult<ProcessInstanceEntity> result;
+      if (authentication != null) {
+        final var securityContext =
+            SecurityContext.of(
+                b ->
+                    b.withAuthentication(authentication)
+                        // Since we are not using the ProcessInstanceServices, we need to also
+                        // define the necessary authorizations
+                        .withAuthorization(
+                            Authorization.of(a -> a.processDefinition().readProcessInstance())));
+
+        result =
+            searchClientsProxy.withSecurityContext(securityContext).searchProcessInstances(query);
+      } else {
+        result = searchClientsProxy.searchProcessInstances(query);
+      }
+
       return new ItemPage(
           result.items().stream()
               .map(pi -> new Item(pi.processInstanceKey(), pi.processInstanceKey()))
@@ -207,11 +244,16 @@ public class BatchOperationItemProvider {
 
   private final class IncidentPageFetcher implements ItemPageFetcher<IncidentFilter> {
     @Override
-    public ItemPage fetchItems(final IncidentFilter filter, final Object[] sortValues) {
+    public ItemPage fetchItems(
+        final IncidentFilter filter,
+        final Object[] sortValues,
+        final Authentication authentication) {
+      final var securityContext = SecurityContext.of(b -> b.withAuthentication(authentication));
       final var page =
           SearchQueryPageBuilders.page().size(queryPageSize).searchAfter(sortValues).build();
       final var query = SearchQueryBuilders.incidentSearchQuery().filter(filter).page(page).build();
-      final var result = searchClientsProxy.searchIncidents(query);
+      final var result =
+          searchClientsProxy.withSecurityContext(securityContext).searchIncidents(query);
       return new ItemPage(
           result.items().stream()
               .map(pi -> new Item(pi.incidentKey(), pi.processInstanceKey()))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -31,6 +31,10 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
     final var command = new ProcessInstanceRecord();
     command.setProcessInstanceKey(itemKey);
     commandWriter.appendFollowUpCommand(
-        itemKey, ProcessInstanceIntent.CANCEL, command, batchOperation.getKey());
+        itemKey,
+        ProcessInstanceIntent.CANCEL,
+        command,
+        batchOperation.getKey(),
+        batchOperation.getAuthentication().claims());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
@@ -52,6 +52,7 @@ public class MigrateProcessInstanceBatchOperationExecutor implements BatchOperat
         processInstanceKey,
         ProcessInstanceMigrationIntent.MIGRATE,
         command,
-        batchOperation.getKey());
+        batchOperation.getKey(),
+        batchOperation.getAuthentication().claims());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
@@ -73,6 +73,7 @@ public class ModifyProcessInstanceBatchOperationExecutor implements BatchOperati
         processInstanceKey,
         ProcessInstanceModificationIntent.MODIFY,
         command,
-        batchOperation.getKey());
+        batchOperation.getKey(),
+        batchOperation.getAuthentication().claims());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
@@ -43,6 +43,10 @@ public class ResolveIncidentBatchOperationExecutor implements BatchOperationExec
     LOGGER.trace("Resolving incident with key '{}'", itemKey);
     final var command = new IncidentRecord();
     commandWriter.appendFollowUpCommand(
-        itemKey, IncidentIntent.RESOLVE, command, batchOperation.getKey());
+        itemKey,
+        IncidentIntent.RESOLVE,
+        command,
+        batchOperation.getKey(),
+        batchOperation.getAuthentication().claims());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
@@ -77,7 +79,8 @@ public final class AuthorizationCheckBehavior {
       return Either.right(null);
     }
 
-    if (!request.getCommand().hasRequestMetadata()) {
+    if (!request.getCommand().hasRequestMetadata()
+        && request.getCommand().getOperationReference() == operationReferenceNullValue()) {
       // The command is written by Zeebe internally. Internal Zeebe commands are always authorized
       return Either.right(null);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedCommandWriter.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import java.util.Map;
 import java.util.function.Supplier;
 
 final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderBackedWriter
@@ -35,8 +37,12 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
 
   @Override
   public void appendFollowUpCommand(
-      final long key, final Intent intent, final RecordValue value, final long operationReference) {
-    appendRecord(key, intent, value, operationReference);
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final long operationReference,
+      final Map<String, Object> claims) {
+    appendRecord(key, intent, value, operationReference, claims);
   }
 
   @Override
@@ -45,11 +51,15 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
   }
 
   private void appendRecord(final long key, final Intent intent, final RecordValue value) {
-    appendRecord(key, intent, value, -1);
+    appendRecord(key, intent, value, -1, null);
   }
 
   private void appendRecord(
-      final long key, final Intent intent, final RecordValue value, final long operationReference) {
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final long operationReference,
+      final Map<String, Object> claims) {
     final var metadata =
         new RecordMetadata()
             .recordType(RecordType.COMMAND)
@@ -57,6 +67,11 @@ final class ResultBuilderBackedTypedCommandWriter extends AbstractResultBuilderB
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
             .operationReference(operationReference);
+
+    if (claims != null) {
+      metadata.authorization(new AuthInfo().setClaims(claims));
+    }
+
     resultBuilder().appendRecord(key, value, metadata);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import java.util.Map;
 
 /** This interface is supposed to replace TypedCommandWriter */
 public interface TypedCommandWriter {
@@ -40,10 +41,16 @@ public interface TypedCommandWriter {
    * @param intent the intent of the command
    * @param value the record of the command
    * @param operationReference the operation reference of the command
+   * @param claims the authorization claims
    * @throws ExceededBatchRecordSizeException if the appended command doesn't fit into the
    *     RecordBatch
    */
-  void appendFollowUpCommand(long key, Intent intent, RecordValue value, long operationReference);
+  void appendFollowUpCommand(
+      long key,
+      Intent intent,
+      RecordValue value,
+      long operationReference,
+      Map<String, Object> claims);
 
   /**
    * @param commandLength the length of the command that will be written

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -123,7 +123,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // given
     when(entityKeyProvider.fetchProcessInstanceItems(
-            eq(PARTITION_ID), queryCaptor.capture(), any()))
+            eq(PARTITION_ID), queryCaptor.capture(), any(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -147,7 +147,8 @@ public class BatchOperationExecutionSchedulerTest {
     when(batchOperation.getBatchOperationType()).thenReturn(RESOLVE_INCIDENT);
 
     // given
-    when(entityKeyProvider.fetchIncidentItems(eq(PARTITION_ID), queryCaptor.capture(), any()))
+    when(entityKeyProvider.fetchIncidentItems(
+            eq(PARTITION_ID), queryCaptor.capture(), any(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -172,7 +173,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // given
     when(entityKeyProvider.fetchProcessInstanceItems(
-            eq(PARTITION_ID), queryCaptor.capture(), any()))
+            eq(PARTITION_ID), queryCaptor.capture(), any(), any()))
         .thenReturn(createItems(1L, 2L, 3L));
 
     // when our scheduler fires
@@ -197,7 +198,7 @@ public class BatchOperationExecutionSchedulerTest {
     // given
     final var queryItems = createItems(LongStream.range(0, CHUNK_SIZE * 2).toArray());
     when(entityKeyProvider.fetchProcessInstanceItems(
-            eq(PARTITION_ID), queryCaptor.capture(), any()))
+            eq(PARTITION_ID), queryCaptor.capture(), any(), any()))
         .thenReturn(new HashSet<>(queryItems));
 
     // when our scheduler fires
@@ -229,7 +230,7 @@ public class BatchOperationExecutionSchedulerTest {
 
     // given
     when(entityKeyProvider.fetchProcessInstanceItems(
-            eq(PARTITION_ID), queryCaptor.capture(), any()))
+            eq(PARTITION_ID), queryCaptor.capture(), any(), any()))
         .thenReturn(new HashSet<>(createItems(1L)));
 
     // when our scheduler fires

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -93,7 +94,8 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
                     mockProcessInstanceEntity(3L)))
             .total(3)
             .build();
-    Mockito.when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
+
+    when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
         .thenReturn(result);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
 
 public final class ModifyProcessInstanceBatchExecutorTest extends AbstractBatchOperationTest {
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.security.auth.Authentication;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
 import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -54,11 +55,14 @@ public class BatchOperationStateTest {
             .processDefinitionIds("process")
             .processDefinitionVersions(1)
             .build();
+    final String username = "bud spencer";
+    final var authentication = Authentication.of(b -> b.user(username));
     final var record =
         new BatchOperationCreationRecord()
             .setBatchOperationKey(batchOperationKey)
             .setBatchOperationType(type)
-            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)));
+            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
+            .setAuthentication(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(authentication)));
 
     // when
     state.create(batchOperationKey, record);
@@ -72,6 +76,7 @@ public class BatchOperationStateTest {
     assertThat(batchOperation.getBatchOperationType()).isEqualTo(type);
     assertThat(recordFilter).isEqualTo(filter);
     assertThat(batchOperation.getStatus()).isEqualTo(BatchOperationStatus.CREATED);
+    assertThat(batchOperation.getAuthentication()).isEqualTo(authentication);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -95,6 +95,13 @@ public final class BatchOperationClient {
       return this;
     }
 
+    public BatchOperationCreationClient withAuthentication(final DirectBuffer authentication) {
+      if (authentication != null) {
+        batchOperationCreationRecord.setAuthentication(authentication);
+      }
+      return this;
+    }
+
     public BatchOperationCreationClient withMigrationPlan(
         final BatchOperationProcessInstanceMigrationPlanValue migrationPlan) {
       batchOperationCreationRecord.setMigrationPlan(migrationPlan);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.search.filter.FilterBase;
+import io.camunda.security.auth.Authentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
@@ -60,6 +61,12 @@ public class BrokerCreateBatchOperationRequest
   public BrokerCreateBatchOperationRequest setModificationPlan(
       final BatchOperationProcessInstanceModificationPlan modificationPlan) {
     requestDto.setModificationPlan(modificationPlan);
+    return this;
+  }
+
+  public BrokerCreateBatchOperationRequest setAuthentication(final Authentication authentication) {
+    requestDto.setAuthentication(
+        new UnsafeBuffer(MsgPackConverter.convertToMsgPack(authentication)));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
@@ -26,6 +27,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public static final String PROP_ENTITY_FILTER = "entityFilter";
   public static final String PROP_MIGRATION_PLAN = "migrationPlan";
   public static final String PROP_MODIFICATION_PLAN = "modificationPlan";
+  public static final String PROP_AUTHENTICATION = "authentication";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
@@ -37,14 +39,17 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   private final ObjectProperty<BatchOperationProcessInstanceModificationPlan> modificationPlanProp =
       new ObjectProperty<>(
           PROP_MODIFICATION_PLAN, new BatchOperationProcessInstanceModificationPlan());
+  // Authentication, needed for query in scheduler + command auth
+  private final DocumentProperty authenticationProp = new DocumentProperty(PROP_AUTHENTICATION);
 
   public BatchOperationCreationRecord() {
-    super(5);
+    super(6);
     declareProperty(batchOperationKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(entityFilterProp)
         .declareProperty(migrationPlanProp)
-        .declareProperty(modificationPlanProp);
+        .declareProperty(modificationPlanProp)
+        .declareProperty(authenticationProp);
   }
 
   @Override
@@ -103,6 +108,15 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     return this;
   }
 
+  public DirectBuffer getAuthenticationBuffer() {
+    return authenticationProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setAuthentication(final DirectBuffer authentication) {
+    authenticationProp.setValue(authentication);
+    return this;
+  }
+
   public DirectBuffer getEntityFilterBuffer() {
     return entityFilterProp.getValue();
   }
@@ -113,6 +127,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     entityFilterProp.setValue(record.getEntityFilterBuffer());
     migrationPlanProp.getValue().wrap(record.getMigrationPlan());
     modificationPlanProp.getValue().wrap(record.getModificationPlan());
+    authenticationProp.setValue(record.getAuthenticationBuffer());
     return this;
   }
 }


### PR DESCRIPTION
## Description

This PR adds the usage of authentication from user when working on the target resources of the batch operation.

* It is used in our item provider (which is used by our scheduler) to query keys to work on based on the given filter. With this, the created batch really just contains resources/items where the user is allowed to read them. 
* It is used in all implementations of the BatchOperationExecutor where we create follow-up commands to do the actual work. With this, the actual processor is able to check if the update operation on the given resource is really allowed. If not, the single item will fail. 

## Implementation hints

* Since most of the work happens async (starting with the scheduler), we need to persist the authentication to the primary storage. Claims are not enough at this place, because the query side just uses the explizit properties like authenticatedUsername. (The engine itself just works with the claims)
* Up to now, Internal Zeebe commands are always authorized. That's why we needed to enable those checks in AuthorizationCheckBehavior for batch operations. Currently, the only marker for batch operations is, if the operationReference is set. This is not optimal ... but we have an issue to replace the usage of the reference. I added there the hint to also refactor the AuthorizationCheckBehavior then. => https://github.com/camunda/camunda/issues/30289
* Log4j xml was not working for QA tests. Which makes sense, since they use logback. That's why I replaced it with a logback.xml to configure logging. (Which worked)
* I added some test helper methods, do do better well scoped testing by using a unique process variable as scope per unit test. 
* I also fixed tests in BatchOperationAuthorizationIT, they were not correctly working at all ...
* Added all batch operation records to JsonSerializableToJsonTest

## Related issues

closes #30932
