### PR TITLE
feat: simple mappings support nested claims

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -35,8 +35,6 @@ import org.springframework.stereotype.Service;
 @Service
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
 public class CamundaOAuthPrincipalService {
-  static final String CLAIM_NOT_STRING =
-      "Configured claim for %s (%s) is not a string. Please check your OIDC configuration.";
 
   private static final Logger LOG = LoggerFactory.getLogger(CamundaOAuthPrincipalService.class);
 

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -12,6 +12,7 @@ import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.service.AuthorizationServices;
@@ -23,7 +24,6 @@ import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,6 +45,7 @@ public class CamundaOAuthPrincipalService {
   private final RoleServices roleServices;
   private final GroupServices groupServices;
   private final AuthorizationServices authorizationServices;
+  private final OidcPrincipalLoader oidcPrincipalLoader;
   private final String usernameClaim;
   private final String clientIdClaim;
 
@@ -60,6 +61,10 @@ public class CamundaOAuthPrincipalService {
     this.roleServices = roleServices;
     this.groupServices = groupServices;
     this.authorizationServices = authorizationServices;
+    oidcPrincipalLoader =
+        new OidcPrincipalLoader(
+            securityConfiguration.getAuthentication().getOidc().getUsernameClaim(),
+            securityConfiguration.getAuthentication().getOidc().getClientIdClaim());
     usernameClaim = securityConfiguration.getAuthentication().getOidc().getUsernameClaim();
     clientIdClaim = securityConfiguration.getAuthentication().getOidc().getClientIdClaim();
   }
@@ -96,8 +101,9 @@ public class CamundaOAuthPrincipalService {
             .withGroups(groups.stream().toList())
             .withRoles(roles);
 
-    final var username = getUsernameFromClaims(claims);
-    final var clientId = getClientIdFromClaims(claims);
+    final var principals = oidcPrincipalLoader.load(claims);
+    final var username = principals.username();
+    final var clientId = principals.clientId();
 
     if (username == null && clientId == null) {
       throw new IllegalArgumentException(
@@ -105,41 +111,13 @@ public class CamundaOAuthPrincipalService {
               .formatted(usernameClaim, clientIdClaim));
     }
     if (username != null) {
-      authContextBuilder.withUsername(getUsernameFromClaims(claims));
+      authContextBuilder.withUsername(username);
     }
 
     if (clientId != null) {
-      authContextBuilder.withClientId(getClientIdFromClaims(claims));
+      authContextBuilder.withClientId(clientId);
     }
 
     return new OAuthContext(mappingIds, authContextBuilder.build());
-  }
-
-  private String getUsernameFromClaims(final Map<String, Object> claims) {
-    final var maybeUsername = Optional.ofNullable(claims.get(usernameClaim));
-
-    if (maybeUsername.isEmpty()) {
-      return null;
-    }
-
-    if (maybeUsername.get() instanceof final String username) {
-      return username;
-    } else {
-      throw new IllegalArgumentException(CLAIM_NOT_STRING.formatted("username", usernameClaim));
-    }
-  }
-
-  private String getClientIdFromClaims(final Map<String, Object> claims) {
-    final var maybeClientId = Optional.ofNullable(claims.get(clientIdClaim));
-
-    if (maybeClientId.isEmpty()) {
-      return null;
-    }
-
-    if (maybeClientId.get() instanceof final String clientId) {
-      return clientId;
-    } else {
-      throw new IllegalArgumentException(CLAIM_NOT_STRING.formatted("client", clientIdClaim));
-    }
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication;
 
-import static io.camunda.authentication.CamundaOAuthPrincipalService.CLAIM_NOT_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -107,7 +106,8 @@ public class CamundaOAuthPrincipalServiceTest {
               () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
 
       assertThat(exception.getMessage())
-          .isEqualTo(CLAIM_NOT_STRING.formatted("client", APPLICATION_ID_CLAIM));
+          .isEqualTo(
+              "Value for $['client-id'] is not a string. Please check your OIDC configuration.");
     }
 
     @Test
@@ -186,7 +186,7 @@ public class CamundaOAuthPrincipalServiceTest {
               () -> camundaOAuthPrincipalService.loadOAuthContext(claims));
 
       assertThat(exception.getMessage())
-          .isEqualTo(CLAIM_NOT_STRING.formatted("username", USERNAME_CLAIM));
+          .isEqualTo("Value for $['email'] is not a string. Please check your OIDC configuration.");
     }
 
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -136,6 +136,7 @@
     <version.jackson-databind-nullable>0.2.6</version.jackson-databind-nullable>
     <version.findbugs.jsr305>3.0.2</version.findbugs.jsr305>
     <version.jackson-annotations>2.18.3</version.jackson-annotations>
+    <version.json-path>2.9.0</version.json-path>
     <version.swagger-annotations>2.2.29</version.swagger-annotations>
     <version.checker-qual>3.49.1</version.checker-qual>
     <version.java-jwt>4.5.0</version.java-jwt>
@@ -1950,6 +1951,12 @@
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-join</artifactId>
         <version>${version.lucene}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+        <artifactId>json-path</artifactId>
+        <version>${version.json-path}</version>
       </dependency>
 
       <dependency>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -26,5 +26,13 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-protocol</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -34,5 +34,16 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -11,8 +11,6 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
 import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,8 +20,8 @@ public final class OidcPrincipalLoader {
       Configuration.builder()
           // Ignore the common case that the last path element is not set
           .options(Option.DEFAULT_PATH_LEAF_TO_NULL)
-          .jsonProvider(new JacksonJsonProvider())
-          .mappingProvider(new JacksonMappingProvider())
+          .jsonProvider(null)
+          .mappingProvider(null)
           .build();
 
   private static final Logger LOG = LoggerFactory.getLogger(OidcPrincipalLoader.class);

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -44,7 +44,14 @@ public final class OidcPrincipalLoader {
       return null;
     }
     try {
-      return path.read(claims, CONFIGURATION);
+      return switch (path.read(claims, CONFIGURATION)) {
+        case final String stringValue -> stringValue;
+        case null -> null;
+        default ->
+            throw new IllegalArgumentException(
+                "Value for %s is not a string. Please check your OIDC configuration."
+                    .formatted(path.getPath()));
+      };
     } catch (final JsonPathException e) {
       LOG.debug("Failed to evaluate expression {} on claims {}", path, claims, e);
       return null;

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -30,8 +30,8 @@ public final class OidcPrincipalLoader {
   private final JsonPath clientIdPath;
 
   public OidcPrincipalLoader(final String usernameClaim, final String clientIdClaim) {
-    usernamePath = JsonPath.compile(usernameClaim);
-    clientIdPath = JsonPath.compile(clientIdClaim);
+    usernamePath = usernameClaim != null ? JsonPath.compile(usernameClaim) : null;
+    clientIdPath = clientIdClaim != null ? JsonPath.compile(clientIdClaim) : null;
   }
 
   public OidcPrincipals load(final Map<String, Object> claims) {
@@ -40,6 +40,9 @@ public final class OidcPrincipalLoader {
   }
 
   private static String tryReadJsonPath(final Map<String, Object> claims, final JsonPath path) {
+    if (path == null) {
+      return null;
+    }
     try {
       return path.read(claims, CONFIGURATION);
     } catch (final JsonPathException e) {

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class OidcPrincipalLoader {
-  public static final Configuration CONFIGURATION =
+  private static final Configuration CONFIGURATION =
       Configuration.builder()
           // Ignore the common case that the last path element is not set
           .options(Option.DEFAULT_PATH_LEAF_TO_NULL)

--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class OidcPrincipalLoader {
+  public static final Configuration CONFIGURATION =
+      Configuration.builder()
+          // Ignore the common case that the last path element is not set
+          .options(Option.DEFAULT_PATH_LEAF_TO_NULL)
+          .jsonProvider(new JacksonJsonProvider())
+          .mappingProvider(new JacksonMappingProvider())
+          .build();
+
+  private static final Logger LOG = LoggerFactory.getLogger(OidcPrincipalLoader.class);
+
+  private final JsonPath usernamePath;
+  private final JsonPath clientIdPath;
+
+  public OidcPrincipalLoader(final String usernameClaim, final String clientIdClaim) {
+    usernamePath = JsonPath.compile(usernameClaim);
+    clientIdPath = JsonPath.compile(clientIdClaim);
+  }
+
+  public OidcPrincipals load(final Map<String, Object> claims) {
+    return new OidcPrincipals(
+        tryReadJsonPath(claims, usernamePath), tryReadJsonPath(claims, clientIdPath));
+  }
+
+  private static String tryReadJsonPath(final Map<String, Object> claims, final JsonPath path) {
+    try {
+      return path.read(claims, CONFIGURATION);
+    } catch (final JsonPathException e) {
+      LOG.debug("Failed to evaluate expression {} on claims {}", path, claims, e);
+      return null;
+    }
+  }
+
+  public record OidcPrincipals(String username, String clientId) {}
+}

--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.security.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,18 @@ final class OidcPrincipalLoaderTest {
     // then
     assertThat(principals.username()).isNull();
     assertThat(principals.clientId()).isNull();
+  }
+
+  @Test
+  void shouldThrowOnUnexpectedClaimType() {
+    // given
+    final var claims = Map.<String, Object>of("username", 12345);
+    final var loader = new OidcPrincipalLoader("$.username", "$.client_id");
+    // when
+    assertThatThrownBy(() -> loader.load(claims))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Value for $['username'] is not a string. Please check your OIDC configuration.");
   }
 
   @Test

--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class OidcPrincipalLoaderTest {
+
+  @Test
+  void shouldLoadUsernameAndClientIdWithSimpleExpression() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "username", "testuser",
+            "client_id", "testclient",
+            "other_claim", "other_value");
+
+    final var loader = new OidcPrincipalLoader("username", "client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isEqualTo("testuser");
+    assertThat(principals.clientId()).isEqualTo("testclient");
+  }
+
+  @Test
+  void shouldLoadUsernameAndClientId() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "username", "testuser",
+            "client_id", "testclient",
+            "other_claim", "other_value");
+
+    final var loader = new OidcPrincipalLoader("$.username", "$.client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isEqualTo("testuser");
+    assertThat(principals.clientId()).isEqualTo("testclient");
+  }
+
+  @Test
+  void shouldLoadJustUsername() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "username", "testuser",
+            "other_claim", "other_value");
+
+    final var loader = new OidcPrincipalLoader("$.username", "$.client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isEqualTo("testuser");
+    assertThat(principals.clientId()).isNull();
+  }
+
+  @Test
+  void shouldLoadJustClientId() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "client_id", "testclient",
+            "other_claim", "other_value");
+
+    final var loader = new OidcPrincipalLoader("$.username", "$.client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isNull();
+    assertThat(principals.clientId()).isEqualTo("testclient");
+  }
+
+  @Test
+  void shouldLoadNestedUsernameAndClientId() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "claims",
+            Map.of(
+                "username", "testuser",
+                "client_id", "testclient",
+                "other_claim", "other_value"));
+
+    final var loader = new OidcPrincipalLoader("$.claims.username", "$.claims.client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isEqualTo("testuser");
+    assertThat(principals.clientId()).isEqualTo("testclient");
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
@@ -15,6 +15,25 @@ import org.junit.jupiter.api.Test;
 final class OidcPrincipalLoaderTest {
 
   @Test
+  void shouldIgnoreMissingConfig() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "username", "testuser",
+            "client_id", "testclient",
+            "other_claim", "other_value");
+
+    final var loader = new OidcPrincipalLoader(null, null);
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isNull();
+    assertThat(principals.clientId()).isNull();
+  }
+
+  @Test
   void shouldLoadUsernameAndClientIdWithSimpleExpression() {
     // given
     final var claims =

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -42,8 +42,6 @@ public sealed interface AuthenticationHandler {
   final class Oidc implements AuthenticationHandler {
     public static final Context.Key<Map<String, Object>> USER_CLAIMS =
         Context.key("io.camunda.zeebe:user_claim");
-    public static final String CONFIGURED_CLAIM_NOT_A_STRING =
-        "Configured claim for %s (%s) is not a string. Please check your OIDC configuration.";
 
     public static final String BEARER_PREFIX = "Bearer ";
     private final JwtDecoder jwtDecoder;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.interceptors.impl;
 
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.util.Either;
@@ -46,6 +47,7 @@ public sealed interface AuthenticationHandler {
     public static final String BEARER_PREFIX = "Bearer ";
     private final JwtDecoder jwtDecoder;
     private final OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+    private final OidcPrincipalLoader oidcPrincipalLoader;
 
     public Oidc(
         final JwtDecoder jwtDecoder,
@@ -53,6 +55,10 @@ public sealed interface AuthenticationHandler {
       this.jwtDecoder = Objects.requireNonNull(jwtDecoder);
       this.oidcAuthenticationConfiguration =
           Objects.requireNonNull(oidcAuthenticationConfiguration);
+      oidcPrincipalLoader =
+          new OidcPrincipalLoader(
+              oidcAuthenticationConfiguration.getUsernameClaim(),
+              oidcAuthenticationConfiguration.getClientIdClaim());
     }
 
     @Override
@@ -73,38 +79,18 @@ public sealed interface AuthenticationHandler {
                 .withCause(e));
       }
 
-      final var username =
-          token.getClaims().get(oidcAuthenticationConfiguration.getUsernameClaim());
-
-      if (username != null) {
-        if (username instanceof String) {
-          return Either.right(
-              Context.current()
-                  .withValue(USERNAME, username.toString())
-                  .withValue(USER_CLAIMS, token.getClaims()));
-        } else {
-          return Either.left(
-              Status.UNAUTHENTICATED.augmentDescription(
-                  CONFIGURED_CLAIM_NOT_A_STRING.formatted(
-                      "username", oidcAuthenticationConfiguration.getUsernameClaim())));
-        }
+      final var principals = oidcPrincipalLoader.load(token.getClaims());
+      if (principals.username() != null) {
+        return Either.right(
+            Context.current()
+                .withValue(USERNAME, principals.username())
+                .withValue(USER_CLAIMS, token.getClaims()));
       }
-
-      final var clientId =
-          token.getClaims().get(oidcAuthenticationConfiguration.getClientIdClaim());
-
-      if (clientId != null) {
-        if (clientId instanceof String) {
-          return Either.right(
-              Context.current()
-                  .withValue(CLIENT_ID, clientId.toString())
-                  .withValue(USER_CLAIMS, token.getClaims()));
-        } else {
-          return Either.left(
-              Status.UNAUTHENTICATED.augmentDescription(
-                  CONFIGURED_CLAIM_NOT_A_STRING.formatted(
-                      "client id", oidcAuthenticationConfiguration.getClientIdClaim())));
-        }
+      if (principals.clientId() != null) {
+        return Either.right(
+            Context.current()
+                .withValue(CLIENT_ID, principals.clientId())
+                .withValue(USER_CLAIMS, token.getClaims()));
       }
 
       return Either.left(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -263,6 +263,10 @@ public class AuthenticationInterceptorTest {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
                   .isEqualTo("Failed to load OIDC principals, see cause for details");
+              assertThat(status.getCause())
+                  .isInstanceOf(IllegalArgumentException.class)
+                  .hasMessageContaining(
+                      "Value for $['username'] is not a string. Please check your OIDC configuration.");
             });
   }
 
@@ -298,6 +302,10 @@ public class AuthenticationInterceptorTest {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
                   .isEqualTo("Failed to load OIDC principals, see cause for details");
+              assertThat(status.getCause())
+                  .isInstanceOf(IllegalArgumentException.class)
+                  .hasMessageContaining(
+                      "Value for $['client_id'] is not a string. Please check your OIDC configuration.");
             });
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.interceptors.impl;
 
 import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.CLIENT_ID;
-import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc.CONFIGURED_CLAIM_NOT_A_STRING;
 import static io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -263,7 +262,7 @@ public class AuthenticationInterceptorTest {
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
-                  .isEqualTo(CONFIGURED_CLAIM_NOT_A_STRING.formatted("username", "username"));
+                  .isEqualTo("Failed to load OIDC principals, see cause for details");
             });
   }
 
@@ -298,7 +297,7 @@ public class AuthenticationInterceptorTest {
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
               assertThat(status.getDescription())
-                  .isEqualTo(CONFIGURED_CLAIM_NOT_A_STRING.formatted("client id", "client_id"));
+                  .isEqualTo("Failed to load OIDC principals, see cause for details");
             });
   }
 


### PR DESCRIPTION
This adds support for arbitrary JsonPath expressions for the username and client id claims. We maintain backwards compatibility with existing config because the library we use doesn't require the full expression (e.g. `$.sub`) but can also work with a simple claim name (e.g. `sub`).

closes #32422
