### PR TITLE
feat: add bugs to quality board

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -126,3 +126,11 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/clients, scope/clients-spring, scope/clients-java, scope/spring-boot-starter-camunda, component/camunda-process-test
+      # this steops needs to stay as last step to not interfer with other steps 
+      - id: add-to-qualityboard
+        name: Add to Quality Board project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/camunda/projects/187
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+          labeled: kind/bug


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With https://github.com/orgs/camunda/projects/187/views/5 we have created a project to provide a centralized overview about open bugs that affect our product components. For the beginning the project focuses on Monorepo issues only. Step by step it should cover all C8 component repositories. 
* Purpose of the function provided with this PR is to add bug issues automatically to the project Quality Board
* The step in the add-to-project workflow will add the issue based on the label kind/bug to the respective project. I would prefer to use the issue type:bug but this is not supported by the action
* Since all other steps in the add-to-project workflow have a condition that the issue is not already assigned to another project I've added this step as last step in the workflow, where it should not interfere with other steps. For a more robust solution I propose to adjust the project check `if: ${{ steps.has-project.outputs.result == 'false' }}` to exclude the **Quality Board** project form this check. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
