### PR TITLE
[Backport stable/optimize-8.7] fix: upgrade Spring security to 6.4.6 to resolve CVE-2025-41232

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -218,13 +218,6 @@
       <artifactId>spring-security-oauth2-resource-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-bom</artifactId>
-      <version>${spring.security.version}</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>${nimbus.jose.jwt.version}</version>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -200,27 +200,29 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>${spring.security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>${spring.security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
-      <version>${spring.security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-jose</artifactId>
-      <version>${spring.security.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-bom</artifactId>
       <version>${spring.security.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <jersey.version>3.1.3</jersey.version>
-    <spring.security.version>6.3.8</spring.security.version>
+    <spring.security.version>6.4.6</spring.security.version>
     <nimbus.jose.jwt.version>9.41.1</nimbus.jose.jwt.version>
     <it.test.excludedGroups />
     <it.test.includedGroups />

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <jersey.version>3.1.3</jersey.version>
-    <spring.security.version>6.4.6</spring.security.version>
     <nimbus.jose.jwt.version>9.41.1</nimbus.jose.jwt.version>
     <it.test.excludedGroups />
     <it.test.includedGroups />

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -123,6 +123,13 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${jetty.version}</version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -53,6 +53,7 @@
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.3.10</spring.boot.version>
     <spring.version>6.1.17</spring.version>
+    <spring.security.version>6.4.6</spring.security.version>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>
     <version.spring>6.1.13</version.spring>
-    <version.spring-security>6.3.3</version.spring-security>
+    <version.spring-security>6.4.6</version.spring-security>
     <version.spring-boot>3.3.4</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>


### PR DESCRIPTION
# Description
Backport of #32443 to `stable/optimize-8.7`.

relates to camunda/camunda#32444