### PR TITLE
[Backport main] [Backport stable/8.7] fix: make publishMessage via REST pickup the default timeToLive

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -82,9 +82,13 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
+<<<<<<< HEAD
+=======
+  public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
+  public static final Duration DEFAULT_MESSAGE_TTL = Duration.ofHours(1);
+>>>>>>> 4ba7dd0e (refactor: extract default messageTimeToLive for reuse)
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
-
   private boolean applyEnvironmentVariableOverrides = true;
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
@@ -101,7 +105,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME_VAR;
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
-  private Duration defaultMessageTimeToLive = Duration.ofHours(1);
+  private Duration defaultMessageTimeToLive = DEFAULT_MESSAGE_TTL;
   private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private boolean usePlaintextConnection = false;
   private String certificatePath;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -60,14 +60,14 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
       final boolean preferRestOverGrpc) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
     this.retryPredicate = retryPredicate;
     grpcRequestObjectBuilder = PublishMessageRequest.newBuilder();
     requestTimeout = configuration.getDefaultRequestTimeout();
-    grpcRequestObjectBuilder.setTimeToLive(configuration.getDefaultMessageTimeToLive().toMillis());
-    tenantId(configuration.getDefaultTenantId());
-    this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     useRest = preferRestOverGrpc;
+    tenantId(configuration.getDefaultTenantId());
+    timeToLive(configuration.getDefaultMessageTimeToLive());
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -29,6 +29,11 @@ import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
+<<<<<<< HEAD
+=======
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
+>>>>>>> 4ba7dd0e (refactor: extract default messageTimeToLive for reuse)
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
@@ -100,7 +105,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobWorkerName()).isEqualTo("default");
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
-      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
+      assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL);
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -64,6 +64,22 @@ public final class PublishMessageTest extends ClientTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // given
+    final long messageKey = 123L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    final PublishMessageResponse response =
+        client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(response.getMessageKey()).isEqualTo(messageKey);
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -75,7 +76,7 @@ public final class PublishMessageTest extends ClientTest {
 
     // then
     final PublishMessageRequest request = gatewayService.getLastRequest();
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
     assertThat(response.getMessageKey()).isEqualTo(messageKey);
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -57,6 +57,17 @@ public class PublishMessageRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldPublishMessageWithDefaultTtl() {
+    // when
+    client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
+
+    // then
+    final MessagePublicationRequest request =
+        gatewayService.getLastRequest(MessagePublicationRequest.class);
+    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+  }
+
+  @Test
   public void shouldPublishMessageWithStringVariables() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/rest/PublishMessageRestTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.process.rest;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -64,7 +65,7 @@ public class PublishMessageRestTest extends ClientRestTest {
     // then
     final MessagePublicationRequest request =
         gatewayService.getLastRequest(MessagePublicationRequest.class);
-    assertThat(request.getTimeToLive()).isEqualTo(Duration.ofHours(1).toMillis());
+    assertThat(request.getTimeToLive()).isEqualTo(DEFAULT_MESSAGE_TTL.toMillis());
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
+import io.camunda.zeebe.spring.client.config.legacy.ZeebeClientStarterAutoConfigurationTest;
+import io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(
+    classes = {
+      CamundaAutoConfiguration.class,
+      ZeebeClientStarterAutoConfigurationTest.TestConfig.class
+    })
+public class ZeebeClientConfigurationDefaultPropertiesTest {
+
+  @Autowired private ApplicationContext applicationContext;
+
+  @Test
+  void testDefaultClientConfiguration() throws URISyntaxException {
+    final ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
+
+    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
+    assertThat(client.getConfiguration().getCaCertificatePath()).isNull();
+    assertThat(client.getConfiguration().getCredentialsProvider())
+        .isInstanceOf(NoopCredentialsProvider.class);
+    assertThat(client.getConfiguration().getDefaultJobPollInterval())
+        .isEqualTo(Duration.ofMillis(100));
+    assertThat(client.getConfiguration().getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(32);
+    assertThat(client.getConfiguration().getDefaultJobWorkerName()).isEqualTo("default");
+    assertThat(client.getConfiguration().getDefaultJobWorkerStreamEnabled()).isFalse();
+    assertThat(client.getConfiguration().getDefaultJobWorkerTenantIds())
+        .isEqualTo(Collections.singletonList("<default>"));
+    assertThat(client.getConfiguration().getDefaultMessageTimeToLive())
+        .isEqualTo(DEFAULT_MESSAGE_TTL);
+    assertThat(client.getConfiguration().getDefaultRequestTimeout())
+        .isEqualTo(Duration.ofSeconds(10));
+    assertThat(client.getConfiguration().getDefaultTenantId()).isEqualTo("<default>");
+    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("0.0.0.0:26500");
+    assertThat(client.getConfiguration().getGrpcAddress())
+        .isEqualTo(new URI("http://0.0.0.0:26500"));
+    assertThat(client.getConfiguration().getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
+    assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(5 * ONE_MB);
+    assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
+    assertThat(client.getConfiguration().getNumJobWorkerExecutionThreads()).isEqualTo(1);
+    assertThat(client.getConfiguration().getOverrideAuthority()).isNull();
+    assertThat(client.getConfiguration().getRestAddress())
+        .isEqualTo(new URI("http://0.0.0.0:8080"));
+    assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #32333 to `main`.

relates to #32326 #32320