### PR TITLE
pg-32153-distribute-to-scaling

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -194,7 +194,9 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
       final CommandDistributionRecord distributionRecord,
       final long distributionKey) {
     final var distributionQueue = Optional.ofNullable(distributionRecord.getQueueId());
-    distributionQueue.ifPresent(queue -> enqueueDistribution(queue, partition, distributionKey));
+    distributionQueue.ifPresentOrElse(
+        queue -> enqueueDistribution(queue, partition, distributionKey),
+        () -> getMetrics().addPendingDistribution(partition));
 
     if (routingInfo.isPartitionScaling(partition)) {
       // If the partition is currently being scaled up, we don't want to distribute the command yet.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -194,9 +194,9 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
       final CommandDistributionRecord distributionRecord,
       final long distributionKey) {
     final var distributionQueue = Optional.ofNullable(distributionRecord.getQueueId());
-    distributionQueue.ifPresentOrElse(
-        queue -> enqueueDistribution(queue, partition, distributionKey),
-        () -> getMetrics().addPendingDistribution(partition));
+    distributionQueue.ifPresent(queue -> enqueueDistribution(queue, partition, distributionKey));
+
+    getMetrics().addPendingDistribution(partition);
 
     if (routingInfo.isPartitionScaling(partition)) {
       // If the partition is currently being scaled up, we don't want to distribute the command yet.
@@ -224,8 +224,6 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
         distributionKey,
         CommandDistributionIntent.ENQUEUED,
         commandDistributionEnqueued.setQueueId(queue).setPartitionId(partition));
-
-    getMetrics().addPendingDistribution(partition);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -188,6 +188,14 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
           distributeToPartition(partition, distributionRecord, distributionKey);
         });
 
+    // Scale up is in progress, enqueue upcoming distributions for the new partitions
+    if (routingInfo.desiredPartitions().size() > routingInfo.partitions().size()) {
+      routingInfo.desiredPartitions().stream()
+          .filter(this::isPartitionScaling)
+          .forEach(
+              partition -> distributeToPartition(partition, distributionRecord, distributionKey));
+    }
+
     getMetrics().startedDistribution();
     getMetrics().addActiveDistribution();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -102,7 +102,7 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
               RejectionType.ALREADY_EXISTS, "The desired partition count was already requested"));
     }
 
