### PR TITLE
feat: pass config into the identity client code from the backend to handle feature toggles

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.identity.webapp.controllers;
 
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.security.SecureRandom;
+import java.util.Base64;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,14 +23,32 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class IdentityIndexController {
+  private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
 
-  @Autowired private ServletContext context;
+  private final ServletContext context;
 
-  @Autowired private WebappsRequestForwardManager webappsRequestForwardManager;
+  private final WebappsRequestForwardManager webappsRequestForwardManager;
+
+  private final SecurityConfiguration securityConfiguration;
+
+  public IdentityIndexController(
+      final ServletContext context,
+      final WebappsRequestForwardManager webappsRequestForwardManager,
+      final SecurityConfiguration securityConfiguration) {
+    this.context = context;
+    this.webappsRequestForwardManager = webappsRequestForwardManager;
+    this.securityConfiguration = securityConfiguration;
+  }
 
   @GetMapping("/identity")
-  public String identity(final Model model) throws IOException {
+  public String identity(final Model model, final HttpServletResponse response) throws IOException {
+    final var envJsNonce = generateNonce();
     model.addAttribute("contextPath", context.getContextPath() + "/identity/");
+    model.addAttribute("clientConfigNonce", envJsNonce);
+    model.addAttribute(
+        "isOidc",
+        securityConfiguration.getAuthentication().getMethod() == AuthenticationMethod.OIDC);
+    setContentSecurePolicyHeader(response, envJsNonce);
     return "identity/index";
   }
 
@@ -34,5 +56,27 @@ public class IdentityIndexController {
       value = {"/identity/", "/identity/{regex:[\\w-]+}", "/identity/**/{regex:[\\w-]+}"})
   public String forwardToIdentity(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "identity");
+  }
+
+  private void setContentSecurePolicyHeader(
+      final HttpServletResponse response, final String envJsNonce) {
+    response.addHeader(
+        CONTENT_SECURITY_POLICY_HEADER,
+        "default-src 'self';"
+            + "script-src 'self' 'nonce-"
+            + envJsNonce
+            + "';"
+            + "style-src 'self' 'unsafe-inline';"
+            + "frame-src 'none';"
+            + "object-src 'none';"
+            + "media-src 'none';");
+  }
+
+  private String generateNonce() {
+    final var secureRandom = new SecureRandom();
+    final var secureBytes = new byte[16];
+    secureRandom.nextBytes(secureBytes);
+
+    return Base64.getEncoder().encodeToString(secureBytes);
   }
 }

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Map;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,9 +46,15 @@ public class IdentityIndexController {
     final var envJsNonce = generateNonce();
     model.addAttribute("contextPath", context.getContextPath() + "/identity/");
     model.addAttribute("clientConfigNonce", envJsNonce);
-    model.addAttribute(
-        "isOidc",
-        securityConfiguration.getAuthentication().getMethod() == AuthenticationMethod.OIDC);
+
+    final var clientConfigMap =
+        Map.of(
+            "VITE_IS_OIDC",
+            String.valueOf(
+                AuthenticationMethod.OIDC.equals(
+                    securityConfiguration.getAuthentication().getMethod())));
+
+    model.addAttribute("clientConfig", clientConfigMap);
     setContentSecurePolicyHeader(response, envJsNonce);
     return "identity/index";
   }

--- a/identity/client/index.html
+++ b/identity/client/index.html
@@ -18,5 +18,10 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script th:inline="javascript" type="text/javascript" th:nonce="${clientConfigNonce}">
+      window.clientConfig = {
+        "VITE_IS_OIDC": "[[${isOidc}]]"
+      }
+    </script>
   </body>
 </html>

--- a/identity/client/index.html
+++ b/identity/client/index.html
@@ -19,9 +19,9 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
     <script th:inline="javascript" type="text/javascript" th:nonce="${clientConfigNonce}">
-      window.clientConfig = {
-        "VITE_IS_OIDC": "[[${isOidc}]]"
-      }
+      /*<![CDATA[*/
+        window.clientConfig = /*[[${clientConfig}]]*/ {};
+      /*]]>*/
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

To be able to show/hide elements in the Identity UI we need to be able to pass configuration from the backend (where the index template is served) to the client side code. This PR achieves this using inspiration from [prior art](https://github.com/camunda-cloud/identity/blob/main/management-api/src/main/java/io/camunda/identity/frontend/controller/FrontendController.java#L72-L90) in the Management Identity codebase.

As we are executing inline code here I've also set the [CSP headers and generated nonce values](https://content-security-policy.com/nonce/) as expected. 

## Related issues

closes #31957 
