### PR TITLE
[Backport stable/8.6] fix: restore even when `lost+found` is found

### DIFF
--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -51,7 +52,7 @@ public class RestoreManager {
   public CompletableFuture<Void> restore(final long backupId, final boolean validateConfig) {
     final Path dataDirectory = Path.of(configuration.getData().getDirectory());
     try {
-      if (!FileUtil.isEmpty(dataDirectory)) {
+      if (!dataFolderIsEmpty(dataDirectory)) {
         LOG.error(
             "Brokers's data directory {} is not empty. Aborting restore to avoid overwriting data. Please restart with a clean directory.",
             dataDirectory);
@@ -144,6 +145,20 @@ public class RestoreManager {
 
     return new InstrumentedRaftPartition(
         factory.createRaftPartition(metadata, partitionRegistry), partitionRegistry);
+  }
+
+  private static boolean dataFolderIsEmpty(final Path dir) throws IOException {
+    if (!Files.exists(dir)) {
+      return true;
+    }
+
+    try (final var entries = Files.list(dir)) {
+      return entries
+          // ignore the well-known lost+found directory, we don't care that it's there.
+          .filter(path -> !path.endsWith("lost+found"))
+          .findFirst()
+          .isEmpty();
+    }
   }
 
   static final class ValidatePartitionCount implements BackupValidator {

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/RestoreManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class RestoreManagerTest {
+
+  @Test
+  void shouldFailWhenDirectoryIsNotEmpty(@TempDir final Path dir) throws IOException {
+    // given
+    final var configuration = new BrokerCfg();
+    configuration.getData().setDirectory(dir.toString());
+    final var restoreManager =
+        new RestoreManager(
+            configuration, new TestRestorableBackupStore(), new SimpleMeterRegistry());
+
+    // when
+    Files.createDirectory(dir.resolve("other-data"));
+
+    // then
+    assertThat(restoreManager.restore(1L, false))
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withRootCauseInstanceOf(DirectoryNotEmptyException.class)
+        .isNotNull();
+  }
+
+  @Test
+  void shouldNotFailOnLostAndFoundDirectory(@TempDir final Path dir) throws IOException {
+    // given
+    final var configuration = new BrokerCfg();
+    configuration.getData().setDirectory(dir.toString());
+    final var restoreManager =
+        new RestoreManager(
+            configuration, new TestRestorableBackupStore(), new SimpleMeterRegistry());
+
+    // when
+    Files.createDirectory(dir.resolve("lost+found"));
+
+    // then
+    assertThat(restoreManager.restore(1L, false))
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withRootCauseInstanceOf(BackupNotFoundException.class)
+        .isNotNull();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #32399 to `stable/8.6`.

relates to #32393