### PR TITLE
fix: disable unwanted focus trap for actionable notification in configuration modal

### DIFF
--- a/optimize/client/src/components/Processes/ConfigureProcessModal.scss
+++ b/optimize/client/src/components/Processes/ConfigureProcessModal.scss
@@ -5,4 +5,10 @@
     display: flex;
     gap: spacing.$spacing-02;
   }
+
+  .cds--actionable-notification {
+    .cds--visually-hidden {
+      display: none;
+    }
+  }
 }

--- a/optimize/client/src/components/Processes/ConfigureProcessModal.tsx
+++ b/optimize/client/src/components/Processes/ConfigureProcessModal.tsx
@@ -62,6 +62,7 @@ export default function ConfigureProcessModal({
                 ),
               })}
               className="emailWarning"
+              role="div"
             />
           )}
           <UserTypeahead

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.js
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.js
@@ -258,6 +258,7 @@ export class AlertModal extends React.Component {
                           'self-managed/optimize-deployment/configuration/system-configuration/#email'
                         ),
                       })}
+                      role="div"
                     />
                   )}
                   <TextInput

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.scss
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.scss
@@ -9,8 +9,14 @@
     }
   }
 
-  .cds--actionable-notification__content {
-    display: inline;
+  .cds--actionable-notification {
+    .cds--visually-hidden {
+      display: none;
+    }
+
+    &__content {
+      display: inline;
+    }
   }
 
   .labelHidden {


### PR DESCRIPTION
## Description

Disabled unwanted focus trap for actionable notification inside configuration modal in Optimize, improving accessibility for keyboard-only users.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32245
