### PR TITLE
[Backport stable/8.6] fix: assemble worker default tenant id config correctly

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrPropertyOrDefault;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
@@ -43,7 +43,7 @@ public class ExecutorServiceConfiguration {
       final CamundaClientProperties camundaClientProperties) {
     final ScheduledExecutorService threadPool =
         Executors.newScheduledThreadPool(
-            getOrLegacyOrDefault(
+            getLegacyOrPropertyOrDefault(
                 "NumJobWorkerExecutionThreads",
                 () -> camundaClientProperties.getZeebe().getExecutionThreads(),
                 configurationProperties::getNumJobWorkerExecutionThreads,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
@@ -35,7 +35,7 @@ public class PropertyUtil {
    * @return the property resolved
    * @param <T> the type of the property
    */
-  public static <T> T getOrLegacyOrDefault(
+  public static <T> T getLegacyOrPropertyOrDefault(
       final String propertyName,
       final Supplier<T> propertySupplier,
       final Supplier<T> legacyPropertySupplier,
@@ -79,7 +79,7 @@ public class PropertyUtil {
       final Supplier<T> propertySupplier,
       final T defaultProperty,
       final Map<String, Object> configCache) {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         propertyName, propertySupplier, noPropertySupplier(), defaultProperty, configCache);
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrPropertyOrDefault;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -54,7 +54,7 @@ public class ZeebeClientAllAutoConfiguration {
       final ZeebeClientConfigurationProperties configurationProperties,
       final CamundaClientProperties camundaClientProperties) {
     return ZeebeClientExecutorService.createDefault(
-        getOrLegacyOrDefault(
+        getLegacyOrPropertyOrDefault(
             "NumJobWorkerExecutionThreads",
             () -> camundaClientProperties.getZeebe().getExecutionThreads(),
             configurationProperties::getNumJobWorkerExecutionThreads,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -80,7 +80,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getGatewayAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "GatewayAddress",
         this::composeGatewayAddress,
         () -> PropertiesUtil.getZeebeGatewayAddress(properties),
@@ -90,7 +90,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public URI getRestAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "RestAddress",
         () -> camundaClientProperties.getZeebe().getRestAddress(),
         () -> properties.getBroker().getRestAddress(),
@@ -100,7 +100,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public URI getGrpcAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "GrpcAddress",
         () -> camundaClientProperties.getZeebe().getGrpcAddress(),
         properties::getGrpcAddress,
@@ -110,7 +110,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getDefaultTenantId() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultTenantId",
         prioritized(
             DEFAULT.getDefaultTenantId(),
@@ -124,7 +124,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public List<String> getDefaultJobWorkerTenantIds() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobWorkerTenantIds",
         prioritized(
             DEFAULT.getDefaultJobWorkerTenantIds(),
@@ -138,7 +138,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public int getNumJobWorkerExecutionThreads() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "NumJobWorkerExecutionThreads",
         () -> camundaClientProperties.getZeebe().getExecutionThreads(),
         () -> properties.getWorker().getThreads(),
@@ -148,7 +148,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public int getDefaultJobWorkerMaxJobsActive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobWorkerMaxJobsActive",
         () -> camundaClientProperties.getZeebe().getDefaults().getMaxJobsActive(),
         () -> properties.getWorker().getMaxJobsActive(),
@@ -158,7 +158,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getDefaultJobWorkerName() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobWorkerName",
         () -> camundaClientProperties.getZeebe().getDefaults().getName(),
         () -> properties.getWorker().getDefaultName(),
@@ -168,7 +168,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public Duration getDefaultJobTimeout() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobTimeout",
         () -> camundaClientProperties.getZeebe().getDefaults().getTimeout(),
         () -> properties.getJob().getTimeout(),
@@ -178,7 +178,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public Duration getDefaultJobPollInterval() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobPollInterval",
         () -> camundaClientProperties.getZeebe().getDefaults().getPollInterval(),
         () -> properties.getJob().getPollInterval(),
@@ -188,7 +188,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public Duration getDefaultMessageTimeToLive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultMessageTimeToLive",
         () -> camundaClientProperties.getZeebe().getMessageTimeToLive(),
         () -> properties.getMessage().getTimeToLive(),
@@ -198,7 +198,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public Duration getDefaultRequestTimeout() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultRequestTimeout",
         prioritized(
             DEFAULT.getDefaultRequestTimeout(),
@@ -212,7 +212,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "PlaintextConnectionEnabled",
         this::composePlaintext,
         () -> properties.getSecurity().isPlaintext(),
@@ -222,7 +222,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getCaCertificatePath() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "CaCertificatePath",
         () -> camundaClientProperties.getZeebe().getCaCertificatePath(),
         () -> properties.getSecurity().getCertPath(),
@@ -232,7 +232,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public CredentialsProvider getCredentialsProvider() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "CredentialsProvider",
         this::credentialsProvider,
         this::legacyCredentialsProvider,
@@ -242,7 +242,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public Duration getKeepAlive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "KeepAlive",
         () -> camundaClientProperties.getZeebe().getKeepAlive(),
         () -> properties.getBroker().getKeepAlive(),
@@ -267,7 +267,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public String getOverrideAuthority() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "OverrideAuthority",
         () -> camundaClientProperties.getZeebe().getOverrideAuthority(),
         () -> properties.getSecurity().getOverrideAuthority(),
@@ -277,7 +277,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public int getMaxMessageSize() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "MaxMessageSize",
         () -> camundaClientProperties.getZeebe().getMaxMessageSize(),
         () -> properties.getMessage().getMaxMessageSize(),
@@ -301,7 +301,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean ownsJobWorkerExecutor() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "ownsJobWorkerExecutor",
         zeebeClientExecutorService::isOwnedByZeebeClient,
         properties::ownsJobWorkerExecutor,
@@ -311,7 +311,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean getDefaultJobWorkerStreamEnabled() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrPropertyOrDefault(
         "DefaultJobWorkerStreamEnabled",
         () -> camundaClientProperties.getZeebe().getDefaults().getStreamEnabled(),
         properties::getDefaultJobWorkerStreamEnabled,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrPropertyOrDefault;
 import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.prioritized;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 import static java.util.Optional.ofNullable;
@@ -140,7 +140,7 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyOverrides(final ZeebeWorkerValue zeebeWorker) {
     final Map<String, ZeebeWorkerValue> workerConfigurationMap =
-        getOrLegacyOrDefault(
+        getLegacyOrPropertyOrDefault(
             "Override",
             () -> camundaClientProperties.getZeebe().getOverride(),
             () -> zeebeClientConfigurationProperties.getWorker().getOverride(),
@@ -176,7 +176,7 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyDefaultWorkerName(final ZeebeWorkerValue zeebeWorker) {
     final String defaultJobWorkerName =
-        getOrLegacyOrDefault(
+        getLegacyOrPropertyOrDefault(
             "DefaultJobWorkerName",
             () -> camundaClientProperties.getZeebe().getDefaults().getName(),
             zeebeClientConfigurationProperties::getDefaultJobWorkerName,
@@ -203,7 +203,7 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyDefaultJobWorkerType(final ZeebeWorkerValue zeebeWorker) {
     final String defaultJobWorkerType =
-        getOrLegacyOrDefault(
+        getLegacyOrPropertyOrDefault(
             "DefaultJobWorkerType",
             () -> camundaClientProperties.getZeebe().getDefaults().getType(),
             zeebeClientConfigurationProperties::getDefaultJobWorkerType,
@@ -230,7 +230,7 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
     tenantIds.addAll(
         // we consider default worker tenant ids configurations first (legacy goes first)
-        getOrLegacyOrDefault(
+        getLegacyOrPropertyOrDefault(
             "DefaultJobWorkerTenantIds",
             prioritized(
                 DEFAULT.getDefaultJobWorkerTenantIds(),

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -51,7 +51,7 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
   private static final CopyNotNullBeanUtilsBean COPY_NOT_NULL_BEAN_UTILS_BEAN =
       new CopyNotNullBeanUtilsBean();
   private static final CopyWithProtectionBeanUtilsBean COPY_WITH_PROTECTION_BEAN_UTILS_BEAN =
-      new CopyWithProtectionBeanUtilsBean(Set.of("name", "type", "fetchVariables"));
+      new CopyWithProtectionBeanUtilsBean(Set.of("name", "type", "fetchVariables", "tenantIds"));
 
   private final ZeebeClientConfigurationProperties zeebeClientConfigurationProperties;
   private final CamundaClientProperties camundaClientProperties;
@@ -226,22 +226,31 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
   }
 
   private void applyDefaultJobWorkerTenantIds(final ZeebeWorkerValue zeebeWorker) {
-    final List<String> defaultJobWorkerTenantIds =
+    final Set<String> tenantIds = new HashSet<>();
+
+    tenantIds.addAll(
+        // we consider default worker tenant ids configurations first (legacy goes first)
         getOrLegacyOrDefault(
             "DefaultJobWorkerTenantIds",
             prioritized(
                 DEFAULT.getDefaultJobWorkerTenantIds(),
                 List.of(
-                    camundaClientProperties::getTenantIds,
-                    () -> camundaClientProperties.getZeebe().getDefaults().getTenantIds())),
+                    // if no legacy property is set, the new defaults workers property is loaded
+                    camundaClientProperties.getZeebe().getDefaults()::getTenantIds,
+                    // otherwise the client defaults
+                    camundaClientProperties::getTenantIds)),
             zeebeClientConfigurationProperties::getDefaultJobWorkerTenantIds,
             DEFAULT.getDefaultJobWorkerTenantIds(),
-            null);
+            null));
 
-    LOG.debug(
-        "Worker '{}': Setting tenantIds to default {}",
-        zeebeWorker.getTenantIds(),
-        defaultJobWorkerTenantIds);
-    zeebeWorker.setTenantIds(defaultJobWorkerTenantIds);
+    // if set, worker annotation defaults get included as well
+    if (zeebeWorker.getTenantIds() != null) {
+      tenantIds.addAll(zeebeWorker.getTenantIds());
+    }
+
+    if (!tenantIds.isEmpty()) {
+      LOG.debug("Worker '{}': Setting tenantIds to {}", zeebeWorker.getName(), tenantIds);
+      zeebeWorker.setTenantIds(new ArrayList<>(tenantIds));
+    }
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/PropertyUtilTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/PropertyUtilTest.java
@@ -25,7 +25,7 @@ public class PropertyUtilTest {
   @Test
   void shouldPreferLegacy() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrPropertyOrDefault(
             "Test", () -> "prop", () -> "legacy", "default", new HashMap<>());
     assertThat(property).isEqualTo("legacy");
   }
@@ -33,7 +33,7 @@ public class PropertyUtilTest {
   @Test
   void shouldApplyDefault() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrPropertyOrDefault(
             "Test", () -> null, () -> null, "default", new HashMap<>());
     assertThat(property).isEqualTo("default");
   }
@@ -41,7 +41,7 @@ public class PropertyUtilTest {
   @Test
   void shouldIgnoreDefaultOnLegacy() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrPropertyOrDefault(
             "Test", () -> "prop", () -> "default", "default", new HashMap<>());
     assertThat(property).isEqualTo("prop");
   }
@@ -49,7 +49,7 @@ public class PropertyUtilTest {
   @Test
   void shouldHandleExceptionOnPropertySupplier() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrPropertyOrDefault(
             "Test",
             () -> {
               throw new NullPointerException();
@@ -63,7 +63,7 @@ public class PropertyUtilTest {
   @Test
   void shouldHandleExceptionOnLegacyPropertySupplier() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrPropertyOrDefault(
             "Test",
             () -> null,
             () -> {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -165,41 +165,6 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldSetDefaultTenantIdsLegacy() {
-    // given
-    final ZeebeClientConfigurationProperties properties = legacyProperties();
-    properties.setDefaultJobWorkerTenantIds(List.of("customTenantId"));
-
-    final PropertyBasedZeebeWorkerValueCustomizer customizer =
-        new PropertyBasedZeebeWorkerValueCustomizer(properties, properties());
-
-    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
-    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
-
-    // when
-    customizer.customize(zeebeWorkerValue);
-    // then
-    assertThat(zeebeWorkerValue.getTenantIds()).contains("customTenantId");
-  }
-
-  @Test
-  void shouldSetDefaultTenantIds() {
-    // given
-    final CamundaClientProperties properties = properties();
-    properties.setTenantIds(List.of("customTenantId"));
-
-    final PropertyBasedZeebeWorkerValueCustomizer customizer =
-        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
-
-    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
-    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
-    // when
-    customizer.customize(zeebeWorkerValue);
-    // then
-    assertThat(zeebeWorkerValue.getTenantIds()).contains("customTenantId");
-  }
-
-  @Test
   void shouldSetDefaultTypeLegacy() {
     // given
     final ZeebeClientConfigurationProperties properties = legacyProperties();
@@ -478,6 +443,138 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     assertThat(jobWorkerValue.getType()).isEqualTo("localOverride");
     assertThat(jobWorkerValue.getName()).isEqualTo("localName");
     assertThat(jobWorkerValue.getFetchVariables()).contains("overrideVariable");
+  }
+
+  @Test
+  void shouldSetDefaultTenantIdsLegacy() {
+    // given
+    final ZeebeClientConfigurationProperties properties = legacyProperties();
+    properties.setDefaultJobWorkerTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties, properties());
+
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getTenantIds()).contains("customTenantId");
+  }
+
+  @Test
+  void shouldSetDefaultTenantIds() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.setTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getTenantIds()).contains("customTenantId");
+  }
+
+  @Test
+  void shouldMergeClientDefaultTenantIdsAndWorkerAnnotationTenantIdsWhenNothingElseConfigured() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.setTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue jobWorkerValue = new ZeebeWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    jobWorkerValue.setTenantIds(List.of("annotationTenantId"));
+    // when
+    customizer.customize(jobWorkerValue);
+    // then
+    assertThat(jobWorkerValue.getTenantIds())
+        .containsExactlyInAnyOrder("annotationTenantId", "customTenantId");
+  }
+
+  @Test
+  void shouldApplyWorkerDefaultTenantIds() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.getZeebe().getDefaults().setTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getTenantIds()).contains("customTenantId");
+  }
+
+  @Test
+  void shouldMergeWorkerDefaultTenantIdsAndWorkerAnnotationTenantIds() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.getZeebe().getDefaults().setTenantIds(List.of("customTenantId"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue jobWorkerValue = new ZeebeWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    jobWorkerValue.setTenantIds(List.of("annotationTenantId"));
+    // when
+    customizer.customize(jobWorkerValue);
+    // then
+    assertThat(jobWorkerValue.getTenantIds())
+        .containsExactlyInAnyOrder("annotationTenantId", "customTenantId");
+  }
+
+  @Test
+  void shouldApplyWorkerDefaultTenantIdsOnlyWhenClientDefaultTenantIdsAreSet() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.setTenantIds(List.of("customTenantId"));
+    properties.getZeebe().getDefaults().setTenantIds(List.of("testTenantId1", "testTenantId2"));
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue jobWorkerValue = new ZeebeWorkerValue();
+    jobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(jobWorkerValue);
+    // then
+    assertThat(jobWorkerValue.getTenantIds())
+        .containsExactlyInAnyOrder("testTenantId1", "testTenantId2");
+  }
+
+  @Test
+  void shouldApplyTenantIdWorkerOverridesRegardlessOfDefaultsSet() {
+    // given
+    final CamundaClientProperties properties = properties();
+    properties.getZeebe().getDefaults().setTenantIds(List.of("workerDefaultsId"));
+    properties.setTenantIds(List.of("deprecatedClientDefaults"));
+    final ZeebeWorkerValue overrideJobWorkerValue = new ZeebeWorkerValue();
+    overrideJobWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    overrideJobWorkerValue.setTenantIds(List.of("overriddenTenantId"));
+    properties.getZeebe().getOverride().put("sampleWorker", overrideJobWorkerValue);
+
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties);
+
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setTenantIds(List.of("annotationWorkerDefaultsId"));
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getTenantIds()).contains("overriddenTenantId");
   }
 
   private static final class ComplexProcessVariable {


### PR DESCRIPTION
# Description
Backport of #32475 to `stable/8.6`.

This required specific re-adjustment of the property resolution which is based on a utility method in 8.6. Also the behavior on 8.6 was different than on 8.7 with the original change.

Previous behavior was not aligned with the documentation:
* camunda.client.zeebe.defaults always overwrote other defaults (e.g. annotation values)
  as it was applied during override and not a protected property
* camunda.client.tenant-ids was preferred over camunda.client.zeebe.defaults when applying defaults
* job worker annotation tenant-ids were not appended to defaults
See https://docs.camunda.io/docs/8.6/apis-tools/spring-zeebe-sdk/configuration/#control-tenant-usage

I added another commit to rename the util method to reflect its actual behavior.

relates to #32464 #32015