### PR TITLE
perf: improve v1 tasks search by variables

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeInstanceEntity.java
@@ -57,8 +57,9 @@ public class FlowNodeInstanceEntity extends TasklistZeebeEntity<FlowNodeInstance
     return state;
   }
 
-  public void setState(final FlowNodeState state) {
+  public FlowNodeInstanceEntity setState(final FlowNodeState state) {
     this.state = state;
+    return this;
   }
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -289,20 +289,24 @@ public class TaskStoreElasticSearch implements TaskStore {
       return scrollInChunks(
           processInstanceIds,
           DEFAULT_MAX_TERMS_COUNT,
-          chunk ->
-              createSearchRequest(taskTemplate)
-                  .source(
-                      searchSource()
-                          .query(
-                              boolQuery()
-                                  .must(termsQuery(TaskTemplate.PROCESS_INSTANCE_ID, chunk))
-                                  .must(termQuery(TaskTemplate.STATE, TaskState.CREATED)))),
+          this::buildSearchCreatedTasksByProcessInstanceIdsRequest,
           TaskEntity.class,
           objectMapper,
           esClient);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
+  }
+
+  private SearchRequest buildSearchCreatedTasksByProcessInstanceIdsRequest(
+      final List<String> processInstanceIds) {
+    return createSearchRequest(taskTemplate)
+        .source(
+            searchSource()
+                .query(
+                    boolQuery()
+                        .must(termsQuery(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceIds))
+                        .must(termQuery(TaskTemplate.STATE, TaskState.CREATED))));
   }
 
   private SearchHit[] getTasksRawResponse(final List<String> ids) throws IOException {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -10,15 +10,19 @@ package io.camunda.tasklist.store.elasticsearch;
 import static io.camunda.tasklist.schema.indices.ProcessInstanceDependant.PROCESS_INSTANCE_ID;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
+import static io.camunda.tasklist.util.ElasticsearchUtil.DEFAULT_MAX_TERMS_COUNT;
 import static io.camunda.tasklist.util.ElasticsearchUtil.QueryType.ALL;
 import static io.camunda.tasklist.util.ElasticsearchUtil.SCROLL_KEEP_ALIVE_MS;
+import static io.camunda.tasklist.util.ElasticsearchUtil.createSearchRequest;
 import static io.camunda.tasklist.util.ElasticsearchUtil.fromSearchHit;
 import static io.camunda.tasklist.util.ElasticsearchUtil.getRawResponseWithTenantCheck;
 import static io.camunda.tasklist.util.ElasticsearchUtil.joinWithAnd;
 import static io.camunda.tasklist.util.ElasticsearchUtil.mapSearchHits;
+import static io.camunda.tasklist.util.ElasticsearchUtil.scrollInChunks;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.WAIT_UNTIL;
 import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
@@ -122,9 +126,9 @@ public class TaskStoreElasticSearch implements TaskStore {
   @Override
   public List<String> getTaskIdsByProcessInstanceId(final String processInstanceId) {
     final SearchRequest searchRequest =
-        ElasticsearchUtil.createSearchRequest(taskTemplate)
+        createSearchRequest(taskTemplate)
             .source(
-                SearchSourceBuilder.searchSource()
+                searchSource()
                     .query(termQuery(PROCESS_INSTANCE_ID, processInstanceId))
                     .fetchField(TaskTemplate.ID));
     try {
@@ -138,9 +142,9 @@ public class TaskStoreElasticSearch implements TaskStore {
   public Map<String, String> getTaskIdsWithIndexByProcessDefinitionId(
       final String processDefinitionId) {
     final SearchRequest searchRequest =
-        ElasticsearchUtil.createSearchRequest(taskTemplate)
+        createSearchRequest(taskTemplate)
             .source(
-                SearchSourceBuilder.searchSource()
+                searchSource()
                     .query(termQuery(TaskTemplate.PROCESS_DEFINITION_ID, processDefinitionId))
                     .fetchField(TaskTemplate.ID));
     try {
@@ -279,16 +283,23 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   private List<TaskEntity> getActiveTasksByProcessInstanceIds(
       final List<String> processInstanceIds) {
-    final SearchRequest searchRequest =
-        ElasticsearchUtil.createSearchRequest(taskTemplate)
-            .source(
-                SearchSourceBuilder.searchSource()
-                    .query(
-                        boolQuery()
-                            .must(termsQuery(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceIds))
-                            .must(termQuery(TaskTemplate.STATE, TaskState.CREATED))));
     try {
-      return ElasticsearchUtil.scroll(searchRequest, TaskEntity.class, objectMapper, esClient);
+      // the number of process instance ids may be large and exceed #DEFAULT_MAX_TERMS_COUNT, so
+      // we need to chunk them
+      return scrollInChunks(
+          processInstanceIds,
+          DEFAULT_MAX_TERMS_COUNT,
+          chunk ->
+              createSearchRequest(taskTemplate)
+                  .source(
+                      searchSource()
+                          .query(
+                              boolQuery()
+                                  .must(termsQuery(TaskTemplate.PROCESS_INSTANCE_ID, chunk))
+                                  .must(termQuery(TaskTemplate.STATE, TaskState.CREATED)))),
+          TaskEntity.class,
+          objectMapper,
+          esClient);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
@@ -299,7 +310,7 @@ public class TaskStoreElasticSearch implements TaskStore {
     final QueryBuilder query = idsQuery().addIds(Arrays.toString(ids.toArray()));
 
     final SearchRequest request =
-        ElasticsearchUtil.createSearchRequest(taskTemplate)
+        createSearchRequest(taskTemplate)
             .source(new SearchSourceBuilder().query(constantScoreQuery(query)));
 
     final SearchResponse response = tenantAwareClient.search(request);
@@ -397,8 +408,7 @@ public class TaskStoreElasticSearch implements TaskStore {
     applySorting(sourceBuilder, query);
 
     final SearchRequest searchRequest =
-        ElasticsearchUtil.createSearchRequest(
-                taskTemplate, getQueryTypeByTaskState(query.getState()))
+        createSearchRequest(taskTemplate, getQueryTypeByTaskState(query.getState()))
             .source(sourceBuilder);
     try {
       final SearchResponse response =

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -43,7 +43,6 @@ import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
 import io.camunda.tasklist.schema.indices.VariableIndex;
 import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
 import io.camunda.tasklist.store.VariableStore;
-import io.camunda.tasklist.store.VariableStore.GetVariablesRequest;
 import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
 import io.camunda.tasklist.util.ElasticsearchUtil;
 import jakarta.annotation.PostConstruct;
@@ -120,19 +119,7 @@ public class VariableStoreElasticSearch implements VariableStore {
       return scrollInChunks(
           flowNodeInstanceIds,
           maxTermsCount,
-          chunk -> {
-            final TermsQueryBuilder flowNodeInstanceKeyQ = termsQuery(SCOPE_FLOW_NODE_ID, chunk);
-            TermsQueryBuilder varNamesQ = null;
-            if (isNotEmpty(varNames)) {
-              varNamesQ = termsQuery(VariableIndex.NAME, varNames);
-            }
-            final SearchSourceBuilder searchSourceBuilder =
-                new SearchSourceBuilder()
-                    .query(constantScoreQuery(joinWithAnd(flowNodeInstanceKeyQ, varNamesQ)));
-            applyFetchSourceForVariableIndex(searchSourceBuilder, fieldNames);
-
-            return new SearchRequest(variableIndex.getAlias()).source(searchSourceBuilder);
-          },
+          chunk -> buildSearchVariablesByScopeFNIsAndVarNamesRequest(chunk, varNames, fieldNames),
           VariableEntity.class,
           objectMapper,
           esClient);
@@ -225,44 +212,7 @@ public class VariableStoreElasticSearch implements VariableStore {
       return scrollInChunks(
           processInstanceIds,
           maxTermsCount,
-          chunk -> {
-            final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
-
-            final TermsQueryBuilder processInstanceKeyQuery =
-                termsQuery(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID, chunk);
-
-            final TermQueryBuilder stateActiveQuery =
-                termQuery(FlowNodeInstanceIndex.STATE, FlowNodeState.ACTIVE.name());
-            final BoolQueryBuilder stateMissingQuery =
-                QueryBuilders.boolQuery()
-                    .mustNot(QueryBuilders.existsQuery(FlowNodeInstanceIndex.STATE));
-            final BoolQueryBuilder stateQuery =
-                QueryBuilders.boolQuery()
-                    .should(stateActiveQuery)
-                    .should(stateMissingQuery)
-                    .minimumShouldMatch(1);
-
-            final TermsQueryBuilder typeQuery =
-                QueryBuilders.termsQuery(
-                    FlowNodeInstanceIndex.TYPE,
-                    FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
-                    FlowNodeType.USER_TASK.toString(),
-                    FlowNodeType.SUB_PROCESS.toString(),
-                    FlowNodeType.EVENT_SUB_PROCESS.toString(),
-                    FlowNodeType.MULTI_INSTANCE_BODY.toString(),
-                    FlowNodeType.PROCESS.toString());
-
-            queryBuilder.must(processInstanceKeyQuery);
-            queryBuilder.must(stateQuery);
-            queryBuilder.must(typeQuery);
-
-            return new SearchRequest(flowNodeInstanceIndex.getAlias())
-                .source(
-                    new SearchSourceBuilder()
-                        .query(constantScoreQuery(queryBuilder))
-                        .sort(FlowNodeInstanceIndex.POSITION, SortOrder.ASC)
-                        .size(tasklistProperties.getElasticsearch().getBatchSize()));
-          },
+          this::buildSearchFNIByProcessInstanceIdsRequest,
           FlowNodeInstanceEntity.class,
           objectMapper,
           esClient);
@@ -395,6 +345,62 @@ public class VariableStoreElasticSearch implements VariableStore {
     return processInstanceIds == null
         ? Collections.emptyList()
         : new ArrayList<>(processInstanceIds);
+  }
+
+  private SearchRequest buildSearchFNIByProcessInstanceIdsRequest(
+      final List<String> processInstanceIds) {
+    final BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
+
+    final TermsQueryBuilder processInstanceKeyQuery =
+        termsQuery(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID, processInstanceIds);
+
+    final TermQueryBuilder stateActiveQuery =
+        termQuery(FlowNodeInstanceIndex.STATE, FlowNodeState.ACTIVE.name());
+    final BoolQueryBuilder stateMissingQuery =
+        QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(FlowNodeInstanceIndex.STATE));
+    final BoolQueryBuilder stateQuery =
+        QueryBuilders.boolQuery()
+            .should(stateActiveQuery)
+            .should(stateMissingQuery)
+            .minimumShouldMatch(1);
+
+    final TermsQueryBuilder typeQuery =
+        QueryBuilders.termsQuery(
+            FlowNodeInstanceIndex.TYPE,
+            FlowNodeType.AD_HOC_SUB_PROCESS.toString(),
+            FlowNodeType.USER_TASK.toString(),
+            FlowNodeType.SUB_PROCESS.toString(),
+            FlowNodeType.EVENT_SUB_PROCESS.toString(),
+            FlowNodeType.MULTI_INSTANCE_BODY.toString(),
+            FlowNodeType.PROCESS.toString());
+
+    queryBuilder.must(processInstanceKeyQuery);
+    queryBuilder.must(stateQuery);
+    queryBuilder.must(typeQuery);
+
+    return new SearchRequest(flowNodeInstanceIndex.getAlias())
+        .source(
+            new SearchSourceBuilder()
+                .query(constantScoreQuery(queryBuilder))
+                .sort(FlowNodeInstanceIndex.POSITION, SortOrder.ASC)
+                .size(tasklistProperties.getElasticsearch().getBatchSize()));
+  }
+
+  private SearchRequest buildSearchVariablesByScopeFNIsAndVarNamesRequest(
+      final List<String> scopeFlowNodeIds,
+      final List<String> varNames,
+      final Set<String> fieldNames) {
+    final TermsQueryBuilder flowNodeInstanceKeyQ = termsQuery(SCOPE_FLOW_NODE_ID, scopeFlowNodeIds);
+    TermsQueryBuilder varNamesQ = null;
+    if (isNotEmpty(varNames)) {
+      varNamesQ = termsQuery(VariableIndex.NAME, varNames);
+    }
+    final SearchSourceBuilder searchSourceBuilder =
+        new SearchSourceBuilder()
+            .query(constantScoreQuery(joinWithAnd(flowNodeInstanceKeyQ, varNamesQ)));
+    applyFetchSourceForVariableIndex(searchSourceBuilder, fieldNames);
+
+    return new SearchRequest(variableIndex.getAlias()).source(searchSourceBuilder);
   }
 
   private UpdateRequest createUpsertRequest(final TaskVariableEntity variableEntity) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -248,13 +248,13 @@ public class VariableStoreOpenSearch implements VariableStore {
       return scrollInChunks(
           processInstanceIds,
           maxTermsCount,
-          chumk -> {
+          chunk -> {
             final TermsQuery processInstanceKeyQuery =
                 TermsQuery.of(
                     t ->
                         t.field(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID)
                             .terms(
-                                terms -> terms.value(chumk.stream().map(FieldValue::of).toList())));
+                                terms -> terms.value(chunk.stream().map(FieldValue::of).toList())));
 
             final TermQuery stateActiveQuery =
                 TermQuery.of(

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -12,7 +12,9 @@ import static io.camunda.tasklist.schema.indices.VariableIndex.ID;
 import static io.camunda.tasklist.schema.indices.VariableIndex.NAME;
 import static io.camunda.tasklist.schema.indices.VariableIndex.SCOPE_FLOW_NODE_ID;
 import static io.camunda.tasklist.util.CollectionUtil.isNotEmpty;
+import static io.camunda.tasklist.util.OpenSearchUtil.DEFAULT_MAX_TERMS_COUNT;
 import static io.camunda.tasklist.util.OpenSearchUtil.createSearchRequest;
+import static io.camunda.tasklist.util.OpenSearchUtil.scrollInChunks;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
@@ -50,7 +52,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.ListUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -75,7 +76,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Conditional(OpenSearchCondition.class)
 public class VariableStoreOpenSearch implements VariableStore {
-  public static final int DEFAULT_MAX_TERMS_COUNT = 65536;
   public static final String MAX_TERMS_COUNT_SETTING = "index.max_terms_count";
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreOpenSearch.class);
 
@@ -101,50 +101,44 @@ public class VariableStoreOpenSearch implements VariableStore {
       final List<String> flowNodeInstanceIds,
       final List<String> varNames,
       final Set<String> fieldNames) {
-
-    final List<List<String>> flowNodeInstanceIdsChunks =
-        ListUtils.partition(flowNodeInstanceIds, maxTermsCount);
-
-    final List<VariableEntity> variableEntities = new ArrayList<>();
-    flowNodeInstanceIdsChunks.forEach(
-        chunk -> {
-          final Query.Builder flowNodeInstanceKeyQ = new Query.Builder();
-          flowNodeInstanceKeyQ.terms(
-              terms ->
-                  terms
-                      .field(SCOPE_FLOW_NODE_ID)
-                      .terms(t -> t.value(chunk.stream().map(FieldValue::of).collect(toList()))));
-
-          Query.Builder varNamesQ = null;
-          if (isNotEmpty(varNames)) {
-            varNamesQ = new Query.Builder();
-            varNamesQ.terms(
+    try {
+      return OpenSearchUtil.scrollInChunks(
+          flowNodeInstanceIds,
+          maxTermsCount,
+          chunk -> {
+            final Query.Builder flowNodeInstanceKeyQ = new Query.Builder();
+            flowNodeInstanceKeyQ.terms(
                 terms ->
                     terms
-                        .field(VariableIndex.NAME)
-                        .terms(
-                            t -> t.value(varNames.stream().map(FieldValue::of).collect(toList()))));
-          }
-          final Query.Builder query = new Query.Builder();
-          query.constantScore(
-              new ConstantScoreQuery.Builder()
-                  .filter(OpenSearchUtil.joinWithAnd(flowNodeInstanceKeyQ, varNamesQ))
-                  .build());
-          final SearchRequest.Builder searchRequest = new SearchRequest.Builder();
-          searchRequest.index(variableIndex.getAlias()).query(query.build());
-          applyFetchSourceForVariableIndex(searchRequest, fieldNames);
+                        .field(SCOPE_FLOW_NODE_ID)
+                        .terms(t -> t.value(chunk.stream().map(FieldValue::of).toList())));
 
-          try {
-            variableEntities.addAll(
-                OpenSearchUtil.scroll(searchRequest, VariableEntity.class, osClient));
-          } catch (final IOException e) {
-            final String message =
-                String.format(
-                    "Exception occurred, while obtaining all variables: %s", e.getMessage());
-            throw new TasklistRuntimeException(message, e);
-          }
-        });
-    return variableEntities;
+            Query.Builder varNamesQ = null;
+            if (isNotEmpty(varNames)) {
+              varNamesQ = new Query.Builder();
+              varNamesQ.terms(
+                  terms ->
+                      terms
+                          .field(VariableIndex.NAME)
+                          .terms(t -> t.value(varNames.stream().map(FieldValue::of).toList())));
+            }
+            final Query.Builder query = new Query.Builder();
+            query.constantScore(
+                new ConstantScoreQuery.Builder()
+                    .filter(OpenSearchUtil.joinWithAnd(flowNodeInstanceKeyQ, varNamesQ))
+                    .build());
+            final SearchRequest.Builder searchRequest = new SearchRequest.Builder();
+            searchRequest.index(variableIndex.getAlias()).query(query.build());
+            applyFetchSourceForVariableIndex(searchRequest, fieldNames);
+            return searchRequest;
+          },
+          VariableEntity.class,
+          osClient);
+    } catch (final IOException e) {
+      final String message =
+          String.format("Exception occurred, while obtaining all variables: %s", e.getMessage());
+      throw new TasklistRuntimeException(message, e);
+    }
   }
 
   @Override
@@ -249,63 +243,73 @@ public class VariableStoreOpenSearch implements VariableStore {
 
   @Override
   public List<FlowNodeInstanceEntity> getFlowNodeInstances(final List<String> processInstanceIds) {
-
-    final TermsQuery processInstanceKeyQuery =
-        TermsQuery.of(
-            t ->
-                t.field(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID)
-                    .terms(
-                        terms ->
-                            terms.value(processInstanceIds.stream().map(FieldValue::of).toList())));
-
-    final TermQuery stateActiveQuery =
-        TermQuery.of(
-            t ->
-                t.field(FlowNodeInstanceIndex.STATE)
-                    .value(FieldValue.of(FlowNodeState.ACTIVE.name())));
-    final BoolQuery stateMissingQuery =
-        BoolQuery.of(b -> b.mustNot(q -> q.exists(e -> e.field(FlowNodeInstanceIndex.STATE))));
-    final BoolQuery stateQuery =
-        BoolQuery.of(
-            b ->
-                b.should(q -> q.term(stateActiveQuery))
-                    .should(q -> q.bool(stateMissingQuery))
-                    .minimumShouldMatch("1"));
-
-    final TermsQuery typeQuery =
-        TermsQuery.of(
-            t ->
-                t.field(FlowNodeInstanceIndex.TYPE)
-                    .terms(
-                        terms ->
-                            terms.value(
-                                Arrays.asList(
-                                    FieldValue.of(FlowNodeType.AD_HOC_SUB_PROCESS.toString()),
-                                    FieldValue.of(FlowNodeType.USER_TASK.toString()),
-                                    FieldValue.of(FlowNodeType.SUB_PROCESS.toString()),
-                                    FieldValue.of(FlowNodeType.EVENT_SUB_PROCESS.toString()),
-                                    FieldValue.of(FlowNodeType.MULTI_INSTANCE_BODY.toString()),
-                                    FieldValue.of(FlowNodeType.PROCESS.toString())))));
-
-    final BoolQuery finalQuery =
-        BoolQuery.of(
-            b ->
-                b.must(q -> q.terms(processInstanceKeyQuery))
-                    .must(q -> q.terms(typeQuery))
-                    .must(q -> q.bool(stateQuery)));
-
-    final Query.Builder combinedQuery = new Query.Builder();
-    combinedQuery.constantScore(cs -> cs.filter(q -> q.bool(finalQuery)));
-
-    final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
-    searchRequestBuilder
-        .index(flowNodeInstanceIndex.getAlias())
-        .query(combinedQuery.build())
-        .sort(sort -> sort.field(f -> f.field(FlowNodeInstanceIndex.POSITION).order(SortOrder.Asc)))
-        .size(tasklistProperties.getOpenSearch().getBatchSize());
-
     try {
-      return OpenSearchUtil.scroll(searchRequestBuilder, FlowNodeInstanceEntity.class, osClient);
+
+      return scrollInChunks(
+          processInstanceIds,
+          maxTermsCount,
+          chumk -> {
+            final TermsQuery processInstanceKeyQuery =
+                TermsQuery.of(
+                    t ->
+                        t.field(FlowNodeInstanceIndex.PROCESS_INSTANCE_ID)
+                            .terms(
+                                terms -> terms.value(chumk.stream().map(FieldValue::of).toList())));
+
+            final TermQuery stateActiveQuery =
+                TermQuery.of(
+                    t ->
+                        t.field(FlowNodeInstanceIndex.STATE)
+                            .value(FieldValue.of(FlowNodeState.ACTIVE.name())));
+            final BoolQuery stateMissingQuery =
+                BoolQuery.of(
+                    b -> b.mustNot(q -> q.exists(e -> e.field(FlowNodeInstanceIndex.STATE))));
+            final BoolQuery stateQuery =
+                BoolQuery.of(
+                    b ->
+                        b.should(q -> q.term(stateActiveQuery))
+                            .should(q -> q.bool(stateMissingQuery))
+                            .minimumShouldMatch("1"));
+
+            final TermsQuery typeQuery =
+                TermsQuery.of(
+                    t ->
+                        t.field(FlowNodeInstanceIndex.TYPE)
+                            .terms(
+                                terms ->
+                                    terms.value(
+                                        Arrays.asList(
+                                            FieldValue.of(
+                                                FlowNodeType.AD_HOC_SUB_PROCESS.toString()),
+                                            FieldValue.of(FlowNodeType.USER_TASK.toString()),
+                                            FieldValue.of(FlowNodeType.SUB_PROCESS.toString()),
+                                            FieldValue.of(
+                                                FlowNodeType.EVENT_SUB_PROCESS.toString()),
+                                            FieldValue.of(
+                                                FlowNodeType.MULTI_INSTANCE_BODY.toString()),
+                                            FieldValue.of(FlowNodeType.PROCESS.toString())))));
+
+            final BoolQuery finalQuery =
+                BoolQuery.of(
+                    b ->
+                        b.must(q -> q.terms(processInstanceKeyQuery))
+                            .must(q -> q.terms(typeQuery))
+                            .must(q -> q.bool(stateQuery)));
+
+            final Query.Builder combinedQuery = new Query.Builder();
+            combinedQuery.constantScore(cs -> cs.filter(q -> q.bool(finalQuery)));
+
+            return new SearchRequest.Builder()
+                .index(flowNodeInstanceIndex.getAlias())
+                .query(combinedQuery.build())
+                .sort(
+                    sort ->
+                        sort.field(
+                            f -> f.field(FlowNodeInstanceIndex.POSITION).order(SortOrder.Asc)))
+                .size(tasklistProperties.getOpenSearch().getBatchSize());
+          },
+          FlowNodeInstanceEntity.class,
+          osClient);
     } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining all flow nodes: %s", e.getMessage());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.tasklist.store.opensearch;
 
+import static io.camunda.tasklist.schema.indices.ProcessInstanceDependant.PROCESS_INSTANCE_ID;
 import static io.camunda.tasklist.schema.indices.VariableIndex.ID;
 import static io.camunda.tasklist.schema.indices.VariableIndex.NAME;
 import static io.camunda.tasklist.schema.indices.VariableIndex.SCOPE_FLOW_NODE_ID;
 import static io.camunda.tasklist.util.CollectionUtil.isNotEmpty;
-import static io.camunda.tasklist.util.OpenSearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.OpenSearchUtil.createSearchRequest;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -55,7 +55,6 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -387,8 +386,7 @@ public class VariableStoreOpenSearch implements VariableStore {
   @Override
   public List<String> getProcessInstanceIdsWithMatchingVars(
       final List<String> varNames, final List<String> varValues) {
-    final List<Set<String>> listProcessIdsMatchingVars = new ArrayList<>();
-
+    Set<String> processInstanceIds = null;
     for (int i = 0; i < varNames.size(); i++) {
       final Query.Builder nameQ = new Query.Builder();
       final int finalI = i;
@@ -413,61 +411,37 @@ public class VariableStoreOpenSearch implements VariableStore {
       final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
       searchRequestBuilder
           .index(variableIndex.getAlias())
-          .query(q -> q.constantScore(cs -> cs.filter(boolQuery)))
-          .scroll(timeBuilder -> timeBuilder.time(SCROLL_KEEP_ALIVE_MS));
-
-      final Set<String> processInstanceIds = new HashSet<>();
-
+          .query(q -> q.constantScore(cs -> cs.filter(boolQuery)));
+      final Set<String> currentIds;
       try {
-        SearchResponse<VariableEntity> response =
-            osClient.search(searchRequestBuilder.build(), VariableEntity.class);
-
-        List<String> scrollProcessIds =
-            response.hits().hits().stream()
-                .map(hit -> hit.source().getProcessInstanceId())
-                .collect(Collectors.toList());
-
-        processInstanceIds.addAll(scrollProcessIds);
-
-        final String scrollId = response.scrollId();
-
-        while (!scrollProcessIds.isEmpty()) {
-          final ScrollRequest scrollRequest =
-              ScrollRequest.of(
-                  builder ->
-                      builder
-                          .scrollId(scrollId)
-                          .scroll(new Time.Builder().time(SCROLL_KEEP_ALIVE_MS).build()));
-
-          response = osClient.scroll(scrollRequest, VariableEntity.class);
-          scrollProcessIds =
-              response.hits().hits().stream()
-                  .map(hit -> hit.source().getProcessInstanceId())
-                  .collect(Collectors.toList());
-
-          processInstanceIds.addAll(scrollProcessIds);
-        }
-
-        OpenSearchUtil.clearScroll(scrollId, osClient);
-
-        listProcessIdsMatchingVars.add(processInstanceIds);
-
+        currentIds =
+            new HashSet<>(
+                OpenSearchUtil.scrollFieldToList(
+                    searchRequestBuilder, PROCESS_INSTANCE_ID, osClient));
       } catch (final IOException e) {
         final String message =
-            String.format("Exception occurred while obtaining flowInstanceIds: %s", e.getMessage());
+            String.format(
+                "Exception occurred while obtaining flowNodeInstanceIds for variable %s: %s",
+                varNames.get(i), e.getMessage());
         throw new TasklistRuntimeException(message, e);
       }
+      // Early exit if empty result
+      if (currentIds.isEmpty()) {
+        return Collections.emptyList();
+      }
+      if (processInstanceIds == null) {
+        processInstanceIds = currentIds;
+      } else {
+        processInstanceIds.retainAll(currentIds);
+        if (processInstanceIds.isEmpty()) {
+          // Early exit if intersection is empty
+          return Collections.emptyList();
+        }
+      }
     }
-
-    // now find the intersection of all sets
-    return new ArrayList<>(
-        listProcessIdsMatchingVars.stream()
-            .reduce(
-                (set1, set2) -> {
-                  set1.retainAll(set2);
-                  return set1;
-                })
-            .orElse(Collections.emptySet()));
+    return processInstanceIds == null
+        ? Collections.emptyList()
+        : new ArrayList<>(processInstanceIds);
   }
 
   private BulkOperation createUpsertRequest(final TaskVariableEntity variableEntity) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/util/TaskVariableSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/util/TaskVariableSearchUtil.java
@@ -14,6 +14,7 @@ import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
 import io.camunda.tasklist.entities.VariableEntity;
 import io.camunda.tasklist.store.VariableStore;
 import io.camunda.tasklist.util.CollectionUtil;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,10 @@ public class TaskVariableSearchUtil {
   public List<String> getTaskIdsContainingVariables(
       final List<VariableStore.GetVariablesRequest> requests,
       final Map<String, String> variableNameAndVar) {
+
+    if (requests.isEmpty() || variableNameAndVar.isEmpty()) {
+      return Collections.emptyList();
+    }
 
     // build flow node trees (for each process instance)
     final Map<String, VariableStore.FlowNodeTree> flowNodeTrees = buildFlowNodeTrees(requests);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.collections4.ListUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
@@ -80,6 +81,7 @@ public abstract class ElasticsearchUtil {
       30000; // this scroll timeout value is used for reindex and delete queries
   public static final int QUERY_MAX_SIZE = 10000;
   public static final int UPDATE_RETRY_COUNT = 3;
+  public static final int DEFAULT_MAX_TERMS_COUNT = 65536;
   public static final Function<SearchHit, Long> SEARCH_HIT_ID_TO_LONG =
       (hit) -> Long.valueOf(hit.getId());
   public static final Function<SearchHit, String> SEARCH_HIT_ID_TO_STRING = SearchHit::getId;
@@ -102,9 +104,9 @@ public abstract class ElasticsearchUtil {
 
   public static SearchHit getRawResponseWithTenantCheck(
       final String id,
-      IndexDescriptor descriptor,
-      QueryType queryType,
-      TenantAwareElasticsearchClient tenantAwareClient)
+      final IndexDescriptor descriptor,
+      final QueryType queryType,
+      final TenantAwareElasticsearchClient tenantAwareClient)
       throws IOException {
     final QueryBuilder query = idsQuery().addIds(id);
 
@@ -174,11 +176,12 @@ public abstract class ElasticsearchUtil {
 
   /* CREATE QUERIES */
 
-  public static SearchRequest createSearchRequest(IndexDescriptor descriptor, QueryType queryType) {
+  public static SearchRequest createSearchRequest(
+      final IndexDescriptor descriptor, final QueryType queryType) {
     return new SearchRequest(whereToSearch(descriptor, queryType));
   }
 
-  public static String whereToSearch(IndexDescriptor descriptor, QueryType queryType) {
+  public static String whereToSearch(final IndexDescriptor descriptor, final QueryType queryType) {
     switch (queryType) {
       case ONLY_RUNTIME:
         return descriptor.getFullQualifiedName();
@@ -189,9 +192,9 @@ public abstract class ElasticsearchUtil {
   }
 
   public static QueryBuilder joinWithOr(
-      BoolQueryBuilder boolQueryBuilder, QueryBuilder... queries) {
+      final BoolQueryBuilder boolQueryBuilder, final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
-    for (QueryBuilder query : notNullQueries) {
+    for (final QueryBuilder query : notNullQueries) {
       boolQueryBuilder.should(query);
     }
     return boolQueryBuilder;
@@ -202,7 +205,7 @@ public abstract class ElasticsearchUtil {
    * parameter is passed, it will be returned back as ia. Otherwise, the new BoolQuery will be
    * created and returned.
    */
-  public static QueryBuilder joinWithOr(QueryBuilder... queries) {
+  public static QueryBuilder joinWithOr(final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
     switch (notNullQueries.size()) {
       case 0:
@@ -211,14 +214,14 @@ public abstract class ElasticsearchUtil {
         return notNullQueries.get(0);
       default:
         final BoolQueryBuilder boolQ = boolQuery();
-        for (QueryBuilder query : notNullQueries) {
+        for (final QueryBuilder query : notNullQueries) {
           boolQ.should(query);
         }
         return boolQ;
     }
   }
 
-  public static QueryBuilder joinWithOr(Collection<QueryBuilder> queries) {
+  public static QueryBuilder joinWithOr(final Collection<QueryBuilder> queries) {
     return joinWithOr(queries.toArray(new QueryBuilder[queries.size()]));
   }
 
@@ -227,7 +230,7 @@ public abstract class ElasticsearchUtil {
    * parameter is passed, it will be returned back as ia. Otherwise, the new BoolQuery will be
    * created and returned.
    */
-  public static QueryBuilder joinWithAnd(QueryBuilder... queries) {
+  public static QueryBuilder joinWithAnd(final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
     switch (notNullQueries.size()) {
       case 0:
@@ -236,21 +239,22 @@ public abstract class ElasticsearchUtil {
         return notNullQueries.get(0);
       default:
         final BoolQueryBuilder boolQ = boolQuery();
-        for (QueryBuilder query : notNullQueries) {
+        for (final QueryBuilder query : notNullQueries) {
           boolQ.must(query);
         }
         return boolQ;
     }
   }
 
-  public static QueryBuilder addToBoolMust(BoolQueryBuilder boolQuery, QueryBuilder... queries) {
+  public static QueryBuilder addToBoolMust(
+      final BoolQueryBuilder boolQuery, final QueryBuilder... queries) {
     if (boolQuery.mustNot().size() != 0
         || boolQuery.filter().size() != 0
         || boolQuery.should().size() != 0) {
       throw new IllegalArgumentException("BoolQuery with only must elements is expected here.");
     }
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
-    for (QueryBuilder query : notNullQueries) {
+    for (final QueryBuilder query : notNullQueries) {
       boolQuery.must(query);
     }
     return boolQuery;
@@ -260,7 +264,8 @@ public abstract class ElasticsearchUtil {
     return boolQuery().must(QueryBuilders.wrapperQuery("{\"match_none\": {}}"));
   }
 
-  public static void processBulkRequest(RestHighLevelClient esClient, BulkRequest bulkRequest)
+  public static void processBulkRequest(
+      final RestHighLevelClient esClient, final BulkRequest bulkRequest)
       throws PersistenceException {
     processBulkRequest(esClient, bulkRequest, RefreshPolicy.NONE);
   }
@@ -278,7 +283,7 @@ public abstract class ElasticsearchUtil {
         bulkRequest = bulkRequest.setRefreshPolicy(refreshPolicy);
         final BulkResponse bulkItemResponses = esClient.bulk(bulkRequest, RequestOptions.DEFAULT);
         final BulkItemResponse[] items = bulkItemResponses.getItems();
-        for (BulkItemResponse responseItem : items) {
+        for (final BulkItemResponse responseItem : items) {
           if (responseItem.isFailed()) {
             LOGGER.error(
                 String.format(
@@ -295,18 +300,19 @@ public abstract class ElasticsearchUtil {
           }
         }
         LOGGER.debug("************* FLUSH BULK FINISH *************");
-      } catch (IOException ex) {
+      } catch (final IOException ex) {
         throw new PersistenceException(
             "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
       }
     }
   }
 
-  public static void executeUpdate(RestHighLevelClient esClient, UpdateRequest updateRequest)
+  public static void executeUpdate(
+      final RestHighLevelClient esClient, final UpdateRequest updateRequest)
       throws PersistenceException {
     try {
       esClient.update(updateRequest, RequestOptions.DEFAULT);
-    } catch (ElasticsearchException | IOException e) {
+    } catch (final ElasticsearchException | IOException e) {
       final String errorMessage =
           String.format(
               "Update request failed for [%s] and id [%s] with the message [%s].",
@@ -316,7 +322,7 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> mapSearchHits(
-      List<SearchHit> searchHits, ObjectMapper objectMapper, JavaType valueType) {
+      final List<SearchHit> searchHits, final ObjectMapper objectMapper, final JavaType valueType) {
     return mapSearchHits(
         searchHits.toArray(new SearchHit[searchHits.size()]), objectMapper, valueType);
   }
@@ -324,23 +330,23 @@ public abstract class ElasticsearchUtil {
   /* MAP QUERY RESULTS */
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, Function<SearchHit, T> searchHitMapper) {
+      final SearchHit[] searchHits, final Function<SearchHit, T> searchHitMapper) {
     return map(searchHits, searchHitMapper);
   }
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, ObjectMapper objectMapper, Class<T> clazz) {
+      final SearchHit[] searchHits, final ObjectMapper objectMapper, final Class<T> clazz) {
     return map(
         searchHits,
         (searchHit) -> fromSearchHit(searchHit.getSourceAsString(), objectMapper, clazz));
   }
 
   public static <T> T fromSearchHit(
-      String searchHitString, ObjectMapper objectMapper, Class<T> clazz) {
+      final String searchHitString, final ObjectMapper objectMapper, final Class<T> clazz) {
     final T entity;
     try {
       entity = objectMapper.readValue(searchHitString, clazz);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error while reading entity of type %s from Elasticsearch!", clazz.getName()),
@@ -350,18 +356,18 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, ObjectMapper objectMapper, JavaType valueType) {
+      final SearchHit[] searchHits, final ObjectMapper objectMapper, final JavaType valueType) {
     return map(
         searchHits,
         (searchHit) -> fromSearchHit(searchHit.getSourceAsString(), objectMapper, valueType));
   }
 
   public static <T> T fromSearchHit(
-      String searchHitString, ObjectMapper objectMapper, JavaType valueType) {
+      final String searchHitString, final ObjectMapper objectMapper, final JavaType valueType) {
     final T entity;
     try {
       entity = objectMapper.readValue(searchHitString, valueType);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(
           String.format(
               "Error while reading entity of type %s from Elasticsearch!", valueType.toString()),
@@ -370,22 +376,42 @@ public abstract class ElasticsearchUtil {
     return entity;
   }
 
+  /**
+   * Helper method to scroll in chunks. This is useful when you have a large number of ids and want
+   * to avoid sending them all at once to OpenSearch to not hit the max allowed terms limit {@link
+   * #DEFAULT_MAX_TERMS_COUNT}
+   */
+  public static <T extends TasklistEntity> List<T> scrollInChunks(
+      final List<String> list,
+      final int chunkSize,
+      final Function<List<String>, SearchRequest> chunkToSearchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient)
+      throws IOException {
+    final var result = new ArrayList<T>();
+    for (final var chunk : ListUtils.partition(list, chunkSize)) {
+      result.addAll(scroll(chunkToSearchRequest.apply(chunk), clazz, objectMapper, esClient));
+    }
+    return result;
+  }
+
   public static <T extends TasklistEntity> List<T> scroll(
-      SearchRequest searchRequest,
-      Class<T> clazz,
-      ObjectMapper objectMapper,
-      RestHighLevelClient esClient)
+      final SearchRequest searchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient)
       throws IOException {
     return scroll(searchRequest, clazz, objectMapper, esClient, null, null);
   }
 
   public static <T extends TasklistEntity> List<T> scroll(
-      SearchRequest searchRequest,
-      Class<T> clazz,
-      ObjectMapper objectMapper,
-      RestHighLevelClient esClient,
-      Consumer<SearchHits> searchHitsProcessor,
-      Consumer<Aggregations> aggsProcessor)
+      final SearchRequest searchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final Consumer<Aggregations> aggsProcessor)
       throws IOException {
 
     searchRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
@@ -423,11 +449,11 @@ public abstract class ElasticsearchUtil {
   }
 
   public static void scrollWith(
-      SearchRequest searchRequest,
-      RestHighLevelClient esClient,
-      Consumer<SearchHits> searchHitsProcessor,
-      Consumer<Aggregations> aggsProcessor,
-      Consumer<SearchHits> firstResponseConsumer)
+      final SearchRequest searchRequest,
+      final RestHighLevelClient esClient,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final Consumer<Aggregations> aggsProcessor,
+      final Consumer<SearchHits> firstResponseConsumer)
       throws IOException {
 
     searchRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
@@ -462,21 +488,21 @@ public abstract class ElasticsearchUtil {
     clearScroll(scrollId, esClient);
   }
 
-  public static void clearScroll(String scrollId, RestHighLevelClient esClient) {
+  public static void clearScroll(final String scrollId, final RestHighLevelClient esClient) {
     if (scrollId != null) {
       // clear the scroll
       final ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
       clearScrollRequest.addScrollId(scrollId);
       try {
         esClient.clearScroll(clearScrollRequest, RequestOptions.DEFAULT);
-      } catch (Exception e) {
+      } catch (final Exception e) {
         LOGGER.warn("Error occurred when clearing the scroll with id [{}]", scrollId);
       }
     }
   }
 
-  public static List<String> scrollIdsToList(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static List<String> scrollIdsToList(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final List<String> result = new ArrayList<>();
 
     final Consumer<SearchHits> collectIds =
@@ -487,7 +513,7 @@ public abstract class ElasticsearchUtil {
   }
 
   public static Map<String, String> scrollIdsWithIndexToMap(
-      SearchRequest request, RestHighLevelClient esClient) throws IOException {
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final Map<String, String> result = new LinkedHashMap();
 
     final Consumer<SearchHits> collectIds =
@@ -500,8 +526,8 @@ public abstract class ElasticsearchUtil {
     return result;
   }
 
-  public static List<Long> scrollKeysToList(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static List<Long> scrollKeysToList(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final List<Long> result = new ArrayList<>();
 
     final Consumer<SearchHits> collectIds =
@@ -512,7 +538,8 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> scrollFieldToList(
-      SearchRequest request, String fieldName, RestHighLevelClient esClient) throws IOException {
+      final SearchRequest request, final String fieldName, final RestHighLevelClient esClient)
+      throws IOException {
     final List<T> result = new ArrayList<>();
     final Function<SearchHit, T> searchHitFieldToString =
         (searchHit) -> (T) searchHit.getSourceAsMap().get(fieldName);
@@ -524,8 +551,8 @@ public abstract class ElasticsearchUtil {
     return result;
   }
 
-  public static Set<String> scrollIdsToSet(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static Set<String> scrollIdsToSet(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final Set<String> result = new HashSet<>();
 
     final Consumer<SearchHits> collectIds =
@@ -552,14 +579,9 @@ public abstract class ElasticsearchUtil {
       if (refresh.getFailedShards() > 0) {
         LOGGER.warn("Unable to refresh indices: {}", indexPattern);
       }
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
     }
-  }
-
-  public enum QueryType {
-    ONLY_RUNTIME,
-    ALL
   }
 
   private static final class DelegatingActionListener<Response>
@@ -571,17 +593,22 @@ public abstract class ElasticsearchUtil {
     private DelegatingActionListener(
         final CompletableFuture<Response> future, final Executor executor) {
       this.future = future;
-      this.executorDelegate = executor;
+      executorDelegate = executor;
     }
 
     @Override
-    public void onResponse(Response response) {
+    public void onResponse(final Response response) {
       executorDelegate.execute(() -> future.complete(response));
     }
 
     @Override
-    public void onFailure(Exception e) {
+    public void onFailure(final Exception e) {
       executorDelegate.execute(() -> future.completeExceptionally(e));
     }
+  }
+
+  public enum QueryType {
+    ONLY_RUNTIME,
+    ALL
   }
 }

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -86,6 +86,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-x-content</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- TEST CONTAINERS -->
     <dependency>
       <groupId>io.zeebe</groupId>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/perf/TaskStorePerfIT.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.perf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.tasklist.entities.FlowNodeInstanceEntity;
+import io.camunda.tasklist.entities.FlowNodeState;
+import io.camunda.tasklist.entities.FlowNodeType;
+import io.camunda.tasklist.entities.ProcessInstanceEntity;
+import io.camunda.tasklist.entities.ProcessInstanceState;
+import io.camunda.tasklist.entities.TaskEntity;
+import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.entities.VariableEntity;
+import io.camunda.tasklist.queries.TaskByVariables;
+import io.camunda.tasklist.queries.TaskQuery;
+import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
+import io.camunda.tasklist.schema.indices.ProcessInstanceIndex;
+import io.camunda.tasklist.schema.indices.VariableIndex;
+import io.camunda.tasklist.schema.templates.TaskTemplate;
+import io.camunda.tasklist.store.TaskStore;
+import io.camunda.tasklist.util.DatabaseTestExtension;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TaskStorePerfIT extends TasklistIntegrationTest {
+  private static final Logger LOG = LoggerFactory.getLogger(TaskStorePerfIT.class);
+
+  @RegisterExtension @Autowired public DatabaseTestExtension databaseTestExtension;
+
+  @Autowired private TaskStore taskStore;
+
+  @Autowired private ProcessInstanceIndex processInstanceIndex;
+
+  @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
+
+  @Autowired private VariableIndex variableIndex;
+
+  @Autowired private TaskTemplate taskTemplate;
+
+  @BeforeEach
+  public void setUp() {
+    super.before();
+    databaseTestExtension.refreshTasklistIndices();
+  }
+
+  /**
+   * This test depends on many factors like Elasticsearch configuration, hardware, current load,
+   * etc. It is mainly meant to assert that the response time is within a certain order of
+   * magnitude. In case of failure, please check if the expected response time should be increased.
+   */
+  @ParameterizedTest
+  @MethodSource("performanceTestParams")
+  void shouldQueryTasksByVariablesNotExceedResponseTime(
+      final int numberOfVariablesPerTask,
+      final int numberOfMatchingTasks,
+      final int maxResponseTimeMs)
+      throws Exception {
+    final int total = 100_000;
+    /**
+     * The test creates 100_000 process instances, flownode instances, tasks and
+     * (numberOfVariablesPerTask* 100_000) variables.
+     */
+    final List<ProcessInstanceEntity> processInstances = new ArrayList<>(total);
+    final List<TaskEntity> tasks = new ArrayList<>(total);
+    final List<FlowNodeInstanceEntity> flowNodeInstances = new ArrayList<>(total);
+    final List<VariableEntity> variables = new ArrayList<>(total);
+    final long piOffset = total * 0;
+    final long fniOffset = total * 1;
+    final long taskOffset = total * 2;
+    final long variableOffset = total * 3;
+    for (int i = 0; i < total; i++) {
+      processInstances.add(
+          new ProcessInstanceEntity()
+              .setId(String.valueOf(piOffset + i))
+              .setKey(piOffset + i)
+              .setState(ProcessInstanceState.ACTIVE));
+      flowNodeInstances.add(
+          new FlowNodeInstanceEntity()
+              .setId(String.valueOf(fniOffset + i))
+              .setKey(fniOffset + i)
+              .setProcessInstanceId(String.valueOf(piOffset + i))
+              .setParentFlowNodeId(String.valueOf(piOffset + i))
+              .setType(FlowNodeType.USER_TASK)
+              .setState(FlowNodeState.ACTIVE));
+      for (int j = 0; j < numberOfVariablesPerTask; j++) {
+        variables.add(
+            new VariableEntity()
+                .setId(String.valueOf(variableOffset + numberOfVariablesPerTask * i + j))
+                .setKey(variableOffset + numberOfVariablesPerTask * i + j)
+                .setProcessInstanceId(String.valueOf(piOffset + i))
+                .setScopeFlowNodeId(String.valueOf(fniOffset + i))
+                .setName("var" + j)
+                .setValue(
+                    i < numberOfMatchingTasks ? String.format("\"value%d\"", j) : "\"other\""));
+      }
+      tasks.add(
+          new TaskEntity()
+              .setId(String.valueOf(taskOffset + i))
+              .setKey(taskOffset + i)
+              .setProcessInstanceId(String.valueOf(piOffset + i))
+              .setFlowNodeInstanceId(String.valueOf(fniOffset + i))
+              .setState(TaskState.CREATED));
+    }
+    databaseTestExtension.bulkIndex(processInstanceIndex, processInstances);
+    databaseTestExtension.bulkIndex(flowNodeInstanceIndex, flowNodeInstances);
+    databaseTestExtension.bulkIndex(variableIndex, variables);
+    databaseTestExtension.bulkIndex(taskTemplate, tasks);
+
+    LOG.info("Data loaded, starting performance test");
+    assertWithRetry(
+        3,
+        () -> {
+          final long start = System.currentTimeMillis();
+          assertThat(
+                  taskStore.getTasks(
+                      new TaskQuery()
+                          .setState(TaskState.CREATED)
+                          .setPageSize(
+                              10_000) // use max allowed page size to make sure we get all tasks
+                          .setTaskVariables(
+                              IntStream.range(0, numberOfVariablesPerTask)
+                                  .mapToObj(
+                                      i ->
+                                          new TaskByVariables()
+                                              .setName("var" + i)
+                                              .setValue(String.format("\"value%d\"", i)))
+                                  .toArray(TaskByVariables[]::new))))
+              .hasSize(numberOfMatchingTasks);
+          LOG.info(
+              "Performance test, for {} matches, finished in {} ms. Max response time is set to {} ms.",
+              numberOfMatchingTasks,
+              System.currentTimeMillis() - start,
+              maxResponseTimeMs);
+          assertThat(System.currentTimeMillis() - start).isLessThan(maxResponseTimeMs);
+        });
+  }
+
+  /** (int numberOfVariablesPerTask, int numberOfMatchingTasks, int maxResponseTimeMs) */
+  private static Stream<Arguments> performanceTestParams() {
+    return Stream.of(
+        Arguments.of(1, 1000, 1000),
+        Arguments.of(1, 3000, 2000),
+        Arguments.of(2, 1000, 1000),
+        Arguments.of(2, 3000, 3000),
+        Arguments.of(1, 10_000, 13_000));
+  }
+
+  private void assertWithRetry(final int maxAttempts, final Runnable assertion)
+      throws InterruptedException {
+    int attempt = 0;
+    while (attempt < maxAttempts) {
+      try {
+        assertion.run();
+        return;
+      } catch (final AssertionError e) {
+        attempt++;
+        if (attempt == maxAttempts) {
+          throw e;
+        }
+        Thread.sleep(500);
+      }
+    }
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.util;
 
+import io.camunda.tasklist.entities.TasklistEntity;
+import io.camunda.tasklist.schema.indices.IndexDescriptor;
 import io.camunda.tasklist.zeebe.ImportValueType;
 import io.camunda.tasklist.zeebeimport.RecordsReader;
 import java.io.IOException;
@@ -58,4 +60,7 @@ public interface DatabaseTestExtension extends Extension {
   void createIndex(String indexName) throws IOException;
 
   void deleteIndex(String indexName);
+
+  <T extends TasklistEntity<T>> void bulkIndex(IndexDescriptor index, List<T> documents)
+      throws IOException;
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Improving the performance of V1 search tasks by variables as this currently does not scale for customers with high number of PIs and user tasks (around 100K~200K)

The pull request contains 3 commits, I recommend reviewing them one by one to ease the review:
- https://github.com/camunda/camunda/pull/32346/commits/83221a98ec9e0c370f0d8861f9d15a64e5c837a4 reducing the number of calls to Elasticsearch to fetch the process instances and user tasks that have the variable name/value in their scope
- https://github.com/camunda/camunda/pull/32346/commits/9452da93f6395ada7aef4d9ea4d8c6a7ff39fd7f using chunks when querying by processInstanceIds as this can quickly exceed 65K terms (similar to the work done in https://github.com/camunda/camunda/pull/31277)
- https://github.com/camunda/camunda/pull/32346/commits/c79111d44387ad7e1bff1e47ce708a7f2578ee96 Adding a Perf Test to assert that the query by variable stays within an order of magnitude response time

**Note:**
performance can degrade with high matching cardinality. If the variable filter matches a large portion of the tasks in the database, for example 50K out of 100K, search performance may suffer. In general, performance remains acceptable when the matching cardinality stays below 10%.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32336 
