### PR TITLE
[Backport stable/operate-8.5] fix: use correct logger class in DecisionType

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/entities/dmn/DecisionType.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/dmn/DecisionType.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.operate.entities.dmn;
 
-import io.camunda.operate.entities.FlowNodeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +26,7 @@ public enum DecisionType {
   UNSPECIFIED,
   UNKNOWN;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FlowNodeType.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DecisionType.class);
 
   public static DecisionType fromString(final String decisionType) {
     if (decisionType == null) {


### PR DESCRIPTION
# Description
Backport of #32539 to `stable/operate-8.5`.

relates to 