### PR TITLE
feat: add support for processing records in separate batches

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -79,6 +79,33 @@ public final class TestHelper {
    * Deploys a process and waits for it to be available in the secondary database.
    *
    * @param client ... CamundaClient
+   * @param processDefinition ... BpmnModelInstance of the process definition
+   * @return the deployed process
+   */
+  public static Process deployProcessAndWaitForIt(
+      final CamundaClient client,
+      final BpmnModelInstance processDefinition,
+      final String resourceName) {
+    final var event =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(processDefinition, resourceName)
+            .send()
+            .join()
+            .getProcesses()
+            .getFirst();
+
+    // sync with secondary database
+    waitForProcessesToBeDeployed(
+        client, f -> f.processDefinitionKey(event.getProcessDefinitionKey()), 1);
+
+    return event;
+  }
+
+  /**
+   * Deploys a process and waits for it to be available in the secondary database.
+   *
+   * @param client ... CamundaClient
    * @param classpath ... e.g. process/migration-process_v1.bpmn
    * @return
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -131,6 +131,10 @@ public class Engine implements RecordProcessor {
       }
 
       if (shouldProcessCommand(typedCommand)) {
+        if (currentProcessor.shouldProcessResultsInSeparateBatches()) {
+          processingResultBuilder.withProcessInASeparateBatch();
+        }
+
         currentProcessor.processRecord(record);
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -114,6 +114,11 @@ public final class BatchOperationExecuteProcessor
         command.getKey(), BatchOperationExecutionIntent.EXECUTE, followupCommand, batchKey, null);
   }
 
+  @Override
+  public boolean shouldProcessResultsInSeparateBatches() {
+    return true;
+  }
+
   private PersistedBatchOperation getBatchOperation(final long batchOperationKey) {
     return batchOperationState.get(batchOperationKey).orElse(null);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -25,6 +25,23 @@ public interface TypedRecordProcessor<T extends UnifiedRecordValue> {
     return ProcessingError.UNEXPECTED_ERROR;
   }
 
+  /**
+   * Indicates whether follow-up records (commands produced during processing) should be scheduled
+   * for processing in separate, new command batches instead of in the current batch.
+   *
+   * <p>This can be useful when follow-up commands are independent, and isolating their execution
+   * improves consistency and error isolation (e.g., a failure in one follow-up command does not
+   * affect others). While this may reduce overall throughput, it allows for finer control of batch
+   * boundaries, potential interleaving of other user or system operations, and clearer error
+   * handling.
+   *
+   * @return {@code true} if the results/follow-up commands should be processed in separate command
+   *     batches; {@code false} otherwise
+   */
+  default boolean shouldProcessResultsInSeparateBatches() {
+    return false;
+  }
+
   enum ProcessingError {
     EXPECTED_ERROR,
     UNEXPECTED_ERROR

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -87,7 +87,7 @@ abstract class AbstractBatchOperationTest {
     final var result =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
-                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
+                itemKeys.stream().map(this::fakeProcessInstanceEntity).collect(Collectors.toList()))
             .total(itemKeys.size())
             .build();
 
@@ -121,7 +121,7 @@ abstract class AbstractBatchOperationTest {
     final var result =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
-                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
+                itemKeys.stream().map(this::fakeProcessInstanceEntity).collect(Collectors.toList()))
             .total(itemKeys.size())
             .build();
 
@@ -177,7 +177,7 @@ abstract class AbstractBatchOperationTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 piAndIncidentKeys.keySet().stream()
-                    .map(this::mockProcessInstanceEntity)
+                    .map(this::fakeProcessInstanceEntity)
                     .collect(Collectors.toList()))
             .total(piAndIncidentKeys.size())
             .build();
@@ -213,14 +213,13 @@ abstract class AbstractBatchOperationTest {
   }
 
   protected long createNewMigrateProcessesBatchOperation(
-      final Set<Long> itemKeys,
+      final List<Long> itemKeys,
       final long targetProcessDefinitionId,
       final Map<String, String> mappingInstructions,
       final Map<String, Object> claims) {
     final var result =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
-            .items(
-                itemKeys.stream().map(this::mockProcessInstanceEntity).collect(Collectors.toList()))
+            .items(itemKeys.stream().map(this::fakeProcessInstanceEntity).toList())
             .total(itemKeys.size())
             .build();
     when(searchClientsProxy.searchProcessInstances(Mockito.any(ProcessInstanceQuery.class)))
@@ -261,10 +260,22 @@ abstract class AbstractBatchOperationTest {
     return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
   }
 
-  protected ProcessInstanceEntity mockProcessInstanceEntity(final long processInstanceKey) {
-    final var entity = mock(ProcessInstanceEntity.class);
-    when(entity.processInstanceKey()).thenReturn(processInstanceKey);
-    return entity;
+  protected ProcessInstanceEntity fakeProcessInstanceEntity(final long processInstanceKey) {
+    return new ProcessInstanceEntity(
+        processInstanceKey,
+        null,
+        null,
+        -1,
+        null,
+        -1L,
+        -1L,
+        -1L,
+        null,
+        null,
+        null,
+        false,
+        null,
+        null);
   }
 
   protected IncidentEntity mockIncidentEntity(final long incidentKey) {
@@ -293,6 +304,19 @@ abstract class AbstractBatchOperationTest {
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.BATCH_OPERATION)
+        .withResourceId("*")
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  protected void addProcessDefinitionPermissionsToUser(
+      final UserRecordValue user, final PermissionType permissionType) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withResourceId("*")
         .create(DEFAULT_USER.getUsername());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -89,9 +89,9 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(1L),
-                    mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L)))
+                    fakeProcessInstanceEntity(1L),
+                    fakeProcessInstanceEntity(2L),
+                    fakeProcessInstanceEntity(3L)))
             .total(3)
             .build();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -49,4 +49,22 @@ public interface ProcessingResult {
    *     false otherwise.
    */
   boolean isEmpty();
+
+  /**
+   * Signals that any follow-up commands generated during the processing of the current record
+   * should be scheduled for handling in a new, separate command batch, rather than being processed
+   * within the current batch.
+   *
+   * <p>This method is typically called when a processor (see {@code
+   * TypedRecordProcessor#shouldProcessResultsInSeparateBatches()}) has requested isolation for the
+   * results it produces. Separating follow-up commands into distinct batches can improve
+   * consistency and error isolation (e.g., a failure in one follow-up will not impact the
+   * processing of others). However, it may also lead to reduced throughput due to increased
+   * overhead, though it enables interleaving with user or system commands at batch boundaries.
+   *
+   * @return this builder instance for chaining
+   */
+  default boolean shouldProcessInASeparateBatch() {
+    return false;
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -84,6 +84,24 @@ public interface ProcessingResultBuilder {
    */
   ProcessingResultBuilder resetPostCommitTasks();
 
+  /**
+   * Signals that any follow-up commands generated during the processing of the current record
+   * should be scheduled for handling in a new, separate command batch, rather than being processed
+   * within the current batch.
+   *
+   * <p>This method is typically called when a processor (see {@code
+   * TypedRecordProcessor#shouldProcessResultsInSeparateBatches()}) has requested isolation for the
+   * results it produces. Separating follow-up commands into distinct batches can improve
+   * consistency and error isolation (e.g., a failure in one follow-up will not impact the
+   * processing of others). However, it may also lead to reduced throughput due to increased
+   * overhead, though it enables interleaving with user or system commands at batch boundaries.
+   *
+   * @return this builder instance for chaining
+   */
+  default ProcessingResultBuilder withProcessInASeparateBatch() {
+    return this;
+  }
+
   ProcessingResult build();
 
   boolean canWriteEventOfLength(int eventLength);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -42,6 +42,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final RecordBatch mutableRecordBatch;
   private ProcessingResponseImpl processingResponse;
   private final long operationReference;
+  private boolean processInASeparateBatch = false;
 
   BufferedProcessingResultBuilder(final RecordBatchSizePredicate predicate) {
     this(predicate, operationReferenceNullValue());
@@ -124,8 +125,15 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   }
 
   @Override
+  public ProcessingResultBuilder withProcessInASeparateBatch() {
+    processInASeparateBatch = true;
+    return this;
+  }
+
+  @Override
   public ProcessingResult build() {
-    return new BufferedResult(mutableRecordBatch, processingResponse, postCommitTasks);
+    return new BufferedResult(
+        mutableRecordBatch, processingResponse, postCommitTasks, processInASeparateBatch);
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
@@ -26,14 +26,17 @@ final class BufferedResult implements ProcessingResult, TaskResult {
   private final List<PostCommitTask> postCommitTasks;
   private final ImmutableRecordBatch immutableRecordBatch;
   private final ProcessingResponseImpl processingResponse;
+  private final boolean processInASeparateBatch;
 
   BufferedResult(
       final ImmutableRecordBatch immutableRecordBatch,
       final ProcessingResponseImpl processingResponse,
-      final List<PostCommitTask> postCommitTasks) {
+      final List<PostCommitTask> postCommitTasks,
+      final boolean processInASeparateBatch) {
     this.postCommitTasks = new ArrayList<>(postCommitTasks);
     this.processingResponse = processingResponse;
     this.immutableRecordBatch = immutableRecordBatch;
+    this.processInASeparateBatch = processInASeparateBatch;
   }
 
   @Override
@@ -66,5 +69,10 @@ final class BufferedResult implements ProcessingResult, TaskResult {
     return getProcessingResponse().isEmpty()
         && getRecordBatch().isEmpty()
         && postCommitTasks.isEmpty();
+  }
+
+  @Override
+  public boolean shouldProcessInASeparateBatch() {
+    return processInASeparateBatch;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -410,7 +410,8 @@ public final class ProcessingStateMachine {
               var toWriteEntry = entry;
               final int potentialBatchSize = currentBatchSize + commandsToProcess.size();
               if (entry.recordMetadata().getRecordType() == RecordType.COMMAND
-                  && potentialBatchSize < currentProcessingBatchLimit) {
+                  && potentialBatchSize < currentProcessingBatchLimit
+                  && !processingResult.shouldProcessInASeparateBatch()) {
                 commandsToProcess.add(
                     new UnwrittenRecord(
                         entry.key(),


### PR DESCRIPTION
## Description
Adds support for isolating record processing into separate command batches when requested by a processor.

- Introduces a `shouldProcessInASeparateBatch` flag throughout `ProcessingResult`, its builder and implementations.
    - The flag is set by default to `false`
- Introduces `shouldProcessResultsInSeparateBatches` in `TypedRecordProcessor` interface, set to `false` by default.
- If a `TypedRecordProcessor` overrides the flag to true, it will be picked up during processing and all the records written by this processor will be executed in a new command batch
- Marks specific processors (e.g., `BatchOperationExecuteProcessor`) to use separate batches and wires the flag in `Engine`.


This solves the problem for BatchOperation Execution that was the root cause of this issue
- Now, errors during processing will be delegated to be handled by the correct initial command 
- Also the rest of the successful commands in the batch will not be rolled back.


## Related issues

closes #31335


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210842404343151