-    if (!desiredPartitionsInRoutingState.isEmpty()) {
+    if (!desiredPartitionsInRoutingState.equals(currentPartitionsInRoutingState)) {
       return Optional.of(
           new Rejection(
               RejectionType.INVALID_STATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -72,6 +72,7 @@ public final class DbRoutingState implements MutableRoutingState {
     currentRoutingInfo.setPartitions(partitions);
     currentRoutingInfo.setMessageCorrelation(new MessageCorrelation.HashMod(partitionCount));
     columnFamily.insert(key, currentRoutingInfo);
+    setDesiredPartitions(partitions);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -65,7 +66,9 @@ public final class DbRoutingState implements MutableRoutingState {
   @Override
   public void initializeRoutingInfo(final int partitionCount) {
     final var partitions =
-        IntStream.rangeClosed(1, partitionCount).boxed().collect(Collectors.toUnmodifiableSet());
+        IntStream.rangeClosed(Protocol.START_PARTITION_ID, partitionCount)
+            .boxed()
+            .collect(Collectors.toSet());
 
     key.wrapString(CURRENT_KEY);
     currentRoutingInfo.reset();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
+import java.util.Collections;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
@@ -37,7 +39,11 @@ final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
   }
 
   public Set<Integer> getPartitions() {
-    return partitions.stream().map(IntegerValue::getValue).collect(Collectors.toUnmodifiableSet());
+    return partitions.stream()
+        .map(IntegerValue::getValue)
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toCollection(TreeSet::new), Collections::unmodifiableSortedSet));
   }
 
   public void setPartitions(final Set<Integer> partitions) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -126,8 +126,7 @@ public interface RoutingInfo {
 
     @Override
     public boolean isPartitionScaling(final int partitionId) {
-      return !routingState.currentPartitions().contains(partitionId)
-          && routingState.desiredPartitions().contains(partitionId);
+      return !partitions().contains(partitionId) && desiredPartitions().contains(partitionId);
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -126,9 +126,9 @@ public class CreateAuthorizationMultipartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     engine
         .user()
         .newUser("foo")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -127,9 +126,9 @@ public class CreateAuthorizationMultipartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
     engine
         .user()
         .newUser("foo")
@@ -188,17 +187,5 @@ public class CreateAuthorizationMultipartitionTest {
         .isEqualTo(
             "Expected to create or update authorization with ownerId '%s', but a mapping with this ID does not exist."
                 .formatted(nonexistentMappingId));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
@@ -135,11 +135,9 @@ public class DeleteAuthorizationMultipartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(
-            partition ->
-                engine.interceptInterPartitionIntent(partition, AuthorizationIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, AuthorizationIntent.CREATE);
+    }
     final var key =
         engine
             .authorization()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -136,11 +136,9 @@ public class UpdateAuthorizationMultipartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(
-            partition ->
-                engine.interceptInterPartitionIntent(partition, AuthorizationIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, AuthorizationIntent.CREATE);
+    }
     final var key =
         engine
             .authorization()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -136,9 +136,11 @@ public class UpdateAuthorizationMultipartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptAuthorizationCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(
+            partition ->
+                engine.interceptInterPartitionIntent(partition, AuthorizationIntent.CREATE));
     final var key =
         engine
             .authorization()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class CommandDistributionScalingTest {
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private MutableRoutingState routingState;
+  private MutableProcessingState state;
+  private TransactionContext transactionContext;
+  private DistributionState distributionState;
+  private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
+  private InterPartitionCommandSender mockInterpartitionCommandSender;
+  private Writers writers;
+
+  private long key;
+  private ValueType valueType;
+  private DeploymentIntent intent;
+  private MockTypedRecord<DeploymentRecord> command;
+
+  @BeforeEach
+  public void setup() {
+    distributionState = new DbDistributionState(zeebeDb, transactionContext);
+    fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
+    mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
+    final var eventAppliers = new EventAppliers().registerEventAppliers(state);
+    writers = new Writers(() -> fakeProcessingResultBuilder, eventAppliers);
+
+    key = Protocol.encodePartitionId(1, 100);
+    valueType = ValueType.DEPLOYMENT;
+    intent = DeploymentIntent.CREATE;
+    command =
+        new MockTypedRecord<>(
+            key, new RecordMetadata().valueType(valueType).intent(intent), new DeploymentRecord());
+  }
+
+  @Test
+  public void shouldWaitInQueueDuringScaling() {
+    state.getRoutingState().initializeRoutingInfo(2);
+    // given a scale operation ongoing to transition to 3 partitions
+    state.getRoutingState().setDesiredPartitions(Set.of(1, 2, 3));
+    final var behavior =
+        new CommandDistributionBehavior(
+            distributionState,
+            writers,
+            1,
+            RoutingInfo.dynamic(state.getRoutingState(), RoutingInfo.forStaticPartitions(2)),
+            mockInterpartitionCommandSender);
+
+    // when distributing first command in queue to all partitions
+    behavior.withKey(key).inQueue("test-queue").distribute(command);
+
+    // then command distribution is started on partition 1, distribution is enqueued and triggered
+    // immediately for partition 2 and partition 3 gets enqueued
+    Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
+        .extracting(Record::getKey, Record::getIntent, r -> r.getValue().getPartitionId())
+        .containsExactly(
+            tuple(key, CommandDistributionIntent.STARTED, 1),
+            tuple(key, CommandDistributionIntent.ENQUEUED, 2),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 2),
+            tuple(key, CommandDistributionIntent.ENQUEUED, 3),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 3));
+
+    // then command is sent immediately to partition 2
+    fakeProcessingResultBuilder.flushPostCommitTasks();
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+    verify(mockInterpartitionCommandSender, times(0))
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+    verifyNoMoreInteractions(mockInterpartitionCommandSender);
+    assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
+  }
+
+  @Test
+  public void shouldQueueUpDistributions() {
+    // given a scale operation ongoing to transition to 3 partitions
+    state.getRoutingState().initializeRoutingInfo(2);
+    state.getRoutingState().setDesiredPartitions(Set.of(1, 2, 3));
+    final var behavior =
+        new CommandDistributionBehavior(
+            distributionState,
+            writers,
+            1,
+            RoutingInfo.dynamic(state.getRoutingState(), RoutingInfo.forStaticPartitions(2)),
+            mockInterpartitionCommandSender);
+
+    // when a distribution command is sent for two records
+    behavior.withKey(key).inQueue("test-queue").distribute(command);
+    final var recordKey = Protocol.encodePartitionId(1, 101);
+    behavior.withKey(recordKey).inQueue("test-queue").distribute(command);
+
+    // then command distribution is started on partition 1
+    // first record is starting to be distributed
+    // second record is enqueued for partitions 2 and 3
+    Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
+        .extracting(Record::getKey, Record::getIntent, r -> r.getValue().getPartitionId())
+        .containsExactly(
+            tuple(key, CommandDistributionIntent.STARTED, 1),
+            tuple(key, CommandDistributionIntent.ENQUEUED, 2),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 2),
+            tuple(key, CommandDistributionIntent.ENQUEUED, 3),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 3),
+            tuple(recordKey, CommandDistributionIntent.STARTED, 1),
+            tuple(recordKey, CommandDistributionIntent.ENQUEUED, 2),
+            tuple(recordKey, CommandDistributionIntent.ENQUEUED, 3));
+
+    // then command is sent immediately to partition 2 for the first record
+    fakeProcessingResultBuilder.flushPostCommitTasks();
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+    verify(mockInterpartitionCommandSender, times(0))
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+
+    verify(mockInterpartitionCommandSender, times(0))
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(recordKey), any());
+    verify(mockInterpartitionCommandSender, times(0))
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(recordKey), any());
+    verifyNoMoreInteractions(mockInterpartitionCommandSender);
+
+    assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
+    assertThat(distributionState.hasPendingDistribution(recordKey, 2)).isTrue();
+    assertThat(distributionState.hasPendingDistribution(recordKey, 3)).isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -112,7 +112,7 @@ public class CommandDistributionScalingTest {
     // then command is sent immediately to partition 2
     verify(mockInterpartitionCommandSender)
         .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
     assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
@@ -151,12 +151,12 @@ public class CommandDistributionScalingTest {
     // then command is sent immediately to partition 2 for the first record
     verify(mockInterpartitionCommandSender)
         .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
     // the second command is enqueued for partitions 2 and 3
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any());
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
 
@@ -197,12 +197,12 @@ public class CommandDistributionScalingTest {
     fakeProcessingResultBuilder.flushPostCommitTasks();
     verify(mockInterpartitionCommandSender)
         .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
 
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(2), eq(valueType), eq(intent), eq(otherKey), any());
-    verify(mockInterpartitionCommandSender, times(0))
+    verify(mockInterpartitionCommandSender, never())
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(otherKey), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -131,9 +131,9 @@ public class AddEntityGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the group creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, GroupIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, GroupIntent.CREATE);
+    }
     final var username =
         engine
             .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
@@ -101,11 +101,9 @@ public class CreateGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the role creation distribution is intercepted
-
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
-
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, RoleIntent.CREATE);
+    }
     engine.role().newRole(UUID.randomUUID().toString()).create();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,9 +109,9 @@ public class DeleteGroupMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptGroupCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, GroupIntent.CREATE));
     final var groupId = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(name).create();
     engine.group().deleteGroup(groupId).delete();
