### PR TITLE
feat: Support `PROPAGATE` variable updates for user task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -90,61 +90,62 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
           "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
           userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-    } else {
-      final var metadata = recordRequestMetadata.get();
-      switch (metadata.getTriggerType()) {
-        case USER_TASK -> {
-          stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-          responseWriter.writeResponse(
-              userTaskKey,
-              UserTaskIntent.UPDATED,
-              userTaskRecord,
-              ValueType.USER_TASK,
-              metadata.getRequestId(),
-              metadata.getRequestStreamId());
-        }
-        case VARIABLE_DOCUMENT ->
-            // Update triggered by a VariableDocument command.
-            // Retrieve the original VariableDocumentRecord to apply correct variable
-            // merge logic and write follow-up event.
-            variableState
-                .findVariableDocumentState(userTaskRecord.getElementInstanceKey())
-                .ifPresentOrElse(
-                    variableDocumentState -> {
-                      final var variableDocumentRecord = variableDocumentState.getRecord();
-                      mergeVariables(userTaskRecord, variableDocumentRecord);
+      return;
+    }
 
-                      // Write follow-up events
-                      stateWriter.appendFollowUpEvent(
-                          userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-                      final long variableDocumentKey = variableDocumentState.getKey();
-                      stateWriter.appendFollowUpEvent(
-                          variableDocumentKey,
-                          VariableDocumentIntent.UPDATED,
-                          variableDocumentRecord);
-
-                      responseWriter.writeResponse(
-                          variableDocumentKey,
-                          VariableDocumentIntent.UPDATED,
-                          variableDocumentRecord,
-                          ValueType.VARIABLE_DOCUMENT,
-                          metadata.getRequestId(),
-                          metadata.getRequestStreamId());
-                    },
-                    () -> {
-                      LOGGER.warn(
-                          "No VariableDocumentState found for elementInstanceKey={} during task update. "
-                              + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
-                          userTaskRecord.getElementInstanceKey());
-
-                      stateWriter.appendFollowUpEvent(
-                          userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-                    });
-        default ->
-            throw new IllegalArgumentException(
-                "Unexpected user task transition trigger type: '%s'"
-                    .formatted(metadata.getTriggerType()));
+    final var metadata = recordRequestMetadata.get();
+    switch (metadata.getTriggerType()) {
+      case USER_TASK -> {
+        stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+        responseWriter.writeResponse(
+            userTaskKey,
+            UserTaskIntent.UPDATED,
+            userTaskRecord,
+            ValueType.USER_TASK,
+            metadata.getRequestId(),
+            metadata.getRequestStreamId());
       }
+      case VARIABLE_DOCUMENT ->
+          // Update triggered by a VariableDocument command.
+          // Retrieve the original VariableDocumentRecord to apply correct variable
+          // merge logic and write follow-up event.
+          variableState
+              .findVariableDocumentState(userTaskRecord.getElementInstanceKey())
+              .ifPresentOrElse(
+                  variableDocumentState -> {
+                    final var variableDocumentRecord = variableDocumentState.getRecord();
+                    mergeVariables(userTaskRecord, variableDocumentRecord);
+
+                    // Write follow-up events
+                    stateWriter.appendFollowUpEvent(
+                        userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+                    final long variableDocumentKey = variableDocumentState.getKey();
+                    stateWriter.appendFollowUpEvent(
+                        variableDocumentKey,
+                        VariableDocumentIntent.UPDATED,
+                        variableDocumentRecord);
+
+                    responseWriter.writeResponse(
+                        variableDocumentKey,
+                        VariableDocumentIntent.UPDATED,
+                        variableDocumentRecord,
+                        ValueType.VARIABLE_DOCUMENT,
+                        metadata.getRequestId(),
+                        metadata.getRequestStreamId());
+                  },
+                  () -> {
+                    LOGGER.warn(
+                        "No VariableDocumentState found for elementInstanceKey={} during task update. "
+                            + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
+                        userTaskRecord.getElementInstanceKey());
+
+                    stateWriter.appendFollowUpEvent(
+                        userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+                  });
+      default ->
+          throw new IllegalArgumentException(
+              "Unexpected user task transition trigger type: '%s'"
+                  .formatted(metadata.getTriggerType()));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -87,8 +87,10 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
     final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
     if (recordRequestMetadata.isEmpty()) {
       LOGGER.error(
-          "Bug: No request metadata found for userTaskKey='{}', writing 'USER_TASK.UPDATED' without response. "
-              + "This may indicate a problem with how the update was triggered. Please investigate.",
+          "No request metadata found for userTaskKey='{}', writing 'USER_TASK.UPDATED' without response. "
+              + "This may indicate a problem with how the update was triggered. "
+              + "If the update was triggered by a user task variables update, variables will not be merged. "
+              + "Please report this as a bug.",
           userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
       return;
@@ -114,9 +116,10 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
             variableState.findVariableDocumentState(userTaskRecord.getElementInstanceKey());
         if (optionalVariableDocumentState.isEmpty()) {
           LOGGER.error(
-              "Bug: No VariableDocumentState found for elementInstanceKey='{}' during a task update triggered by user task variables update. "
+              "No variable document state found for elementInstanceKey='{}' during a task update triggered by a user task variables update. "
                   + "No variables will be merged, and only 'USER_TASK.UPDATED' will be written. "
-                  + "This may be caused by a corrupted or incomplete variable update request. Please investigate.",
+                  + "This may be caused by a corrupted or incomplete variable update request. "
+                  + "Please report this as a bug.",
               userTaskRecord.getElementInstanceKey());
           stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
           return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -81,75 +81,74 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
       responseWriter.writeEventOnCommand(
           userTaskKey, UserTaskIntent.UPDATED, userTaskRecord, command);
-    } else {
-      userTaskState
-          .findRecordRequestMetadata(userTaskKey)
-          .ifPresentOrElse(
-              metadata -> {
-                switch (metadata.getTriggerType()) {
-                  case USER_TASK -> {
-                    stateWriter.appendFollowUpEvent(
-                        userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-                    responseWriter.writeResponse(
-                        userTaskKey,
-                        UserTaskIntent.UPDATED,
-                        userTaskRecord,
-                        ValueType.USER_TASK,
-                        metadata.getRequestId(),
-                        metadata.getRequestStreamId());
-                  }
-                  case VARIABLE_DOCUMENT ->
-                      // Update triggered by a VariableDocument command.
-                      // Retrieve the original VariableDocumentRecord to apply correct variable
-                      // merge logic and write follow-up event.
-                      variableState
-                          .findVariableDocumentState(userTaskRecord.getElementInstanceKey())
-                          .ifPresentOrElse(
-                              variableDocumentState -> {
-                                final var variableDocumentRecord =
-                                    variableDocumentState.getRecord();
-                                mergeVariables(userTaskRecord, variableDocumentRecord);
-
-                                // Write follow-up events
-                                stateWriter.appendFollowUpEvent(
-                                    userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-                                final long variableDocumentKey = variableDocumentState.getKey();
-                                stateWriter.appendFollowUpEvent(
-                                    variableDocumentKey,
-                                    VariableDocumentIntent.UPDATED,
-                                    variableDocumentRecord);
-
-                                responseWriter.writeResponse(
-                                    variableDocumentKey,
-                                    VariableDocumentIntent.UPDATED,
-                                    variableDocumentRecord,
-                                    ValueType.VARIABLE_DOCUMENT,
-                                    metadata.getRequestId(),
-                                    metadata.getRequestStreamId());
-                              },
-                              () -> {
-                                LOGGER.warn(
-                                    "No VariableDocumentState found for elementInstanceKey={} during task update. "
-                                        + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
-                                    userTaskRecord.getElementInstanceKey());
-
-                                stateWriter.appendFollowUpEvent(
-                                    userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-                              });
-                  default ->
-                      throw new IllegalArgumentException(
-                          "Unexpected user task transition trigger type: '%s'"
-                              .formatted(metadata.getTriggerType()));
-                }
-              },
-              () -> {
-                LOGGER.warn(
-                    "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
-                    userTaskKey);
-                stateWriter.appendFollowUpEvent(
-                    userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-              });
+      return;
     }
+
+    userTaskState
+        .findRecordRequestMetadata(userTaskKey)
+        .ifPresentOrElse(
+            metadata -> {
+              switch (metadata.getTriggerType()) {
+                case USER_TASK -> {
+                  stateWriter.appendFollowUpEvent(
+                      userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+                  responseWriter.writeResponse(
+                      userTaskKey,
+                      UserTaskIntent.UPDATED,
+                      userTaskRecord,
+                      ValueType.USER_TASK,
+                      metadata.getRequestId(),
+                      metadata.getRequestStreamId());
+                }
+                case VARIABLE_DOCUMENT ->
+                    // Update triggered by a VariableDocument command.
+                    // Retrieve the original VariableDocumentRecord to apply correct variable
+                    // merge logic and write follow-up event.
+                    variableState
+                        .findVariableDocumentState(userTaskRecord.getElementInstanceKey())
+                        .ifPresentOrElse(
+                            variableDocumentState -> {
+                              final var variableDocumentRecord = variableDocumentState.getRecord();
+                              mergeVariables(userTaskRecord, variableDocumentRecord);
+
+                              // Write follow-up events
+                              stateWriter.appendFollowUpEvent(
+                                  userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+                              final long variableDocumentKey = variableDocumentState.getKey();
+                              stateWriter.appendFollowUpEvent(
+                                  variableDocumentKey,
+                                  VariableDocumentIntent.UPDATED,
+                                  variableDocumentRecord);
+
+                              responseWriter.writeResponse(
+                                  variableDocumentKey,
+                                  VariableDocumentIntent.UPDATED,
+                                  variableDocumentRecord,
+                                  ValueType.VARIABLE_DOCUMENT,
+                                  metadata.getRequestId(),
+                                  metadata.getRequestStreamId());
+                            },
+                            () -> {
+                              LOGGER.warn(
+                                  "No VariableDocumentState found for elementInstanceKey={} during task update. "
+                                      + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
+                                  userTaskRecord.getElementInstanceKey());
+
+                              stateWriter.appendFollowUpEvent(
+                                  userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+                            });
+                default ->
+                    throw new IllegalArgumentException(
+                        "Unexpected user task transition trigger type: '%s'"
+                            .formatted(metadata.getTriggerType()));
+              }
+            },
+            () -> {
+              LOGGER.warn(
+                  "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
+                  userTaskKey);
+              stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+            });
   }
 
   private void mergeVariables(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -85,7 +85,12 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
     }
 
     final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
-    if (recordRequestMetadata.isPresent()) {
+    if (recordRequestMetadata.isEmpty()) {
+      LOGGER.warn(
+          "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
+          userTaskKey);
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+    } else {
       final var metadata = recordRequestMetadata.get();
       switch (metadata.getTriggerType()) {
         case USER_TASK -> {
@@ -140,11 +145,6 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
                 "Unexpected user task transition trigger type: '%s'"
                     .formatted(metadata.getTriggerType()));
       }
-    } else {
-      LOGGER.warn(
-          "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
-          userTaskKey);
-      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -86,8 +86,9 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
 
     final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
     if (recordRequestMetadata.isEmpty()) {
-      LOGGER.warn(
-          "No request metadata found for userTaskKey={}, writing 'USER_TASK.UPDATED' without response.",
+      LOGGER.error(
+          "Bug: No request metadata found for userTaskKey='{}', writing 'USER_TASK.UPDATED' without response. "
+              + "This may indicate a problem with how the update was triggered. Please investigate.",
           userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
       return;
@@ -109,13 +110,13 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
         // Update triggered by a VariableDocument command.
         // Retrieve the original VariableDocumentRecord to apply correct variable
         // merge logic and write follow-up event.
-
         final var optionalVariableDocumentState =
             variableState.findVariableDocumentState(userTaskRecord.getElementInstanceKey());
         if (optionalVariableDocumentState.isEmpty()) {
-          LOGGER.warn(
-              "No VariableDocumentState found for elementInstanceKey={} during task update. "
-                  + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
+          LOGGER.error(
+              "Bug: No VariableDocumentState found for elementInstanceKey='{}' during a task update triggered by user task variables update. "
+                  + "No variables will be merged, and only 'USER_TASK.UPDATED' will be written. "
+                  + "This may be caused by a corrupted or incomplete variable update request. Please investigate.",
               userTaskRecord.getElementInstanceKey());
           stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
           return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -117,27 +117,27 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               "No VariableDocumentState found for elementInstanceKey={} during task update. "
                   + "Skipping variable merge, only writing 'USER_TASK.UPDATED'.",
               userTaskRecord.getElementInstanceKey());
-
           stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-        } else {
-          final var variableDocumentState = optionalVariableDocumentState.get();
-          final var variableDocumentRecord = variableDocumentState.getRecord();
-          mergeVariables(userTaskRecord, variableDocumentRecord);
-
-          // Write follow-up events
-          stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-          final long variableDocumentKey = variableDocumentState.getKey();
-          stateWriter.appendFollowUpEvent(
-              variableDocumentKey, VariableDocumentIntent.UPDATED, variableDocumentRecord);
-
-          responseWriter.writeResponse(
-              variableDocumentKey,
-              VariableDocumentIntent.UPDATED,
-              variableDocumentRecord,
-              ValueType.VARIABLE_DOCUMENT,
-              metadata.getRequestId(),
-              metadata.getRequestStreamId());
+          return;
         }
+
+        final var variableDocumentState = optionalVariableDocumentState.get();
+        final var variableDocumentRecord = variableDocumentState.getRecord();
+        mergeVariables(userTaskRecord, variableDocumentRecord);
+
+        // Write follow-up events
+        stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
+        final long variableDocumentKey = variableDocumentState.getKey();
+        stateWriter.appendFollowUpEvent(
+            variableDocumentKey, VariableDocumentIntent.UPDATED, variableDocumentRecord);
+
+        responseWriter.writeResponse(
+            variableDocumentKey,
+            VariableDocumentIntent.UPDATED,
+            variableDocumentRecord,
+            ValueType.VARIABLE_DOCUMENT,
+            metadata.getRequestId(),
+            metadata.getRequestStreamId());
       }
       default ->
           throw new IllegalArgumentException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -48,9 +48,6 @@ public final class VariableDocumentUpdateProcessor
   private static final String INVALID_USER_TASK_STATE_MESSAGE =
       "Expected to trigger update transition for user task with key '%d', but it is in state '%s'";
 
-  private static final String USER_TASK_PROPAGATE_SEMANTIC_NOT_SUPPORTED =
-      "Expected to update variables for user task with key '%d', but updates with 'PROPAGATE' semantic are not supported yet.";
-
   private final ElementInstanceState elementInstanceState;
   private final MutableUserTaskState userTaskState;
   private final ProcessState processState;
@@ -115,15 +112,6 @@ public final class VariableDocumentUpdateProcessor
 
     if (isCamundaUserTask(scope)) {
       final long userTaskKey = scope.getUserTaskKey();
-      // Temporary check: to reject variable updates with 'PROPAGATE' semantic for a user task.
-      // This will be removed in the following PRs when support for propagation is implemented.
-      if (value.getUpdateSemantics() == VariableDocumentUpdateSemantic.PROPAGATE) {
-        final var reason = USER_TASK_PROPAGATE_SEMANTIC_NOT_SUPPORTED.formatted(userTaskKey);
-        writers.rejection().appendRejection(record, RejectionType.INVALID_ARGUMENT, reason);
-        writers.response().writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
-        return;
-      }
-
       final var lifecycleState = userTaskState.getLifecycleState(userTaskKey);
       if (lifecycleState != LifecycleState.CREATED) {
         final var reason = INVALID_USER_TASK_STATE_MESSAGE.formatted(userTaskKey, lifecycleState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -146,13 +146,28 @@ public final class VariableDocumentUpdateProcessor
         return;
       }
 
-      variableBehavior.mergeLocalDocument(
-          userTaskRecord.getElementInstanceKey(),
-          userTaskRecord.getProcessDefinitionKey(),
-          userTaskRecord.getProcessInstanceKey(),
-          userTaskRecord.getBpmnProcessIdBuffer(),
-          userTaskRecord.getTenantId(),
-          value.getVariablesBuffer());
+      switch (value.getUpdateSemantics()) {
+        case LOCAL ->
+            variableBehavior.mergeLocalDocument(
+                userTaskRecord.getElementInstanceKey(),
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                value.getVariablesBuffer());
+        case PROPAGATE ->
+            variableBehavior.mergeDocument(
+                userTaskRecord.getElementInstanceKey(),
+                userTaskRecord.getProcessDefinitionKey(),
+                userTaskRecord.getProcessInstanceKey(),
+                userTaskRecord.getBpmnProcessIdBuffer(),
+                userTaskRecord.getTenantId(),
+                value.getVariablesBuffer());
+        default ->
+            throw new IllegalStateException(
+                "Unexpected variable update semantic: '%s'. Expected either 'LOCAL' or 'PROPAGATE'."
+                    .formatted(value.getUpdateSemantics()));
+      }
 
       writers
           .state()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -1015,38 +1015,6 @@ public final class CamundaUserTaskTest {
   }
 
   @Test
-  public void shouldRejectVariableUpdateWithPropagateSemanticForUserTask() {
-    // given
-    ENGINE.deployment().withXmlResource(process()).deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    final var createdUserTaskRecord =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-
-    // when: attempting to update variables with 'PROPAGATE' semantic for a user task instance
-    final var variableUpdateRejection =
-        ENGINE
-            .variables()
-            .ofScope(createdUserTaskRecord.getValue().getElementInstanceKey())
-            .withDocument(Map.of("approvalStatus", "SUBMITTED"))
-            .withPropagateSemantic()
-            .expectRejection()
-            .update();
-
-    // then
-    Assertions.assertThat(variableUpdateRejection)
-        .describedAs(
-            "Expect rejection when trying to update variables for a user task instance with 'PROPAGATE' semantic")
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasValueType(ValueType.VARIABLE_DOCUMENT)
-        .hasRejectionReason(
-            "Expected to update variables for user task with key '%d', but updates with 'PROPAGATE' semantic are not supported yet."
-                .formatted(createdUserTaskRecord.getKey()));
-  }
-
-  @Test
   public void
       shouldUpdateVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CamundaUserTaskTest.java
@@ -1016,7 +1016,7 @@ public final class CamundaUserTaskTest {
 
   @Test
   public void
-      shouldUpdateVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
+      shouldUpdateLocalVariablesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();
     final long processInstanceKey =
@@ -1057,6 +1057,60 @@ public final class CamundaUserTaskTest {
         .hasName("approvalStatus")
         .hasValue("\"SUBMITTED\"");
 
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.UPDATED))
+        .extracting(Record::getIntent, r -> r.getValue().getChangedAttributes())
+        .describedAs(
+            "Expect the user task to pass the update transition with variables as a changed attribute")
+        .containsSequence(
+            Tuple.tuple(UserTaskIntent.UPDATING, List.of(UserTaskRecord.VARIABLES)),
+            Tuple.tuple(UserTaskIntent.UPDATED, List.of(UserTaskRecord.VARIABLES)));
+  }
+
+  @Test
+  public void
+      shouldPropagateVariableUpdatesAndPassUserTaskUpdateTransitionWhenUserTaskHasNoUpdatingListeners() {
+    // given: a process with a user task and one process-level variable
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("approvalStatus", "PENDING"))
+            .create();
+
+    final var createdUserTaskRecord =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when: updating a process-level variable and creating a new one using `PROPAGATE` semantic
+    ENGINE
+        .variables()
+        .ofScope(createdUserTaskRecord.getValue().getElementInstanceKey())
+        .withDocument(
+            Map.of(
+                "approvalStatus", "SUBMITTED",
+                "reviewerComment", "LGTM"))
+        .withPropagateSemantic()
+        .update();
+
+    // then: process-level variables should be updated/created accordingly
+    assertThat(
+            RecordingExporter.variableRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+        .extracting(
+            Record::getIntent,
+            r -> r.getValue().getScopeKey(),
+            r -> r.getValue().getName(),
+            r -> r.getValue().getValue())
+        .contains(
+            tuple(VariableIntent.CREATED, processInstanceKey, "approvalStatus", "\"PENDING\""),
+            tuple(VariableIntent.UPDATED, processInstanceKey, "approvalStatus", "\"SUBMITTED\""),
+            tuple(VariableIntent.CREATED, processInstanceKey, "reviewerComment", "\"LGTM\""));
+
+    // and: user task should pass update transition with VARIABLES in changedAttributes
     assertThat(
             RecordingExporter.userTaskRecords()
                 .withProcessInstanceKey(processInstanceKey)


### PR DESCRIPTION
## Description
This PR introduces support for variable updates with `PROPAGATE` semantic for user tasks, **based on Option 1** from [this discussion](https://camunda.slack.com/archives/C0622NWC9LK/p1742231724058349?thread_ts=1741972997.669529&cid=C0622NWC9LK).

This approach reuses the `VariableDocumentRecord` that was persisted on handling `VARIABLE_DOUCMENT:UPDATE` command to determine the semantic at runtime in `UserTaskUpdateProcessor#onFinalizeCommand`.

This allows the engine to properly merge variables (`mergeLocalDocument` or `mergeDocument`).

Support for `PROPAGATE` semantic implemented according to [Option 1](https://camunda.slack.com/archives/C0622NWC9LK/p1742231724058349?thread_ts=1741972997.669529&cid=C0622NWC9LK):
* Listeners see all variables (including those to be propagated to higher scopes).
* No variables are set if the update is denied by the listener.

### Key changes
- `UserTaskUpdateProcessor` reads the persisted `VariableDocumentRecord` when available and uses its `updateSemantics` to perform the appropriate merge logic.
- Fallback logic and logging added for cases where metadata or the document state is unavailable.
- Added tests to verify updates with `PROPAGATE` semantic.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30053 
