### PR TITLE
Refactor `unassign` role from tenant command to follow the agreed pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1329,17 +1329,17 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newUnassignRoleFromTenantCommand("tenantId")
+   *  .newUnassignRoleFromTenantCommand()
    *  .roleId("roleId")
+   *  .tenantId("tenantId")
    *  .send();
    * </pre>
    *
    * <p>This command is only sent via REST over HTTP.
    *
-   * @param tenantId the ID of the tenant
    * @return a builder for the unassign role from tenant command
    */
-  UnassignRoleFromTenantCommandStep1 newUnassignRoleFromTenantCommand(String tenantId);
+  UnassignRoleFromTenantCommandStep1 newUnassignRoleFromTenantCommand();
 
   /**
    * Executes a search request to query roles assigned to a specific tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignRoleFromTenantCommandStep1.java
@@ -17,8 +17,7 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UnassignRoleFromTenantResponse;
 
-public interface UnassignRoleFromTenantCommandStep1
-    extends FinalCommandStep<UnassignRoleFromTenantResponse> {
+public interface UnassignRoleFromTenantCommandStep1 {
 
   /**
    * Sets the role ID to unassign from the tenant.
@@ -26,5 +25,18 @@ public interface UnassignRoleFromTenantCommandStep1
    * @param roleId the ID of the role to unassign
    * @return the builder for this command
    */
