### PR TITLE
test: increase timeout in RaftCorruptedDataTest

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import org.awaitility.Awaitility;
@@ -71,7 +72,9 @@ public class RaftCorruptedDataTest {
     server2.bootstrap(node0, node1, node2);
 
     // node does not become follower - goes to inactive as it detects that it has longer log
-    Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole().equals(Role.INACTIVE));
+    Awaitility.await("node becomes INACTIVE")
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> server2.getRole().equals(Role.INACTIVE));
   }
 
   @Test


### PR DESCRIPTION
## Description
After taking a look at this flaky test result, I noticed that this is probably just a matter of time.
In the first run the test runs much slower than the second iteration  and most importantly, at the end of the test the node becomes INACTIVE because it detects the lower commitIndex.
