### PR TITLE
fix: fix type of batchOperationKey in camunda-client API to String

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2124,14 +2124,14 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newBatchOperationGetRequest(batchOperationKey)
+   *  .newBatchOperationGetRequest(batchOperationId)
    *  .send();
    * </pre>
    *
-   * @param batchOperationKey the key which identifies the corresponding batch operation
+   * @param batchOperationId the key which identifies the corresponding batch operation
    * @return a builder for the request
    */
-  BatchOperationGetRequest newBatchOperationGetRequest(Long batchOperationKey);
+  BatchOperationGetRequest newBatchOperationGetRequest(String batchOperationId);
 
   /**
    * Executes a search request to query batch operations.

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateBatchOperationResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateBatchOperationResponse.java
@@ -17,5 +17,5 @@ package io.camunda.client.api.response;
 
 public interface CreateBatchOperationResponse {
 
-  long getBatchOperationKey();
+  String getBatchOperationId();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1115,8 +1115,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public BatchOperationGetRequest newBatchOperationGetRequest(final Long batchOperationKey) {
-    return new BatchOperationGetRequestImpl(httpClient, batchOperationKey);
+  public BatchOperationGetRequest newBatchOperationGetRequest(final String batchOperationId) {
+    return new BatchOperationGetRequestImpl(httpClient, batchOperationId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/BatchOperationGetRequestImpl.java
@@ -31,12 +31,12 @@ public class BatchOperationGetRequestImpl implements BatchOperationGetRequest {
 
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final long batchOperationKey;
+  private final String batchOperationId;
 
-  public BatchOperationGetRequestImpl(final HttpClient httpClient, final long batchOperationKey) {
+  public BatchOperationGetRequestImpl(final HttpClient httpClient, final String batchOperationId) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
-    this.batchOperationKey = batchOperationKey;
+    this.batchOperationId = batchOperationId;
   }
 
   @Override
@@ -49,7 +49,7 @@ public class BatchOperationGetRequestImpl implements BatchOperationGetRequest {
   public CamundaFuture<BatchOperation> send() {
     final HttpCamundaFuture<BatchOperation> result = new HttpCamundaFuture<>();
     httpClient.get(
-        String.format("/batch-operations/%d", batchOperationKey),
+        String.format("/batch-operations/%s", batchOperationId),
         httpRequestConfig.build(),
         BatchOperationResponse.class,
         SearchResponseMapper::toBatchOperationGetResponse,

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateBatchOperationResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateBatchOperationResponseImpl.java
@@ -20,15 +20,15 @@ import io.camunda.client.protocol.rest.BatchOperationCreatedResult;
 
 public class CreateBatchOperationResponseImpl implements CreateBatchOperationResponse {
 
-  private long batchOperationKey;
+  private String batchOperationId;
 
   @Override
-  public long getBatchOperationKey() {
-    return batchOperationKey;
+  public String getBatchOperationId() {
+    return batchOperationId;
   }
 
   public CreateBatchOperationResponseImpl setResponse(final BatchOperationCreatedResult response) {
-    batchOperationKey = Long.parseLong(response.getBatchOperationKey());
+    batchOperationId = response.getBatchOperationId();
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -36,7 +36,7 @@ public class BatchOperationImpl implements BatchOperation {
   private final List<Long> keys = new ArrayList<>();
 
   public BatchOperationImpl(final BatchOperationCreatedResult item) {
-    batchOperationId = item.getBatchOperationKey();
+    batchOperationId = item.getBatchOperationId();
     type =
         item.getBatchOperationType() != null
             ? BatchOperationType.valueOf(item.getBatchOperationType().name())

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/QueryBatchOperationTest.java
@@ -30,7 +30,7 @@ public class QueryBatchOperationTest extends ClientRestTest {
   @Test
   public void shouldGetBatchOperationByKey() {
     // when
-    client.newBatchOperationGetRequest(123L).send().join();
+    client.newBatchOperationGetRequest("123").send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -484,7 +484,7 @@
 
   <changeSet id="create_batch_operation_table" author="pwunderlich">
     <createTable tableName="${prefix}BATCH_OPERATION">
-      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
+      <column name="BATCH_OPERATION_ID" type="VARCHAR(255)">
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="STATE" type="VARCHAR(255)"/>
@@ -497,11 +497,11 @@
     </createTable>
 
     <createTable tableName="${prefix}BATCH_OPERATION_ITEM">
-      <column name="BATCH_OPERATION_KEY" type="VARCHAR(255)">
+      <column name="BATCH_OPERATION_ID" type="VARCHAR(255)">
         <constraints
           foreignKeyName="${prefix}FK_BATCH_OPERATION_ITEM_BATCH_OPERATION"
           referencedTableName="${prefix}BATCH_OPERATION"
-          referencedColumnNames="BATCH_OPERATION_KEY"
+          referencedColumnNames="BATCH_OPERATION_ID"
           deleteCascade="true"/>
         />
       </column>
@@ -514,7 +514,7 @@
 
     <createIndex tableName="${prefix}BATCH_OPERATION_ITEM"
       indexName="${prefix}IDX_BATCH_OPERATION_ITEM_KEY">
-      <column name="BATCH_OPERATION_KEY"/>
+      <column name="BATCH_OPERATION_ID"/>
     </createIndex>
 
     <modifySql dbms="mariadb">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
@@ -14,7 +14,7 @@ public class BatchOperationEntityMapper {
 
   public static BatchOperationEntity toEntity(final BatchOperationDbModel dbModel) {
     return new BatchOperationEntity(
-        dbModel.batchOperationKey().toString(),
+        dbModel.batchOperationId(),
         dbModel.state(),
         dbModel.operationType(),
         dbModel.startDate(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationItemReader.java
@@ -31,7 +31,7 @@ public class BatchOperationItemReader extends AbstractEntityReader<BatchOperatio
     final var dbSort =
         convertSort(
             query.sort(),
-            BatchOperationItemSearchColumn.BATCH_OPERATION_KEY,
+            BatchOperationItemSearchColumn.BATCH_OPERATION_ID,
             BatchOperationItemSearchColumn.ITEM_KEY);
     final var dbQuery =
         BatchOperationItemDbQuery.of(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -29,23 +29,23 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
     this.batchOperationMapper = batchOperationMapper;
   }
 
-  public boolean exists(final String batchOperationKey) {
+  public boolean exists(final String batchOperationId) {
     final var query =
         new BatchOperationDbQuery.Builder()
-            .filter(b -> b.batchOperationIds(batchOperationKey))
+            .filter(b -> b.batchOperationIds(batchOperationId))
             .build();
 
     return batchOperationMapper.count(query) == 1;
   }
 
-  public Optional<BatchOperationEntity> findOne(final String batchOperationKey) {
+  public Optional<BatchOperationEntity> findOne(final String batchOperationId) {
     final var result =
-        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationKey))));
+        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationIds(batchOperationId))));
     return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
   }
 
   public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {
-    final var dbSort = convertSort(query.sort(), BatchOperationSearchColumn.BATCH_OPERATION_KEY);
+    final var dbSort = convertSort(query.sort(), BatchOperationSearchColumn.BATCH_OPERATION_ID);
     final var dbQuery =
         BatchOperationDbQuery.of(
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -42,23 +42,23 @@ public interface BatchOperationMapper {
   List<BatchOperationItemEntity> searchItems(BatchOperationItemDbQuery query);
 
   record BatchOperationUpdateDto(
-      String batchOperationKey, BatchOperationState state, OffsetDateTime endDate) {}
+      String batchOperationId, BatchOperationState state, OffsetDateTime endDate) {}
 
-  record BatchOperationUpdateTotalCountDto(String batchOperationKey, int operationsTotalCount) {}
+  record BatchOperationUpdateTotalCountDto(String batchOperationId, int operationsTotalCount) {}
 
-  record BatchOperationUpdateCountsDto(String batchOperationKey, long itemKey) {}
+  record BatchOperationUpdateCountsDto(String batchOperationId, long itemKey) {}
 
-  record BatchOperationItemsDto(String batchOperationKey, List<BatchOperationItemDbModel> items) {}
+  record BatchOperationItemsDto(String batchOperationId, List<BatchOperationItemDbModel> items) {}
 
   record BatchOperationItemDto(
-      String batchOperationKey,
+      String batchOperationId,
       Long itemKey,
       BatchOperationEntity.BatchOperationItemState state,
       OffsetDateTime processedDate,
       String errorMessage) {}
 
   record BatchOperationItemStatusUpdateDto(
-      String batchOperationKey,
+      String batchOperationId,
       BatchOperationEntity.BatchOperationItemState oldState,
       BatchOperationEntity.BatchOperationItemState newState) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationItemSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationItemSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import java.util.function.Function;
 
 public enum BatchOperationItemSearchColumn implements SearchColumn<BatchOperationItemEntity> {
-  BATCH_OPERATION_KEY("batchOperationId", BatchOperationItemEntity::batchOperationId),
+  BATCH_OPERATION_ID("batchOperationId", BatchOperationItemEntity::batchOperationId),
   ITEM_KEY("itemKey", BatchOperationItemEntity::itemKey),
   PROCESS_INSTANCE_KEY("processInstanceKey", BatchOperationItemEntity::processInstanceKey),
   STATE("state", BatchOperationItemEntity::state),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import java.util.function.Function;
 
 public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
-  BATCH_OPERATION_KEY("batchOperationId", BatchOperationEntity::batchOperationId);
+  BATCH_OPERATION_ID("batchOperationId", BatchOperationEntity::batchOperationId);
 
   private final String property;
   private final Function<BatchOperationEntity, Object> propertyReader;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -12,7 +12,7 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 
 public record BatchOperationDbModel(
-    String batchOperationKey,
+    String batchOperationId,
     BatchOperationState state,
     String operationType,
     OffsetDateTime startDate,
@@ -24,7 +24,7 @@ public record BatchOperationDbModel(
   // Builder class
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
 
-    private String batchOperationKey;
+    private String batchOperationId;
     private BatchOperationState state;
     private String operationType;
     private OffsetDateTime startDate;
@@ -35,8 +35,8 @@ public record BatchOperationDbModel(
 
     public Builder() {}
 
-    public Builder batchOperationKey(final String batchOperationKey) {
-      this.batchOperationKey = batchOperationKey;
+    public Builder batchOperationId(final String batchOperationId) {
+      this.batchOperationId = batchOperationId;
       return this;
     }
 
@@ -78,7 +78,7 @@ public record BatchOperationDbModel(
     @Override
     public BatchOperationDbModel build() {
       return new BatchOperationDbModel(
-          batchOperationKey,
+          batchOperationId,
           state,
           operationType,
           startDate,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -10,7 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.search.entities.BatchOperationEntity;
 
 public record BatchOperationItemDbModel(
-    String batchOperationKey,
+    String batchOperationId,
     long itemKey,
     long processInstanceKey,
     BatchOperationEntity.BatchOperationItemState state) {}

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -8,7 +8,7 @@
   <resultMap id="BatchOperationResultMap"
     type="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
+      <idArg column="BATCH_OPERATION_ID" javaType="java.lang.String"/>
       <arg column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationState"/>
       <arg column="OPERATION_TYPE" javaType="java.lang.String"/>
@@ -23,7 +23,7 @@
   <resultMap id="BatchOperationItemResultMap"
     type="io.camunda.search.entities.BatchOperationEntity$BatchOperationItemEntity">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
+      <idArg column="BATCH_OPERATION_ID" javaType="java.lang.String"/>
       <arg column="ITEM_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="STATE"
@@ -34,7 +34,7 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
-    INSERT INTO ${prefix}BATCH_OPERATION (BATCH_OPERATION_KEY,
+    INSERT INTO ${prefix}BATCH_OPERATION (BATCH_OPERATION_ID,
                                  STATE,
                                  OPERATION_TYPE,
                                  START_DATE,
@@ -42,7 +42,7 @@
                                  OPERATIONS_TOTAL_COUNT,
                                  OPERATIONS_FAILED_COUNT,
                                  OPERATIONS_COMPLETED_COUNT)
-    VALUES (#{batchOperationKey},
+    VALUES (#{batchOperationId},
             #{state},
             #{operationType},
             #{startDate},
@@ -54,10 +54,10 @@
 
   <insert id="insertItems"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto">
-    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY)
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY)
     VALUES
     <foreach collection="items" item="item" separator=",">
-      (#{batchOperationKey}, #{item.itemKey}, #{item.processInstanceKey})
+      (#{batchOperationId}, #{item.itemKey}, #{item.processInstanceKey})
     </foreach>
   </insert>
 
@@ -66,7 +66,7 @@
     UPDATE ${prefix}BATCH_OPERATION
     SET STATE = #{state},
         END_DATE = #{endDate}
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
 
   <update id="updateItem"
@@ -75,7 +75,7 @@
     SET STATE = #{state},
         PROCESSED_DATE = #{processedDate},
         ERROR_MESSAGE = #{errorMessage}
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
       AND ITEM_KEY = #{itemKey}
   </update>
 
@@ -83,7 +83,7 @@
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemStatusUpdateDto">
     UPDATE ${prefix}BATCH_OPERATION_ITEM
     SET STATE = #{newState}
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
       AND STATE = #{oldState}
   </update>
 
@@ -91,18 +91,18 @@
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateTotalCountDto">
     UPDATE ${prefix}BATCH_OPERATION
     SET OPERATIONS_TOTAL_COUNT = OPERATIONS_TOTAL_COUNT + #{operationsTotalCount}
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
   </update>
 
   <update id="incrementFailedOperationsCount"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + 1
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
     AND EXISTS(
       SELECT 1
       FROM ${prefix}BATCH_OPERATION_ITEM i
-      WHERE i.BATCH_OPERATION_KEY = t.BATCH_OPERATION_KEY
+      WHERE i.BATCH_OPERATION_ID = t.BATCH_OPERATION_ID
       AND i.ITEM_KEY = #{itemKey}
     )
   </update>
@@ -111,11 +111,11 @@
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + 1
-    WHERE BATCH_OPERATION_KEY = #{batchOperationKey}
+    WHERE BATCH_OPERATION_ID = #{batchOperationId}
       AND EXISTS(
       SELECT 1
       FROM ${prefix}BATCH_OPERATION_ITEM i
-      WHERE i.BATCH_OPERATION_KEY = t.BATCH_OPERATION_KEY
+      WHERE i.BATCH_OPERATION_ID = t.BATCH_OPERATION_ID
         AND i.ITEM_KEY = #{itemKey}
     )
   </update>
@@ -133,7 +133,7 @@
 
   SELECT * FROM (
     SELECT
-    bo.BATCH_OPERATION_KEY,
+    bo.BATCH_OPERATION_ID,
     bo.STATE,
     bo.OPERATION_TYPE,
     bo.START_DATE,
@@ -153,7 +153,7 @@
     WHERE 1 = 1
     <!-- basic filters -->
     <if test="filter.batchOperationIds != null and !filter.batchOperationIds.isEmpty()">
-      AND BATCH_OPERATION_KEY IN
+      AND BATCH_OPERATION_ID IN
       <foreach collection="filter.batchOperationIds" item="value" open="(" separator=", "
         close=")">#{value}
       </foreach>
@@ -183,7 +183,7 @@
     statementType="PREPARED">
 
     SELECT * FROM (
-    SELECT BATCH_OPERATION_KEY, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE, PROCESSED_DATE, ERROR_MESSAGE
+    SELECT BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE, PROCESSED_DATE, ERROR_MESSAGE
     FROM ${prefix}BATCH_OPERATION_ITEM
     <include refid="io.camunda.db.rdbms.sql.BatchOperationMapper.itemSearchFilter"/>
     ) filtered
@@ -196,7 +196,7 @@
     WHERE 1 = 1
     <!-- basic filters -->
     <if test="filter.batchOperationIds != null and !filter.batchOperationIds.isEmpty()">
-      AND BATCH_OPERATION_KEY IN
+      AND BATCH_OPERATION_ID IN
       <foreach collection="filter.batchOperationIds" item="value" open="(" separator=", "
         close=")">#{value}
       </foreach>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BatchOperationAuthorizationIT.java
@@ -151,12 +151,12 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 3);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 3);
 
     // then
     final var batchOperationResponse =
-        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+        camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
     assertThat(batchOperationResponse).isNotNull();
     assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(3);
   }
@@ -172,14 +172,14 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 3);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 3);
 
     // when
     final var batchOperationResponse =
         camundaClient
             .newBatchOperationSearchRequest()
-            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationId)))
             .send()
             .join();
 
@@ -201,19 +201,19 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 1);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 1);
 
     // then
     final var batchOperationResponse =
-        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+        camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
     assertThat(batchOperationResponse).isNotNull();
     assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(1);
 
     final List<BatchOperationItem> batchOperationItems =
         camundaClient
             .newBatchOperationItemsSearchRequest()
-            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationId)))
             .send()
             .join()
             .items();
@@ -236,19 +236,19 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 1);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 1);
 
     // then
     final var batchOperationResponse =
-        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+        camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
     assertThat(batchOperationResponse).isNotNull();
     assertThat(batchOperationResponse.getOperationsTotalCount()).isEqualTo(1);
 
     final List<BatchOperationItem> batchOperationItems =
         camundaClient
             .newBatchOperationItemsSearchRequest()
-            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationId)))
             .send()
             .join()
             .items();
@@ -274,12 +274,12 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 1);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 1);
 
     // when
     final var batchOperationResponse =
-        camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+        camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
 
     // then
     assertThat(batchOperationResponse).isNotNull();
@@ -298,14 +298,14 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaClient, batchOperationKey, 1);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaClient, batchOperationId, 1);
 
     // when
     final var batchOperationResponse =
         camundaClient
             .newBatchOperationSearchRequest()
-            .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+            .filter(f -> f.batchOperationId(String.valueOf(batchOperationId)))
             .send()
             .join();
 
@@ -347,8 +347,8 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaAdminClient, batchOperationKey, 3);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaAdminClient, batchOperationId, 3);
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
@@ -358,7 +358,7 @@ class BatchOperationAuthorizationIT {
             () -> {
               int code = 0;
               try {
-                camundaRestictedClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+                camundaRestictedClient.newBatchOperationGetRequest(batchOperationId).send().join();
               } catch (final ProblemException e) {
                 code = e.code();
               }
@@ -379,8 +379,8 @@ class BatchOperationAuthorizationIT {
 
     // and we wait for it
     assertThat(batchOperationCreatedResponse).isNotNull();
-    final var batchOperationKey = batchOperationCreatedResponse.getBatchOperationKey();
-    waitForBatchOperation(camundaAdminClient, batchOperationKey, 0);
+    final var batchOperationId = batchOperationCreatedResponse.getBatchOperationId();
+    waitForBatchOperation(camundaAdminClient, batchOperationId, 0);
 
     // then we should find nothing with our restricted user
     Awaitility.await("should not return batch operation")
@@ -391,7 +391,7 @@ class BatchOperationAuthorizationIT {
               final var batchOperationResponse =
                   camundaRestictedClient
                       .newBatchOperationSearchRequest()
-                      .filter(f -> f.batchOperationId(String.valueOf(batchOperationKey)))
+                      .filter(f -> f.batchOperationId(String.valueOf(batchOperationId)))
                       .send()
                       .join();
               assertThat(batchOperationResponse.items()).isEmpty();
@@ -415,7 +415,7 @@ class BatchOperationAuthorizationIT {
   }
 
   public static void waitForBatchOperation(
-      final CamundaClient camundaClient, final long batchOperationKey, final long itemsCount) {
+      final CamundaClient camundaClient, final String batchOperationId, final long itemsCount) {
     Awaitility.await("should wait for started batch operation")
         .atMost(Duration.ofSeconds(15))
         .pollInterval(Duration.ofMillis(100))
@@ -423,7 +423,7 @@ class BatchOperationAuthorizationIT {
         .untilAsserted(
             () -> {
               final var batch =
-                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+                  camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
               assertThat(batch).isNotNull();
               assertThat(batch.getOperationsTotalCount()).isEqualTo(itemsCount);
             });

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceTest.java
@@ -88,18 +88,18 @@ public class BatchOperationCancelProcessInstanceTest {
             .filter(b -> b.variables(getScopedVariables(testScopeId)))
             .send()
             .join();
-    final var batchOperationKey = result.getBatchOperationKey();
+    final var batchOperationId = result.getBatchOperationId();
 
     // then
     assertThat(result).isNotNull();
 
     // and wait if batch has correct amount of items. (To fail fast if not)
     waitForBatchOperationWithCorrectTotalCount(
-        camundaClient, batchOperationKey, activeProcessInstances.size());
+        camundaClient, batchOperationId, activeProcessInstances.size());
 
     // and
     waitForBatchOperationCompleted(
-        camundaClient, batchOperationKey, activeProcessInstances.size(), 0);
+        camundaClient, batchOperationId, activeProcessInstances.size(), 0);
 
     // and
     final var activeKeys =
@@ -112,7 +112,7 @@ public class BatchOperationCancelProcessInstanceTest {
     final var itemsObj =
         camundaClient
             .newBatchOperationItemsSearchRequest()
-            .filter(f -> f.batchOperationId(Long.toString(batchOperationKey)))
+            .filter(f -> f.batchOperationId(batchOperationId))
             .send()
             .join();
     final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationMigrateProcessInstanceTest.java
@@ -94,11 +94,11 @@ public class BatchOperationMigrateProcessInstanceTest {
 
     // then wait if batch has correct amount of items. (To fail fast if not)
     waitForBatchOperationWithCorrectTotalCount(
-        client, batchCreated.getBatchOperationKey(), processInstances.size());
+        client, batchCreated.getBatchOperationId(), processInstances.size());
 
     // and wait for the batch operation to complete
     waitForBatchOperationCompleted(
-        client, batchCreated.getBatchOperationKey(), processInstances.size(), 0);
+        client, batchCreated.getBatchOperationId(), processInstances.size(), 0);
 
     Awaitility.await("should update batch operation items")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
@@ -109,10 +109,7 @@ public class BatchOperationMigrateProcessInstanceTest {
               final var batchItems =
                   client
                       .newBatchOperationItemsSearchRequest()
-                      .filter(
-                          f ->
-                              f.batchOperationId(
-                                  Long.toString(batchCreated.getBatchOperationKey())))
+                      .filter(f -> f.batchOperationId(batchCreated.getBatchOperationId()))
                       .send()
                       .join()
                       .items();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationResolveIncidentTest.java
@@ -108,16 +108,16 @@ public class BatchOperationResolveIncidentTest {
             .filter(f -> f.variables(getScopedVariables(testScopeId)))
             .send()
             .join();
-    final var batchOperationKey = result.getBatchOperationKey();
+    final var batchOperationId = result.getBatchOperationId();
 
     // then
     assertThat(result).isNotNull();
 
     // and wait if batch has correct amount of items. (To fail fast if not)
-    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationKey, 3);
+    waitForBatchOperationWithCorrectTotalCount(camundaClient, batchOperationId, 3);
 
     // and
-    waitForBatchOperationCompleted(camundaClient, batchOperationKey, 3, 0);
+    waitForBatchOperationCompleted(camundaClient, batchOperationId, 3, 0);
 
     // and
     waitUntilIncidentsAreResolved(camundaClient, activeIncidents.size());
@@ -126,7 +126,7 @@ public class BatchOperationResolveIncidentTest {
     final var itemsObj =
         camundaClient
             .newBatchOperationItemsSearchRequest()
-            .filter(f -> f.batchOperationId(Long.toString(batchOperationKey)))
+            .filter(f -> f.batchOperationId(batchOperationId))
             .send()
             .join();
     final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -109,7 +109,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
             .filter(new ProcessInstanceFilterImpl())
             .send()
             .join();
-    final var batchOperationKey = result.getBatchOperationKey();
+    final var batchOperationKey = result.getBatchOperationId();
 
     // then
     assertThat(result).isNotNull();
@@ -145,7 +145,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
     final var itemsObj =
         camundaClient
             .newBatchOperationItemsSearchRequest()
-            .filter(f -> f.batchOperationId(Long.toString(batchOperationKey)))
+            .filter(f -> f.batchOperationId(batchOperationKey))
             .send()
             .join();
     final var itemKeys = itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -57,7 +57,7 @@ public class BatchOperationIT {
         createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b).getLast();
 
     final var searchResult =
-        rdbmsService.getBatchOperationReader().exists(batchOperation.batchOperationKey());
+        rdbmsService.getBatchOperationReader().exists(batchOperation.batchOperationId());
 
     assertThat(searchResult).isTrue();
   }
@@ -84,9 +84,9 @@ public class BatchOperationIT {
             writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null).operationsTotalCount(0));
 
     // when
-    insertBatchOperationsItems(writer, batchOperation.batchOperationKey(), Set.of(nextKey()));
+    insertBatchOperationsItems(writer, batchOperation.batchOperationId(), Set.of(nextKey()));
     insertBatchOperationsItems(
-        writer, batchOperation.batchOperationKey(), Set.of(nextKey(), nextKey()));
+        writer, batchOperation.batchOperationId(), Set.of(nextKey(), nextKey()));
 
     // then
     final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
@@ -100,7 +100,7 @@ public class BatchOperationIT {
 
     // and items are there
     final var updatedItems =
-        getBatchOperationItems(rdbmsService, batchOperation.batchOperationKey());
+        getBatchOperationItems(rdbmsService, batchOperation.batchOperationId());
     assertThat(updatedItems).isNotNull();
     assertThat(updatedItems.items()).hasSize(3);
     assertThat(updatedItems.items().stream().map(BatchOperationItemEntity::state))
@@ -123,13 +123,13 @@ public class BatchOperationIT {
                     .operationsCompletedCount(0));
 
     final List<Long> items =
-        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
     // when
     writer
         .getBatchOperationWriter()
         .updateItem(
-            batchOperation.batchOperationKey(),
+            batchOperation.batchOperationId(),
             items.getFirst(),
             BatchOperationItemState.COMPLETED,
             NOW,
@@ -148,7 +148,7 @@ public class BatchOperationIT {
 
     // and items have correct state
     final var updatedItems =
-        getBatchOperationItems(rdbmsService, batchOperation.batchOperationKey()).items();
+        getBatchOperationItems(rdbmsService, batchOperation.batchOperationId()).items();
     assertThat(updatedItems).isNotNull();
     assertThat(updatedItems).hasSize(2);
     final var firstItem =
@@ -185,13 +185,13 @@ public class BatchOperationIT {
                     .operationsFailedCount(0));
 
     final List<Long> items =
-        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
     // when
     writer
         .getBatchOperationWriter()
         .updateItem(
-            batchOperation.batchOperationKey(),
+            batchOperation.batchOperationId(),
             items.getFirst(),
             BatchOperationItemState.FAILED,
             NOW,
@@ -210,7 +210,7 @@ public class BatchOperationIT {
 
     // and items have correct state
     final var updatedItems =
-        getBatchOperationItems(rdbmsService, batchOperation.batchOperationKey()).items();
+        getBatchOperationItems(rdbmsService, batchOperation.batchOperationId()).items();
     assertThat(updatedItems).isNotNull();
     assertThat(updatedItems).hasSize(2);
     final var firstItem =
@@ -242,12 +242,12 @@ public class BatchOperationIT {
         createAndSaveBatchOperation(writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null));
 
     final var items =
-        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
     writer
         .getBatchOperationWriter()
         .updateItem(
-            batchOperation.batchOperationKey(),
+            batchOperation.batchOperationId(),
             items.getFirst(),
             BatchOperationItemState.COMPLETED,
             NOW,
@@ -255,7 +255,7 @@ public class BatchOperationIT {
 
     // when
     final OffsetDateTime endDate = OffsetDateTime.now();
-    writer.getBatchOperationWriter().cancel(batchOperation.batchOperationKey(), endDate);
+    writer.getBatchOperationWriter().cancel(batchOperation.batchOperationId(), endDate);
     writer.flush();
 
     // then
@@ -278,10 +278,10 @@ public class BatchOperationIT {
     final var batchOperation =
         createAndSaveBatchOperation(writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null));
 
-    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
     // when
-    writer.getBatchOperationWriter().pause(batchOperation.batchOperationKey());
+    writer.getBatchOperationWriter().pause(batchOperation.batchOperationId());
     writer.flush();
 
     // then
@@ -302,13 +302,13 @@ public class BatchOperationIT {
     final var batchOperation =
         createAndSaveBatchOperation(writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null));
 
-    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
-    writer.getBatchOperationWriter().pause(batchOperation.batchOperationKey());
+    writer.getBatchOperationWriter().pause(batchOperation.batchOperationId());
     writer.flush();
 
     // when
-    writer.getBatchOperationWriter().resume(batchOperation.batchOperationKey());
+    writer.getBatchOperationWriter().resume(batchOperation.batchOperationId());
     writer.flush();
 
     // then
@@ -329,11 +329,11 @@ public class BatchOperationIT {
     final var batchOperation =
         createAndSaveBatchOperation(writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null));
 
-    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 2);
 
     // when
     final OffsetDateTime endDate = OffsetDateTime.now();
-    writer.getBatchOperationWriter().finish(batchOperation.batchOperationKey(), endDate);
+    writer.getBatchOperationWriter().finish(batchOperation.batchOperationId(), endDate);
     writer.flush();
 
     // then
@@ -359,7 +359,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
-                        .batchOperationIds(batchOperation.batchOperationKey())
+                        .batchOperationIds(batchOperation.batchOperationId())
                         .build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));
@@ -456,7 +456,7 @@ public class BatchOperationIT {
         .usingRecursiveComparison()
         .ignoringFields("batchOperationId", "startDate", "endDate")
         .isEqualTo(batchOperation);
-    assertThat(instance.batchOperationId()).isEqualTo(batchOperation.batchOperationKey());
+    assertThat(instance.batchOperationId()).isEqualTo(batchOperation.batchOperationId());
     assertThat(instance.startDate())
         .isCloseTo(batchOperation.startDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(instance.endDate())
@@ -470,7 +470,7 @@ public class BatchOperationIT {
         .search(
             new BatchOperationQuery(
                 new BatchOperationFilter.Builder()
-                    .batchOperationIds(batchOperation.batchOperationKey())
+                    .batchOperationIds(batchOperation.batchOperationId())
                     .build(),
                 BatchOperationSort.of(b -> b),
                 SearchQueryPage.of(b -> b)));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationItemSortIT.java
@@ -76,14 +76,14 @@ public class BatchOperationItemSortIT {
 
     final var batchOperation = createAndSaveBatchOperation(rdbmsWriter, b -> b);
 
-    createAndSaveRandomBatchOperationItems(rdbmsWriter, batchOperation.batchOperationKey(), 20);
+    createAndSaveRandomBatchOperationItems(rdbmsWriter, batchOperation.batchOperationId(), 20);
 
     final var searchResult =
         reader
             .search(
                 new BatchOperationItemQuery(
                     new BatchOperationItemFilter.Builder()
-                        .batchOperationIds(batchOperation.batchOperationKey())
+                        .batchOperationIds(batchOperation.batchOperationId())
                         .build(),
                     BatchOperationItemSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -32,7 +32,7 @@ public final class BatchOperationFixtures {
     final var key = CommonFixtures.nextStringKey();
     final var builder =
         new Builder()
-            .batchOperationKey(key)
+            .batchOperationId(key)
             .state(randomEnum(BatchOperationState.class))
             .operationType("some-operation" + RANDOM.nextInt(1000))
             .startDate(OffsetDateTime.now())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -310,7 +310,7 @@ public final class TestHelper {
   }
 
   public static void waitForBatchOperationWithCorrectTotalCount(
-      final CamundaClient camundaClient, final long batchOperationKey, final int expectedItems) {
+      final CamundaClient camundaClient, final String batchOperationId, final int expectedItems) {
     Awaitility.await("should start batch operation with correct total count")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -318,7 +318,7 @@ public final class TestHelper {
             () -> {
               // and
               final var batch =
-                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+                  camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
               assertThat(batch).isNotNull();
               assertThat(batch.getOperationsTotalCount()).isEqualTo(expectedItems);
             });
@@ -326,7 +326,7 @@ public final class TestHelper {
 
   public static void waitForBatchOperationCompleted(
       final CamundaClient camundaClient,
-      final long batchOperationKey,
+      final String batchOperationId,
       final int expectedCompletedItems,
       final int expectedFailedItems) {
     Awaitility.await("should complete batch operation with correct completed/failed count")
@@ -336,7 +336,7 @@ public final class TestHelper {
             () -> {
               // and
               final var batch =
-                  camundaClient.newBatchOperationGetRequest(batchOperationKey).send().join();
+                  camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
               assertThat(batch).isNotNull();
               assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
               assertThat(batch.getOperationsCompletedCount()).isEqualTo(expectedCompletedItems);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -44,14 +44,14 @@ public class BatchOperationChunkExportHandler
   }
 
   private List<BatchOperationItemDbModel> mapItems(
-      final Collection<BatchOperationItemValue> items, final long batchOperationKey) {
-    return items.stream().map(item -> mapItem(item, batchOperationKey)).toList();
+      final Collection<BatchOperationItemValue> items, final long batchOperationId) {
+    return items.stream().map(item -> mapItem(item, batchOperationId)).toList();
   }
 
   private BatchOperationItemDbModel mapItem(
-      final BatchOperationItemValue value, final long batchOperationKey) {
+      final BatchOperationItemValue value, final long batchOperationId) {
     return new BatchOperationItemDbModel(
-        Long.toString(batchOperationKey),
+        Long.toString(batchOperationId),
         value.getItemKey(),
         value.getProcessInstanceKey(),
         BatchOperationItemState.ACTIVE);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCompletedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCompletedExportHandler.java
@@ -33,8 +33,7 @@ public class BatchOperationCompletedExportHandler
   @Override
   public void export(final Record<BatchOperationExecutionRecordValue> record) {
     final var value = record.getValue();
-    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
-    batchOperationWriter.finish(
-        batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));
+    final var batchOperationId = String.valueOf(value.getBatchOperationKey());
+    batchOperationWriter.finish(batchOperationId, DateUtil.toOffsetDateTime(record.getTimestamp()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -43,9 +43,9 @@ public class BatchOperationCreatedExportHandler
 
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
     final var value = record.getValue();
-    final String batchOperationKey = String.valueOf(record.getKey());
+    final String batchOperationId = String.valueOf(record.getKey());
     return new BatchOperationDbModel.Builder()
-        .batchOperationKey(batchOperationKey)
+        .batchOperationId(batchOperationId)
         .state(BatchOperationState.ACTIVE)
         .operationType(value.getBatchOperationType().name())
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationLifecycleManagementExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationLifecycleManagementExportHandler.java
@@ -40,14 +40,14 @@ public class BatchOperationLifecycleManagementExportHandler
   @Override
   public void export(final Record<BatchOperationLifecycleManagementRecordValue> record) {
     final var value = record.getValue();
-    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
+    final var batchOperationId = String.valueOf(value.getBatchOperationKey());
     if (record.getIntent().equals(BatchOperationIntent.CANCELED)) {
       batchOperationWriter.cancel(
-          batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));
+          batchOperationId, DateUtil.toOffsetDateTime(record.getTimestamp()));
     } else if (record.getIntent().equals(BatchOperationIntent.PAUSED)) {
-      batchOperationWriter.pause(batchOperationKey);
+      batchOperationWriter.pause(batchOperationId);
     } else if (record.getIntent().equals(BatchOperationIntent.RESUMED)) {
-      batchOperationWriter.resume(batchOperationKey);
+      batchOperationWriter.resume(batchOperationId);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9368,8 +9368,8 @@ components:
     BatchOperationCreatedResult:
       type: object
       properties:
-        batchOperationKey:
-          description: Key of the batch operation.
+        batchOperationId:
+          description: Id of the batch operation.
           type: string
         batchOperationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -483,7 +483,7 @@ public final class ResponseMapper {
       final BatchOperationCreationRecord brokerResponse) {
     final var response =
         new BatchOperationCreatedResult()
-            .batchOperationKey(KeyUtil.keyToString(brokerResponse.getBatchOperationKey()))
+            .batchOperationId(KeyUtil.keyToString(brokerResponse.getBatchOperationKey()))
             .batchOperationType(
                 BatchOperationTypeEnum.valueOf(brokerResponse.getBatchOperationType().name()));
     return new ResponseEntity<>(response, HttpStatus.ACCEPTED);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1338,7 +1338,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"batchOperationKey":"123","batchOperationType":"CANCEL_PROCESS_INSTANCE"}
+          {"batchOperationId":"123","batchOperationType":"CANCEL_PROCESS_INSTANCE"}
         """);
 
     verify(processInstanceServices)
@@ -1386,7 +1386,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"batchOperationKey":"123","batchOperationType":"MODIFY_PROCESS_INSTANCE"}
+          {"batchOperationId":"123","batchOperationType":"MODIFY_PROCESS_INSTANCE"}
         """);
 
     verify(processInstanceServices)
@@ -1462,7 +1462,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"batchOperationKey":"123","batchOperationType":"RESOLVE_INCIDENT"}
+          {"batchOperationId":"123","batchOperationType":"RESOLVE_INCIDENT"}
         """);
 
     verify(processInstanceServices)
@@ -1512,7 +1512,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .expectBody()
         .json(
             """
-          {"batchOperationKey":"123","batchOperationType":"MIGRATE_PROCESS_INSTANCE"}
+          {"batchOperationId":"123","batchOperationType":"MIGRATE_PROCESS_INSTANCE"}
         """);
 
     verify(processInstanceServices)


### PR DESCRIPTION
## Description

The Camunda Client API for batch operations has inconsistent typing for the batchOperationKey (long and String). This PR changes all remaining code locations to String.

## Related issues

closes #32205
