### PR TITLE
feat: support searching groups by role in the CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -112,6 +112,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -2319,4 +2320,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the roles by group search request
    */
   RolesByGroupSearchRequest newRolesByGroupSearchRequest(String groupId);
+
+  /**
+   * Executes a search request to query groups by role.
+   *
+   * <pre>
+   * camundaClient
+   *  .newGroupsByRoleSearchRequest("roleId")
+   *  .sort((s) -> s.name().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @param roleId the ID of the role
+   * @return a builder for the groups by role search request
+   */
+  GroupsByRoleSearchRequest newGroupsByRoleSearchRequest(String roleId);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/GroupsByRoleSearchRequest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.sort.GroupSort;
+
+public interface GroupsByRoleSearchRequest
+    extends TypedSearchRequest<GroupFilter, GroupSort, GroupsByRoleSearchRequest>,
+        FinalSearchRequestStep<Group> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -123,6 +123,7 @@ import io.camunda.client.api.search.request.DecisionDefinitionSearchRequest;
 import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
+import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -230,6 +231,7 @@ import io.camunda.client.impl.search.request.DecisionInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestImpl;
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
+import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByRoleSearchRequestImpl;
@@ -1172,6 +1174,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public RolesByGroupSearchRequest newRolesByGroupSearchRequest(final String groupId) {
     return new RolesByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest newGroupsByRoleSearchRequest(final String roleId) {
+    return new GroupsByRoleSearchRequestImpl(httpClient, jsonMapper, roleId);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/GroupsByRoleSearchRequestImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupFilter;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.groupSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.filter.GroupFilter;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.GroupSort;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.GroupSearchQueryRequest;
+import io.camunda.client.protocol.rest.GroupSearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class GroupsByRoleSearchRequestImpl
+    extends TypedSearchRequestPropertyProvider<GroupSearchQueryRequest>
+    implements GroupsByRoleSearchRequest {
+
+  private final GroupSearchQueryRequest request;
+  private final String roleId;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public GroupsByRoleSearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String roleId) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.roleId = roleId;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new GroupSearchQueryRequest();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Group> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Group>> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("roleId", roleId);
+    final HttpCamundaFuture<SearchResponse<Group>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/roles/%s/groups/search", roleId),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        GroupSearchQueryResult.class,
+        SearchResponseMapper::toGroupsResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest filter(final GroupFilter value) {
+    request.setFilter(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest filter(final Consumer<GroupFilter> fn) {
+    return filter(groupFilter(fn));
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest sort(final GroupSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toGroupSearchQuerySortRequest(provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest sort(final Consumer<GroupSort> fn) {
+    return sort(groupSort(fn));
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public GroupsByRoleSearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected GroupSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/GroupsByRoleSearchRequestTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.role;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class GroupsByRoleSearchRequestTest extends ClientRestTest {
+
+  private static final String ROLE_ID = "roleId";
+
+  @Test
+  void shouldSendSearchGroupsByRoleRequest() {
+    client.newGroupsByRoleSearchRequest(ROLE_ID).send().join();
+
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).startsWith(REST_API_PATH + "/roles/" + ROLE_ID + "/groups/search");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  void shouldSendRequestWithGroupNameSort() {
+    client.newGroupsByRoleSearchRequest(ROLE_ID).sort(s -> s.name().asc()).send().join();
+
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBodyAsString())
+        .contains("\"sort\":[{\"field\":\"name\",\"order\":\"ASC\"}]");
+  }
+
+  @Test
+  void shouldSendRequestWithGroupNameFilter() {
+    client
+        .newGroupsByRoleSearchRequest(ROLE_ID)
+        .filter(f -> f.name("groupName").groupId("groupId"))
+        .send()
+        .join();
+
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBodyAsString())
+        .contains("{\"sort\":[],\"filter\":{\"groupId\":\"groupId\",\"name\":\"groupName\"}}");
+  }
+
+  @Test
+  void shouldFailOnEmptyRoleId() {
+    assertThatThrownBy(() -> client.newGroupsByRoleSearchRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be empty");
+  }
+
+  @Test
+  void shouldFailOnNullRoleId() {
+    assertThatThrownBy(() -> client.newGroupsByRoleSearchRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("roleId must not be null");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
@@ -156,7 +156,6 @@ public class GroupsByRoleIntegrationTest {
                   camundaClient
                       .newGroupsByRoleSearchRequest(roleId)
                       .filter(f -> f.groupId(groupId))
-                      .filter(f -> f.groupId(groupId))
                       .send()
                       .join()
                       .items();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GroupsByRoleIntegrationTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.Group;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+public class GroupsByRoleIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldReturnGroupsByRole() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId1 = Strings.newRandomValidIdentityId();
+    final var groupId2 = Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role Name", "desc");
+    createGroup(groupId1, "Group 1", "desc");
+    createGroup(groupId2, "Group 2", "desc");
+
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Groups should appear in role group search")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final List<Group> groups =
+                  camundaClient.newGroupsByRoleSearchRequest(roleId).send().join().items();
+              assertThat(groups).extracting(Group::getGroupId).contains(groupId1, groupId2);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByRoleSortedByGroupIdAsc() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId1 = "b" + Strings.newRandomValidIdentityId();
+    final var groupId2 = "a" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role", "desc");
+    createGroup(groupId1, "Group B", "desc");
+    createGroup(groupId2, "Group A", "desc");
+
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Groups sorted ASC by groupId should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var groups =
+                  camundaClient
+                      .newGroupsByRoleSearchRequest(roleId)
+                      .sort(s -> s.groupId().asc())
+                      .send()
+                      .join()
+                      .items();
+              assertThat(groups).extracting(Group::getGroupId).containsExactly(groupId2, groupId1);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByRoleSortedByGroupIdDesc() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId1 = "a" + Strings.newRandomValidIdentityId();
+    final var groupId2 = "b" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role", "desc");
+    createGroup(groupId1, "Group A", "desc");
+    createGroup(groupId2, "Group B", "desc");
+
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Groups sorted DESC by groupId should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var groups =
+                  camundaClient
+                      .newGroupsByRoleSearchRequest(roleId)
+                      .sort(s -> s.groupId().desc())
+                      .send()
+                      .join()
+                      .items();
+              assertThat(groups).extracting(Group::getGroupId).containsExactly(groupId2, groupId1);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByRoleSortedByName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId1 = "a" + Strings.newRandomValidIdentityId();
+    final var groupId2 = "b" + Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role", "desc");
+    createGroup(groupId1, "Group A", "desc");
+    createGroup(groupId2, "Group B", "desc");
+
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Sorted groups should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var groups =
+                  camundaClient
+                      .newGroupsByRoleSearchRequest(roleId)
+                      .sort(s -> s.name().desc())
+                      .send()
+                      .join()
+                      .items();
+              assertThat(groups).extracting(Group::getGroupId).containsExactly(groupId2, groupId1);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByRoleFiltered() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId = Strings.newRandomValidIdentityId();
+    final var groupId1 = Strings.newRandomValidIdentityId();
+    final var groupId2 = Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role", "desc");
+    createGroup(groupId, "FilterGroup", "desc");
+    createGroup(groupId1, "FilterGroupOne", "desc");
+    createGroup(groupId2, "FilterGroupTwo", "desc");
+
+    assignGroupToRole(roleId, groupId);
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Filtered group should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var groups =
+                  camundaClient
+                      .newGroupsByRoleSearchRequest(roleId)
+                      .filter(f -> f.groupId(groupId))
+                      .filter(f -> f.groupId(groupId))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(groups).extracting(Group::getGroupId).containsOnly(groupId);
+            });
+  }
+
+  @Test
+  void shouldReturnGroupsByRoleFilteredByName() {
+    final var roleId = Strings.newRandomValidIdentityId();
+    final var groupId1 = Strings.newRandomValidIdentityId();
+    final var groupId2 = Strings.newRandomValidIdentityId();
+
+    createRole(roleId, "Role", "desc");
+    createGroup(groupId1, "MatchName", "desc");
+    createGroup(groupId2, "OtherName", "desc");
+
+    assignGroupToRole(roleId, groupId1);
+    assignGroupToRole(roleId, groupId2);
+
+    Awaitility.await("Group with matching name should appear")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var groups =
+                  camundaClient
+                      .newGroupsByRoleSearchRequest(roleId)
+                      .filter(f -> f.name("MatchName"))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(groups).extracting(Group::getGroupId).containsOnly(groupId1);
+            });
+  }
+
+  private static void createRole(final String roleId, final String name, final String desc) {
+    camundaClient.newCreateRoleCommand().roleId(roleId).name(name).description(desc).send().join();
+  }
+
+  private static void createGroup(final String groupId, final String name, final String desc) {
+    camundaClient
+        .newCreateGroupCommand()
+        .groupId(groupId)
+        .name(name)
+        .description(desc)
+        .send()
+        .join();
+  }
+
+  private static void assignGroupToRole(final String roleId, final String groupId) {
+    camundaClient.newAssignRoleToGroupCommand().roleId(roleId).groupId(groupId).send().join();
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -353,6 +353,9 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     if (groupQuery.filter().tenantId() != null) {
       query = expandTenantFilter(groupQuery);
     }
+    if (groupQuery.filter().roleId() != null) {
+      query = expandRoleFilter(groupQuery);
+    }
     return getSearchExecutor()
         .search(query, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
   }
@@ -538,6 +541,13 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     final var mappingIds = getRoleMemberIds(mappingQuery.filter().roleId(), MAPPING);
     return mappingQuery.toBuilder()
         .filter(mappingQuery.filter().toBuilder().mappingIds(mappingIds).build())
+        .build();
+  }
+
+  private GroupQuery expandRoleFilter(final GroupQuery groupQuery) {
+    final var groupIds = getRoleMemberIds(groupQuery.filter().roleId(), GROUP);
+    return groupQuery.toBuilder()
+        .filter(groupQuery.filter().toBuilder().groupIds(groupIds).build())
         .build();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -21,7 +21,8 @@ public record GroupFilter(
     EntityType memberType,
     String tenantId,
     Set<String> groupIds,
-    EntityType childMemberType)
+    EntityType childMemberType,
+    String roleId)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -35,7 +36,8 @@ public record GroupFilter(
         .memberType(memberType)
         .tenantId(tenantId)
         .groupIds(groupIds)
-        .childMemberType(childMemberType);
+        .childMemberType(childMemberType)
+        .roleId(roleId);
   }
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
@@ -49,6 +51,7 @@ public record GroupFilter(
     private String tenantId;
     private Set<String> groupIds;
     private EntityType childMemberType;
+    private String roleId;
 
     public Builder groupKey(final Long value) {
       groupKey = value;
@@ -104,6 +107,11 @@ public record GroupFilter(
       return this;
     }
 
+    public Builder roleId(final String value) {
+      roleId = value;
+      return this;
+    }
+
     @Override
     public GroupFilter build() {
       return new GroupFilter(
@@ -116,7 +124,8 @@ public record GroupFilter(
           memberType,
           tenantId,
           groupIds,
-          childMemberType);
+          childMemberType,
+          roleId);
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3101,6 +3101,48 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /roles/{roleId}/groups/search:
+    post:
+      tags:
+        - Role
+      operationId: searchGroupsForRole
+      summary: Search role groups
+      description: |
+        Search groups assigned to a role.
+      parameters:
+        - name: roleId
+          in: path
+          required: true
+          description: The role ID.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupSearchQueryRequest"
+      responses:
+        "200":
+          description: The groups assigned to the role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The role with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /roles/{roleId}/mappings/{mappingId}:
     put:
       tags:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.RoleServices.CreateRoleRequest;
@@ -48,12 +49,14 @@ public class RoleControllerTest extends RestControllerTest {
   @MockBean private RoleServices roleServices;
   @MockBean private UserServices userServices;
   @MockBean private MappingServices mappingServices;
+  @MockBean private GroupServices groupServices;
 
   @BeforeEach
   void setup() {
     when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
     when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
     when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
+    when(groupServices.withAuthentication(any(Authentication.class))).thenReturn(groupServices);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

This PR adds support for searching groups by role in the CamundaClient. Key changes include:

 - Adding a new endpoint and controller method in RoleController to handle groups search by role.
 - Adding support searching groups by role in the CamundaClient
 - Adding integration tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31740
