### PR TITLE
feat: upgrade zod to 0.49

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-query": "5.67.2",
     "@tanstack/react-query-devtools": "^5.67.1",
     "@types/loadable__component": "5.13.9",
-    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.46",
+    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.49",
     "bpmn-js": "18.3.1",
     "bpmn-moddle": "9.0.1",
     "date-fns": "4.1.0",

--- a/operate/client/src/App/ProcessInstance/Breadcrumb/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/Breadcrumb/v2/index.test.tsx
@@ -45,14 +45,17 @@ const callHierarchy: CallHierarchy[] = [
   {
     processInstanceKey: '546546543276',
     processDefinitionName: 'Parent Process Name',
+    processDefinitionKey: '',
   },
   {
     processInstanceKey: '968765314354',
     processDefinitionName: '1st level Child Process Name',
+    processDefinitionKey: '',
   },
   {
     processInstanceKey: '2251799813685447',
     processDefinitionName: '2nd level Child Process Name',
+    processDefinitionKey: '',
   },
 ];
 

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/v2/Error.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/Messages/v2/Error.tsx
@@ -27,7 +27,7 @@ function getParentAndRootProcessInformation(callHierarchy?: CallHierarchy[]) {
 const Error: React.FC = () => {
   const {data: callHierarchy} = useCallHierarchy();
   const {parentProcessId, parentProcessName, rootProcessId, rootProcessName} =
-    getParentAndRootProcessInformation(callHierarchy?.items);
+    getParentAndRootProcessInformation(callHierarchy);
 
   if (parentProcessId === undefined || rootProcessId === undefined) {
     return null;

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/v2/index.test.tsx
@@ -776,12 +776,18 @@ describe('Modification Summary Modal', () => {
       ...mockProcessInstance,
       parentProcessInstanceKey: '2',
     });
-    mockFetchCallHierarchy().withSuccess({
-      items: [
-        {processInstanceKey: '3', processDefinitionName: 'some root process'},
-        {processInstanceKey: '2', processDefinitionName: 'some parent process'},
-      ],
-    });
+    mockFetchCallHierarchy().withSuccess([
+      {
+        processInstanceKey: '3',
+        processDefinitionName: 'some root process',
+        processDefinitionKey: 'process-key',
+      },
+      {
+        processInstanceKey: '2',
+        processDefinitionName: 'some parent process',
+        processDefinitionKey: 'process-key',
+      },
+    ]);
 
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.test.tsx
@@ -239,7 +239,7 @@ describe('InstanceHeader', () => {
   });
 
   it.skip('should show spinner when operation is applied', async () => {
-    mockFetchCallHierarchy().withSuccess({items: []});
+    mockFetchCallHierarchy().withSuccess([]);
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockApplyOperation().withSuccess(mockOperationCreated);
@@ -330,7 +330,7 @@ describe('InstanceHeader', () => {
   });
 
   it.skip('should remove spinner when operation fails', async () => {
-    mockFetchCallHierarchy().withSuccess({items: []});
+    mockFetchCallHierarchy().withSuccess([]);
     mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockApplyOperation().withDelayedServerError();

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -150,7 +150,7 @@ const ProcessInstance: React.FC = observer(() => {
     state: {modifications, status: modificationStatus},
   } = modificationsStore;
 
-  const isBreadcrumbVisible = callHierarchy && callHierarchy.items.length > 0;
+  const isBreadcrumbVisible = callHierarchy && callHierarchy.length > 0;
 
   const hasPendingModifications = modifications.length > 0;
 
@@ -183,7 +183,7 @@ const ProcessInstance: React.FC = observer(() => {
             breadcrumb={
               isBreadcrumbVisible && callHierarchy ? (
                 <Breadcrumb
-                  callHierarchy={callHierarchy.items}
+                  callHierarchy={callHierarchy}
                   processInstance={processInstance}
                 />
               ) : undefined

--- a/operate/client/src/App/ProcessInstance/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/mocks.tsx
@@ -112,7 +112,7 @@ const mockRequests = (contextPath: string = '') => {
   );
   mockFetchProcessInstance(contextPath).withSuccess(mockProcessInstance);
   mockFetchProcessInstance(contextPath).withSuccess(mockProcessInstance);
-  mockFetchCallHierarchy(contextPath).withSuccess({items: []});
+  mockFetchCallHierarchy(contextPath).withSuccess([]);
   mockFetchProcessDefinitionXml({contextPath}).withSuccess('');
   mockFetchProcessSequenceFlows().withSuccess({items: mockSequenceFlowsV2});
   mockFetchFlowNodeInstances(contextPath).withSuccess(

--- a/operate/client/src/App/ProcessInstance/v2/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/modifications.test.tsx
@@ -546,8 +546,8 @@ describe('ProcessInstance - modification mode', () => {
 
     mockFetchProcessInstance(contextPath).withSuccess(mockProcessInstance);
     mockFetchProcessInstance(contextPath).withSuccess(mockProcessInstance);
-    mockFetchCallHierarchy(contextPath).withSuccess({items: []});
-    mockFetchCallHierarchy(contextPath).withSuccess({items: []});
+    mockFetchCallHierarchy(contextPath).withSuccess([]);
+    mockFetchCallHierarchy(contextPath).withSuccess([]);
 
     storeStateLocally({
       [`hideModificationHelperModal`]: true,

--- a/operate/client/src/modules/components/Operations/v2/cancel-operation.test.tsx
+++ b/operate/client/src/modules/components/Operations/v2/cancel-operation.test.tsx
@@ -25,12 +25,18 @@ describe('Operations - Cancel Operation', () => {
   });
 
   it('should show modal when trying to cancel called instance', async () => {
-    mockFetchCallHierarchy().withSuccess({
-      items: [
-        {processInstanceKey: '3', processDefinitionName: 'some root process'},
-        {processInstanceKey: '2', processDefinitionName: 'some parent process'},
-      ],
-    });
+    mockFetchCallHierarchy().withSuccess([
+      {
+        processInstanceKey: '3',
+        processDefinitionName: 'some root process',
+        processDefinitionKey: 'process-key',
+      },
+      {
+        processInstanceKey: '2',
+        processDefinitionName: 'some parent process',
+        processDefinitionKey: 'process-key',
+      },
+    ]);
     const onOperationMock = jest.fn();
 
     const modalText =
@@ -66,14 +72,13 @@ describe('Operations - Cancel Operation', () => {
 
   it('should redirect to linked parent instance', async () => {
     const rootInstanceId = '6755399441058622';
-    mockFetchCallHierarchy().withSuccess({
-      items: [
-        {
-          processInstanceKey: rootInstanceId,
-          processDefinitionName: 'some root process',
-        },
-      ],
-    });
+    mockFetchCallHierarchy().withSuccess([
+      {
+        processInstanceKey: rootInstanceId,
+        processDefinitionName: 'some root process',
+        processDefinitionKey: 'process-key',
+      },
+    ]);
 
     const {user} = render(
       <Operations

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -39,12 +39,12 @@ const mockEndpoints = [
         {
           processInstanceKey: '2251799833223965',
           processDefinitionName: 'Call Activity Process',
-          processDefinitionKey: '',
+          processDefinitionKey: '2251799816361742',
         },
         {
           processInstanceKey: '2251799833223971',
           processDefinitionName: 'called-process',
-          processDefinitionKey: '',
+          processDefinitionKey: '2251799816361742',
         },
       ];
 

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -35,18 +35,18 @@ const mockEndpoints = [
   rest.get(
     '/v2/process-instances/:processInstanceKey/call-hierarchy',
     async (req, res, ctx) => {
-      const mockResponse: GetProcessInstanceCallHierarchyResponseBody = {
-        items: [
-          {
-            processInstanceKey: '2251799833223965',
-            processDefinitionName: 'Call Activity Process',
-          },
-          {
-            processInstanceKey: '2251799833223971',
-            processDefinitionName: 'called-process',
-          },
-        ],
-      };
+      const mockResponse: GetProcessInstanceCallHierarchyResponseBody = [
+        {
+          processInstanceKey: '2251799833223965',
+          processDefinitionName: 'Call Activity Process',
+          processDefinitionKey: '',
+        },
+        {
+          processInstanceKey: '2251799833223971',
+          processDefinitionName: 'called-process',
+          processDefinitionKey: '',
+        },
+      ];
 
       return res(ctx.json(mockResponse));
     },

--- a/operate/client/src/modules/queries/callHierarchy/useRootInstanceId.ts
+++ b/operate/client/src/modules/queries/callHierarchy/useRootInstanceId.ts
@@ -12,7 +12,7 @@ import {useCallHierarchy} from './useCallHierarchy';
 const rootInstanceIdParser = (
   data: GetProcessInstanceCallHierarchyResponseBody,
 ) => {
-  return data.items[0]?.processInstanceKey;
+  return data[0]?.processInstanceKey;
 };
 
 const useRootInstanceId = () =>

--- a/operate/client/yarn.lock
+++ b/operate/client/yarn.lock
@@ -3365,10 +3365,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@vzeta/camunda-api-zod-schemas@0.0.2-beta.46":
-  version "0.0.2-beta.46"
-  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.46.tgz#8e1214f35acdfd90d895158005344d9d53808192"
-  integrity sha512-ixAUOBq0CPvjgPLFlLB9xEhC7Sxm8rgw2aVvJIhLJT2GdsB+RspABKL60i21Fo7W+fk4Pg5SUAsTmm3ahlM4gQ==
+"@vzeta/camunda-api-zod-schemas@0.0.2-beta.49":
+  version "0.0.2-beta.49"
+  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.49.tgz#6535474a9e58a874dfe55010d2c798d34a7d4b7f"
+  integrity sha512-rCaLEFrstvlSKhmU20vf4Vs84U00Q2tZZ50Yb3GMWXnJMhMDqWCzTqoyUVVvibHGpji3Ni7SIRLWNLSNjfSUUQ==
 
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"


### PR DESCRIPTION
## Description

There's been 2 unrelated updates in zod coming from 2 separate migration : `callHierarchy` and `jobs`. Basically call hierarchy changes was part of 0.49 version and jobs changes was part of 0.50 which blocked jobs work from getting merged as jumping to 0.50 would break code that hasn't been updated to 0.49 yet.

This PR is making necessary updates in `camunda/camunda` repo so it can unblock dev work in jobs migration

## Related issues

related to https://github.com/camunda/camunda/issues/31203
