### PR TITLE
feat: Support` PROPAGATE` variable updates for user task

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -10,7 +10,6 @@ package io.camunda.optimize.dto.zeebe.usertask;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.util.DateFormatterUtil;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
-import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,6 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   private String tenantId;
   private List<String> changedAttributes;
   private Map<String, Object> variables;
-  private UserTaskVariablesUpdateSemantic variablesUpdateSemantic;
   private String followUpDate;
   private long formKey;
   private String action;
@@ -240,16 +238,6 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     this.variables = variables;
   }
 
-  @Override
-  public UserTaskVariablesUpdateSemantic getVariableUpdateSemantics() {
-    return variablesUpdateSemantic;
-  }
-
-  public void setVariablesUpdateSemantic(
-      final UserTaskVariablesUpdateSemantic variablesUpdateSemantic) {
-    this.variablesUpdateSemantic = variablesUpdateSemantic;
-  }
-
   protected boolean canEqual(final Object other) {
     return other instanceof ZeebeUserTaskDataDto;
   }
@@ -326,7 +314,6 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     public static final String tenantId = "tenantId";
     public static final String changedAttributes = "changedAttributes";
     public static final String variables = "variables";
-    public static final String variablesUpdateSemantic = "variablesUpdateSemantic";
     public static final String followUpDate = "followUpDate";
     public static final String formKey = "formKey";
     public static final String action = "action";

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.dto.zeebe.usertask;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.optimize.service.util.DateFormatterUtil;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
   private String tenantId;
   private List<String> changedAttributes;
   private Map<String, Object> variables;
+  private UserTaskVariablesUpdateSemantic variablesUpdateSemantic;
   private String followUpDate;
   private long formKey;
   private String action;
@@ -238,6 +240,16 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     this.variables = variables;
   }
 
+  @Override
+  public UserTaskVariablesUpdateSemantic getVariableUpdateSemantics() {
+    return variablesUpdateSemantic;
+  }
+
+  public void setVariablesUpdateSemantic(
+      final UserTaskVariablesUpdateSemantic variablesUpdateSemantic) {
+    this.variablesUpdateSemantic = variablesUpdateSemantic;
+  }
+
   protected boolean canEqual(final Object other) {
     return other instanceof ZeebeUserTaskDataDto;
   }
@@ -314,6 +326,7 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     public static final String tenantId = "tenantId";
     public static final String changedAttributes = "changedAttributes";
     public static final String variables = "variables";
