### PR TITLE
fix: switch to get username fro CamundaPrinciapl

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -8,7 +8,6 @@
 package io.camunda.operate.webapp.security.permission;
 
 import io.camunda.authentication.entity.CamundaPrincipal;
-import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.operate.webapp.security.tenant.TenantService;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.auth.Authorization;
@@ -199,7 +198,7 @@ public class PermissionsService {
         SecurityContextHolder.getContext().getAuthentication();
     if (requestAuthentication != null) {
       final Object principal = requestAuthentication.getPrincipal();
-      if (principal instanceof final CamundaUser authenticatedPrincipal) {
+      if (principal instanceof final CamundaPrincipal authenticatedPrincipal) {
         return authenticatedPrincipal.getUsername();
       }
     }


### PR DESCRIPTION
## Description

To apply the the allowed process filter in operate, it needs a username be available.
Right now, io.camunda.operate.webapp.security.permission.PermissionsService just consider it when the principal is of type CamundaUser but it should also take care of other type of principal that inherits CamundaPrincipal.

## Related issues

closes #26962 
