### PR TITLE
[Backport stable/8.5] fix: upgrade Spring security to 6.4.6 to resolve CVE-2025-41232

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,12 +92,21 @@
     <version.testcontainers>1.19.8</version.testcontainers>
     <version.netflix.concurrency>0.4.2</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.5</version.zeebe-test-container>
+<<<<<<< HEAD
     <version.feel-scala>1.17.11</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.2.7</version.spring>
     <version.spring-security>6.5.0</version.spring-security>
     <version.spring-boot>3.4.6</version.spring-boot>
+=======
+    <version.feel-scala>1.19.3</version.feel-scala>
+    <version.dmn-scala>1.10.1</version.dmn-scala>
+    <version.rest-assured>5.5.1</version.rest-assured>
+    <version.spring>6.2.6</version.spring>
+    <version.spring-security>6.4.6</version.spring-security>
+    <version.spring-boot>3.4.5</version.spring-boot>
+>>>>>>> 272860f1 (fix: upgrade Spring security to 6.4.6 to resolve CVE-2025-41232)
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
# Description
Backport of #32443 to `stable/8.5`.

relates to camunda/camunda#32444