### PR TITLE
Filter users using advanced filtering

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -51,7 +51,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
   public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
     final var userQuery =
         SearchQueryBuilders.userSearchQuery(
-            fn -> fn.filter(f -> f.username(username)).page(p -> p.size(1)));
+            fn -> fn.filter(f -> f.usernames(username)).page(p -> p.size(1)));
     final var storedUser =
         userServices.search(userQuery).items().stream()
             .filter(Objects::nonNull)

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
@@ -32,7 +32,7 @@ public interface UserFilter extends SearchRequestFilter {
   /**
    * Filters users by the specified username using {@link StringProperty} consumer.
    *
-   * @param fn the userbane {@link StringProperty} consumer of the user
+   * @param fn the username {@link StringProperty} consumer of the user
    * @return the updated filter
    */
   UserFilter username(final Consumer<StringProperty> fn);
@@ -46,10 +46,26 @@ public interface UserFilter extends SearchRequestFilter {
   UserFilter name(final String name);
 
   /**
+   * Filters users by the specified name using {@link StringProperty} consumer.
+   *
+   * @param fn the name {@link StringProperty} consumer of the user
+   * @return the updated filter
+   */
+  UserFilter name(final Consumer<StringProperty> fn);
+
+  /**
    * Filter users by the specified email.
    *
    * @param email the email of the user
    * @return the updated filter
    */
   UserFilter email(final String email);
+
+  /**
+   * Filters users by the specified email using {@link StringProperty} consumer.
+   *
+   * @param fn the email {@link StringProperty} consumer of the user
+   * @return the updated filter
+   */
+  UserFilter email(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
 public interface UserFilter extends SearchRequestFilter {
 
@@ -26,6 +28,14 @@ public interface UserFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   UserFilter username(final String username);
+
+  /**
+   * Filters users by the specified username using {@link StringProperty} consumer.
+   *
+   * @param fn the userbane {@link StringProperty} consumer of the user
+   * @return the updated filter
+   */
+  UserFilter username(final Consumer<StringProperty> fn);
 
   /**
    * Filter users by the specified name.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
@@ -16,8 +16,11 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.UserFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.UserFilterRequest;
+import java.util.function.Consumer;
 
 public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilterRequest>
     implements UserFilter {
@@ -30,7 +33,15 @@ public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilte
 
   @Override
   public UserFilter username(final String username) {
-    filter.setUsername(username);
+    username(b -> b.eq(username));
+    return this;
+  }
+
+  @Override
+  public UserFilter username(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setUsername(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
@@ -33,8 +33,7 @@ public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilte
 
   @Override
   public UserFilter username(final String username) {
-    username(b -> b.eq(username));
-    return this;
+    return username(b -> b.eq(username));
   }
 
   @Override
@@ -47,13 +46,23 @@ public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilte
 
   @Override
   public UserFilter name(final String name) {
-    filter.setName(name);
-    return this;
+    return name(b -> b.eq(name));
   }
 
   @Override
   public UserFilter email(final String email) {
-    filter.setEmail(email);
+    return email(b -> b.eq(email));
+  }
+
+  @Override
+  public UserFilter name(final Consumer<StringProperty> fn) {
+    filter.setName(provideSearchRequestProperty(fn));
+    return this;
+  }
+
+  @Override
+  public UserFilter email(final Consumer<StringProperty> fn) {
+    filter.setEmail(provideSearchRequestProperty(fn));
     return this;
   }
 

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -67,8 +67,18 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.name != null">AND t.NAME = #{filter.name}</if>
-    <if test="filter.email != null">AND t.EMAIL = #{filter.email}</if>
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
+        AND t.NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.emailOperations != null and !filter.emailOperations.isEmpty()">
+      <foreach collection="filter.emailOperations" item="operation">
+        AND t.EMAIL
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
     <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
     <if test="filter.groupId != null">AND gm.GROUP_ID = #{filter.groupId}</if>
     <if test="filter.roleId != null">AND rm.ROLE_ID = #{filter.roleId}</if>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -61,7 +61,12 @@
     WHERE 1 = 1
     <!-- basic filters -->
     <if test="filter.key != null">AND t.USER_KEY = #{filter.key}</if>
-    <if test="filter.username != null">AND t.USERNAME = #{filter.username}</if>
+    <if test="filter.usernameOperations != null and !filter.usernameOperations.isEmpty()">
+      <foreach collection="filter.usernameOperations" item="operation">
+        AND t.USERNAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
     <if test="filter.name != null">AND t.NAME = #{filter.name}</if>
     <if test="filter.email != null">AND t.EMAIL = #{filter.email}</if>
     <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -98,7 +98,7 @@ public class UserIT {
     final var searchResult =
         userReader.search(
             new UserQuery(
-                new UserFilter.Builder().username(user.username()).build(),
+                new UserFilter.Builder().usernames(user.username()).build(),
                 UserSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(10))));
 
@@ -151,7 +151,7 @@ public class UserIT {
             new UserQuery(
                 new UserFilter.Builder()
                     .key(user.userKey())
-                    .username(user.username())
+                    .usernames(user.username())
                     .name(user.name())
                     .email(user.email())
                     .build(),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -127,7 +127,7 @@ public class UserIT {
     final var searchResult =
         userReader.search(
             new UserQuery(
-                new UserFilter.Builder().name("John Doe").build(),
+                new UserFilter.Builder().names("John Doe").build(),
                 UserSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
@@ -152,8 +152,8 @@ public class UserIT {
                 new UserFilter.Builder()
                     .key(user.userKey())
                     .usernames(user.username())
-                    .name(user.name())
-                    .email(user.email())
+                    .names(user.name())
+                    .emails(user.email())
                     .build(),
                 UserSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
@@ -174,14 +174,14 @@ public class UserIT {
     final var searchResult =
         userReader.search(
             UserQuery.of(
-                b -> b.filter(f -> f.name("Alice Doe")).sort(sort).page(p -> p.from(0).size(20))));
+                b -> b.filter(f -> f.names("Alice Doe")).sort(sort).page(p -> p.from(0).size(20))));
 
     final var instanceAfter = searchResult.items().get(9);
     final var nextPage =
         userReader.search(
             UserQuery.of(
                 b ->
-                    b.filter(f -> f.name("Alice Doe"))
+                    b.filter(f -> f.names("Alice Doe"))
                         .sort(sort)
                         .page(
                             p ->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
@@ -89,7 +89,7 @@ public class UserSortIT {
         reader
             .search(
                 new UserQuery(
-                    new UserFilter.Builder().email(email).build(),
+                    new UserFilter.Builder().emails(email).build(),
                     UserSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))
             .items();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -182,7 +182,7 @@ public class UserSpecificFilterIT {
   static List<UserFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new UserFilter.Builder().key(1337L).build(),
-        new UserFilter.Builder().username("user-1337").build(),
+        new UserFilter.Builder().usernames("user-1337").build(),
         new UserFilter.Builder().name("User 1337").build(),
         new UserFilter.Builder().email("user-1337@camunda-test.com").build());
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -183,8 +183,8 @@ public class UserSpecificFilterIT {
     return List.of(
         new UserFilter.Builder().key(1337L).build(),
         new UserFilter.Builder().usernames("user-1337").build(),
-        new UserFilter.Builder().name("User 1337").build(),
-        new UserFilter.Builder().email("user-1337@camunda-test.com").build());
+        new UserFilter.Builder().names("User 1337").build(),
+        new UserFilter.Builder().emails("user-1337@camunda-test.com").build());
   }
 
   private void addUserToTenant(final String tenantId, final String entityId) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -8,17 +8,18 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
-import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
-import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.EMAIL;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.USERNAME;
+import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
 
 public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
 
@@ -28,16 +29,17 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
 
   @Override
   public SearchQuery toSearchQuery(final UserFilter filter) {
-
-    return and(
-        filter.key() == null ? null : term(KEY, filter.key()),
-        filter.username() == null ? null : term(USERNAME, filter.username()),
-        filter.usernames() == null
-            ? null
-            : filter.usernames().isEmpty()
-                ? matchNone()
-                : stringTerms(USERNAME, filter.usernames()),
-        filter.email() == null ? null : term(EMAIL, filter.email()),
-        filter.name() == null ? null : term(NAME, filter.name()));
+    final var queries = new ArrayList<SearchQuery>();
+    if (filter.key() != null) {
+      queries.add(term(KEY, filter.key()));
+    }
+    ofNullable(stringOperations(USERNAME, filter.usernameOperations())).ifPresent(queries::addAll);
+    if (filter.email() != null) {
+      queries.add(term(EMAIL, filter.email()));
+    }
+    if (filter.name() != null) {
+      queries.add(term(NAME, filter.name()));
+    }
+    return and(queries);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -34,12 +34,8 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
       queries.add(term(KEY, filter.key()));
     }
     ofNullable(stringOperations(USERNAME, filter.usernameOperations())).ifPresent(queries::addAll);
-    if (filter.email() != null) {
-      queries.add(term(EMAIL, filter.email()));
-    }
-    if (filter.name() != null) {
-      queries.add(term(NAME, filter.name()));
-    }
+    ofNullable(stringOperations(NAME, filter.nameOperations())).ifPresent(queries::addAll);
+    ofNullable(stringOperations(EMAIL, filter.emailOperations())).ifPresent(queries::addAll);
     return and(queries);
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
@@ -188,7 +188,7 @@ class SearchClientBasedQueryExecutorTest {
                         Authentication.of(a -> a.user("foo").tenants(tenantIds)))));
 
     final var query =
-        new UserQuery.Builder().filter(new UserFilter.Builder().name("x").build()).build();
+        new UserQuery.Builder().filter(new UserFilter.Builder().usernames("x").build()).build();
 
     // when
     final SearchQueryRequest searchQueryRequest =

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
@@ -56,9 +56,9 @@ public class UserQueryTransformerTest extends AbstractTransformerTest {
             "username",
             "username1"),
         Arguments.of(
-            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.name("name1"), "name", "name1"),
+            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.names("name1"), "name", "name1"),
         Arguments.of(
-            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.email("email1"),
+            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.emails("email1"),
             "email",
             "email1"));
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserQueryTransformerTest.java
@@ -11,9 +11,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserFilter.Builder;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +51,8 @@ public class UserQueryTransformerTest extends AbstractTransformerTest {
     return Stream.of(
         Arguments.of((Function<Builder, ObjectBuilder<UserFilter>>) f -> f.key(1L), "key", 1L),
         Arguments.of(
-            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.username("username1"),
+            (Function<Builder, ObjectBuilder<UserFilter>>)
+                f -> f.usernameOperations(List.of(Operation.eq("username1"))),
             "username",
             "username1"),
         Arguments.of(

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -10,7 +10,6 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
-import io.camunda.search.filter.UserTaskFilter.Builder;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
@@ -22,8 +21,8 @@ import java.util.Set;
 public record UserFilter(
     Long key,
     List<Operation<String>> usernameOperations,
-    String name,
-    String email,
+    List<Operation<String>> nameOperations,
+    List<Operation<String>> emailOperations,
     String tenantId,
     String groupId,
     String roleId)
@@ -32,8 +31,8 @@ public record UserFilter(
   public Builder toBuilder() {
     return new Builder()
         .usernameOperations(usernameOperations)
-        .name(name)
-        .email(email)
+        .nameOperations(nameOperations)
+        .emailOperations(emailOperations)
         .tenantId(tenantId)
         .groupId(groupId)
         .roleId(roleId);
@@ -42,8 +41,8 @@ public record UserFilter(
   public static final class Builder implements ObjectBuilder<UserFilter> {
     private Long key;
     private List<Operation<String>> usernameOperations;
-    private String name;
-    private String email;
+    private List<Operation<String>> nameOperations;
+    private List<Operation<String>> emailOperations;
     private String tenantId;
     private String groupId;
     private String roleId;
@@ -72,14 +71,42 @@ public record UserFilter(
       return usernameOperations(collectValues(operation, operations));
     }
 
-    public Builder name(final String value) {
-      name = value;
+    public Builder nameOperations(final List<Operation<String>> operations) {
+      nameOperations = addValuesToList(nameOperations, operations);
       return this;
     }
 
-    public Builder email(final String value) {
-      email = value;
+    public Builder names(final Set<String> value) {
+      return nameOperations(FilterUtil.mapDefaultToOperation(new ArrayList<>(value)));
+    }
+
+    public Builder names(final String value, final String... values) {
+      return nameOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder nameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return nameOperations(collectValues(operation, operations));
+    }
+
+    public Builder emailOperations(final List<Operation<String>> operations) {
+      emailOperations = addValuesToList(emailOperations, operations);
       return this;
+    }
+
+    public Builder emails(final Set<String> value) {
+      return emailOperations(FilterUtil.mapDefaultToOperation(new ArrayList<>(value)));
+    }
+
+    public Builder emails(final String value, final String... values) {
+      return emailOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder emailOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return emailOperations(collectValues(operation, operations));
     }
 
     public Builder tenantId(final String value) {
@@ -102,8 +129,8 @@ public record UserFilter(
       return new UserFilter(
           key,
           Objects.requireNonNullElse(usernameOperations, Collections.emptyList()),
-          name,
-          email,
+          nameOperations,
+          emailOperations,
           tenantId,
           groupId,
           roleId);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -164,7 +164,7 @@ public sealed interface AuthenticationHandler {
     private Optional<UserEntity> loadUserByUsername(final String username) {
       final var userQuery =
           SearchQueryBuilders.userSearchQuery(
-              fn -> fn.filter(f -> f.username(username)).page(p -> p.size(1)));
+              fn -> fn.filter(f -> f.usernames(username)).page(p -> p.size(1)));
       return userServices.search(userQuery).items().stream().filter(Objects::nonNull).findFirst();
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7034,7 +7034,8 @@ components:
       properties:
         username:
           description: The username of the user.
-          type: "string"
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         name:
           description: The name of the user.
           type: "string"

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -7038,10 +7038,12 @@ components:
             - $ref: "#/components/schemas/StringFilterProperty"
         name:
           description: The name of the user.
-          type: "string"
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         email:
           description: The email of the user.
-          type: "string"
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
     MappingFilterRequest:
       description: Mapping search filter.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1052,15 +1052,16 @@ public final class SearchQueryRequestMapper {
   }
 
   private static UserFilter toUserFilter(final UserFilterRequest filter) {
-    return Optional.ofNullable(filter)
-        .map(
-            f ->
-                FilterBuilders.user()
-                    .username(f.getUsername())
-                    .name(f.getName())
-                    .email(f.getEmail())
-                    .build())
-        .orElse(null);
+
+    final var builder = FilterBuilders.user();
+    if (filter != null) {
+      Optional.ofNullable(filter.getUsername())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::usernameOperations);
+      Optional.ofNullable(filter.getName()).ifPresent(builder::name);
+      Optional.ofNullable(filter.getEmail()).ifPresent(builder::email);
+    }
+    return builder.build();
   }
 
   private static IncidentFilter toIncidentFilter(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1058,8 +1058,12 @@ public final class SearchQueryRequestMapper {
       Optional.ofNullable(filter.getUsername())
           .map(mapToOperations(String.class))
           .ifPresent(builder::usernameOperations);
-      Optional.ofNullable(filter.getName()).ifPresent(builder::name);
-      Optional.ofNullable(filter.getEmail()).ifPresent(builder::email);
+      Optional.ofNullable(filter.getName())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::nameOperations);
+      Optional.ofNullable(filter.getEmail())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::emailOperations);
     }
     return builder.build();
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -156,7 +156,7 @@ public class AuthorizationsUtil implements CloseableSilently {
   }
 
   public void awaitUserExistsInElasticsearch(final String username) {
-    final var userQuery = UserQuery.of(b -> b.filter(f -> f.username(username)));
+    final var userQuery = UserQuery.of(b -> b.filter(f -> f.usernames(username)));
     awaitEntityExistsInElasticsearch(() -> documentBasedSearchClients.searchUsers(userQuery));
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR enables filtering users when searching using advanced filters

This enables us to filter using advanced filters on username, email and name. It allows stuff like filtering in a collection, not 
in a collection, equality or inequality, etc.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32373 
