### PR TITLE
Refactor `newAssignRoleToTenantCommand` to follow the agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1312,17 +1312,17 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newAssignRoleToTenantCommand("tenantId")
+   *  .newAssignRoleToTenantCommand()
    *  .roleId("roleId")
+   *  .tenantId("tenantId")
    *  .send();
    * </pre>
    *
    * <p>This command is only sent via REST over HTTP.
    *
-   * @param tenantId the ID of the tenant
    * @return a builder for the assign role to tenant command
    */
-  AssignRoleToTenantCommandStep1 newAssignRoleToTenantCommand(String tenantId);
+  AssignRoleToTenantCommandStep1 newAssignRoleToTenantCommand();
 
   /**
    * Command to unassign a role from a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignRoleToTenantCommandStep1.java
@@ -18,8 +18,7 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.AssignRoleToTenantResponse;
 
 /** Step to assign a role to a tenant. */
-public interface AssignRoleToTenantCommandStep1
-    extends FinalCommandStep<AssignRoleToTenantResponse> {
+public interface AssignRoleToTenantCommandStep1 {
 
   /**
    * Sets the ID of the role to assign.
@@ -27,5 +26,17 @@ public interface AssignRoleToTenantCommandStep1
    * @param roleId the ID of the role
    * @return the builder for this command
    */
-  AssignRoleToTenantCommandStep1 roleId(String roleId);
+  AssignRoleToTenantCommandStep2 roleId(String roleId);
+
+  interface AssignRoleToTenantCommandStep2 extends FinalCommandStep<AssignRoleToTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the tenantId of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignRoleToTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -878,8 +878,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignRoleToTenantCommandStep1 newAssignRoleToTenantCommand(final String tenantId) {
-    return new AssignRoleToTenantCommandImpl(httpClient, tenantId);
+  public AssignRoleToTenantCommandStep1 newAssignRoleToTenantCommand() {
+    return new AssignRoleToTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignRoleToTenantCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignRoleToTenantCommandStep1;
+import io.camunda.client.api.command.AssignRoleToTenantCommandStep1.AssignRoleToTenantCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignRoleToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class AssignRoleToTenantCommandImpl implements AssignRoleToTenantCommandStep1 {
+public final class AssignRoleToTenantCommandImpl
+    implements AssignRoleToTenantCommandStep1, AssignRoleToTenantCommandStep2 {
 
-  private final String tenantId;
+  private String tenantId;
   private String roleId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignRoleToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public AssignRoleToTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignRoleToTenantCommandStep1 roleId(final String roleId) {
+  public AssignRoleToTenantCommandStep2 roleId(final String roleId) {
     this.roleId = roleId;
+    return this;
+  }
+
+  @Override
+  public AssignRoleToTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignRoleToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignRoleToTenantTest.java
@@ -30,6 +30,17 @@ public class AssignRoleToTenantTest extends ClientRestTest {
   private static final String ROLE_ID = "test-role";
 
   @Test
+  void shouldAssignRoleToTenant() {
+    // when
+    client.newAssignRoleToTenantCommand().roleId(ROLE_ID).tenantId(TENANT_ID).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/roles/" + ROLE_ID);
+  }
+
+  @Test
   void shouldUnassignRoleFromTenant() {
     // when
     client.newUnassignRoleFromTenantCommand(TENANT_ID).roleId(ROLE_ID).send().join();
@@ -43,14 +54,16 @@ public class AssignRoleToTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullTenantId() {
     assertThatThrownBy(
-            () -> client.newAssignRoleToTenantCommand(null).roleId(ROLE_ID).send().join())
+            () ->
+                client.newAssignRoleToTenantCommand().roleId(ROLE_ID).tenantId(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be null");
   }
 
   @Test
   void shouldRaiseExceptionOnEmptyTenantId() {
-    assertThatThrownBy(() -> client.newAssignRoleToTenantCommand("").roleId(ROLE_ID).send().join())
+    assertThatThrownBy(
+            () -> client.newAssignRoleToTenantCommand().roleId(ROLE_ID).tenantId("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
   }
@@ -58,7 +71,13 @@ public class AssignRoleToTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullRoleId() {
     assertThatThrownBy(
-            () -> client.newAssignRoleToTenantCommand(TENANT_ID).roleId(null).send().join())
+            () ->
+                client
+                    .newAssignRoleToTenantCommand()
+                    .roleId(null)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
   }
@@ -66,7 +85,8 @@ public class AssignRoleToTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnEmptyRoleId() {
     assertThatThrownBy(
-            () -> client.newAssignRoleToTenantCommand(TENANT_ID).roleId("").send().join())
+            () ->
+                client.newAssignRoleToTenantCommand().roleId("").tenantId(TENANT_ID).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be empty");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
@@ -55,7 +55,7 @@ public class RolesByTenantIntegrationTest {
     createTenant(tenantId);
     createRole(roleId, roleName, roleDesc);
     // when
-    camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(roleId).send().join();
+    camundaClient.newAssignRoleToTenantCommand().roleId(roleId).tenantId(tenantId).send().join();
     // then
     Awaitility.await("Role should be visible in tenant role search")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
@@ -85,8 +85,9 @@ public class RolesByTenantIntegrationTest {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newAssignRoleToTenantCommand(nonExistingTenantId)
+                    .newAssignRoleToTenantCommand()
                     .roleId(roleId)
+                    .tenantId(nonExistingTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -100,7 +101,13 @@ public class RolesByTenantIntegrationTest {
     final var roleId = "role-" + Strings.newRandomValidIdentityId();
     createTenant(tenantId);
     assertThatThrownBy(
-            () -> camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(roleId).send().join())
+            () ->
+                camundaClient
+                    .newAssignRoleToTenantCommand()
+                    .roleId(roleId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("404: 'Not Found'")
         .hasMessageContaining("role doesn't exist");
@@ -115,10 +122,16 @@ public class RolesByTenantIntegrationTest {
     final var roleDesc = "desc-" + Strings.newRandomValidIdentityId();
     createTenant(tenantId);
     createRole(roleId, roleName, roleDesc);
-    camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(roleId).send().join();
+    camundaClient.newAssignRoleToTenantCommand().roleId(roleId).tenantId(tenantId).send().join();
     // when and then
     assertThatThrownBy(
-            () -> camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(roleId).send().join())
+            () ->
+                camundaClient
+                    .newAssignRoleToTenantCommand()
+                    .roleId(roleId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("409: 'Conflict'")
         .hasMessageContaining("the role is already assigned to the tenant");
@@ -134,8 +147,18 @@ public class RolesByTenantIntegrationTest {
     createRole(firstRoleId, "name1", "desc1");
     createRole(secondRoleId, "name2", "desc2");
 
-    camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(firstRoleId).send().join();
-    camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(secondRoleId).send().join();
+    camundaClient
+        .newAssignRoleToTenantCommand()
+        .roleId(firstRoleId)
+        .tenantId(tenantId)
+        .send()
+        .join();
+    camundaClient
+        .newAssignRoleToTenantCommand()
+        .roleId(secondRoleId)
+        .tenantId(tenantId)
+        .send()
+        .join();
 
     // when and then
     Awaitility.await("Roles should be visible in tenant role search")
@@ -182,7 +205,7 @@ public class RolesByTenantIntegrationTest {
     final var roleId = "role-" + Strings.newRandomValidIdentityId();
     createTenant(tenantId);
     createRole(roleId, "name", "desc");
-    camundaClient.newAssignRoleToTenantCommand(tenantId).roleId(roleId).send().join();
+    camundaClient.newAssignRoleToTenantCommand().roleId(roleId).tenantId(tenantId).send().join();
     // when
     camundaClient.newUnassignRoleFromTenantCommand(tenantId).roleId(roleId).send().join();
     // then


### PR DESCRIPTION
## Description

All role commands should follow the same pattern:
`assignXToY().x("").y("") `

This PR is focusing on `newAssignRoleToTenantCommand`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32435
