### PR TITLE
feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -58,7 +58,7 @@ public class DbMigratorImpl implements DbMigrator {
           new ColumnFamilyPrefixCorrectionMigration(),
           new MultiTenancySignalSubscriptionStateMigration(),
           new JobBackoffRestoreMigration(),
-          new RoutingInfoMigration(),
+          new RoutingInfoInitializationMigration(),
           new OrderedCommandDistributionMigration(),
           new IdempotentCommandDistributionMigration());
   private static final Logger LOGGER =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -106,7 +106,7 @@ public class DbMigratorImpl implements DbMigrator {
     var initializationOnly = false;
     switch (checkVersionCompatibility()) {
       case final Indeterminate.PreviousVersionUnknown unknown:
-        LOGGER.debug("Snapshot is empty, no migrations to run");
+        LOGGER.debug("Snapshot is empty, only initialization migrations will be run.");
         initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
@@ -115,7 +115,7 @@ public class DbMigratorImpl implements DbMigrator {
       default:
         break;
     }
-    logPreview(migrationTasks);
+    logPreview(migrationTasks, initializationOnly);
 
     final var executedMigrations = runMigrations(initializationOnly);
 
@@ -185,7 +185,8 @@ public class DbMigratorImpl implements DbMigrator {
     migrationTaskContext.processingState().getMigrationState().setMigratedByVersion(currentVersion);
   }
 
-  private void logPreview(final List<MigrationTask> migrationTasks) {
+  private void logPreview(
+      final List<MigrationTask> migrationTasks, final boolean initializationOnly) {
     LOGGER.info(
         "Starting processing {} migration tasks (use LogLevel.DEBUG for more details) ... ",
         migrationTasks.size());
@@ -193,6 +194,7 @@ public class DbMigratorImpl implements DbMigrator {
         "Found {} migration tasks: {}",
         migrationTasks.size(),
         migrationTasks.stream()
+            .filter(task -> !initializationOnly || task.isInitialization())
             .map(MigrationTask::getIdentifier)
             .collect(Collectors.joining(", ")));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -51,6 +51,14 @@ public interface MigrationTask {
   /** Returns whether the migration needs to run. */
   boolean needsToRun(final MigrationTaskContext context);
 
+  /**
+   * Returns whether the migration is an initialization task, that must be executed even when the
+   * database is empty.
+   */
+  default boolean isInitialization() {
+    return false;
+  }
+
   /** Implementations of this method perform the actual migration */
   void runMigration(final MutableMigrationTaskContext context);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-public class RoutingInfoMigration implements MigrationTask {
+public class RoutingInfoInitializationMigration implements MigrationTask {
 
   @Override
   public String getIdentifier() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigration.java
@@ -20,6 +20,11 @@ public class RoutingInfoMigration implements MigrationTask {
   }
 
   @Override
+  public boolean isInitialization() {
+    return true;
+  }
+
+  @Override
   public void runMigration(final MutableMigrationTaskContext context) {
     final var routingState = context.processingState().getRoutingState();
     final var partitionCount = context.clusterContext().partitionCount();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -31,10 +31,10 @@ import org.mockito.Mockito;
 public class DbMigratorImplTest {
 
   private static final String CURRENT_VERSION = "8.8.0";
-  MutableProcessingState mockProcessingState;
-  MigrationTaskContextImpl context;
-  ArrayList<MigrationTask> migrations = new ArrayList<>();
-  DbMigratorImpl sut;
+  private MutableProcessingState mockProcessingState;
+  private MigrationTaskContextImpl context;
+  private final ArrayList<MigrationTask> migrations = new ArrayList<>();
+  private DbMigratorImpl sut;
 
   @BeforeEach
   public void setup() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -251,7 +252,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration, never()).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
@@ -270,7 +271,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -251,7 +251,27 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
+    verify(migration).isInitialization();
     verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
+  }
+
+  @Test
+  void shouldOnlyRunInitializationMigrationsWhenDbIsEmpty() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    when(migration.isInitialization()).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration).isInitialization();
+    verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.migration;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -17,29 +18,38 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
-import io.camunda.zeebe.util.VersionUtil;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 public class DbMigratorImplTest {
 
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  MigrationTaskContextImpl context;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    migrations.clear();
+    sut = new DbMigratorImpl(true, context, migrations, CURRENT_VERSION);
+  }
+
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(true);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -51,15 +61,9 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(false);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -71,17 +75,12 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -96,19 +95,13 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- first migration fails
     doThrow(RuntimeException.class).when(mockMigration1).runMigration(context);
@@ -118,25 +111,19 @@ public class DbMigratorImplTest {
     // then -- second migration is not run
     verify(mockMigration2, never()).runMigration(any());
     // then -- version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- second migration fails
     doThrow(RuntimeException.class).when(mockMigration2).runMigration(context);
@@ -145,64 +132,54 @@ public class DbMigratorImplTest {
     assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
 
     // then -- the version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldSetVersionAfterRunningMigrations() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- running migrations
     sut.runMigrations();
 
     // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
   }
 
   @Test
-  void shouldThrowOnInvalidUpgrade() {
+  void shouldThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(any())).thenReturn(true);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Snapshot is not compatible with current version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
+  }
 
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+  @Test
+  void shouldThrowOnInvalidUpgradeFromAlpha() {
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(true, context, migrations, "2.0.0-alpha1");
 
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot upgrade to or from a pre-release version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot upgrade to or from a pre-release version");
 
     // then -- migration is not run
     verify(mockMigration, never())
@@ -210,62 +187,71 @@ public class DbMigratorImplTest {
   }
 
   @Test
-  void shouldNotThrowOnInvalidUpgrade() {
+  void shouldNotThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
     final boolean versionCheckEnabled = false; // disable version check
-
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(any())).thenReturn(true);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
-    final var sut =
-        new DbMigratorImpl(versionCheckEnabled, context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
-    // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatNoException().isThrownBy(sut::runMigrations);
-    }
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
 
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
 
-      // then -- running migrations throws
-      assertThatNoException().isThrownBy(sut::runMigrations);
-    }
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromAlphas() {
+    // given - upgrading to a pre-release version
+    final boolean versionCheckEnabled = false; // disable version check
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0-alpha1");
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
 
     // then -- migration is run
-    verify(mockMigration, times(2))
+    verify(mockMigration, times(1))
         .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
   }
 
   @Test
   void shouldNotRunMigrationsIfTheSameVersion() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
     // the version is the same as the migrated version
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final String currentVersion = VersionUtil.getVersion();
-    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
 
     final var mockMigration = mock(MigrationTask.class);
 
-    final var sut =
-        new DbMigratorImpl(
-            new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState),
-            Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
 
     // then
     verify(mockMigration, never()).runMigration(any());
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
-final class RoutingInfoMigrationTest {
+final class RoutingInfoInitializationMigrationTest {
   @SuppressWarnings("unused")
   private MutableProcessingState processingState;
 
@@ -27,7 +27,7 @@ final class RoutingInfoMigrationTest {
     final var clusterContext = new ClusterContextImpl(3);
 
     // when
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
     migration.runMigration(context);
 
@@ -40,7 +40,7 @@ final class RoutingInfoMigrationTest {
   void shouldNotRunMigrationAgain() {
     // given
     final var clusterContext = new ClusterContextImpl(3);
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
 
     // when
@@ -54,7 +54,7 @@ final class RoutingInfoMigrationTest {
   void shouldInitializeRoutingInfo() {
     // given
     final var clusterContext = new ClusterContextImpl(3);
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
 
     // when
@@ -66,5 +66,14 @@ final class RoutingInfoMigrationTest {
     assertThat(updatedRoutingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(updatedRoutingState.messageCorrelation())
         .isEqualTo(new MessageCorrelation.HashMod(3));
+  }
+
+  @Test
+  void shouldBeAnInitialization() {
+    // given
+    final var migration = new RoutingInfoInitializationMigration();
+
+    // when/then
+    assertThat(migration.isInitialization()).isTrue();
   }
 }


### PR DESCRIPTION
## Description
When zeebe is run for the first time the snapshot version is unknown, so migration can be safely skipped.

For context, these 4 migrations are run at startup:
- `ProcessInstanceByProcessDefinitionMigration` (checks in the state if needs to run)
- `JobTimeoutCleanupMigration` always run
- `JobBackoffCleanupMigration` always run
- `ColumnFamilyPrefixCorrectionMigration` always run

I added a new method to `MigrationTask` so that migrations that needs to be run even if the DB is empty, they can do so, example:
- `RoutingInfoMigrationTask`

Other small changes:
- `DBMigratorImpl` does not use directly `VersionUtil.currentVersion` to simplify testing
- `DbMigratorImplTest` common mocks have been setup in a `@BeforeEach` block and deep stubs are used


relates to #32388