### PR TITLE
31495 allow resourcename to be used for filtering decision requirements

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionRequirementsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionRequirementsFilter.java
@@ -59,4 +59,12 @@ public interface DecisionRequirementsFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   DecisionRequirementsFilter tenantId(final String tenantId);
+
+  /**
+   * Filters Decision Requirements by the specified resource name.
+   *
+   * @param resourceName the name of the resource from which the decision requirements were parsed
+   * @return the updated filter
+   */
+  DecisionRequirementsFilter resourceName(final String resourceName);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionRequirementsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionRequirementsFilterImpl.java
@@ -61,6 +61,12 @@ public class DecisionRequirementsFilterImpl
   }
 
   @Override
+  public DecisionRequirementsFilter resourceName(final String resourceName) {
+    filter.setResourceName(resourceName);
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.DecisionRequirementsFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionRequirementsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionRequirementsTest.java
@@ -94,6 +94,21 @@ public class SearchDecisionRequirementsTest extends ClientRestTest {
     assertThat(request.getFilter().getVersion()).isEqualTo(1);
   }
 
+  @Test
+  void shouldSearchDecisionRequirementsByResourceName() {
+    // when
+    client
+        .newDecisionRequirementsSearchRequest()
+        .filter(f -> f.resourceName("resource name"))
+        .send()
+        .join();
+
+    // then
+    final DecisionRequirementsSearchQuery request =
+        gatewayService.getLastRequest(DecisionRequirementsSearchQuery.class);
+    assertThat(request.getFilter().getResourceName()).isEqualTo("resource name");
+  }
+
   // Consolidated sort test
   @Test
   void shouldSortDecisionRequirements() {

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -67,6 +67,12 @@
         #{value}
       </foreach>
     </if>
+    <if test="filter.resourceNames != null and !filter.resourceNames.isEmpty()">
+      AND RESOURCE_NAME IN
+      <foreach collection="filter.resourceNames" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionRequirementsEntity">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -320,6 +320,24 @@ class DecisionSearchTest {
   }
 
   @Test
+  void shouldRetrieveByResourceName() {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionRequirementsSearchRequest()
+            .filter(f -> f.resourceName("decisions/decision_model_1.dmn"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    result
+        .items()
+        .forEach(
+            item -> assertThat(item.getResourceName()).isEqualTo("decisions/decision_model_1.dmn"));
+  }
+
+  @Test
   void shouldSortByDecisionRequirementsKey() {
     // when
     final var resultAsc =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex.DECISION_REQUIREMENTS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex.RESOURCE_NAME;
 import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex.VERSION;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -37,8 +38,15 @@ public final class DecisionRequirementsFilterTransformer
     final var decisionRequirementsIdsQuery =
         getDecisionRequirementsIdsQuery(filter.decisionRequirementsIds());
     final var tenantIdsQuery = getTenantIdsQuery(filter.tenantIds());
+    final var resourceNamesQuery = getResourceNamesQuery(filter.resourceNames());
 
-    return and(keysQuery, namesQuery, versionsQuery, decisionRequirementsIdsQuery, tenantIdsQuery);
+    return and(
+        keysQuery,
+        namesQuery,
+        versionsQuery,
+        decisionRequirementsIdsQuery,
+        tenantIdsQuery,
+        resourceNamesQuery);
   }
 
   private SearchQuery getKeysQuery(final List<Long> keys) {
@@ -59,5 +67,9 @@ public final class DecisionRequirementsFilterTransformer
 
   private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {
     return stringTerms(TENANT_ID, tenantIds);
+  }
+
+  private SearchQuery getResourceNamesQuery(final List<String> resourceNames) {
+    return stringTerms(RESOURCE_NAME, resourceNames);
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsQueryTransformerTest.java
@@ -144,4 +144,20 @@ public final class DecisionRequirementsQueryTransformerTest extends AbstractTran
               assertThat(t.value().intValue()).isEqualTo(1);
             });
   }
+
+  @Test
+  public void shouldQueryByResourceName() {
+    // given
+    final var decisionRequirementFilter =
+        FilterBuilders.decisionRequirements(f -> f.resourceNames("rN"));
+
+    // when
+    final var searchRequest = transformQuery(decisionRequirementFilter);
+
+    // then
+    final var query = (SearchTermQuery) searchRequest.queryOption();
+
+    assertThat(query.field()).isEqualTo("resourceName");
+    assertThat(query.value().stringValue()).isEqualTo("rN");
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionRequirementsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionRequirementsFilter.java
@@ -20,7 +20,8 @@ public record DecisionRequirementsFilter(
     List<String> names,
     List<Integer> versions,
     List<String> decisionRequirementsIds,
-    List<String> tenantIds)
+    List<String> tenantIds,
+    List<String> resourceNames)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<DecisionRequirementsFilter> {
@@ -30,6 +31,7 @@ public record DecisionRequirementsFilter(
     private List<Integer> versions;
     private List<String> decisionRequirementsIds;
     private List<String> tenantIds;
+    private List<String> resourceNames;
 
     public Builder decisionRequirementsKeys(final List<Long> values) {
       decisionRequirementsKeys = addValuesToList(decisionRequirementsKeys, values);
@@ -76,6 +78,15 @@ public record DecisionRequirementsFilter(
       return tenantIds(collectValuesAsList(values));
     }
 
+    public Builder resourceNames(final List<String> values) {
+      resourceNames = addValuesToList(resourceNames, values);
+      return this;
+    }
+
+    public Builder resourceNames(final String... values) {
+      return resourceNames(collectValuesAsList(values));
+    }
+
     @Override
     public DecisionRequirementsFilter build() {
       return new DecisionRequirementsFilter(
@@ -83,7 +94,8 @@ public record DecisionRequirementsFilter(
           Objects.requireNonNullElse(names, Collections.emptyList()),
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsIds, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          Objects.requireNonNullElse(resourceNames, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8340,6 +8340,9 @@ components:
         decisionRequirementsKey:
           type: string
           description: The assigned key, which acts as a unique identifier for this decision requirements.
+        resourceName:
+          type: string
+          description: The name of the resource from which the decision requirements were parsed.
     DecisionRequirementsSearchQueryResult:
       type: object
       allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -956,6 +956,7 @@ public final class SearchQueryRequestMapper {
               Optional.ofNullable(f.getDecisionRequirementsId())
                   .ifPresent(builder::decisionRequirementsIds);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
+              Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
             });
 
     return builder.build();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -164,7 +164,8 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                 "decisionRequirementsKey": 0,
                 "decisionRequirementsName": "name",
                 "version": 1,
-                "decisionRequirementsId": "drId"
+                "decisionRequirementsId": "drId",
+                "resourceName": "rN"
               }
             }""";
 
@@ -193,6 +194,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
                         .names("name")
                         .versions(1)
                         .decisionRequirementsIds("drId")
+                        .resourceNames("rN")
                         .build())
                 .build());
   }


### PR DESCRIPTION
## Description

Todo
- [x] add to api spec
- [x] add to controller/filter
- [x] add to transformer / mapper
- [x] add to client 
- [ ] ~~backport to ZeebeClient?~~
- [x] add to docs / update migration guide ([here](https://github.com/camunda/camunda-docs/pull/5859))

Questions:
- is there another place where the field/query needs to be adjusted (like with the [DecisionRequirementsMapper.xml](https://github.com/camunda/camunda/pull/32379/files#diff-e44a2afe06e9e14349e859be087b182e1641631c8ab7f6b86fd7c13cfbd30e3f)?

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31495
