### PR TITLE
feat: runtime instructions when starting a process instance via API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9064,6 +9064,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProcessInstanceCreationStartInstruction"
+        runtimeInstructions:
+          description: |
+            List of instructions that affect the runtime behavior of the process instance.
+            By default, the process instance will run until it terminates normally. If provided,
+            the process instance may finish earlier. Refer to specific instruction types for more
+            details.
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessInstanceCreationRuntimeInstruction"
         awaitCompletion:
           description: |
             Wait for the process instance to complete. If the process instance completion does
@@ -9100,6 +9109,38 @@ components:
 
             For now, however, the start instruction is implicitly a "startBeforeElement" instruction
           type: string
+    RuntimeInstructionType:
+      type: string
+      description: |
+        The type of the runtime instruction. For now, only CANCEL_PROCESS_INSTANCE is supported.
+      enum:
+        - CANCEL_PROCESS_INSTANCE
+    ProcessInstanceCreationRuntimeInstruction:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          $ref: "#/components/schemas/RuntimeInstructionType"
+      discriminator:
+        propertyName: type
+        mapping:
+          CANCEL_PROCESS_INSTANCE: "#/components/schemas/ProcessInstanceCreationCancellationInstruction"
+      description: |
+        Base type for all runtime instructions.
+    ProcessInstanceCreationCancellationInstruction:
+      allOf:
+        - $ref: "#/components/schemas/ProcessInstanceCreationRuntimeInstruction"
+        - type: object
+          required:
+            - afterElementId
+          properties:
+            afterElementId:
+              description: |
+                The ID of the element that, once completed, will cause the process to terminate.
+              type: string
+          description: |
+            Cancels the process instance after a specific BPMN element is completed.
     CreateProcessInstanceResult:
       type: object
       properties:


### PR DESCRIPTION
## Description

This PR will introduce the necessary API changes to support process instance runtime instructions.

This is needed as part of the effort to [Run process segment](https://github.com/camunda/camunda/issues/32217). The idea is to introduce the runtime instructions array that may contain different types of instructions. However, in the first iteration we will only support `CANCEL_PROCESS_INSTANCE`.

Example:
```
"runtimeInstructions":[
      {
        "type": "CANCEL_PROCESS_INSTANCE",
        "afterElementId": "myTask1"
      },
      {
        "type": "CANCEL_PROCESS_INSTANCE",
        "afterElementId": "myTask2"
      }
   ]
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32271 
