### PR TITLE
Append message expired events with message data

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -54,11 +54,12 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
         if (persistedMessage != null) {
           stateWriter.appendFollowUpEvent(messageKey, EXPIRED, persistedMessage.getMessage());
           expiredMessagesCount++;
+        } else {
+          // the message was expired before processing it here, so we can skip it
+          LOG.warn(
+              "Expected to expire messages in a batch, but message with key {} was not found.",
+              messageKey);
         }
-        // else, the message was expired before processing it here, so we can skip it
-        LOG.warn(
-            "Expected to expire messages in a batch, but message with key {} was not found.",
-            messageKey);
       } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {
         LOG.warn(
             "Expected to expire messages in a batch, but exceeded the resulting batch size after expiring {} out of {} messages. "

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -12,8 +12,12 @@ import static io.camunda.zeebe.protocol.record.intent.MessageIntent.*;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.slf4j.Logger;
@@ -24,23 +28,37 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
 
   private static final Logger LOG = LoggerFactory.getLogger(MessageBatchExpireProcessor.class);
   private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final MessageState messageState;
 
   private final MessageRecord emptyDeleteMessageCommand =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
-  public MessageBatchExpireProcessor(final StateWriter stateWriter) {
+  public MessageBatchExpireProcessor(
+      final StateWriter stateWriter,
+      final TypedRejectionWriter rejectionWriter,
+      final MessageState messageState) {
     this.stateWriter = stateWriter;
+    this.rejectionWriter = rejectionWriter;
+    this.messageState = messageState;
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageBatchRecord> record) {
-
     int expiredMessagesCount = 0;
     final int totalMessagesCount = record.getValue().getMessageKeys().size();
+
     for (final long messageKey : record.getValue().getMessageKeys()) {
       try {
-        stateWriter.appendFollowUpEvent(messageKey, EXPIRED, emptyDeleteMessageCommand);
-        expiredMessagesCount++;
+        final StoredMessage persistedMessage = messageState.getMessage(messageKey);
+        if (persistedMessage != null) {
+          stateWriter.appendFollowUpEvent(messageKey, EXPIRED, persistedMessage.getMessage());
+          expiredMessagesCount++;
+        }
+        // else, the message was expired before processing it here, so we can skip it
+        LOG.warn(
+            "Expected to expire messages in a batch, but message with key {} was not found.",
+            messageKey);
       } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {
         LOG.warn(
             "Expected to expire messages in a batch, but exceeded the resulting batch size after expiring {} out of {} messages. "
@@ -49,6 +67,15 @@ public final class MessageBatchExpireProcessor implements TypedRecordProcessor<M
             totalMessagesCount);
         break;
       }
+    }
+
+    if (expiredMessagesCount == 0) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.NOT_FOUND,
+          String.format(
+              "Expected to expire %d messages in a batch, but none of the messages were found in the state.",
+              totalMessagesCount));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -77,7 +77,7 @@ public final class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE_BATCH,
             MessageBatchIntent.EXPIRE,
-            new MessageBatchExpireProcessor(writers.state()))
+            new MessageBatchExpireProcessor(writers.state(), writers.rejection(), messageState))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
@@ -7,19 +7,26 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
@@ -29,8 +36,10 @@ import org.mockito.Mockito;
 public final class MessageBatchExpireProcessorTest {
 
   private final StateWriter stateWriter = Mockito.mock(StateWriter.class);
+  private final TypedRejectionWriter rejectionWriter = Mockito.mock(TypedRejectionWriter.class);
+  private final MessageState messageState = Mockito.mock(MessageState.class);
   final MessageBatchExpireProcessor messageBatchExpireProcessor =
-      new MessageBatchExpireProcessor(stateWriter);
+      new MessageBatchExpireProcessor(stateWriter, rejectionWriter, messageState);
 
   @Test
   public void shouldStopProcessingWhenExceedingBatchLimit() {
@@ -43,6 +52,9 @@ public final class MessageBatchExpireProcessorTest {
             .addMessageKey(3)
             .addMessageKey(4);
 
+    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(1);
+    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(2);
+    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(3);
     doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
     doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
 
@@ -58,5 +70,130 @@ public final class MessageBatchExpireProcessorTest {
 
     // then
     verify(stateWriter, times(3)).appendFollowUpEvent(anyLong(), any(), any());
+  }
+
+  @Test
+  public void shouldExportWithMessageBody() {
+    // given
+    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
+
+    doReturn(
+            new StoredMessage()
+                .setMessage(
+                    new MessageRecord()
+                        .setName("message1")
+                        .setCorrelationKey("correlationKey1")
+                        .setTimeToLive(100L)))
+        .when(messageState)
+        .getMessage(1L);
+    doReturn(
+            new StoredMessage()
+                .setMessage(
+                    new MessageRecord()
+                        .setName("message2")
+                        .setCorrelationKey("correlationKey2")
+                        .setTimeToLive(101L)))
+        .when(messageState)
+        .getMessage(2L);
+    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
+    doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
+
+    // when
+    messageBatchExpireProcessor.processRecord(
+        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
+
+    // then
+    verify(stateWriter, times(1))
+        .appendFollowUpEvent(
+            eq(1L),
+            eq(MessageIntent.EXPIRED),
+            argThat(
+                record -> {
+                  final var messageRecord = (MessageRecord) record;
+                  return messageRecord.getName().equals("message1")
+                      && messageRecord.getCorrelationKey().equals("correlationKey1")
+                      && messageRecord.getTimeToLive() == 100L;
+                }));
+
+    verify(stateWriter, times(1))
+        .appendFollowUpEvent(
+            eq(2L),
+            eq(MessageIntent.EXPIRED),
+            argThat(
+                record -> {
+                  final var messageRecord = (MessageRecord) record;
+                  return messageRecord.getName().equals("message2")
+                      && messageRecord.getCorrelationKey().equals("correlationKey2")
+                      && messageRecord.getTimeToLive() == 101L;
+                }));
+  }
+
+  @Test
+  public void shouldSkipNotFoundMessages() {
+    // given
+    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
+
+    doReturn(
+            new StoredMessage()
+                .setMessage(
+                    new MessageRecord()
+                        .setName("message1")
+                        .setCorrelationKey("correlationKey1")
+                        .setTimeToLive(100L)))
+        .when(messageState)
+        .getMessage(1L);
+    doReturn(null).when(messageState).getMessage(2L);
+    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
+
+    // when
+    messageBatchExpireProcessor.processRecord(
+        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
+
+    // then
+    verify(stateWriter, times(1))
+        .appendFollowUpEvent(
+            eq(1L),
+            eq(MessageIntent.EXPIRED),
+            argThat(
+                record -> {
+                  final var messageRecord = (MessageRecord) record;
+                  return messageRecord.getName().equals("message1")
+                      && messageRecord.getCorrelationKey().equals("correlationKey1")
+                      && messageRecord.getTimeToLive() == 100L;
+                }));
+
+    verify(stateWriter, times(0)).appendFollowUpEvent(eq(2L), eq(MessageIntent.EXPIRED), any());
+  }
+
+  @Test
+  public void shouldRejectIfNoMessagesFound() {
+    // given
+    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
+
+    doReturn(
+            new StoredMessage()
+                .setMessage(
+                    new MessageRecord()
+                        .setName("message1")
+                        .setCorrelationKey("correlationKey1")
+                        .setTimeToLive(100L)))
+        .when(messageState)
+        .getMessage(1L);
+    doReturn(null).when(messageState).getMessage(1L);
+    doReturn(null).when(messageState).getMessage(2L);
+
+    // when
+    final UnwrittenRecord record =
+        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata());
+    messageBatchExpireProcessor.processRecord(record);
+
+    // then
+    verify(rejectionWriter, times(1))
+        .appendRejection(
+            record,
+            RejectionType.NOT_FOUND,
+            "Expected to expire 2 messages in a batch, but none of the messages were found in the state.");
+    verify(stateWriter, times(0)).appendFollowUpEvent(eq(1L), eq(MessageIntent.EXPIRED), any());
+    verify(stateWriter, times(0)).appendFollowUpEvent(eq(2L), eq(MessageIntent.EXPIRED), any());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -38,6 +40,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
@@ -158,6 +161,12 @@ public final class RecordToWrite implements LogAppendEntry {
         .valueType(ValueType.PROCESS_INSTANCE_MIGRATION)
         .intent(ProcessInstanceMigrationIntent.MIGRATE);
     unifiedRecordValue = (ProcessInstanceMigrationRecord) value;
+    return this;
+  }
+
+  public RecordToWrite messageBatch(final MessageBatchRecordValue value) {
+    recordMetadata.valueType(ValueType.MESSAGE_BATCH).intent(MessageBatchIntent.EXPIRE);
+    unifiedRecordValue = (MessageBatchRecord) value;
     return this;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Please refer to the [discussion thread](https://camunda.slack.com/archives/C08F5RD5X8B/p1747911442739179) related to the implementation of this feature.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32233 
