### PR TITLE
fix: make publishMessage via REST pickup the default timeToLive

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -81,9 +81,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
   public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
+  public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
-
   private boolean applyEnvironmentVariableOverrides = true;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
@@ -100,7 +100,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME_VAR;
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
-  private Duration defaultMessageTimeToLive = Duration.ofHours(1);
+  private Duration defaultMessageTimeToLive = DEFAULT_MESSAGE_TTL;
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private boolean usePlaintextConnection = false;
   private String certificatePath;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -60,14 +60,14 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
     this.retryPredicate = retryPredicate;
     grpcRequestObjectBuilder = PublishMessageRequest.newBuilder();
     requestTimeout = configuration.getDefaultRequestTimeout();
-    grpcRequestObjectBuilder.setTimeToLive(configuration.getDefaultMessageTimeToLive().toMillis());
-    tenantId(configuration.getDefaultTenantId());
-    this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     useRest = preferRestOverGrpc;
+    tenantId(configuration.getDefaultTenantId());
+    timeToLive(configuration.getDefaultMessageTimeToLive());
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -32,6 +32,7 @@ import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_TENANT_ID_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.GRPC_ADDRESS_VAR;
@@ -100,7 +101,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobWorkerName()).isEqualTo("default");
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
-      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
+      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL);
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -64,6 +64,22 @@ public final class PublishMessageTest extends ClientTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // given
+    final long messageKey = 123L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    final PublishMessageResponse response =
+        client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(response.getMessageKey()).isEqualTo(messageKey);
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -75,7 +76,7 @@ public final class PublishMessageTest extends ClientTest {
 
     // then
     final PublishMessageRequest request = gatewayService.getLastRequest();
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
     assertThat(response.getMessageKey()).isEqualTo(messageKey);
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -57,6 +57,17 @@ public class PublishMessageRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // when
+    client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final MessagePublicationRequest request =
+        gatewayService.getLastRequest(MessagePublicationRequest.class);
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process.rest;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -64,7 +65,7 @@ public class PublishMessageRestTest extends ClientRestTest {
     // then
     final MessagePublicationRequest request =
         gatewayService.getLastRequest(MessagePublicationRequest.class);
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.config;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,7 +62,7 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
     assertThat(client.getConfiguration().getDefaultJobWorkerTenantIds())
         .isEqualTo(Collections.singletonList("<default>"));
     assertThat(client.getConfiguration().getDefaultMessageTimeToLive())
-        .isEqualTo(Duration.ofHours(1));
+        .isEqualTo(DEFAULT_MESSAGE_TTL);
     assertThat(client.getConfiguration().getDefaultRequestTimeout())
         .isEqualTo(Duration.ofSeconds(10));
     assertThat(client.getConfiguration().getDefaultTenantId()).isEqualTo("<default>");


### PR DESCRIPTION
## Description

The default ttl was not applied to publishMessage requests via REST. The cause was that the default was only applied to the GRPC request builder.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32320
