### PR TITLE
Update thread count in the background task manager

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -109,20 +109,16 @@ public final class BackgroundTaskManagerFactory {
 
   private List<RunnableTask> buildTasks() {
     final List<RunnableTask> tasks = new ArrayList<>();
-    int threadCount = 2;
 
     tasks.add(buildIncidentMarkerTask());
     tasks.add(buildProcessInstanceArchiverJob());
     if (partitionId == START_PARTITION_ID) {
-      threadCount = 3;
       tasks.add(buildBatchOperationArchiverJob());
       tasks.add(new ApplyRolloverPeriodJob(archiverRepository));
-    }
-    if (partitionId == START_PARTITION_ID) {
       tasks.add(buildBatchOperationUpdateTask());
     }
 
-    executor.setCorePoolSize(threadCount);
+    executor.setCorePoolSize(tasks.size());
     return tasks;
   }
 


### PR DESCRIPTION
## Description

- Combine the two same if blocks and set threadCount to match the total tasks.
   In the current implementation, when partitionId == START_PARTITION_ID,  the threadCount was set to 3, but it means the core pool has only 3 threads to handle 5 scheduled tasks simultaneously, which may cause two of them to sit queued.
- Update setCorePoolSize based on task size

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
