### PR TITLE
[stable/8.7] fix: assemble worker default tenant id config correctly

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -204,21 +204,21 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
     final Set<String> tenantIds = new HashSet<>();
 
     // we consider default worker tenant ids configurations first
-    if (camundaClientProperties.getZeebe().getDefaults().getTenantIds() != null) {
+    if (camundaClientProperties.getZeebe().getDefaults().getTenantIds() != null
+        && !camundaClientProperties.getZeebe().getDefaults().getTenantIds().isEmpty()) {
       tenantIds.addAll(camundaClientProperties.getZeebe().getDefaults().getTenantIds());
-    } else if (camundaClientProperties.getTenantIds() != null) {
+    } else if (camundaClientProperties.getTenantIds() != null
+        && !camundaClientProperties.getTenantIds().isEmpty()) {
       // the deprecated config only gets considered in the absence of it's successor
       tenantIds.addAll(camundaClientProperties.getTenantIds());
+    } else if (StringUtils.isNotBlank(camundaClientProperties.getTenantId())) {
+      // the default tenant set on the client is included in the default if no other default is set
+      tenantIds.add(camundaClientProperties.getTenantId());
     }
 
     // if set, worker annotation defaults get included as well
     if (zeebeWorker.getTenantIds() != null) {
       tenantIds.addAll(zeebeWorker.getTenantIds());
-    }
-
-    // lastly the default tenant set on the client is included in the default
-    if (StringUtils.isNotBlank(camundaClientProperties.getTenantId())) {
-      tenantIds.add(camundaClientProperties.getTenantId());
     }
 
     if (!tenantIds.isEmpty()) {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -407,6 +407,25 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
+  void shouldMergeWorkerDefaultTenantIdsAndWorkerAnnotationTenantIds() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.getZeebe().getDefaults().setTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+
+    final ZeebeWorkerValue jobWorkerValue = new ZeebeWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    jobWorkerValue.setTenantIds(List.of("annotationTenantId"));
+    // when
+    customizer.customize(jobWorkerValue);
+    // then
+    assertThat(jobWorkerValue.getTenantIds())
+        .containsExactlyInAnyOrder("annotationTenantId", "customTenantId");
+  }
+
+  @Test
   void shouldApplyClientDefaultTenantIdWhenNothingElseConfigured() {
     // given
     final CamundaClientProperties properties = properties();
@@ -420,7 +439,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldMergeWorkerDefaultTenantIdsAndClientDefaultTenantIdWhenNothingElseConfigured() {
+  void shouldApplyWorkerDefaultTenantIdsOnlyWhenClientDefaultTenantIdIsSet() {
     // given
     final CamundaClientProperties properties = properties();
     properties.setTenantId("customTenantId");
@@ -435,7 +454,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     customizer.customize(jobWorkerValue);
     // then
     assertThat(jobWorkerValue.getTenantIds())
-        .containsExactlyInAnyOrder("testTenantId1", "testTenantId2", "customTenantId");
+        .containsExactlyInAnyOrder("testTenantId1", "testTenantId2");
   }
 
   @Test
@@ -457,27 +476,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldMergeDeprecatedDefaultTenantIdsAndClientDefaultTenantIdWhenNothingElseConfigured() {
-    // given
-    final CamundaClientProperties properties = properties();
-    properties.setTenantIds(List.of("testTenantId1", "testTenantId2"));
-    properties.setTenantId("customTenantId");
-
-    final PropertyBasedZeebeWorkerValueCustomizer customizer =
-        new PropertyBasedZeebeWorkerValueCustomizer(properties);
-
-    final ZeebeWorkerValue jobWorkerValue = new ZeebeWorkerValue();
-    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
-    // when
-    customizer.customize(jobWorkerValue);
-    // then
-    assertThat(jobWorkerValue.getTenantIds())
-        .containsExactlyInAnyOrder("testTenantId1", "testTenantId2", "customTenantId");
-  }
-
-  @Test
-  void
-      shouldOverrideDeprecatedDefaultTenantIdsWhenWorkerDefaultTenantIdsAndNothingElseConfigured() {
+  void shouldApplyWorkerDefaultTenantIdsWhenDeprecatedDefaultTenantIdsAreSet() {
     // given
     final CamundaClientProperties properties = properties();
     properties.setTenantIds(List.of("testTenantId1", "testTenantId2"));
@@ -515,7 +514,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldApplyWorkerOverridesRegardlessOfDefaultsSet() {
+  void shouldApplyTenantIdWorkerOverridesRegardlessOfDefaultsSet() {
     // given
     final CamundaClientProperties properties = properties();
     properties.getZeebe().getDefaults().setTenantIds(List.of("workerDefaultsId"));


### PR DESCRIPTION
## Description

Previous behavior was not aligned with the documentation:
* camunda.client.tenant-id was not taken into account as default
* camunda.client.zeebe.defaults always overwrote other defaults (e.g. annotation values) as it was applied during override and not a protected property

See https://docs.camunda.io/docs/apis-tools/spring-zeebe-sdk/configuration/#control-tenant-usage

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates #32464
relates #32015
