### PR TITLE
feat: support searching mappings by role in the CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -112,6 +112,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
@@ -2267,6 +2268,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the mappings by group search request
    */
   MappingsByGroupSearchRequest newMappingsByGroupSearchRequest(String groupId);
+
+  /**
+   * Executes a search request to query mappings by role.
+   *
+   * <pre>
+   * camundaClient
+   *  .newMappingsByRoleSearchRequest("roleId")
+   *  .filter((f) -> f.mappingId("mapping-123"))
+   *  .sort((s) -> s.mappingId().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @param roleId the ID of the role
+   * @return a builder for the mappings by role search request
+   */
+  MappingsByRoleSearchRequest newMappingsByRoleSearchRequest(String roleId);
 
   /**
    * Executes a search request to query roles by group.

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/MappingsByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/MappingsByRoleSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.MappingFilter;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.client.api.search.sort.MappingSort;
+
+public interface MappingsByRoleSearchRequest
+    extends TypedSearchRequest<MappingFilter, MappingSort, MappingsByRoleSearchRequest>,
+        FinalSearchRequestStep<Mapping> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -123,6 +123,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSequenceFlowsRequest;
@@ -229,6 +230,7 @@ import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByGroupSearchRequestImpl;
+import io.camunda.client.impl.search.request.MappingsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessDefinitionSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessInstanceSequenceFlowsRequestImpl;
@@ -1154,6 +1156,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public MappingsByGroupSearchRequest newMappingsByGroupSearchRequest(final String groupId) {
     return new MappingsByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest newMappingsByRoleSearchRequest(final String roleId) {
+    return new MappingsByRoleSearchRequestImpl(httpClient, jsonMapper, roleId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/MappingsByRoleSearchRequestImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.mappingSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.MappingFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.MappingSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.MappingSearchQueryRequest;
+import io.camunda.client.protocol.rest.MappingSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class MappingsByRoleSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<MappingSearchQueryRequest>
+    implements MappingsByRoleSearchRequest {
+
+  private final MappingSearchQueryRequest request;
+  private final String roleId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public MappingsByRoleSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String roleId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.roleId = roleId;
+    this.httpRequestConfig = httpClient.newRequestConfig();
+    this.request = new MappingSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Mapping> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Mapping>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
+    final HttpCamundaFuture<SearchResponse<Mapping>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/roles/%s/mapping-rules/search", roleId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        MappingSearchQueryResult.class,
+        SearchResponseMapper::toMappingsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest filter(final MappingFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest filter(final Consumer<MappingFilter> fn) {
+    return filter(mappingFilter(fn));
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest sort(final MappingSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toMappingSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest sort(final Consumer<MappingSort> fn) {
+    return sort(mappingSort(fn));
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public MappingsByRoleSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected MappingSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/role/MappingsByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/MappingsByRoleSearchRequestTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.role;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class MappingsByRoleSearchRequestTest extends ClientRestTest {
+
+  @Test
+  void shouldSendSearchMappingsByRoleRequest() {
+    final String roleId = "testRoleId";
+    client.newMappingsByRoleSearchRequest(roleId).send().join();
+
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .startsWith(REST_API_PATH + "/roles/" + roleId + "/mapping-rules/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSendRequestWithSortByResourceType() {
+    final String roleId = "testRoleId";
+    client.newMappingsByRoleSearchRequest(roleId).sort(s -> s.claimValue().asc()).send().join();
+
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBodyAsString())
+        .contains("{\"sort\":[{\"field\":\"claimValue\",\"order\":\"ASC\"}]}");
+  }
+
+  @Test
+  void shouldFailOnEmptyRoleId() {
+    assertThatThrownBy(() -> client.newMappingsByRoleSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be empty");
+  }
+
+  @Test
+  void shouldFailOnNullRoleId() {
+    assertThatThrownBy(() -> client.newMappingsByRoleSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be null");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
@@ -10,21 +10,13 @@ package io.camunda.it.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.client.protocol.rest.MappingSearchQueryResult;
+import io.camunda.client.api.search.response.Mapping;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -34,11 +26,6 @@ public class RolesByMappingIntegrationTest {
   private static CamundaClient camundaClient;
 
   private static final String EXISTING_ROLE_ID = Strings.newRandomValidIdentityId();
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @BeforeAll
   static void setup() {
@@ -63,15 +50,7 @@ public class RolesByMappingIntegrationTest {
     final var mappingId = Strings.newRandomValidIdentityId();
 
     createRole(roleId, "ARoleName", "description");
-
-    camundaClient
-        .newCreateMappingCommand()
-        .mappingId(mappingId)
-        .name("mappingName")
-        .claimName("testClaimName")
-        .claimValue("testClaimValue")
-        .send()
-        .join();
+    createMapping(mappingId, "mappingName", "testClaimName", "testClaimValue");
 
     // when
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
@@ -86,15 +65,7 @@ public class RolesByMappingIntegrationTest {
     final var mappingId = Strings.newRandomValidIdentityId();
 
     createRole(roleId, "ARoleName", "description");
-
-    camundaClient
-        .newCreateMappingCommand()
-        .mappingId(mappingId)
-        .name("someMappingName")
-        .claimName("someTestClaimName")
-        .claimValue("someTestClaimValue")
-        .send()
-        .join();
+    createMapping(mappingId, "someMappingName", "someTestClaimName", "someTestClaimValue");
 
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
 
@@ -111,14 +82,7 @@ public class RolesByMappingIntegrationTest {
     // then
     Awaitility.await("Mapping is unassigned from the role")
         .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        searchMappingRuleByRole(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                roleId)
-                            .getItems())
-                    .isEmpty());
+        .untilAsserted(() -> assertThat(searchMappingRuleByRole(roleId).items()).isEmpty());
   }
 
   @Test
@@ -128,15 +92,7 @@ public class RolesByMappingIntegrationTest {
     final var mappingId = Strings.newRandomValidIdentityId();
 
     createRole(roleId, "ARoleName", "description");
-
-    camundaClient
-        .newCreateMappingCommand()
-        .mappingId(mappingId)
-        .name("mappingName")
-        .claimName("aClaimName")
-        .claimValue("aClaimValue")
-        .send()
-        .join();
+    createMapping(mappingId, "mappingName", "aClaimName", "aClaimValue");
 
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
 
@@ -148,14 +104,7 @@ public class RolesByMappingIntegrationTest {
     // then
     Awaitility.await("Mapping is unassigned from deleted role")
         .ignoreExceptionsInstanceOf(ProblemException.class)
-        .untilAsserted(
-            () ->
-                assertThat(
-                        searchMappingRuleByRole(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                roleId)
-                            .getItems())
-                    .isEmpty());
+        .untilAsserted(() -> assertThat(searchMappingRuleByRole(roleId).items()).isEmpty());
   }
 
   @Test
@@ -163,14 +112,7 @@ public class RolesByMappingIntegrationTest {
     // given
     final var mappingId = Strings.newRandomValidIdentityId();
 
-    camundaClient
-        .newCreateMappingCommand()
-        .mappingId(mappingId)
-        .name("mappingName")
-        .claimName("claimName")
-        .claimValue("claimValue")
-        .send()
-        .join();
+    createMapping(mappingId, "mappingName", "claimName", "claimValue");
 
     camundaClient
         .newAssignRoleToMappingCommand()
@@ -202,14 +144,7 @@ public class RolesByMappingIntegrationTest {
     // given
     final var mappingId = Strings.newRandomValidIdentityId();
 
-    camundaClient
-        .newCreateMappingCommand()
-        .mappingId(mappingId)
-        .name("mappingName")
-        .claimName("someClaimName")
-        .claimValue("someClaimValue")
-        .send()
-        .join();
+    createMapping(mappingId, "mappingName", "someClaimName", "someClaimValue");
 
     // when/then
     assertThatThrownBy(
@@ -227,36 +162,6 @@ public class RolesByMappingIntegrationTest {
                 + "' from role with ID '"
                 + EXISTING_ROLE_ID
                 + "', but the entity is not assigned to this role.");
-  }
-
-  @Test
-  void shouldRejectUnassigningRoleFromMappingIfMissingRoleId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newUnassignRoleFromMappingCommand()
-                    .roleId(null)
-                    .mappingId("someMappingId")
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("roleId must not be null");
-  }
-
-  @Test
-  void shouldRejectUnassigningRoleFromMappingIfMissingMappingId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newUnassignRoleFromMappingCommand()
-                    .roleId(EXISTING_ROLE_ID)
-                    .mappingId(null)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("mappingId must not be null");
   }
 
   @Test
@@ -338,33 +243,258 @@ public class RolesByMappingIntegrationTest {
   }
 
   @Test
-  void shouldRejectAssigningRoleToMappingIfMissingMappingId() {
+  void shouldSearchMappingsByRole() {
+    // given
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    final var mappingName = Strings.newRandomValidIdentityId();
+    final var claimName = Strings.newRandomValidIdentityId();
+    final var claimValue = Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "SearchRole", "desc");
+    createMapping(mappingId, mappingName, claimName, claimValue);
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
     // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignRoleToMappingCommand()
-                    .roleId(EXISTING_ROLE_ID)
-                    .mappingId(null)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("mappingId must not be null");
+    Awaitility.await("Mapping should be found by role")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result = camundaClient.newMappingsByRoleSearchRequest(roleId).send().join();
+              assertThat(result.items())
+                  .singleElement()
+                  .satisfies(
+                      mapping -> {
+                        assertThat(mapping.getName()).isEqualTo(mappingName);
+                        assertThat(mapping.getMappingId()).isEqualTo(mappingId);
+                        assertThat(mapping.getClaimValue()).isEqualTo(claimValue);
+                        assertThat(mapping.getClaimName()).isEqualTo(claimName);
+                      });
+            });
   }
 
   @Test
-  void shouldRejectAssigningRoleToMappingIfMissingRoleId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newAssignRoleToMappingCommand()
-                    .roleId(null)
-                    .mappingId(Strings.newRandomValidIdentityId())
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("roleId must not be null");
+  void shouldReturnEmptyListForRoleWithoutMappings() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    createRole(roleId, "EmptyRole", "desc");
+    final var result = camundaClient.newMappingsByRoleSearchRequest(roleId).send().join();
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortMappingsByName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingA = Strings.newRandomValidIdentityId();
+    final var mappingB = Strings.newRandomValidIdentityId();
+    final var mappingC = Strings.newRandomValidIdentityId();
+
+    final var nameA = "AAA-" + Strings.newRandomValidIdentityId();
+    final var nameB = "BBB-" + Strings.newRandomValidIdentityId();
+    final var nameC = "CCC-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "SortRole", "desc");
+    createMapping(
+        mappingA, nameA, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId());
+    createMapping(
+        mappingB, nameB, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId());
+    createMapping(
+        mappingC, nameC, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId());
+
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingA).send().join();
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingB).send().join();
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingC).send().join();
+
+    Awaitility.await("Mappings are sorted by name")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .sort(s -> s.name().desc())
+                      .send()
+                      .join();
+
+              assertThat(result.items())
+                  .extracting(Mapping::getName)
+                  .containsExactly(nameC, nameB, nameA);
+            });
+  }
+
+  @Test
+  void shouldSortMappingsByClaimName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingA = Strings.newRandomValidIdentityId();
+    final var mappingB = Strings.newRandomValidIdentityId();
+
+    final var claimA = "AAA-" + Strings.newRandomValidIdentityId();
+    final var claimB = "BBB-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "SortRole", "desc");
+    createMapping(
+        mappingA, Strings.newRandomValidIdentityId(), claimA, Strings.newRandomValidIdentityId());
+    createMapping(
+        mappingB, Strings.newRandomValidIdentityId(), claimB, Strings.newRandomValidIdentityId());
+
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingA).send().join();
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingB).send().join();
+
+    Awaitility.await("Mappings are sorted by claimName")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .sort(s -> s.claimName().asc())
+                      .send()
+                      .join();
+
+              assertThat(result.items())
+                  .extracting(Mapping::getClaimName)
+                  .containsExactly(claimA, claimB);
+            });
+  }
+
+  @Test
+  void shouldSortMappingsByClaimValueAsc() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingA = Strings.newRandomValidIdentityId();
+    final var mappingB = Strings.newRandomValidIdentityId();
+
+    final var valueA = "aaa-" + Strings.newRandomValidIdentityId();
+    final var valueB = "bbb-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "SortRole", "desc");
+    createMapping(
+        mappingA, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId(), valueA);
+    createMapping(
+        mappingB, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId(), valueB);
+
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingA).send().join();
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingB).send().join();
+
+    Awaitility.await("Mappings are sorted by claimValue")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .sort(s -> s.claimValue().desc())
+                      .send()
+                      .join();
+
+              assertThat(result.items())
+                  .extracting(Mapping::getClaimValue)
+                  .containsExactly(valueB, valueA);
+            });
+  }
+
+  @Test
+  void shouldFilterByMappingName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    final var name = "filter-name-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "FilterRole", "desc");
+    createMapping(
+        mappingId, name, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId());
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+
+    Awaitility.await("Mapping is filtered by name")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .filter(f -> f.name(name))
+                      .send()
+                      .join();
+              assertThat(result.items())
+                  .singleElement()
+                  .extracting(Mapping::getName)
+                  .isEqualTo(name);
+            });
+  }
+
+  @Test
+  void shouldFilterByClaimName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    final var claimName = "filter-claimName-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "FilterRole", "desc");
+    createMapping(
+        mappingId,
+        Strings.newRandomValidIdentityId(),
+        claimName,
+        Strings.newRandomValidIdentityId());
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+
+    Awaitility.await("Mapping is filtered by claimName")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .filter(f -> f.claimName(claimName))
+                      .send()
+                      .join();
+              assertThat(result.items())
+                  .singleElement()
+                  .extracting(Mapping::getClaimName)
+                  .isEqualTo(claimName);
+            });
+  }
+
+  @Test
+  void shouldFilterByClaimValue() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    final var claimValue = "filter-claimValue-" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "FilterRole", "desc");
+    createMapping(
+        mappingId,
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId(),
+        claimValue);
+    createMapping(
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId());
+    camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+
+    Awaitility.await("Mapping is filtered by claimValue")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newMappingsByRoleSearchRequest(roleId)
+                      .filter(f -> f.claimValue(claimValue))
+                      .send()
+                      .join();
+              assertThat(result.items())
+                  .singleElement()
+                  .extracting(Mapping::getClaimValue)
+                  .isEqualTo(claimValue);
+            });
+  }
+
+  private static void createMapping(
+      final String mappingId, final String name, final String claimName, final String claimValue) {
+    camundaClient
+        .newCreateMappingCommand()
+        .mappingId(mappingId)
+        .name(name)
+        .claimName(claimName)
+        .claimValue(claimValue)
+        .send()
+        .join();
   }
 
   private static void verifyRoleIsAssignedToMapping(final String roleId, final String mappingId) {
@@ -372,30 +502,13 @@ public class RolesByMappingIntegrationTest {
         .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
             () ->
-                assertThat(
-                        searchMappingRuleByRole(
-                                camundaClient.getConfiguration().getRestAddress().toString(),
-                                roleId)
-                            .getItems())
+                assertThat(searchMappingRuleByRole(roleId).items())
                     .hasSize(1)
                     .anyMatch(m -> mappingId.equals(m.getMappingId())));
   }
 
-  // TODO once available, this test should use the client to make the request
-  private static MappingSearchQueryResult searchMappingRuleByRole(
-      final String restAddress, final String roleId)
-      throws URISyntaxException, IOException, InterruptedException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    "%s%s".formatted(restAddress, "v2/roles/" + roleId + "/mapping-rules/search")))
-            .POST(HttpRequest.BodyPublishers.ofString(""))
-            .build();
-
-    final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), MappingSearchQueryResult.class);
+  private static SearchResponse<Mapping> searchMappingRuleByRole(final String roleId) {
+    return camundaClient.newMappingsByRoleSearchRequest(roleId).send().join();
   }
 
   private static void createRole(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByMappingIntegrationTest.java
@@ -394,12 +394,25 @@ public class RolesByMappingIntegrationTest {
   void shouldFilterByMappingName() {
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
+    final var nonMatchingMappingId = Strings.newRandomValidIdentityId();
     final var name = "filter-name-" + Strings.newRandomValidIdentityId();
 
     createRole(roleId, "FilterRole", "desc");
     createMapping(
         mappingId, name, Strings.newRandomValidIdentityId(), Strings.newRandomValidIdentityId());
+    createMapping(
+        nonMatchingMappingId,
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId());
+
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+    camundaClient
+        .newAssignRoleToMappingCommand()
+        .roleId(roleId)
+        .mappingId(nonMatchingMappingId)
+        .send()
+        .join();
 
     Awaitility.await("Mapping is filtered by name")
         .ignoreExceptionsInstanceOf(ProblemException.class)
@@ -422,6 +435,7 @@ public class RolesByMappingIntegrationTest {
   void shouldFilterByClaimName() {
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
+    final var nonMatchingMappingId = Strings.newRandomValidIdentityId();
     final var claimName = "filter-claimName-" + Strings.newRandomValidIdentityId();
 
     createRole(roleId, "FilterRole", "desc");
@@ -430,7 +444,19 @@ public class RolesByMappingIntegrationTest {
         Strings.newRandomValidIdentityId(),
         claimName,
         Strings.newRandomValidIdentityId());
+    createMapping(
+        nonMatchingMappingId,
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId(),
+        Strings.newRandomValidIdentityId());
+
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+    camundaClient
+        .newAssignRoleToMappingCommand()
+        .roleId(roleId)
+        .mappingId(nonMatchingMappingId)
+        .send()
+        .join();
 
     Awaitility.await("Mapping is filtered by claimName")
         .ignoreExceptionsInstanceOf(ProblemException.class)
@@ -453,6 +479,7 @@ public class RolesByMappingIntegrationTest {
   void shouldFilterByClaimValue() {
     final var roleId = Strings.newRandomValidIdentityId();
     final var mappingId = Strings.newRandomValidIdentityId();
+    final var nonMatchingMappingId = Strings.newRandomValidIdentityId();
     final var claimValue = "filter-claimValue-" + Strings.newRandomValidIdentityId();
 
     createRole(roleId, "FilterRole", "desc");
@@ -462,11 +489,17 @@ public class RolesByMappingIntegrationTest {
         Strings.newRandomValidIdentityId(),
         claimValue);
     createMapping(
-        Strings.newRandomValidIdentityId(),
+        nonMatchingMappingId,
         Strings.newRandomValidIdentityId(),
         Strings.newRandomValidIdentityId(),
         Strings.newRandomValidIdentityId());
     camundaClient.newAssignRoleToMappingCommand().roleId(roleId).mappingId(mappingId).send().join();
+    camundaClient
+        .newAssignRoleToMappingCommand()
+        .roleId(roleId)
+        .mappingId(nonMatchingMappingId)
+        .send()
+        .join();
 
     Awaitility.await("Mapping is filtered by claimValue")
         .ignoreExceptionsInstanceOf(ProblemException.class)


### PR DESCRIPTION
## Description

This PR introduces support for querying mappings by role through the CamundaClient, updates integration tests to exercise the new search path, and adds corresponding unit tests and implementations.

Add newMappingsByRoleSearchRequest API, its interface, and implementation
Update acceptance tests to call the new search method instead of a custom HTTP helper
Add unit tests in MappingsByRoleSearchRequestTest for the new request builder

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31739
