### PR TITLE
pg-32472-redistributor-routing-aware

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -162,7 +162,8 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         config,
         clock,
-        authCheckBehavior);
+        authCheckBehavior,
+        routingInfo);
     addMessageProcessors(
         bpmnBehaviors,
         subscriptionCommandSender,
@@ -409,7 +410,8 @@ public final class EngineProcessors {
       final CommandDistributionBehavior distributionBehavior,
       final EngineConfiguration config,
       final InstantSource clock,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final RoutingInfo routingInfo) {
 
     // on deployment partition CREATE Command is received and processed
     // it will cause a distribution to other partitions
@@ -431,7 +433,8 @@ public final class EngineProcessors {
     final var deploymentRedistributor =
         new DeploymentRedistributor(
             deploymentDistributionCommandSender,
-            scheduledTaskStateSupplier.get().getDeploymentState());
+            scheduledTaskStateSupplier.get().getDeploymentState(),
+            routingInfo);
     typedRecordProcessors.withListener(deploymentRedistributor);
 
     // on other partitions DISTRIBUTE command is received and processed

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentRedistributor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.distribute;
 import static io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
 
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
@@ -31,11 +32,14 @@ public class DeploymentRedistributor implements StreamProcessorLifecycleAware {
   private static final Logger LOG = LoggerFactory.getLogger(DeploymentRedistributor.class);
   private final DeploymentDistributionCommandSender deploymentDistributionCommandSender;
   private final DeploymentState deploymentState;
+  private final RoutingInfo routingInfo;
   private final Map<PendingDistribution, Long> retryCyclesPerDistribution = new HashMap<>();
 
   public DeploymentRedistributor(
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
-      final DeploymentState deploymentState) {
+      final DeploymentState deploymentState,
+      final RoutingInfo routingInfo) {
+    this.routingInfo = routingInfo;
     this.deploymentDistributionCommandSender = deploymentDistributionCommandSender;
     this.deploymentState = deploymentState;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -33,6 +33,9 @@ public interface RoutingInfo {
   /** Returns the current partition id for the given correlation key. */
   int partitionForCorrelationKey(final DirectBuffer correlationKey);
 
+  // Returns whether a partition is being scaled up at that point in time
+  boolean isPartitionScaling(final int partitionId);
+
   /**
    * Creates a {@link RoutingInfo} instance for static partitions. This is used when the partitions
    * are fixed and known at startup. Only relevant for testing.
@@ -71,6 +74,11 @@ public interface RoutingInfo {
     @Override
     public int partitionForCorrelationKey(final DirectBuffer correlationKey) {
       return SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionCount);
+    }
+
+    @Override
+    public boolean isPartitionScaling(final int partitionId) {
+      return false;
     }
   }
 
@@ -114,6 +122,12 @@ public interface RoutingInfo {
           return SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionCount);
         }
       }
+    }
+
+    @Override
+    public boolean isPartitionScaling(final int partitionId) {
+      return !routingState.currentPartitions().contains(partitionId)
+          && routingState.desiredPartitions().contains(partitionId);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -27,6 +27,9 @@ public interface RoutingInfo {
   /** Returns the current set of partitions. */
   Set<Integer> partitions();
 
+  /** Returns the desired set of partitions. */
+  Set<Integer> desiredPartitions();
+
   /** Returns the current partition id for the given correlation key. */
   int partitionForCorrelationKey(final DirectBuffer correlationKey);
 
@@ -61,6 +64,11 @@ public interface RoutingInfo {
     }
 
     @Override
+    public Set<Integer> desiredPartitions() {
+      return partitions();
+    }
+
+    @Override
     public int partitionForCorrelationKey(final DirectBuffer correlationKey) {
       return SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionCount);
     }
@@ -85,6 +93,14 @@ public interface RoutingInfo {
         return fallback.partitions();
       }
       return routingState.currentPartitions();
+    }
+
+    @Override
+    public Set<Integer> desiredPartitions() {
+      if (!routingState.isInitialized()) {
+        return fallback.partitions();
+      }
+      return routingState.desiredPartitions();
     }
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -33,7 +33,7 @@ public interface RoutingInfo {
   /** Returns the current partition id for the given correlation key. */
   int partitionForCorrelationKey(final DirectBuffer correlationKey);
 
-  // Returns whether a partition is being scaled up at that point in time
+  /** Returns whether a partition is being scaled up at that point in time. */
   boolean isPartitionScaling(final int partitionId);
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.engine.state.immutable.DeploymentState.PendingDeploymentVisitor;
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo.StaticRoutingInfo;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.impl.StreamProcessorContext;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DeploymentRedistributorTest {
+
+  @Mock private DeploymentDistributionCommandSender deploymentDistributionCommandSender;
+  @Mock private DeploymentState deploymentState;
+  @Mock private StreamProcessorContext context;
+  @Mock private RoutingState routingState;
+  @Mock private PendingDeploymentVisitor visitor;
+  private ProcessingScheduleService mockScheduleService;
+  private DeploymentRedistributor deploymentRedistributor;
+  private ArgumentCaptor<Runnable> taskCaptor;
+  private long recordKey;
+  private DirectBuffer resourceBuffer;
+
+  @BeforeEach
+  public void setUp() {
+    mockScheduleService = mock(ProcessingScheduleService.class);
+    when(context.getPartitionId()).thenReturn(1);
+    when(context.getScheduleService()).thenReturn(mockScheduleService);
+
+    when(routingState.currentPartitions()).thenReturn(Set.of(1, 2));
+    when(routingState.desiredPartitions()).thenReturn(Set.of(1, 2, 3));
+
+    final RoutingInfo routingInfo =
+        RoutingInfo.dynamic(routingState, new StaticRoutingInfo(Set.of(1, 2), 2));
+
+    deploymentRedistributor =
+        new DeploymentRedistributor(
+            deploymentDistributionCommandSender, deploymentState, routingInfo);
+
+    recordKey = Protocol.encodePartitionId(1, 100);
+    final DeploymentResource deploymentResource =
+        new DeploymentResource()
+            .setResourceName("test.bpmn")
+            .setResource(BufferUtil.wrapString("test"));
+    resourceBuffer = BufferUtil.createCopy(deploymentResource);
+
+    taskCaptor = forClass(Runnable.class);
+  }
+
+  @Test
+  void shouldNotRedistributeToScalingPartitions() {
+    // given
+
+    doAnswer(
+            invocation -> {
+              final PendingDeploymentVisitor visitor = invocation.getArgument(0);
+              visitor.visit(recordKey, 1, resourceBuffer);
+              // Revisit this to simulate interval
+              visitor.visit(recordKey, 1, resourceBuffer);
+              visitor.visit(recordKey, 2, resourceBuffer);
+              // Revisit this to simulate interval
+              visitor.visit(recordKey, 2, resourceBuffer);
+              // Simulate multiple visits for the deployment on the scaling partition
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              return null;
+            })
+        .when(deploymentState)
+        .foreachPendingDeploymentDistribution(any());
+
+    // when
+    deploymentRedistributor.onRecovered(context);
+    Awaitility.await()
+        .untilAsserted(
+            () -> verify(mockScheduleService).runAtFixedRate(any(), taskCaptor.capture()));
+    final Runnable scheduledTask = taskCaptor.getValue();
+    scheduledTask.run();
+    // then
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord.wrap(resourceBuffer);
+    verify(deploymentDistributionCommandSender, times(1))
+        .distributeToPartition(recordKey, 1, deploymentRecord);
+    verify(deploymentDistributionCommandSender, times(1))
+        .distributeToPartition(recordKey, 2, deploymentRecord);
+    verify(deploymentDistributionCommandSender, times(0))
+        .distributeToPartition(recordKey, 3, deploymentRecord);
+  }
+
+  @Test
+  void shouldRedistributeToScaledPartition() {
+    // given
+
+    doAnswer(
+            invocation -> {
+              final PendingDeploymentVisitor visitor = invocation.getArgument(0);
+              visitor.visit(recordKey, 1, resourceBuffer);
+              // Revisit this to simulate interval
+              visitor.visit(recordKey, 1, resourceBuffer);
+              visitor.visit(recordKey, 2, resourceBuffer);
+              // Revisit this to simulate interval
+              visitor.visit(recordKey, 2, resourceBuffer);
+              // Simulate multiple visits for the deployment on the scaling partition
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              // Simulate scaling up is finished
+              when(routingState.currentPartitions()).thenReturn(Set.of(1, 2, 3));
+              visitor.visit(recordKey, 3, resourceBuffer);
+              visitor.visit(recordKey, 3, resourceBuffer);
+              return null;
+            })
+        .when(deploymentState)
+        .foreachPendingDeploymentDistribution(any());
+
+    // when
+    deploymentRedistributor.onRecovered(context);
+    Awaitility.await()
+        .untilAsserted(
+            () -> verify(mockScheduleService).runAtFixedRate(any(), taskCaptor.capture()));
+    final Runnable scheduledTask = taskCaptor.getValue();
+    scheduledTask.run();
+    // then
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord.wrap(resourceBuffer);
+    verify(deploymentDistributionCommandSender, times(1))
+        .distributeToPartition(recordKey, 1, deploymentRecord);
+    verify(deploymentDistributionCommandSender, times(1))
+        .distributeToPartition(recordKey, 2, deploymentRecord);
+    verify(deploymentDistributionCommandSender, times(1))
+        .distributeToPartition(recordKey, 3, deploymentRecord);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR.  -->

Make the `DeploymentRedistributor` scheduled job `RoutingInfo` aware. When a partition is being scaled up, pending distributions for this partition must not yet be distributed.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32472