@@ -127,17 +126,5 @@ public class DeleteGroupMultiPartitionTest {
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.GROUP, GroupIntent.CREATE), tuple(ValueType.GROUP, GroupIntent.DELETE));
-  }
-
-  private void interceptGroupCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == GroupIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
@@ -109,9 +109,9 @@ public class DeleteGroupMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var name = UUID.randomUUID().toString();
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, GroupIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, GroupIntent.CREATE);
+    }
     final var groupId = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(name).create();
     engine.group().deleteGroup(groupId).delete();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -142,9 +142,9 @@ public class RemoveEntityGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     final var username =
         engine
             .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -143,9 +142,9 @@ public class RemoveEntityGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
     final var username =
         engine
             .user()
@@ -183,17 +182,5 @@ public class RemoveEntityGroupMultiPartitionTest {
             tuple(ValueType.GROUP, GroupIntent.CREATE),
             tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY),
             tuple(ValueType.GROUP, GroupIntent.REMOVE_ENTITY));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -110,10 +110,9 @@ public class UpdateGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the group creation distribution is intercepted
-
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, GroupIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, GroupIntent.CREATE);
+    }
     final var groupId = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(UUID.randomUUID().toString()).create().getKey();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -111,9 +110,10 @@ public class UpdateGroupMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the group creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptGroupCommandForPartition(partitionId, GroupIntent.CREATE);
-    }
+
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, GroupIntent.CREATE));
     final var groupId = UUID.randomUUID().toString();
     engine.group().newGroup(groupId).withName(UUID.randomUUID().toString()).create().getKey();
 
