### PR TITLE
ci: increase renovate's hourly PR limit to 5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 5,
   "updateNotScheduled": false,
   "schedule": [
     "at any time"


### PR DESCRIPTION
## Description

Due to a current backlog of rate-limited PRs we decided to increase the hourly rate at which renovate opens new PRs. This shall mitigate the current flaky renovate behavior where we run into timeouts every once in while.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

- discussion: https://camunda.slack.com/archives/C071KP5BTHB/p1748247473429909?thread_ts=1748235802.275349&cid=C071KP5BTHB
