### PR TITLE
Refactor the `CamundaMultiDBExtension` to support easy creation of Groups and Roles

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/GroupAuthorizationIT.java
@@ -8,29 +8,28 @@
 package io.camunda.it.auth;
 
 import static io.camunda.client.api.search.enums.PermissionType.*;
-import static io.camunda.client.api.search.enums.ResourceType.AUTHORIZATION;
-import static io.camunda.client.api.search.enums.ResourceType.GROUP;
-import static io.camunda.client.api.search.enums.ResourceType.ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Group;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.Membership;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestRole;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.net.http.HttpClient;
-import java.time.Duration;
 import java.util.List;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -43,29 +42,9 @@ class GroupAuthorizationIT {
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
 
-  private static final String GROUP_ID_1 = Strings.newRandomValidIdentityId();
-  private static final String GROUP_ID_2 = Strings.newRandomValidIdentityId();
-  private static final String ROLE_ID = Strings.newRandomValidIdentityId();
-  private static final String GROUP_NAME_1 = "AGroupName";
-  private static final String GROUP_NAME_2 = "BGroupName";
-  private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";
   private static final String RESTRICTED_WITH_READ = "restricteUser2";
   private static final String DEFAULT_PASSWORD = "password";
-  private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);
-
-  @UserDefinition
-  private static final User ADMIN_USER =
-      new User(
-          ADMIN,
-          DEFAULT_PASSWORD,
-          List.of(
-              new Permissions(GROUP, CREATE, List.of("*")),
-              new Permissions(GROUP, UPDATE, List.of("*")),
-              new Permissions(GROUP, READ, List.of("*")),
-              new Permissions(ROLE, CREATE, List.of("*")),
-              new Permissions(ROLE, UPDATE, List.of("*")),
-              new Permissions(AUTHORIZATION, UPDATE, List.of("*"))));
 
   @UserDefinition
   private static final User RESTRICTED_USER = new User(RESTRICTED, DEFAULT_PASSWORD, List.of());
@@ -76,19 +55,23 @@ class GroupAuthorizationIT {
           RESTRICTED_WITH_READ,
           DEFAULT_PASSWORD,
           List.of(
-              new Permissions(GROUP, READ, List.of("*")),
-              new Permissions(ROLE, READ, List.of("*"))));
+              new Permissions(ResourceType.GROUP, READ, List.of("*")),
+              new Permissions(ResourceType.ROLE, READ, List.of("*"))));
 
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  @GroupDefinition
+  private static final TestGroup GROUP_1 =
+      new TestGroup(Strings.newRandomValidIdentityId(), "AGroupName");
 
