### PR TITLE
[Backport stable/optimize-8.6] fix: disable unwanted focus trap for actionable notification in configuration modal

### DIFF
--- a/optimize/client/src/components/Processes/ConfigureProcessModal.js
+++ b/optimize/client/src/components/Processes/ConfigureProcessModal.js
@@ -58,6 +58,7 @@ export function ConfigureProcessModal({
                 ),
               })}
               className="emailWarning"
+              role="div"
             />
           )}
           <UserTypeahead

--- a/optimize/client/src/components/Processes/ConfigureProcessModal.scss
+++ b/optimize/client/src/components/Processes/ConfigureProcessModal.scss
@@ -5,4 +5,10 @@
     display: flex;
     gap: spacing.$spacing-02;
   }
+
+  .cds--actionable-notification {
+    .cds--visually-hidden {
+      display: none;
+    }
+  }
 }

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.js
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.js
@@ -268,6 +268,7 @@ export class AlertModal extends React.Component {
                           'self-managed/optimize-deployment/configuration/system-configuration/#email'
                         ),
                       })}
+                      role="div"
                     />
                   )}
                   {inactive && (

--- a/optimize/client/src/modules/components/AlertModal/AlertModal.scss
+++ b/optimize/client/src/modules/components/AlertModal/AlertModal.scss
@@ -9,8 +9,14 @@
     }
   }
 
-  .cds--actionable-notification__content {
-    display: inline;
+  .cds--actionable-notification {
+    .cds--visually-hidden {
+      display: none;
+    }
+
+    &__content {
+      display: inline;
+    }
   }
 
   .labelHidden {


### PR DESCRIPTION
# Description
Backport of #32357 to `stable/optimize-8.6`.

relates to #32245