### PR TITLE
Auth request tenant id fix

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -97,7 +97,8 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
         new AuthorizationRequest(
                 command,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                PermissionType.UPDATE_PROCESS_INSTANCE)
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                incident.getTenantId())
             .addResourceId(incident.getBpmnProcessId());
     final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
     if (isAuthorized.isLeft()) {
@@ -152,7 +153,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             });
   }
 
-  private void processFailedCommand(TypedRecord<? extends UnifiedRecordValue> failedCommand) {
+  private void processFailedCommand(final TypedRecord<? extends UnifiedRecordValue> failedCommand) {
     if (failedCommand.getValue() instanceof ProcessInstanceRecord) {
       bpmnStreamProcessor.processRecord((TypedRecord<ProcessInstanceRecord>) failedCommand);
     } else if (failedCommand.getValue() instanceof UserTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -78,7 +78,8 @@ public final class DefaultJobCommandPreconditionGuard {
         new AuthorizationRequest(
                 command,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                PermissionType.UPDATE_PROCESS_INSTANCE)
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
     return authCheckBehavior.isAuthorized(request).map(unused -> job);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -93,6 +93,8 @@ final class JobBatchCollector {
             ? List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             : value.getTenantIds();
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
+    // the tenant check is performed earlier in the JobBatchActivateProcessor, so we can skip it
+    // here and only check if the requester has the correct permissions to access the jobs
     final var authorizedProcessIds =
         authCheckBehavior.getAllAuthorizedResourceIdentifiers(
             new AuthorizationRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -205,7 +205,8 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
         new AuthorizationRequest(
                 command,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                PermissionType.UPDATE_PROCESS_INSTANCE)
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
     return authCheckBehavior.isAuthorized(request).map(unused -> job);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -61,7 +61,8 @@ public class JobUpdateBehaviour {
         new AuthorizationRequest(
                 command,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                PermissionType.UPDATE_PROCESS_INSTANCE)
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                job.getTenantId())
             .addResourceId(job.getBpmnProcessId());
     return authCheckBehavior.isAuthorized(authRequest).map(unused -> job);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -197,7 +197,8 @@ public class ResourceDeletionDeleteProcessor
           command,
           AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_PROCESS,
-          bufferAsString(process.getBpmnProcessId()));
+          bufferAsString(process.getBpmnProcessId()),
+          process.getTenantId());
       setTenantId(command, tenantId);
       deleteProcess(process);
       return true;
@@ -211,7 +212,8 @@ public class ResourceDeletionDeleteProcessor
           command,
           AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_DRD,
-          bufferAsString(drg.getDecisionRequirementsId()));
+          bufferAsString(drg.getDecisionRequirementsId()),
+          drg.getTenantId());
       setTenantId(command, tenantId);
       deleteDecisionRequirements(drg);
       return true;
@@ -224,7 +226,8 @@ public class ResourceDeletionDeleteProcessor
           command,
           AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_FORM,
-          bufferAsString(form.getFormId()));
+          bufferAsString(form.getFormId()),
+          form.getTenantId());
       setTenantId(command, tenantId);
       deleteForm(form);
       return true;
@@ -237,7 +240,8 @@ public class ResourceDeletionDeleteProcessor
           command,
           AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_RESOURCE,
-          bufferAsString(resource.getResourceId()));
+          bufferAsString(resource.getResourceId()),
+          resource.getTenantId());
       setTenantId(command, tenantId);
       deleteResource(resource);
       return true;
@@ -465,9 +469,11 @@ public class ResourceDeletionDeleteProcessor
       final TypedRecord<ResourceDeletionRecord> command,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
-      final String resourceId) {
+      final String resourceId,
+      final String tenantId) {
     final var authRequest =
-        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
 
     if (authCheckBehavior.isAuthorized(authRequest).isLeft()) {
       throw new ForbiddenException(authRequest);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -76,7 +76,8 @@ public class UserTaskCommandPreconditionChecker {
         new AuthorizationRequest(
                 command,
                 AuthorizationResourceType.PROCESS_DEFINITION,
-                PermissionType.UPDATE_USER_TASK)
+                PermissionType.UPDATE_USER_TASK,
+                persistedRecord.getTenantId())
             .addResourceId(persistedRecord.getBpmnProcessId());
     final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
     if (isAuthorized.isLeft()) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -323,6 +323,28 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   @Test
+  void shouldBeAuthorizedForInternalData() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.GROUP;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, null, false, false)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
   void shouldBeUnauthorizedWhenMappingIsNotAssignedToRequestedTenant() {
     // given
     final var claimName = UUID.randomUUID().toString();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that the ID of the tenant that owns a given resource is passed to the authorization check when a processor accepts a command to operate on that resource.

Furthermore, internal data (like Users, Roles, Groups, Tenants) is not owned by tenants, and tenant ownership doesn't need to be validated in the authorization check for this type of entities. This PR adds a flag to the AuthorizationRequest class to specify when data is tenant-owned. The flag is then used to skip tenant checks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31977
