### PR TITLE
[Backport stable/optimize-8.7] fix: when optimize is in SSL mode, properly add interceptors

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilder.java
@@ -96,7 +96,8 @@ public class ElasticsearchClientBuilder {
         }
 
         builder.setHttpClientConfigCallback(
-            createHttpClientConfigCallback(configurationService, sslContext));
+            createHttpClientConfigCallback(
+                configurationService, sslContext, pluginRepository.asRequestInterceptor()));
       } catch (final Exception e) {
         final String message = "Could not build secured Elasticsearch client.";
         throw new OptimizeRuntimeException(message, e);

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilderTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/upgrade/es/ElasticsearchClientBuilderTest.java
@@ -28,12 +28,15 @@ import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.protocol.BasicHttpContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 class ElasticsearchClientBuilderTest {
 
-  @Test
-  void buildExtendedClient_HappyPath() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void buildExtendedClientHappyPath(final boolean sslEnabled) {
     // given
     final BasicHttpContext context = new BasicHttpContext();
     final ConfigurationService config = Mockito.mock(ConfigurationService.class);
@@ -53,6 +56,7 @@ class ElasticsearchClientBuilderTest {
     Mockito.when(connection.getAwsEnabled()).thenReturn(false);
     Mockito.when(esConfig.getConnectionNodes()).thenReturn(List.of(host));
     Mockito.when(esConfig.getConnection()).thenReturn(connection);
+    Mockito.when(esConfig.getSecuritySSLEnabled()).thenReturn(sslEnabled);
 
     final ElasticsearchClient extendedClient =
         ElasticsearchClientBuilder.build(config, new ObjectMapper(), new PluginRepository());


### PR DESCRIPTION
# Description
Backport of #32237 to `stable/optimize-8.7`.

relates to camunda/camunda#32240