### PR TITLE
fix: do not retry deserializing a record in ExporterDirector

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -27,9 +27,9 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.BackOffRetryStrategy;
-import io.camunda.zeebe.scheduler.retry.EndlessRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EventFilter;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -52,6 +52,8 @@ import org.slf4j.Logger;
 
 public final class ExporterDirector extends Actor implements HealthMonitorable, LogRecordAwaiter {
 
+  private static final String ERROR_MESSAGE_DESERIALIZATION_ERROR_EXPORTING_ABORTED =
+      "Expected to export record '{}' successfully, but exception was thrown when deserializing the record.";
   private static final String ERROR_MESSAGE_EXPORTING_ABORTED =
       "Expected to export record '{}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
@@ -69,7 +71,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final ExporterMetrics metrics;
   private final String name;
   private final RetryStrategy exportingRetryStrategy;
-  private final RetryStrategy recordWrapStrategy;
   private final Set<FailureListener> listeners = new HashSet<>();
   private LogStreamReader logStreamReader;
   private EventFilter eventFilter;
@@ -96,6 +97,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   public ExporterDirector(
       final ExporterDirectorContext context, final ExporterPhase exporterPhase) {
+    this(context, exporterPhase, Function.identity());
+  }
+
+  @VisibleForTesting
+  ExporterDirector(
+      final ExporterDirectorContext context,
+      final ExporterPhase exporterPhase,
+      final Function<RecordExporter, RecordExporter> recorderExporter) {
     name = context.getName();
     logStream = Objects.requireNonNull(context.getLogStream());
     partitionId = logStream.getPartitionId();
@@ -114,9 +123,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
             .collect(Collectors.toCollection(ArrayList::new));
     metrics = new ExporterMetrics(meterRegistry);
     metrics.initializeExporterState(exporterPhase);
-    recordExporter = new RecordExporter(metrics, containers, partitionId, clock);
+    recordExporter =
+        recorderExporter.apply(new RecordExporter(metrics, containers, partitionId, clock));
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
-    recordWrapStrategy = new EndlessRetryStrategy(actor);
     zeebeDb = context.getZeebeDb();
     this.exporterPhase = exporterPhase;
     partitionMessagingService = context.getPartitionMessagingService();
@@ -636,37 +645,29 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private void exportEvent(final LoggedEvent event) {
-    final ActorFuture<Boolean> wrapRetryFuture =
-        recordWrapStrategy.runWithRetry(
-            () -> {
-              recordExporter.wrap(event);
-              return true;
-            },
-            this::isClosed);
+    try {
+      recordExporter.wrap(event);
+    } catch (final Exception exception) {
+      LOG.warn(ERROR_MESSAGE_DESERIALIZATION_ERROR_EXPORTING_ABORTED, event, exception);
+      onFailure();
+      return;
+    }
+
+    final ActorFuture<Boolean> retryFuture =
+        exportingRetryStrategy.runWithRetry(recordExporter::export, this::isClosed);
 
     actor.runOnCompletion(
-        wrapRetryFuture,
-        (b, t) -> {
-          assert t == null : "Throwable must be null";
-
-          final ActorFuture<Boolean> retryFuture =
-              exportingRetryStrategy.runWithRetry(recordExporter::export, this::isClosed);
-
-          actor.runOnCompletion(
-              retryFuture,
-              (bool, throwable) -> {
-                if (throwable != null) {
-                  LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
-                  onFailure();
-                } else {
-                  logStream
-                      .getFlowControl()
-                      .onExported(recordExporter.getTypedEvent().getPosition());
-                  metrics.eventExported(recordExporter.getTypedEvent().getValueType());
-                  inExportingPhase = false;
-                  actor.submit(this::readNextEvent);
-                }
-              });
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
+            onFailure();
+          } else {
+            logStream.getFlowControl().onExported(recordExporter.getTypedEvent().getPosition());
+            metrics.eventExported(recordExporter.getTypedEvent().getValueType());
+            inExportingPhase = false;
+            actor.submit(this::readNextEvent);
+          }
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -429,7 +429,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         failure,
         failure);
     actor.fail(failure);
+    updateHealthStatusWithError(failure);
+  }
 
+  private void updateHealthStatusWithError(final Throwable failure) {
     if (failure instanceof UnrecoverableException) {
       healthReport = HealthReport.dead(this).withIssue(failure, clock.instant());
 
@@ -649,6 +652,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       recordExporter.wrap(event);
     } catch (final Exception exception) {
       LOG.warn(ERROR_MESSAGE_DESERIALIZATION_ERROR_EXPORTING_ABORTED, event, exception);
+      updateHealthStatusWithError(new UnrecoverableException(exception));
       onFailure();
       return;
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import java.time.InstantSource;
 import java.util.List;
 
-final class RecordExporter {
+class RecordExporter {
 
   private final RecordValues recordValues = new RecordValues();
   private final RecordMetadata rawMetadata = new RecordMetadata();


### PR DESCRIPTION
## Description
Record deserialization was endlessly retry.
Considering that retrying to deserialize a record should not succeed, it's better to avoid retrying it altogether. 

Testing that no retry is performed is a bit difficult, as records are not really serialized in `ExporterDirectorTest`, but just saved in a list. 
There was no test beforehand testing the retries.
If there is a simple way to test it, I will add a test case

## Related issues
closes #31919