### PR TITLE
feat: StartScaleUp operation is generated before PartitionBootstrap

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -145,13 +145,13 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var hasNewPartitions = !newPartitions.isEmpty();
 
     if (hasNewPartitions) {
+      operations.add(new StartPartitionScaleUp(coordinatorNodeId, newPartitionCount.get()));
       for (final PartitionId partition : newPartitions) {
         final var newMetadata = newDistribution.get(partition);
         operations.addAll(addPartition(newMetadata));
       }
       operations.addAll(
           List.of(
-              new StartPartitionScaleUp(coordinatorNodeId, newPartitionCount.get()),
               new AwaitRedistributionCompletion(
                   coordinatorNodeId,
                   newPartitionCount.get(),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -62,13 +62,11 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
               "Desired partition count must not exceed %d".formatted(Protocol.MAXIMUM_PARTITIONS)));
     }
 
-    for (int partition = Protocol.START_PARTITION_ID;
-        partition < Protocol.START_PARTITION_ID + desiredPartitionCount;
-        partition++) {
-      if (!currentClusterConfiguration.hasPartition(partition)) {
-        return new Left<>(
-            new IllegalStateException("Partition %d is not known.".formatted(partition)));
-      }
+    if (desiredPartitionCount <= currentClusterConfiguration.partitionCount()) {
+      return new Left<>(
+          new IllegalStateException(
+              "Desired partition count (%d) must be greater than current partition count(%d)"
+                  .formatted(desiredPartitionCount, currentClusterConfiguration.partitionCount())));
     }
 
     if (currentClusterConfiguration.routingState().isEmpty()) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -371,8 +371,8 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),
-            new PartitionBootstrapOperation(id0, 3, 1, true),
             new StartPartitionScaleUp(id0, 3),
+            new PartitionBootstrapOperation(id0, 3, 1, true),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
             new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));
   }
@@ -398,8 +398,8 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2, 1),
-            new PartitionBootstrapOperation(id0, 3, 1, true),
             new StartPartitionScaleUp(id0, 3),
+            new PartitionBootstrapOperation(id0, 3, 1, true),
             new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
             new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))));
   }


### PR DESCRIPTION
## Description

By scheduling before `StartScaleUp` before `PartitionBootstrap`, the desiredPartitions in `RoutingState` will already include the new partitions that need to be run. This is necessary so that re-distribution already know about the all scaling partitions before they bootstrap.

## Related issues

closes #32155 