@@ -131,18 +131,5 @@ public class UpdateGroupMultiPartitionTest {
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.GROUP, GroupIntent.CREATE), tuple(ValueType.GROUP, GroupIntent.UPDATE));
-  }
-
-  private void interceptGroupCommandForPartition(
-      final int partitionId, final GroupIntent groupIntent) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == groupIntent);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
@@ -113,9 +113,9 @@ public class CreateMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the role creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, RoleIntent.CREATE);
+    }
 
     final var roleName = UUID.randomUUID().toString();
     engine.role().newRole(roleName).create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -114,9 +113,10 @@ public class CreateMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the role creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptRoleCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
+
     final var roleName = UUID.randomUUID().toString();
     engine.role().newRole(roleName).create();
     final var mappingId = Strings.newRandomValidIdentityId();
@@ -140,17 +140,5 @@ public class CreateMappingMultiPartitionTest {
         .containsExactly(
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.MAPPING, MappingIntent.CREATE));
-  }
-
-  private void interceptRoleCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
@@ -116,10 +116,9 @@ public class DeleteMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(
-            partition -> engine.interceptInterPartitionIntent(partition, MappingIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, MappingIntent.CREATE);
+    }
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingId = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -117,9 +116,10 @@ public class DeleteMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptMappingCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(
+            partition -> engine.interceptInterPartitionIntent(partition, MappingIntent.CREATE));
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingId = UUID.randomUUID().toString();
@@ -143,17 +143,5 @@ public class DeleteMappingMultiPartitionTest {
         .containsExactly(
             tuple(ValueType.MAPPING, MappingIntent.CREATE),
             tuple(ValueType.MAPPING, MappingIntent.DELETE));
-  }
-
-  private void interceptMappingCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == MappingIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
@@ -103,10 +103,9 @@ public class UpdateMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the role creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(
-            partition -> engine.interceptInterPartitionIntent(partition, MappingIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, MappingIntent.CREATE);
+    }
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -104,9 +103,10 @@ public class UpdateMappingMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the role creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(
+            partition -> engine.interceptInterPartitionIntent(partition, MappingIntent.CREATE));
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
@@ -137,17 +137,5 @@ public class UpdateMappingMultiPartitionTest {
         .containsExactly(
             tuple(ValueType.MAPPING, MappingIntent.CREATE),
             tuple(ValueType.MAPPING, MappingIntent.UPDATE));
-  }
-
-  private void interceptCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == MappingIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -127,9 +126,9 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
     final var username = "foo";
     engine
         .user()
@@ -158,17 +157,5 @@ public class AddEntityRoleMultiPartitionTest {
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
@@ -126,9 +126,9 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     final var username = "foo";
     engine
         .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
@@ -101,10 +101,9 @@ public class CreateRoleMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
 
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
-
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     engine
         .user()
         .newUser(UUID.randomUUID().toString())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -101,9 +100,10 @@ public class CreateRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
 
     engine
         .user()
@@ -129,17 +129,5 @@ public class CreateRoleMultiPartitionTest {
             tuple(ValueType.USER, UserIntent.CREATE),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.CREATE));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
@@ -112,9 +112,9 @@ public class DeleteRoleMultiPartitionTest {
     // when
     final var name = UUID.randomUUID().toString();
     final var roleId = Strings.newRandomValidIdentityId();
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, RoleIntent.CREATE);
+    }
     engine.role().newRole(roleId).withName(name).create();
     engine.role().deleteRole(roleId).delete();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
@@ -137,9 +137,9 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     final var username = Strings.newRandomValidUsername();
     engine
         .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -138,9 +137,9 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
     final var username = Strings.newRandomValidUsername();
     engine
         .user()
@@ -174,17 +173,5 @@ public class RemoveEntityRoleMultiPartitionTest {
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY),
             tuple(ValueType.ROLE, RoleIntent.REMOVE_ENTITY));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -109,9 +108,9 @@ public class UpdateRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptRoleCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
     final var roleId = UUID.randomUUID().toString();
     engine.role().newRole(roleId).withName("created").create();
     engine.role().updateRole(roleId).withName("updated").update();
@@ -126,17 +125,5 @@ public class UpdateRoleMultiPartitionTest {
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.ROLE, RoleIntent.CREATE), tuple(ValueType.ROLE, RoleIntent.UPDATE));
-  }
-
-  private void interceptRoleCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
@@ -108,9 +108,9 @@ public class UpdateRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, RoleIntent.CREATE);
+    }
     final var roleId = UUID.randomUUID().toString();
     engine.role().newRole(roleId).withName("created").create();
     engine.role().updateRole(roleId).withName("updated").update();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