-  @BeforeAll
-  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createRole(adminClient);
-    createGroup(adminClient, GROUP_ID_1, GROUP_NAME_1);
-    assignGroupToRole(adminClient, GROUP_ID_1, ROLE_ID);
-    createGroup(adminClient, GROUP_ID_2, GROUP_NAME_2);
-    waitForGroupsToBeCreated(adminClient, 2);
-  }
+  @GroupDefinition
+  private static final TestGroup GROUP_2 =
+      new TestGroup(Strings.newRandomValidIdentityId(), "BGroupName");
+
+  @RoleDefinition
+  private static final TestRole ROLE =
+      TestRole.withoutPermissions(
+          Strings.newRandomValidIdentityId(),
+          "roleName",
+          List.of(new Membership(GROUP_1.id(), EntityType.GROUP)));
 
   @Test
   void searchShouldReturnAuthorizedGroups(
@@ -98,7 +81,7 @@ class GroupAuthorizationIT {
     assertThat(groupSearchResponse.items())
         .hasSize(2)
         .map(Group::getGroupId)
-        .containsExactlyInAnyOrder(GROUP_ID_1, GROUP_ID_2);
+        .containsExactlyInAnyOrder(GROUP_1.id(), GROUP_2.id());
   }
 
   @Test
@@ -110,31 +93,31 @@ class GroupAuthorizationIT {
     assertThat(groupSearchResponse.items())
         .hasSize(2)
         .map(Group::getName)
-        .containsExactly(GROUP_NAME_2, GROUP_NAME_1);
+        .containsExactly(GROUP_2.name(), GROUP_1.name());
   }
 
   @Test
   void searchShouldReturnGroupFilteredByGroupId(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     final var groupSearchResponse =
-        camundaClient.newGroupsSearchRequest().filter(fn -> fn.groupId(GROUP_ID_1)).send().join();
+        camundaClient.newGroupsSearchRequest().filter(fn -> fn.groupId(GROUP_1.id())).send().join();
 
     assertThat(groupSearchResponse.items())
         .hasSize(1)
         .map(Group::getGroupId)
-        .containsExactly(GROUP_ID_1);
+        .containsExactly(GROUP_1.id());
   }
 
   @Test
   void searchShouldReturnGroupsFilteredByName(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     final var groupSearchResponse =
-        camundaClient.newGroupsSearchRequest().filter(fn -> fn.name(GROUP_NAME_2)).send().join();
+        camundaClient.newGroupsSearchRequest().filter(fn -> fn.name(GROUP_2.name())).send().join();
 
     assertThat(groupSearchResponse.items())
         .hasSize(1)
         .map(Group::getName)
-        .containsExactly(GROUP_NAME_2);
+        .containsExactly(GROUP_2.name());
   }
 
   @Test
@@ -148,15 +131,15 @@ class GroupAuthorizationIT {
   @Test
   void getGroupByIdShouldReturnGroupIfAuthorized(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
-    final var group = camundaClient.newGroupGetRequest(GROUP_ID_1).send().join();
+    final var group = camundaClient.newGroupGetRequest(GROUP_1.id()).send().join();
 
-    assertThat(group.getGroupId()).isEqualTo(GROUP_ID_1);
+    assertThat(group.getGroupId()).isEqualTo(GROUP_1.id());
   }
 
   @Test
   void getGroupByIdShouldReturnNotFoundIfUnauthorized(
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    assertThatThrownBy(() -> camundaClient.newGroupGetRequest(GROUP_ID_1).send().join())
+    assertThatThrownBy(() -> camundaClient.newGroupGetRequest(GROUP_1.id()).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("404: 'Not Found'");
   }
@@ -164,42 +147,16 @@ class GroupAuthorizationIT {
   @Test
   void getRolesByGroupShouldReturnRolesIfAuthorized(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
-    final var roles = camundaClient.newRolesByGroupSearchRequest(GROUP_ID_1).send().join();
+    final var roles = camundaClient.newRolesByGroupSearchRequest(GROUP_1.id()).send().join();
 
     assertThat(roles.items().size()).isEqualTo(1);
-    assertThat(roles.items().getFirst().getRoleId()).isEqualTo(ROLE_ID);
+    assertThat(roles.items().getFirst().getRoleId()).isEqualTo(ROLE.id());
   }
 
   @Test
   void getRolesByGroupShouldReturnNotFoundIfUnauthorized(
       @Authenticated(RESTRICTED) final CamundaClient camundaClient) {
-    final var roles = camundaClient.newRolesByGroupSearchRequest(GROUP_ID_1).send().join();
+    final var roles = camundaClient.newRolesByGroupSearchRequest(GROUP_1.id()).send().join();
     assertThat(roles.items().size()).isEqualTo(0);
-  }
-
-  private static void createGroup(
-      final CamundaClient adminClient, final String groupId, final String groupName) {
-    adminClient.newCreateGroupCommand().groupId(groupId).name(groupName).send().join();
-  }
-
-  private static void createRole(final CamundaClient adminClient) {
-    adminClient.newCreateRoleCommand().roleId(ROLE_ID).name("name").send().join();
-  }
-
-  private static void assignGroupToRole(
-      final CamundaClient adminClient, final String groupId, final String roleId) {
-    adminClient.newAssignRoleToGroupCommand().roleId(roleId).groupId(groupId).send().join();
-  }
-
-  private static void waitForGroupsToBeCreated(
-      final CamundaClient client, final int expectedCount) {
-    Awaitility.await("should create groups and import in ES")
-        .atMost(AWAIT_TIMEOUT)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var groupSearchResponse = client.newGroupsSearchRequest().send().join();
-              assertThat(groupSearchResponse.items()).hasSize(expectedCount);
-            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/RoleAuthorizationIT.java
@@ -91,7 +91,9 @@ class RoleAuthorizationIT {
       new User(
           RESTRICTED_WITH_READ,
           DEFAULT_PASSWORD,
-          List.of(new Permissions(ResourceType.ROLE, PermissionType.READ, List.of("*"))));
+          List.of(
+              new Permissions(
+                  ResourceType.ROLE, PermissionType.READ, List.of(ROLE_ID_1, ROLE_ID_2))));
 
   @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
@@ -303,12 +305,12 @@ class RoleAuthorizationIT {
 
   @Test
   void searchShouldReturnAuthorizedRoles(
-      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) throws Exception {
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     final var roleSearchResponse = camundaClient.newRolesSearchRequest().send().join();
 
     assertThat(roleSearchResponse.items())
         .map(Role::getName)
-        .containsExactlyInAnyOrder("Admin", "RPA", "Connectors", ROLE_NAME_1, ROLE_NAME_2);
+        .containsExactlyInAnyOrder(ROLE_NAME_1, ROLE_NAME_2);
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
@@ -83,7 +83,7 @@ class UserSearchingAuthorizationIT {
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
     createUser(adminClient, "user1");
     createUser(adminClient, "user2");
-    final var expectedCount = 4; // demo, admin, user1, user2
+    final var expectedCount = 6; // demo, admin, user1, user2, restricted, restrictedWithRead
     waitForUsersToBeCreated(
         adminClient.getConfiguration().getRestAddress().toString(), ADMIN, expectedCount);
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/GroupDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/GroupDefinition.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// TODO javadoc
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface GroupDefinition {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/GroupDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/GroupDefinition.java
@@ -7,13 +7,41 @@
  */
 package io.camunda.qa.util.auth;
 
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-// TODO javadoc
+/**
+ * Marker annotation for a group definition, that is picked up by the {@link
+ * CamundaMultiDBExtension}. This is to clearly communicate that this group definition,
+ * will be consumed and created (related permissions and memberships) by the {@link CamundaMultiDBExtension}.
+ *
+ *  <pre>{@code
+ *  @Tag("multi-db-test")
+ *  final class MyAuthMultiDbTest {
+ *
+ *    static final TestStandaloneBroker BROKER =
+ *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *    @RegisterExtension
+ *    static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+ *
+ *    @GroupDefinition
+ *    private static final TestGroup GROUP =
+ *      new TestGroup("groupId",
+ *                    "groupName",
+ *                    List.of(new Permissions(AUTHORIZATION, PermissionTypeEnum.READ, List.of("*"))),
+ *                    List.of(new Membership("username", EntityType.USER)));
+ *
+ *    @Test
+ *    void shouldHaveCreatedGroup(@Authenticated(ADMIN) final CamundaClient adminClient) {
+ *      // The group, permissions and memberships are created before this test runs
+ *    }
+ *  }</pre>
+ */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/Membership.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/Membership.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import io.camunda.zeebe.protocol.record.value.EntityType;
+
+public record Membership(String memberId, EntityType entityType) {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/RoleDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/RoleDefinition.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// TODO javadoc
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RoleDefinition {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/RoleDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/RoleDefinition.java
@@ -7,13 +7,41 @@
  */
 package io.camunda.qa.util.auth;
 
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-// TODO javadoc
+/**
+ * Marker annotation for a role definition, that is picked up by the {@link
+ * CamundaMultiDBExtension}. This is to clearly communicate that this role definition,
+ * will be consumed and created (related permissions and memberships) by the {@link CamundaMultiDBExtension}.
+ *
+ *  <pre>{@code
+ *  @Tag("multi-db-test")
+ *  final class MyAuthMultiDbTest {
+ *
+ *    static final TestStandaloneBroker BROKER =
+ *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *    @RegisterExtension
+ *    static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+ *
+ *    @RoleDefinition
+ *    private static final TestRole ROLE =
+ *      new TestRole("roleId",
+ *                   "roleName",
+ *                   List.of(new Permissions(AUTHORIZATION, PermissionTypeEnum.READ, List.of("*"))),
+ *                   List.of(new Membership("username", EntityType.USER)));
+ *
+ *    @Test
+ *    void shouldHaveCreatedRole(@Authenticated(ADMIN) final CamundaClient adminClient) {
+ *      // The role, permissions and memberships are created before this test runs
+ *    }
+ *  }</pre>
+ */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestGroup.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestGroup.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.util.List;
+
+public record TestGroup(
+    String id, String name, List<Permissions> permissions, List<Membership> memberships) {
+
+  public TestGroup(final String groupId, final String groupName) {
+    this(groupId, groupName, List.of(), List.of());
+  }
+
+  public static TestGroup withoutMemberships(
+      final String groupId, final String groupName, final List<Permissions> permissions) {
+    return new TestGroup(groupId, groupName, permissions, List.of());
+  }
+
+  public static TestGroup withoutPermissions(
+      final String groupId, final String groupName, final List<Membership> memberships) {
+    return new TestGroup(groupId, groupName, List.of(), memberships);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestRole.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestRole.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.util.List;
+
+public record TestRole(
+    String id, String name, List<Permissions> permissions, List<Membership> memberships) {
+
+  public TestRole(final String roleId, final String roleName) {
+    this(roleId, roleName, List.of(), List.of());
+  }
+
+  public static TestRole withoutMemberships(
+      final String roleId, final String roleName, final List<Permissions> permissions) {
+    return new TestRole(roleId, roleName, permissions, List.of());
+  }
+
+  public static TestRole withoutPermissions(
+      final String roleId, final String roleName, final List<Membership> memberships) {
+    return new TestRole(roleId, roleName, List.of(), memberships);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/UserDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/UserDefinition.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.qa.util.auth;
 
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -15,8 +16,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marker annotation for a user definition, that is picked up by the {@link
- * CamundaMultiDbExtension}. This is to clearly communicate that this user definition,
- * will be consumed and created (related permissions) by the {@link CamundaMultiDbExtension}.
+ * CamundaMultiDBExtension}. This is to clearly communicate that this user definition,
+ * will be consumed and created (related permissions) by the {@link CamundaMultiDBExtension}.
  *
  *  <pre>{@code
  *  @Tag("multi-db-test")

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
@@ -8,17 +8,14 @@
 package io.camunda.qa.util.multidb;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.qa.util.auth.Authenticated;
-import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.agrona.CloseHelper;
@@ -32,19 +29,17 @@ public final class CamundaClientTestFactory implements AutoCloseable {
 
   private final Map<String, CamundaClient> cachedClients = new ConcurrentHashMap<>();
 
-  public CamundaClientTestFactory withUsers(
-      final TestStandaloneApplication<?> application, final List<User> users) {
-    final CamundaClient defaultClient =
-        cachedClients.computeIfAbsent(
-            InitializationConfiguration.DEFAULT_USER_USERNAME,
-            __ -> createDefaultUserClient(application));
-    users.forEach(
-        user -> {
-          createUserWithPermissions(
-              defaultClient, user.username(), user.password(), user.permissions());
-          createClientForUser(application, user);
-        });
-    return this;
+  public CamundaClientTestFactory(final TestStandaloneApplication<?> application) {
+    cachedClients.put(
+        InitializationConfiguration.DEFAULT_USER_USERNAME, createDefaultUserClient(application));
+  }
+
+  public CamundaClient getDefaultUserCamundaClient() {
+    return getCamundaClient(InitializationConfiguration.DEFAULT_USER_USERNAME);
+  }
+
+  public CamundaClient getCamundaClient(final String username) {
+    return cachedClients.get(username);
   }
 
   public CamundaClient getCamundaClient(
@@ -63,7 +58,7 @@ public final class CamundaClientTestFactory implements AutoCloseable {
     return cachedClients.get(username);
   }
 
-  private void createClientForUser(final TestGateway<?> gateway, final User user) {
+  public void createClientForUser(final TestGateway<?> gateway, final User user) {
     final var client = createAuthenticatedClient(gateway, user.username(), user.password());
     cachedClients.put(user.username(), client);
   }
@@ -83,45 +78,6 @@ public final class CamundaClientTestFactory implements AutoCloseable {
                 TopologyAssert.assertThat(defaultClient.newTopologyRequest().send().join())
                     .isHealthy());
     return defaultClient;
-  }
-
-  private void createUserWithPermissions(
-      final CamundaClient defaultClient,
-      final String username,
-      final String password,
-      final List<Permissions> permissions) {
-    defaultClient
-        .newUserCreateCommand()
-        .username(username)
-        .password(password)
-        .name(username)
-        .email("%s@foo.com".formatted(username))
-        .send()
-        .join();
-
-    permissions.forEach(
-        permission -> {
-          permission
-              .resourceIds()
-              .forEach(
-                  resourceId -> {
-                    defaultClient
-                        .newCreateAuthorizationCommand()
-                        .ownerId(username)
-                        .ownerType(OwnerType.USER)
-                        .resourceId(resourceId)
-                        .resourceType(permission.resourceType())
-                        .permissionTypes(permission.permissionType())
-                        .send()
-                        .join();
-                  });
-        });
-    // TODO replace with proper user get by key once it is implemented
-    try {
-      Thread.sleep(2000);
-    } catch (final InterruptedException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private CamundaClient createAuthenticatedClient(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -318,7 +318,7 @@ public class CamundaMultiDBExtension
     final var users = findUsers(testClass, null, ModifierSupport::isStatic);
     final var groups = findGroups(testClass, null, ModifierSupport::isStatic);
     final var roles = findRoles(testClass, null, ModifierSupport::isStatic);
-    entityManager.withUser(users).withGroups(groups).withRoles(roles);
+    entityManager.withUser(users).withGroups(groups).withRoles(roles).await();
     users.forEach(
         user ->
             authenticatedClientFactory.createClientForUser(applicationUnderTest.application, user));

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -305,7 +305,7 @@ public class CamundaMultiDBExtension
       manageApplicationUnderTest();
     }
 
-    authenticatedClientFactory = new CamundaClientTestFactory(applicationUnderTest.application);
+    authenticatedClientFactory = new CamundaClientTestFactory(applicationUnderTest);
     entityManager = new EntityManager(authenticatedClientFactory.getDefaultUserCamundaClient());
     createEntities(testClass);
     // we support only static fields for now - to make sure test setups are build in a way
@@ -464,7 +464,8 @@ public class CamundaMultiDBExtension
         applicationUnderTest.application, authenticated);
   }
 
-  record ApplicationUnderTest(TestStandaloneApplication<?> application, boolean shouldBeManaged) {}
+  public record ApplicationUnderTest(
+      TestStandaloneApplication<?> application, boolean shouldBeManaged) {}
 
   private static final class NoopDBSetupHelper implements MultiDbSetupHelper {
     @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -153,7 +153,7 @@ public final class EntityManager {
   public void await() {
     // TODO replace with proper search queries when they are implemented
     try {
-      Thread.sleep(2000);
+      Thread.sleep(5000);
     } catch (final InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.qa.util.auth.Membership;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.auth.User;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class EntityManager {
+
+  final Map<String, User> users = new ConcurrentHashMap<>();
+  final Map<String, TestGroup> groups = new ConcurrentHashMap<>();
+  final Map<String, TestRole> roles = new ConcurrentHashMap<>();
+  private final CamundaClient defaultClient;
+
+  public EntityManager(final CamundaClient defaultClient) {
+    this.defaultClient = defaultClient;
+  }
+
+  public EntityManager withUser(final List<User> users) {
+    users.stream()
+        .filter(user -> !this.users.containsKey(user.username()))
+        .forEach(
+            user -> {
+              this.users.put(user.username(), user);
+              defaultClient
+                  .newUserCreateCommand()
+                  .username(user.username())
+                  .password(user.password())
+                  .name(user.username())
+                  .email("%s@example.com".formatted(user.username()))
+                  .send()
+                  .join();
+              addPermissions(user.username(), OwnerType.USER, user.permissions());
+            });
+    return this;
+  }
+
+  public EntityManager withGroups(final List<TestGroup> groups) {
+    groups.stream()
+        .filter(group -> !this.groups.containsKey(group.id()))
+        .forEach(
+            group -> {
+              this.groups.put(group.id(), group);
+              defaultClient
+                  .newCreateGroupCommand()
+                  .groupId(group.id())
+                  .name(group.name())
+                  .description(group.id())
+                  .send()
+                  .join();
+              addPermissions(group.id(), OwnerType.GROUP, group.permissions());
+              addGroupMemberships(group.id(), group.memberships());
+            });
+    return this;
+  }
+
+  public EntityManager withRoles(final List<TestRole> roles) {
+    roles.stream()
+        .filter(role -> !this.roles.containsKey(role.id()))
+        .forEach(
+            role -> {
+              this.roles.put(role.id(), role);
+              defaultClient
+                  .newCreateRoleCommand()
+                  .roleId(role.id())
+                  .name(role.id())
+                  .description(role.id())
+                  .send()
+                  .join();
+              addPermissions(role.id(), OwnerType.ROLE, role.permissions());
+              addRoleMemberships(role.id(), role.memberships());
+            });
+    return this;
+  }
+
+  private void addPermissions(
+      final String ownerId, final OwnerType ownerType, final List<Permissions> permissions) {
+    permissions.forEach(
+        permission ->
+            permission
+                .resourceIds()
+                .forEach(
+                    resourceId ->
+                        defaultClient
+                            .newCreateAuthorizationCommand()
+                            .ownerId(ownerId)
+                            .ownerType(ownerType)
+                            .resourceId(resourceId)
+                            .resourceType(permission.resourceType())
+                            .permissionTypes(permission.permissionType())
+                            .send()
+                            .join()));
+  }
+
+  private void addGroupMemberships(final String groupId, final List<Membership> memberships) {
+    memberships.forEach(
+        membership -> {
+          final var entityType = membership.entityType();
+          if (entityType == EntityType.USER) {
+            defaultClient
+                .newAssignUserToGroupCommand(groupId)
+                .username(membership.memberId())
+                .send()
+                .join();
+          } else {
+            throw new IllegalArgumentException("Unsupported entity type: " + entityType);
+          }
+        });
+  }
+
+  private void addRoleMemberships(final String roleId, final List<Membership> memberships) {
+    memberships.forEach(
+        membership -> {
+          final var entityType = membership.entityType();
+          switch (entityType) {
+            case USER:
+              defaultClient
+                  .newAssignRoleToUserCommand()
+                  .roleId(roleId)
+                  .username(membership.memberId())
+                  .send()
+                  .join();
+              break;
+            case GROUP:
+              defaultClient
+                  .newAssignRoleToGroupCommand()
+                  .roleId(roleId)
+                  .groupId(membership.memberId())
+                  .send()
+                  .join();
+              break;
+            default:
+              throw new IllegalArgumentException("Unsupported entity type: " + entityType);
+          }
+        });
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -148,4 +148,14 @@ public final class EntityManager {
           }
         });
   }
+
+  /** Will wait until all entities are created and permissions are assigned. */
+  public void await() {
+    // TODO replace with proper search queries when they are implemented
+    try {
+      Thread.sleep(2000);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/RoleAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/RoleAuthorizationQueryTransformer.java
@@ -22,7 +22,7 @@ public class RoleAuthorizationQueryTransformer implements AuthorizationQueryTran
       final PermissionType permissionType,
       final List<String> resourceIds) {
     if (resourceType == AuthorizationResourceType.ROLE && permissionType == PermissionType.READ) {
-      return stringTerms("groupId", resourceIds);
+      return stringTerms("roleId", resourceIds);
     }
     throw new IllegalArgumentException(
         "Unsupported authorizations with resource:%s and permission:%s: "

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -183,7 +183,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   protected T withUnauthenticatedAccess(final boolean unprotectedApi) {
-    return withProperty(AuthenticationProperties.API_UNPROTECTED, String.valueOf(unprotectedApi));
+    return withProperty(AuthenticationProperties.API_UNPROTECTED, unprotectedApi);
   }
 
   public final T withUnauthenticatedAccess() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We already had a `@UserDefinition` which would take care of user creation. I've expanded upon this concept and have added `@GroupDefinition` and `@RoleDefinition`. As you'd expect, when you add these to a test class the extension will take care of creating the groups and roles. Like users it also allows adding permissions. As a bonus you can provide it with a list of members, which will automatically be added to the group/role.

Example:

```java
  @GroupDefinition
  private static final TestGroup GROUP_1 =
      new TestGroup(Strings.newRandomValidIdentityId(), "AGroupName");

  @RoleDefinition
  private static final TestRole ROLE =
      TestRole.withoutPermissions(
          Strings.newRandomValidIdentityId(),
          "roleName",
          List.of(new Membership(GROUP_1.id(), EntityType.GROUP)));
```

I have refactored on test to this new structure (`GroupAuthorizationIT`). My hope is we slowly migrate tests when we touch them, as it reduces a bunch of complexity from the tests itself.

During this I made a larger refactoring int he `CamundaMultiDBExtension` which slightly changes the way it deals with users and camunda clients. Before it would only create the user, it's permissions and the client once the user was used in a parameter with the `@Authenticated` annotation. This caused some confusing behavior. Now the users, permissions and clients are always created on startup, regardless of the parameters.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

I wanted to make my life easier for #31999.
