### PR TITLE
Group similar error bulk messages from ES.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -206,6 +205,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
     final String errorMessages =
         groupedErrors.entrySet().stream()
+            .limit(50)
             .map(
                 entry ->
                     String.format(
@@ -235,22 +235,5 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   private record ErrorValues(List<String> indexes, List<String> ids) {}
 
-  private record ErrorKey(OperationType operationType, String errorReason) {
-    @Override
-    public boolean equals(final Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!(obj instanceof final ErrorKey errorKey)) {
-        return false;
-      }
-      return Objects.equals(operationType, errorKey.operationType)
-          && Objects.equals(errorReason, errorKey.errorReason);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(operationType, errorReason);
-    }
-  }
+  private record ErrorKey(OperationType operationType, String errorReason) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -14,12 +14,15 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkRequest.Builder;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -188,14 +191,29 @@ public class ElasticsearchBatchRequest implements BatchRequest {
       return;
     }
 
-    final String errorMessages =
+    final Map<ErrorKey, List<String>> groupedErrors =
         errorItems.stream()
+            .collect(
+                Collectors.groupingBy(
+                    item -> new ErrorKey(item.operationType(), item.index(), item.error().reason()),
+                    LinkedHashMap::new,
+                    Collectors.mapping(BulkResponseItem::id, Collectors.toList())));
+
+    final String errorMessages =
+        groupedErrors.entrySet().stream()
+            // these error groups can sometimes be too large and even
+            // overflow the logger buffer.
+            .limit(100)
             .map(
-                item ->
+                entry ->
                     String.format(
-                        "%s failed for type [%s] and id [%s]: %s",
-                        item.operationType(), item.index(), item.id(), item.error().reason()))
+                        "%s failed for type %s with ids: %s: %s",
+                        entry.getKey().operationType,
+                        entry.getKey().index,
+                        entry.getValue(),
+                        entry.getKey().errorReason))
             .collect(Collectors.joining(", \n"));
+
     LOGGER.debug("Bulk request execution failed: \n[{}]", errorMessages);
 
     errorItems.forEach(
@@ -211,5 +229,25 @@ public class ElasticsearchBatchRequest implements BatchRequest {
             throw new PersistenceException(message);
           }
         });
+  }
+
+  private record ErrorKey(OperationType operationType, String index, String errorReason) {
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof final ErrorKey errorKey)) {
+        return false;
+      }
+      return Objects.equals(operationType, errorKey.operationType)
+          && Objects.equals(index, errorKey.index)
+          && Objects.equals(errorReason, errorKey.errorReason);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(operationType, index, errorReason);
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -207,6 +206,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
     final String errorMessages =
         groupedErrors.entrySet().stream()
+            .limit(50)
             .map(
                 entry ->
                     String.format(
@@ -236,22 +236,5 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   private record ErrorValues(List<String> indexes, List<String> ids) {}
 
-  private record ErrorKey(OperationType operationType, String errorReason) {
-    @Override
-    public boolean equals(final Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!(obj instanceof final ErrorKey errorKey)) {
-        return false;
-      }
-      return Objects.equals(operationType, errorKey.operationType)
-          && Objects.equals(errorReason, errorKey.errorReason);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(operationType, errorReason);
-    }
-  }
+  private record ErrorKey(OperationType operationType, String errorReason) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -368,7 +368,7 @@ class ElasticsearchBatchRequestTest {
 
     final String message =
         String.format(
-            "%s failed for type [%s] and id [%s]: %s",
+            "%s failed on index [%s] and id [%s]: %s",
             item.operationType(), item.index(), item.id(), item.error().reason());
 
     // When


### PR DESCRIPTION
## Description

Sometimes it can happen that, in OpenSearch or ElasticSearch bulk requests, the log messages reporting the failure for BatchRequests become too large and even "break" Google's Logs exporter.

This PR groups similar messages and shows the IDs where this happens instead of printing unique message for each ID. Additionally also limits the number of possible group errors by 50.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/31627