@@ -144,9 +144,9 @@ public class AddEntityTenantMultiPartitionTest {
         .create()
         .getKey();
 
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, TenantIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, TenantIntent.CREATE);
+    }
 
     // when
     final var tenantId = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
@@ -101,9 +101,9 @@ public class CreateTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, TenantIntent.CREATE);
+    }
 
     // Create a role to ensure proper order
     final var roleName = UUID.randomUUID().toString();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,9 +101,9 @@ public class CreateTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptTenantCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, RoleIntent.CREATE));
 
     // Create a role to ensure proper order
     final var roleName = UUID.randomUUID().toString();
@@ -123,17 +122,5 @@ public class CreateTenantMultiPartitionTest {
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.ROLE, RoleIntent.CREATE), tuple(ValueType.TENANT, TenantIntent.CREATE));
-  }
-
-  private void interceptTenantCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
@@ -108,9 +108,9 @@ public class DeleteTenantMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var tenantId = UUID.randomUUID().toString();
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, TenantIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, TenantIntent.CREATE);
+    }
     final var tenantKey =
         engine
             .tenant()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -109,9 +108,9 @@ public class DeleteTenantMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
     final var tenantId = UUID.randomUUID().toString();
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptTenantCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, TenantIntent.CREATE));
     final var tenantKey =
         engine
             .tenant()
@@ -132,17 +131,5 @@ public class DeleteTenantMultiPartitionTest {
         .containsExactly(
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.DELETE));
-  }
-
-  private void interceptTenantCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == TenantIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -126,9 +125,9 @@ public class RemoveEntityTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
     setupTenantWithUserAndRemoveEntity();
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));
@@ -144,17 +143,5 @@ public class RemoveEntityTenantMultiPartitionTest {
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.ADD_ENTITY),
             tuple(ValueType.TENANT, TenantIntent.REMOVE_ENTITY));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -125,9 +125,9 @@ public class RemoveEntityTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
     setupTenantWithUserAndRemoveEntity();
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -118,9 +118,9 @@ public class UpdateTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, TenantIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, TenantIntent.CREATE);
+    }
     final var tenantId = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
@@ -119,9 +118,9 @@ public class UpdateTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptTenantCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, TenantIntent.CREATE));
     final var tenantId = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
     engine
@@ -145,17 +144,5 @@ public class UpdateTenantMultiPartitionTest {
         .containsExactly(
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.UPDATE));
-  }
-
-  private void interceptTenantCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == TenantIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
@@ -141,9 +140,10 @@ public class DeleteUserMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptUserCreateForPartition(partitionId);
-    }
+    engine.getProcessingState().getRoutingState().currentPartitions().stream()
+        .skip(1)
+        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+
     final var userRecord =
         engine
             .user()
@@ -174,17 +174,5 @@ public class DeleteUserMultiPartitionTest {
             Assertions.tuple(ValueType.USER, UserIntent.CREATE),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE),
             Assertions.tuple(ValueType.USER, UserIntent.DELETE));
-  }
-
-  private void interceptUserCreateForPartition(final int partitionId) {
-    final var hasInterceptedPartition = new AtomicBoolean(false);
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) -> {
-          if (hasInterceptedPartition.get()) {
-            return true;
-          }
-          hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
-        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -140,9 +140,9 @@ public class DeleteUserMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
-    engine.getProcessingState().getRoutingState().currentPartitions().stream()
-        .skip(1)
-        .forEach(partition -> engine.interceptInterPartitionIntent(partition, UserIntent.CREATE));
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      engine.interceptInterPartitionIntent(partitionId, UserIntent.CREATE);
+    }
 
     final var userRecord =
         engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -54,7 +54,8 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.ROLES,
           ZbColumnFamilies.TENANTS,
           ZbColumnFamilies.AUTHORIZATIONS,
-          ZbColumnFamilies.AUTHORIZATION_KEYS_BY_OWNER);
+          ZbColumnFamilies.AUTHORIZATION_KEYS_BY_OWNER,
+          ZbColumnFamilies.ROUTING);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
During partition scale up operation, distribution events should be enqueued for newly created partitions. 

Also includes changes regarding:
- Initialize `desired` partitions as `current`
- Make `EngineRule`  run DbMigrations to include RoutingInfo intialization
- Extract common interceptors from Identity distribution tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32153
