### PR TITLE
[Backport main] fix: make publishMessage via REST pickup the default timeToLive

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -85,6 +85,7 @@ public final class CamundaClientBuilderImpl
       getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
+  public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
 
@@ -104,7 +105,7 @@ public final class CamundaClientBuilderImpl
   private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME_VAR;
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
-  private Duration defaultMessageTimeToLive = Duration.ofHours(1);
+  private Duration defaultMessageTimeToLive = DEFAULT_MESSAGE_TTL;
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private Duration defaultRequestTimeoutOffset = Duration.ofSeconds(1);
   private boolean usePlaintextConnection = false;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
@@ -60,14 +60,14 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
     this.retryPredicate = retryPredicate;
     grpcRequestObjectBuilder = PublishMessageRequest.newBuilder();
-    requestTimeout = configuration.getDefaultRequestTimeout();
-    grpcRequestObjectBuilder.setTimeToLive(configuration.getDefaultMessageTimeToLive().toMillis());
-    tenantId(configuration.getDefaultTenantId());
-    this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
+    requestTimeout = configuration.getDefaultRequestTimeout();
     useRest = preferRestOverGrpc;
+    tenantId(configuration.getDefaultTenantId());
+    timeToLive(configuration.getDefaultMessageTimeToLive());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -82,9 +82,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
+  public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
-
   private boolean applyEnvironmentVariableOverrides = true;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
@@ -101,7 +101,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME_VAR;
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
-  private Duration defaultMessageTimeToLive = Duration.ofHours(1);
+  private Duration defaultMessageTimeToLive = DEFAULT_MESSAGE_TTL;
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private boolean usePlaintextConnection = false;
   private String certificatePath;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -60,14 +60,14 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
     this.retryPredicate = retryPredicate;
     grpcRequestObjectBuilder = PublishMessageRequest.newBuilder();
     requestTimeout = configuration.getDefaultRequestTimeout();
-    grpcRequestObjectBuilder.setTimeToLive(configuration.getDefaultMessageTimeToLive().toMillis());
-    tenantId(configuration.getDefaultTenantId());
-    this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     useRest = preferRestOverGrpc;
+    tenantId(configuration.getDefaultTenantId());
+    timeToLive(configuration.getDefaultMessageTimeToLive());
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -44,6 +44,7 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.REST_ADDR
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_MB;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -104,7 +105,7 @@ public final class CamundaClientTest {
       assertThat(configuration.getDefaultJobWorkerName()).isEqualTo("default");
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
-      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
+      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL);
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
       assertThat(configuration.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofSeconds(1));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);

--- a/clients/java/src/test/java/io/camunda/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/PublishMessageTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.process;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -61,6 +62,22 @@ public final class PublishMessageTest extends ClientTest {
     assertThat(response.getMessageKey()).isEqualTo(messageKey);
 
     rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // given
+    final long messageKey = 123L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    final PublishMessageResponse response =
+        client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
+    assertThat(response.getMessageKey()).isEqualTo(messageKey);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/PublishMessageRestTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.process.rest;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -54,6 +55,17 @@ public class PublishMessageRestTest extends ClientRestTest {
     assertThat(request.getMessageId()).isEqualTo("theId");
     assertThat(request.getTimeToLive()).isEqualTo(Duration.ofDays(1).toMillis());
     assertThat(request.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // when
+    client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final MessagePublicationRequest request =
+        gatewayService.getLastRequest(MessagePublicationRequest.class);
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -29,6 +29,7 @@ import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
@@ -100,7 +101,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobWorkerName()).isEqualTo("default");
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
-      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
+      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL);
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -64,6 +64,22 @@ public final class PublishMessageTest extends ClientTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // given
+    final long messageKey = 123L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    final PublishMessageResponse response =
+        client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(response.getMessageKey()).isEqualTo(messageKey);
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -75,7 +76,7 @@ public final class PublishMessageTest extends ClientTest {
 
     // then
     final PublishMessageRequest request = gatewayService.getLastRequest();
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
     assertThat(response.getMessageKey()).isEqualTo(messageKey);
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -57,6 +57,17 @@ public class PublishMessageRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // when
+    client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final MessagePublicationRequest request =
+        gatewayService.getLastRequest(MessagePublicationRequest.class);
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process.rest;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -64,7 +65,7 @@ public class PublishMessageRestTest extends ClientRestTest {
     // then
     final MessagePublicationRequest request =
         gatewayService.getLastRequest(MessagePublicationRequest.class);
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #32326 to `main`.

relates to #32320