### PR TITLE
[Backport stable/8.5] fix: assemble worker default tenant id config correctly

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
-import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 import static org.apache.commons.lang3.StringUtils.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -185,21 +184,18 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
   }
 
   private void applyDefaultJobWorkerTenantIds(final ZeebeWorkerValue zeebeWorker) {
-    final List<String> defaultJobWorkerTenantIds =
-        zeebeClientConfigurationProperties.getDefaultJobWorkerTenantIds();
-    if (zeebeWorker.getTenantIds() == null || zeebeWorker.getTenantIds().isEmpty()) {
-      if (!defaultJobWorkerTenantIds.isEmpty()) {
-        LOG.debug(
-            "Worker '{}': Setting tenantIds {}",
-            zeebeWorker.getTenantIds(),
-            defaultJobWorkerTenantIds);
-        zeebeWorker.setTenantIds(defaultJobWorkerTenantIds);
-      }
-    } else {
-      final var defaultTenantIds = DEFAULT.getDefaultJobWorkerTenantIds();
-      LOG.debug(
-          "Worker '{}': Setting tenantIds to default {}", zeebeWorker.getName(), defaultTenantIds);
-      zeebeWorker.setTenantIds(defaultTenantIds);
+    // we consider default worker tenant ids configurations first
+    final Set<String> tenantIds =
+        new HashSet<>(zeebeClientConfigurationProperties.getDefaultJobWorkerTenantIds());
+
+    // if set, worker annotation defaults get included as well
+    if (zeebeWorker.getTenantIds() != null) {
+      tenantIds.addAll(zeebeWorker.getTenantIds());
+    }
+
+    if (!tenantIds.isEmpty()) {
+      LOG.debug("Worker '{}': Setting tenantIds to {}", zeebeWorker.getName(), tenantIds);
+      zeebeWorker.setTenantIds(new ArrayList<>(tenantIds));
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #32475 to `stable/8.5`.

Previous behavior was not aligned with the documentation:
* job worker annotation tenant-ids were not appended to defaults
See https://docs.camunda.io/docs/8.5/apis-tools/spring-zeebe-sdk/configuration/#control-tenant-usage

relates to #32464 #32015