+    public static final String variablesUpdateSemantic = "variablesUpdateSemantic";
     public static final String followUpDate = "followUpDate";
     public static final String formKey = "formKey";
     public static final String action = "action";

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/UserTaskRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/UserTaskRecordValueImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.zeebeimport.v870.record.value;
 
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,6 +37,7 @@ public class UserTaskRecordValueImpl implements UserTaskRecordValue {
   private long processDefinitionKey;
 
   private Map<String, Object> variables;
+  private UserTaskVariablesUpdateSemantic variableUpdateSemantics;
 
   private String tenantId;
 
@@ -216,6 +218,16 @@ public class UserTaskRecordValueImpl implements UserTaskRecordValue {
   }
 
   @Override
+  public UserTaskVariablesUpdateSemantic getVariableUpdateSemantics() {
+    return variableUpdateSemantics;
+  }
+
+  public void setVariableUpdateSemantics(
+      final UserTaskVariablesUpdateSemantic variableUpdateSemantics) {
+    this.variableUpdateSemantics = variableUpdateSemantics;
+  }
+
+  @Override
   public String getTenantId() {
     return tenantId;
   }
@@ -249,6 +261,7 @@ public class UserTaskRecordValueImpl implements UserTaskRecordValue {
         processDefinitionVersion,
         processDefinitionKey,
         variables,
+        variableUpdateSemantics,
         tenantId,
         processInstanceKey,
         changedAttributes,
@@ -270,6 +283,7 @@ public class UserTaskRecordValueImpl implements UserTaskRecordValue {
         && processDefinitionVersion == that.processDefinitionVersion
         && processDefinitionKey == that.processDefinitionKey
         && processInstanceKey == that.processInstanceKey
+        && variableUpdateSemantics == that.variableUpdateSemantics
         && Objects.equals(assignee, that.assignee)
         && Objects.equals(candidateGroups, that.candidateGroups)
         && Objects.equals(candidateUsers, that.candidateUsers)
@@ -319,6 +333,8 @@ public class UserTaskRecordValueImpl implements UserTaskRecordValue {
         + processDefinitionKey
         + ", variables="
         + variables
+        + ", variableUpdateSemantics="
+        + variableUpdateSemantics
         + ", tenantId='"
         + tenantId
         + '\''

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -125,7 +125,10 @@ public final class VariableDocumentUpdateProcessor
 
       final var userTaskRecord = userTaskState.getUserTask(userTaskKey);
       if (hasVariables(value)) {
-        userTaskRecord.setVariables(value.getVariablesBuffer()).setVariablesChanged();
+        userTaskRecord
+            .setVariables(value.getVariablesBuffer())
+            .setVariablesChanged()
+            .setVariableUpdateSemantics(value.getUpdateSemantics());
       }
       writers.state().appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATING, userTaskRecord);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -48,9 +48,6 @@ public final class VariableDocumentUpdateProcessor
   private static final String INVALID_USER_TASK_STATE_MESSAGE =
       "Expected to trigger update transition for user task with key '%d', but it is in state '%s'";
 
-  private static final String USER_TASK_PROPAGATE_SEMANTIC_NOT_SUPPORTED =
-      "Expected to update variables for user task with key '%d', but updates with 'PROPAGATE' semantic are not supported yet.";
-
   private final ElementInstanceState elementInstanceState;
   private final MutableUserTaskState userTaskState;
   private final ProcessState processState;
@@ -115,15 +112,6 @@ public final class VariableDocumentUpdateProcessor
 
     if (isCamundaUserTask(scope)) {
       final long userTaskKey = scope.getUserTaskKey();
-      // Temporary check: to reject variable updates with 'PROPAGATE' semantic for a user task.
-      // This will be removed in the following PRs when support for propagation is implemented.
-      if (value.getUpdateSemantics() == VariableDocumentUpdateSemantic.PROPAGATE) {
-        final var reason = USER_TASK_PROPAGATE_SEMANTIC_NOT_SUPPORTED.formatted(userTaskKey);
-        writers.rejection().appendRejection(record, RejectionType.INVALID_ARGUMENT, reason);
-        writers.response().writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
-        return;
-      }
-
       final var lifecycleState = userTaskState.getLifecycleState(userTaskKey);
       if (lifecycleState != LifecycleState.CREATED) {
         final var reason = INVALID_USER_TASK_STATE_MESSAGE.formatted(userTaskKey, lifecycleState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -146,13 +146,28 @@ public final class VariableDocumentUpdateProcessor
         return;
       }
 
-      variableBehavior.mergeLocalDocument(
-          userTaskRecord.getElementInstanceKey(),
-          userTaskRecord.getProcessDefinitionKey(),
-          userTaskRecord.getProcessInstanceKey(),
-          userTaskRecord.getBpmnProcessIdBuffer(),
-          userTaskRecord.getTenantId(),
-          value.getVariablesBuffer());
+      switch (value.getUpdateSemantics()) {
+        case LOCAL ->
+            variableBehavior.mergeLocalDocument(
+                userTaskRecord.getElementInstanceKey(),
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                value.getVariablesBuffer());
+        case PROPAGATE ->
+            variableBehavior.mergeDocument(
+                userTaskRecord.getElementInstanceKey(),
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                value.getVariablesBuffer());
+        default ->
+            throw new IllegalStateException(
+                "Unexpected variable update semantic: '%s'. Expected either 'LOCAL' or 'PROPAGATE'."
+                    .formatted(value.getUpdateSemantics()));
+      }
 
       writers
           .state()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -1061,12 +1062,21 @@ public final class CamundaUserTaskTest {
             RecordingExporter.userTaskRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .limit(r -> r.getIntent() == UserTaskIntent.UPDATED))
-        .extracting(Record::getIntent, r -> r.getValue().getChangedAttributes())
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getChangedAttributes(),
+            r -> r.getValue().getVariableUpdateSemantics())
         .describedAs(
-            "Expect the user task to pass the update transition with variables as a changed attribute")
+            "Expect the user task to pass the update transition with variables as a changed attribute and LOCAL semantic")
         .containsSequence(
-            Tuple.tuple(UserTaskIntent.UPDATING, List.of(UserTaskRecord.VARIABLES)),
-            Tuple.tuple(UserTaskIntent.UPDATED, List.of(UserTaskRecord.VARIABLES)));
+            Tuple.tuple(
+                UserTaskIntent.UPDATING,
+                List.of(UserTaskRecord.VARIABLES),
+                UserTaskVariablesUpdateSemantic.LOCAL),
+            Tuple.tuple(
+                UserTaskIntent.UPDATED,
+                List.of(UserTaskRecord.VARIABLES),
+                UserTaskVariablesUpdateSemantic.LOCAL));
   }
 
   @Test
@@ -1115,11 +1125,20 @@ public final class CamundaUserTaskTest {
             RecordingExporter.userTaskRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .limit(r -> r.getIntent() == UserTaskIntent.UPDATED))
-        .extracting(Record::getIntent, r -> r.getValue().getChangedAttributes())
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getChangedAttributes(),
+            r -> r.getValue().getVariableUpdateSemantics())
         .describedAs(
-            "Expect the user task to pass the update transition with variables as a changed attribute")
+            "Expect the user task to pass the update transition with variables as a changed attribute and PROPAGATE semantic")
         .containsSequence(
-            Tuple.tuple(UserTaskIntent.UPDATING, List.of(UserTaskRecord.VARIABLES)),
-            Tuple.tuple(UserTaskIntent.UPDATED, List.of(UserTaskRecord.VARIABLES)));
+            Tuple.tuple(
+                UserTaskIntent.UPDATING,
+                List.of(UserTaskRecord.VARIABLES),
+                UserTaskVariablesUpdateSemantic.PROPAGATE),
+            Tuple.tuple(
+                UserTaskIntent.UPDATED,
+                List.of(UserTaskRecord.VARIABLES),
+                UserTaskVariablesUpdateSemantic.PROPAGATE));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -1015,38 +1015,6 @@ public final class CamundaUserTaskTest {
   }
 
   @Test