-  UnassignRoleFromTenantCommandStep1 roleId(String roleId);
+  UnassignRoleFromTenantCommandStep2 roleId(String roleId);
+
+  interface UnassignRoleFromTenantCommandStep2
+      extends FinalCommandStep<UnassignRoleFromTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the tenantId of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UnassignRoleFromTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -883,9 +883,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UnassignRoleFromTenantCommandStep1 newUnassignRoleFromTenantCommand(
-      final String tenantId) {
-    return new UnassignRoleFromTenantCommandImpl(httpClient, tenantId);
+  public UnassignRoleFromTenantCommandStep1 newUnassignRoleFromTenantCommand() {
+    return new UnassignRoleFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignRoleFromTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1;
+import io.camunda.client.api.command.UnassignRoleFromTenantCommandStep1.UnassignRoleFromTenantCommandStep2;
 import io.camunda.client.api.response.UnassignRoleFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class UnassignRoleFromTenantCommandImpl implements UnassignRoleFromTenantCommandStep1 {
+public final class UnassignRoleFromTenantCommandImpl
+    implements UnassignRoleFromTenantCommandStep1, UnassignRoleFromTenantCommandStep2 {
 
   private final HttpClient httpClient;
-  private final String tenantId;
   private final RequestConfig.Builder httpRequestConfig;
   private String roleId;
+  private String tenantId;
 
-  public UnassignRoleFromTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public UnassignRoleFromTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public UnassignRoleFromTenantCommandStep1 roleId(final String roleId) {
+  public UnassignRoleFromTenantCommandStep2 roleId(final String roleId) {
     this.roleId = roleId;
+    return this;
+  }
+
+  @Override
+  public UnassignRoleFromTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignRoleToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignRoleToTenantTest.java
@@ -43,7 +43,7 @@ public class AssignRoleToTenantTest extends ClientRestTest {
   @Test
   void shouldUnassignRoleFromTenant() {
     // when
-    client.newUnassignRoleFromTenantCommand(TENANT_ID).roleId(ROLE_ID).send().join();
+    client.newUnassignRoleFromTenantCommand().roleId(ROLE_ID).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignRoleFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignRoleFromTenantTest.java
@@ -32,7 +32,7 @@ public class UnassignRoleFromTenantTest extends ClientRestTest {
   @Test
   void shouldUnassignRoleFromTenant() {
     // when
-    client.newUnassignRoleFromTenantCommand(TENANT_ID).roleId(ROLE_ID).send().join();
+    client.newUnassignRoleFromTenantCommand().roleId(ROLE_ID).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -43,7 +43,13 @@ public class UnassignRoleFromTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullTenantId() {
     assertThatThrownBy(
-            () -> client.newUnassignRoleFromTenantCommand(null).roleId(ROLE_ID).send().join())
+            () ->
+                client
+                    .newUnassignRoleFromTenantCommand()
+                    .roleId(ROLE_ID)
+                    .tenantId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be null");
   }
@@ -51,7 +57,13 @@ public class UnassignRoleFromTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnEmptyTenantId() {
     assertThatThrownBy(
-            () -> client.newUnassignRoleFromTenantCommand("").roleId(ROLE_ID).send().join())
+            () ->
+                client
+                    .newUnassignRoleFromTenantCommand()
+                    .roleId(ROLE_ID)
+                    .tenantId("")
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
   }
@@ -59,7 +71,13 @@ public class UnassignRoleFromTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullRoleId() {
     assertThatThrownBy(
-            () -> client.newUnassignRoleFromTenantCommand(TENANT_ID).roleId(null).send().join())
+            () ->
+                client
+                    .newUnassignRoleFromTenantCommand()
+                    .roleId(null)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be null");
   }
@@ -67,7 +85,13 @@ public class UnassignRoleFromTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnEmptyRoleId() {
     assertThatThrownBy(
-            () -> client.newUnassignRoleFromTenantCommand(TENANT_ID).roleId("").send().join())
+            () ->
+                client
+                    .newUnassignRoleFromTenantCommand()
+                    .roleId("")
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("roleId must not be empty");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -388,7 +388,7 @@ class RoleAuthorizationIT {
         .description("description")
         .send()
         .join();
-    adminClient.newAssignRoleToTenantCommand(tenantId).roleId(ROLE_ID_1).send().join();
+    adminClient.newAssignRoleToTenantCommand().roleId(ROLE_ID_1).tenantId(tenantId).send().join();
 
     adminClient
         .newUnassignRoleFromTenantCommand()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -377,6 +377,51 @@ class RoleAuthorizationIT {
   }
 
   @Test
+  void shouldUnassignRoleFromTenantIfAuthorized(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    final String tenantId = Strings.newRandomValidIdentityId();
+
+    adminClient
+        .newCreateTenantCommand()
+        .tenantId(tenantId)
+        .name("tenantName")
+        .description("description")
+        .send()
+        .join();
+    adminClient.newAssignRoleToTenantCommand(tenantId).roleId(ROLE_ID_1).send().join();
+
+    adminClient
+        .newUnassignRoleFromTenantCommand()
+        .roleId(ROLE_ID_1)
+        .tenantId(tenantId)
+        .send()
+        .join();
+
+    Awaitility.await("Role is unassigned from the tenant")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminClient.newRolesByTenantSearchRequest(tenantId).send().join().items())
+                    .isEmpty());
+  }
+
+  @Test
+  void unassignRoleFromTenantShouldReturnForbiddenIfUnauthorized(
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUnassignRoleFromTenantCommand()
+                    .roleId(Strings.newRandomValidIdentityId())
+                    .tenantId(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
+  }
+
+  @Test
   void unassignRoleFromClientShouldReturnForbiddenIfUnauthorized(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     assertThatThrownBy(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesByTenantIntegrationTest.java
@@ -207,7 +207,12 @@ public class RolesByTenantIntegrationTest {
     createRole(roleId, "name", "desc");
     camundaClient.newAssignRoleToTenantCommand().roleId(roleId).tenantId(tenantId).send().join();
     // when
-    camundaClient.newUnassignRoleFromTenantCommand(tenantId).roleId(roleId).send().join();
+    camundaClient
+        .newUnassignRoleFromTenantCommand()
+        .roleId(roleId)
+        .tenantId(tenantId)
+        .send()
+        .join();
     // then
     Awaitility.await("Role should be unassigned from tenant")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
@@ -236,8 +241,9 @@ public class RolesByTenantIntegrationTest {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newUnassignRoleFromTenantCommand(tenantId)
+                    .newUnassignRoleFromTenantCommand()
                     .roleId(roleId)
+                    .tenantId(tenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -252,8 +258,9 @@ public class RolesByTenantIntegrationTest {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newUnassignRoleFromTenantCommand(tenantId)
+                    .newUnassignRoleFromTenantCommand()
                     .roleId(roleId)
+                    .tenantId(tenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -269,8 +276,9 @@ public class RolesByTenantIntegrationTest {
     assertThatThrownBy(
             () ->
                 camundaClient
-                    .newUnassignRoleFromTenantCommand(tenantId)
+                    .newUnassignRoleFromTenantCommand()
                     .roleId(roleId)
+                    .tenantId(tenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)


### PR DESCRIPTION
## Description

Ensure `newUnassignRoleFromTenantCommand` is following the agreed pattern: `assignXToY().x("").y("")`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32437
