### PR TITLE
Optionally use basic authentication in benchmarks

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.config.AppCfg;
+import io.camunda.zeebe.config.AuthenticationMode;
 import io.camunda.zeebe.config.StarterCfg;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
@@ -226,6 +228,15 @@ public class Starter extends App {
 
     if (!appCfg.isTls()) {
       builder.usePlaintext();
+    }
+
+    if (appCfg.getAuthenticationMode().equals(AuthenticationMode.basic)) {
+      final var basicAuthCfg = appCfg.getBasicAuth();
+      builder.credentialsProvider(
+          new BasicAuthCredentialsProviderBuilder()
+              .username(basicAuthCfg.getUsername())
+              .password(basicAuthCfg.getPassword())
+              .build());
     }
 
     return builder.build();

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -20,7 +20,9 @@ import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.client.api.worker.JobWorkerMetrics;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.config.AppCfg;
+import io.camunda.zeebe.config.AuthenticationMode;
 import io.camunda.zeebe.config.WorkerCfg;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.Tags;
@@ -184,6 +186,15 @@ public class Worker extends App {
 
     if (!appCfg.isTls()) {
       builder.usePlaintext();
+    }
+
+    if (appCfg.getAuthenticationMode().equals(AuthenticationMode.basic)) {
+      final var basicAuthCfg = appCfg.getBasicAuth();
+      builder.credentialsProvider(
+          new BasicAuthCredentialsProviderBuilder()
+              .username(basicAuthCfg.getUsername())
+              .password(basicAuthCfg.getPassword())
+              .build());
     }
 
     return builder.build();

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -22,12 +22,14 @@ public class AppCfg {
   private int monitoringPort;
   private StarterCfg starter;
   private WorkerCfg worker;
+  private AuthenticationMode authenticationMode = AuthenticationMode.none;
+  private BasicAuthCfg basicAuth;
 
   public String getBrokerUrl() {
     return brokerUrl;
   }
 
-  public void setBrokerUrl(String brokerUrl) {
+  public void setBrokerUrl(final String brokerUrl) {
     this.brokerUrl = brokerUrl;
   }
 
@@ -43,7 +45,7 @@ public class AppCfg {
     return starter;
   }
 
-  public void setStarter(StarterCfg starter) {
+  public void setStarter(final StarterCfg starter) {
     this.starter = starter;
   }
 
@@ -51,7 +53,7 @@ public class AppCfg {
     return worker;
   }
 
-  public void setWorker(WorkerCfg worker) {
+  public void setWorker(final WorkerCfg worker) {
     this.worker = worker;
   }
 
@@ -59,7 +61,23 @@ public class AppCfg {
     return monitoringPort;
   }
 
-  public void setMonitoringPort(int monitoringPort) {
+  public void setMonitoringPort(final int monitoringPort) {
     this.monitoringPort = monitoringPort;
+  }
+
+  public AuthenticationMode getAuthenticationMode() {
+    return authenticationMode;
+  }
+
+  public void setAuthenticationMode(final AuthenticationMode authenticationMode) {
+    this.authenticationMode = authenticationMode;
+  }
+
+  public BasicAuthCfg getBasicAuth() {
+    return basicAuth;
+  }
+
+  public void setBasicAuth(final BasicAuthCfg basicAuth) {
+    this.basicAuth = basicAuth;
   }
 }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthenticationMode.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AuthenticationMode.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.config;
+
+public enum AuthenticationMode {
+  none,
+  basic
+}

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/BasicAuthCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/BasicAuthCfg.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.config;
+
+public class BasicAuthCfg {
+  private String username;
+  private String password;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+}

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -3,6 +3,12 @@ app {
   brokerUrl = ${?ZEEBE_ADDRESS}
   tls = false
   monitoringPort = 9600
+  authenticationMode = "none"
+
+  basicAuth{
+    username = "demo"
+    password = "demo"
+  }
 
   starter {
     processId = "benchmark"

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -32,6 +32,13 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.getAuthenticationMode()).isEqualTo(AuthenticationMode.none);
+
+    // basic auth
+    final var basicAuthCfg = appCfg.getBasicAuth();
+    assertThat(basicAuthCfg).isNotNull();
+    assertThat(basicAuthCfg.getUsername()).isEqualTo("demo");
+    assertThat(basicAuthCfg.getPassword()).isEqualTo("demo");
 
     // starter
     final var starterCfg = appCfg.getStarter();
@@ -79,6 +86,13 @@ public class ConfigTest {
     assertThat(appCfg.getBrokerUrl()).isEqualTo("localhost:26500");
     assertThat(appCfg.isTls()).isFalse();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
+    assertThat(appCfg.getAuthenticationMode()).isEqualTo(AuthenticationMode.basic);
+
+    // basic auth
+    final var basicAuthCfg = appCfg.getBasicAuth();
+    assertThat(basicAuthCfg).isNotNull();
+    assertThat(basicAuthCfg.getUsername()).isEqualTo("zeebe");
+    assertThat(basicAuthCfg.getPassword()).isEqualTo("ebeez");
 
     // starter
     final var starterCfg = appCfg.getStarter();

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -3,6 +3,12 @@ app {
   brokerUrl = ${?ZEEBE_ADDRESS}
   tls = false
   monitoringPort = 9600
+  authenticationMode = "basic"
+
+  basicAuth {
+    username = "zeebe"
+    password = "ebeez"
+  }
 
   starter {
     processId = "benchmark"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetrics.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static io.camunda.zeebe.engine.metrics.AuthorizationCheckMetricsDoc.AUTHORIZATION_CHECK_TIME;
+import static io.camunda.zeebe.engine.metrics.AuthorizationCheckMetricsDoc.GET_AUTHORIZED_RESORCE_IDENTIFIER_TIME;
+
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public final class AuthorizationCheckMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final Map<ResourceTypePermissionType, ResourcePermissionAuthorizationCheckMetrics>
+      metricsMap = new HashMap<>();
+
+  public AuthorizationCheckMetrics(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void startAuthorizationCheck(
+      final long key,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    getMetrics(resourceType, permissionType).startAuthorizationCheck(key);
+  }
+
+  public void stopAuthorizationCheck(
+      final long key,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    getMetrics(resourceType, permissionType).stopAuthorizationCheck(key);
+  }
+
+  public void startGettingResourceIdentifiers(
+      final long key,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    getMetrics(resourceType, permissionType).startGettingResourceIdentifiers(key);
+  }
+
+  public void stopGettingResourceIdentifiers(
+      final long key,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    getMetrics(resourceType, permissionType).stopGettingResourceIdentifiers(key);
+  }
+
+  private ResourcePermissionAuthorizationCheckMetrics getMetrics(
+      final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+    return metricsMap.computeIfAbsent(
+        new ResourceTypePermissionType(resourceType, permissionType),
+        k ->
+            new ResourcePermissionAuthorizationCheckMetrics(
+                meterRegistry, resourceType, permissionType));
+  }
+
+  private record ResourceTypePermissionType(
+      AuthorizationResourceType resourceType, PermissionType permissionType) {}
+
+  private static final class ResourcePermissionAuthorizationCheckMetrics {
+    private final Map<Long, Long> pendingChecksMap = new HashMap<>();
+    private final Map<Long, Long> getIdentifierMap = new HashMap<>();
+    private final Timer authCheckTimer;
+    private final Timer getResourceIdentifiersTimer;
+
+    public ResourcePermissionAuthorizationCheckMetrics(
+        final MeterRegistry meterRegistry,
+        final AuthorizationResourceType resourceType,
+        final PermissionType permissionType) {
+      authCheckTimer =
+          MicrometerUtil.buildTimer(AUTHORIZATION_CHECK_TIME)
+              .tag("resourceType", resourceType.name())
+              .tag("permissionType", permissionType.name())
+              .register(meterRegistry);
+      getResourceIdentifiersTimer =
+          MicrometerUtil.buildTimer(GET_AUTHORIZED_RESORCE_IDENTIFIER_TIME)
+              .tag("resourceType", resourceType.name())
+              .tag("permissionType", permissionType.name())
+              .register(meterRegistry);
+    }
+
+    public void startAuthorizationCheck(final long key) {
+      pendingChecksMap.put(key, System.nanoTime());
+    }
+
+    public void stopAuthorizationCheck(final long key) {
+      final long startTime = pendingChecksMap.remove(key);
+      observeAuthorizationCheckTime(startTime, System.nanoTime());
+    }
+
+    private void observeAuthorizationCheckTime(final long startTime, final long endTime) {
+      authCheckTimer.record(endTime - startTime, TimeUnit.NANOSECONDS);
+    }
+
+    public void startGettingResourceIdentifiers(final long key) {
+      getIdentifierMap.put(key, System.nanoTime());
+    }
+
+    public void stopGettingResourceIdentifiers(final long key) {
+      final long startTime = getIdentifierMap.remove(key);
+      observeGetResourceIdentifiersTime(startTime, System.nanoTime());
+    }
+
+    private void observeGetResourceIdentifiersTime(final long startTime, final long endTime) {
+      getResourceIdentifiersTimer.record(endTime - startTime, TimeUnit.NANOSECONDS);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/AuthorizationCheckMetricsDoc.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+public enum AuthorizationCheckMetricsDoc implements ExtendedMeterDocumentation {
+  AUTHORIZATION_CHECK_TIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(50),
+      Duration.ofNanos(75),
+      Duration.ofNanos(100),
+      Duration.ofNanos(250),
+      Duration.ofNanos(500),
+      Duration.ofNanos(750),
+      Duration.ofNanos(1000),
+      Duration.ofNanos(1500),
+      Duration.ofNanos(2000),
+      Duration.ofNanos(4000),
+      Duration.ofNanos(6000),
+      Duration.ofNanos(10000)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The time took to do the authorization checks";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.authorization.check.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  GET_AUTHORIZED_RESORCE_IDENTIFIER_TIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(50),
+      Duration.ofNanos(75),
+      Duration.ofNanos(100),
+      Duration.ofNanos(250),
+      Duration.ofNanos(500),
+      Duration.ofNanos(750),
+      Duration.ofNanos(1000),
+      Duration.ofNanos(1500),
+      Duration.ofNanos(2000),
+      Duration.ofNanos(4000),
+      Duration.ofNanos(6000),
+      Duration.ofNanos(10000)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The time took to retrieve the resource ids. Used when activating jobs";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.authorization.get.identifiers.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSetupProcessors;
@@ -122,7 +123,11 @@ public final class EngineProcessors {
     final var decisionBehavior =
         new DecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
-    final var authCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+
+    final var authCheckMetrics =
+        new AuthorizationCheckMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var authCheckBehavior =
+        new AuthorizationCheckBehavior(processingState, securityConfig, authCheckMetrics);
     final var transientProcessMessageSubscriptionState =
         typedRecordProcessorContext.getTransientProcessMessageSubscriptionState();
     final BpmnBehaviorsImpl bpmnBehaviors =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
@@ -83,7 +84,9 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var multiTenancyConfig = new MultiTenancyConfiguration();
     multiTenancyConfig.setEnabled(true);
     securityConfig.setMultiTenancy(multiTenancyConfig);
-    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(
+            processingState, securityConfig, mock(AuthorizationCheckMetrics.class));
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingCreatedApplier = new MappingCreatedApplier(processingState.getMappingState());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.AuthorizationsConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
@@ -73,7 +74,9 @@ final class AuthorizationCheckBehaviorTest {
     final var authConfig = new AuthorizationsConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
-    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+    authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(
+            processingState, securityConfig, mock(AuthorizationCheckMetrics.class));
 
     userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
     mappingCreatedApplier = new MappingCreatedApplier(processingState.getMappingState());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -60,7 +62,8 @@ final class JobBatchCollectorTest {
   @BeforeEach
   void beforeEach() {
     final var authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(state, new SecurityConfiguration());
+        new AuthorizationCheckBehavior(
+            state, new SecurityConfiguration(), mock(AuthorizationCheckMetrics.class));
     collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This commit adds configuration options to enable basic the use of basic auth in the starter and worker. I chose to add an enum AuthenticationMode, as I expect in the near-future we may want to add OIDC as well.

When the authentication mode is set to BASIC we provide a credentials provider to the camunda client. This credentials provider takes a configured username/password and adds it to requests made.

By default, we stick to no authentication. If basic auth is enabled and no credentials are configured we will be using demo/demo. This are the default credentials used for camunda run.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