-  public void shouldRejectVariableUpdateWithPropagateSemanticForUserTask() {
-    // given
-    ENGINE.deployment().withXmlResource(process()).deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    final var createdUserTaskRecord =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-
-    // when: attempting to update variables with 'PROPAGATE' semantic for a user task instance
-    final var variableUpdateRejection =
-        ENGINE
-            .variables()
-            .ofScope(createdUserTaskRecord.getValue().getElementInstanceKey())
-            .withDocument(Map.of("approvalStatus", "SUBMITTED"))
-            .withPropagateSemantic()
-            .expectRejection()
-            .update();
-
-    // then
-    Assertions.assertThat(variableUpdateRejection)
-        .describedAs(
-            "Expect rejection when trying to update variables for a user task instance with 'PROPAGATE' semantic")
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasValueType(ValueType.VARIABLE_DOCUMENT)
-        .hasRejectionReason(
-            "Expected to update variables for user task with key '%d', but updates with 'PROPAGATE' semantic are not supported yet."
-                .formatted(createdUserTaskRecord.getKey()));
-  }
-
-  @Test
   public void
       shouldUpdateVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -1016,7 +1016,7 @@ public final class CamundaUserTaskTest {
 
   @Test
   public void
-      shouldUpdateVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
+      shouldUpdateLocalVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();
     final long processInstanceKey =
@@ -1057,6 +1057,60 @@ public final class CamundaUserTaskTest {
         .hasName("approvalStatus")
         .hasValue("\"SUBMITTED\"");
 
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.UPDATED))
+        .extracting(Record::getIntent, r -> r.getValue().getChangedAttributes())
+        .describedAs(
+            "Expect the user task to pass the update transition with variables as a changed attribute")
+        .containsSequence(
+            Tuple.tuple(UserTaskIntent.UPDATING, List.of(UserTaskRecord.VARIABLES)),
+            Tuple.tuple(UserTaskIntent.UPDATED, List.of(UserTaskRecord.VARIABLES)));
+  }
+
+  @Test
+  public void
+      shouldPropagateVariableUpdatesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
+    // given: a process with a user task and one process-level variable
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("approvalStatus", "PENDING"))
+            .create();
+
+    final var createdUserTaskRecord =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when: updating a process-level variable and creating a new one using `PROPAGATE` semantic
+    ENGINE
+        .variables()
+        .ofScope(createdUserTaskRecord.getValue().getElementInstanceKey())
+        .withDocument(
+            Map.of(
+                "approvalStatus", "SUBMITTED",
+                "reviewerComment", "LGTM"))
+        .withPropagateSemantic()
+        .update();
+
+    // then: process-level variables should be updated/created accordingly
+    assertThat(
+            RecordingExporter.variableRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getScopeKey(),
+            r -> r.getValue().getName(),
+            r -> r.getValue().getValue())
+        .contains(
+            tuple(VariableIntent.CREATED, processInstanceKey, "approvalStatus", "\"PENDING\""),
+            tuple(VariableIntent.UPDATED, processInstanceKey, "approvalStatus", "\"SUBMITTED\""),
+            tuple(VariableIntent.CREATED, processInstanceKey, "reviewerComment", "\"LGTM\""));
+
+    // and: user task should pass update transition with VARIABLES in changedAttributes
     assertThat(
             RecordingExporter.userTaskRecords()
                 .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -513,6 +514,8 @@ public class TaskListenerBlockedTransitionTest {
             Assertions.assertThat(userTask)
                 .hasVariables(Map.of("status", "APPROVED"))
                 .hasOnlyChangedAttributes(UserTaskRecord.VARIABLES)
+                .hasVariableUpdateSemantics(
+                    UserTaskVariablesUpdateSemantic.valueOf(semantic.name()))
                 .hasAction(""));
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -73,6 +73,9 @@
             "variables": {
               "enabled": false
             },
+            "variableUpdateSemantics": {
+              "type": "keyword"
+            },
             "customHeaders": {
               "enabled": false
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -73,6 +73,9 @@
             "variables": {
               "enabled": false
             },
+            "variableUpdateSemantics": {
+              "type": "keyword"
+            },
             "customHeaders": {
               "enabled": false
             },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -83,6 +83,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskVariablesUpdateSemantic;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -2398,6 +2399,7 @@ final class JsonSerializableToJsonTest {
                     .setFormKey(456)
                     .setExternalFormReference("myReference")
                     .setVariables(VARIABLES_MSGPACK)
+                    .setVariableUpdateSemantics(UserTaskVariablesUpdateSemantic.PROPAGATE)
                     .setCustomHeaders(
                         wrapArray(MsgPackConverter.convertToMsgPack(Map.of("foo", "bar"))))
                     .setChangedAttributes(List.of("foo", "bar"))
@@ -2429,6 +2431,7 @@ final class JsonSerializableToJsonTest {
         "variables": {
           "foo": "bar"
         },
+        "variableUpdateSemantics": "PROPAGATE",
         "customHeaders": {
           "foo": "bar"
         },
@@ -2465,6 +2468,7 @@ final class JsonSerializableToJsonTest {
         "changedAttributes": [],
         "externalFormReference": "",
         "variables": {},
+        "variableUpdateSemantics": "NULL",
         "customHeaders": {},
         "action": "",
         "formKey": -1,
@@ -2484,7 +2488,8 @@ final class JsonSerializableToJsonTest {
             () ->
                 new UserTaskRecord()
                     .setVariables(
-                        new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{'foo':null}"))),
+                        new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{'foo':null}")))
+                    .setVariableUpdateSemantics(VariableDocumentUpdateSemantic.LOCAL),
         """
       {
         "bpmnProcessId": "",
@@ -2504,6 +2509,7 @@ final class JsonSerializableToJsonTest {
         "variables": {
           "foo": null
         },
+        "variableUpdateSemantics": "LOCAL",
         "customHeaders": {},
         "action": "",
         "formKey": -1,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -84,7 +84,14 @@ public interface UserTaskRecordValue
   int getPriority();
 
   /**
+   * Note:Temporary default implementation is provided to avoid breaking builds in Optimize module
+   * that compile in parallel and rely on this interface. This will be replaced with an abstract
+   * method, and a real implementation will be added in {@code optimize/ZeebeUserTaskDataDto} in a
+   * subsequent PR.
+   *
    * @return the variable update semantics used when updating variables on the user task
    */
-  UserTaskVariablesUpdateSemantic getVariableUpdateSemantics();
+  default UserTaskVariablesUpdateSemantic getVariableUpdateSemantics() {
+    return UserTaskVariablesUpdateSemantic.NULL;
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -82,4 +82,9 @@ public interface UserTaskRecordValue
   long getProcessDefinitionKey();
 
   int getPriority();
+
+  /**
+   * @return the variable update semantics used when updating variables on the user task
+   */
+  UserTaskVariablesUpdateSemantic getVariableUpdateSemantics();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskVariablesUpdateSemantic.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskVariablesUpdateSemantic.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * Defines the semantics of a variable update for a user task.
+ *
+ * <p>This enum is used to indicate how variable updates should be applied when interacting with a
+ * user task, for example, via the SetVariables command.
+ *
+ * <ul>
+ *   <li>{@code NULL} – Unspecified or not set.
+ *   <li>{@code LOCAL} – Variables are set locally on the user task's element instance scope.
+ *   <li>{@code PROPAGATE} – Variables are propagated to the closest parent scope where the variable
+ *       is defined, or created at the process instance level if not yet defined.
+ * </ul>
+ */
+public enum UserTaskVariablesUpdateSemantic {
+  NULL,
+  LOCAL,
+  PROPAGATE,
+}


### PR DESCRIPTION
## Description
This PR introduces support for variable updates with `PROPAGATE` semantic, both when a user task has `"updating"` user task listeners and when it does not, and is based on this  [PoC](https://github.com/camunda/camunda/pull/31884).

Previously, the engine only supported triggering variable updates with `LOCAL` semantic. 

This enhancement ensures consistent propagation and handling of variable updates with both `LOCAL` and `PROPAGATE` semantics.

### Key changes
- Introduced a new `variableUpdateSemantic` field on `UserTaskRecord`;
- `VariableDocumentUpdateProcessor` now set this semantic on `UserTaskRecord`;
- `VariableDocumentUpdate` and `UserTaskUpdate` processor use the semantic to choose between `mergeLocalDocument` and `mergeDocument` for merging variables;
- Added tests to verify updates with `PROPAGATE` semantic.

> [!NOTE]  
> There's an alternative solution implemented in a separate PR (https://github.com/camunda/camunda/pull/32367), which avoids persisting `variableUpdateSemantic` on `UserTaskRecord`. It relies on reading the original `VariableDocumentRecord` retrieved from state and using `updateSemantics` property to determine how variables should be merged.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30053 
