### PR TITLE
ci: c8run - call workflow to get token for chp repo

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -25,6 +25,12 @@ permissions:
   statuses: write
 
 jobs:
+  generate-github-token:
+    uses: camunda/camunda-platform-helm/.github/workflows/generate-github-app-token.yaml@main
+    secrets:
+      GH_APP_ID: ${{ secrets.GH_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
   update-closed-at-field:
     name: Update closed at field
     runs-on: ubuntu-latest
@@ -40,20 +46,12 @@ jobs:
               echo "match=true" >> "$GITHUB_OUTPUT"
             fi
 
-        - name: Generate GitHub token
-          if: ${{ steps.vars.outputs.match == 'true' }}
-          uses: tibdex/github-app-token@v2
-          id: generate-github-token
-          with:
-            app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-            private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-
         - name: Update Closed At field
           if: ${{ steps.vars.outputs.match == 'true' }}
           uses: github/update-project-action@21f8a8478d7c5253e166ee62517d3a942b170fa4 # main
           id: update-closed-at
           with:
-            github_token: ${{ steps.generate-github-token.outputs.token }} }}
+            github_token: ${{ needs.generate-github-token.outputs.token }}
             organization: ${{ github.repository_owner }}
             project_number: ${{ steps.vars.outputs.project_id }}
             content_id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Trying to call the [reusable workflow for token generation](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/generate-github-app-token.yaml) in the camunda-platform helm repo - Goal is get a token to update issues camunda repo, pointing to a project in the camunda-platform-helm repo.

Related to https://github.com/camunda/team-distribution/issues/467

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
