### PR TITLE
ci: run operate importer tests on PR

### DIFF
--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   run-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -1,11 +1,19 @@
-name: Operate Run Test Importer
+name: "[Legacy] Operate / [IT] Import"
 on:
-  schedule:
-    - cron: "0 5 * * *"
-  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+    paths:
+      - '.github/workflows/operate-*'
+      - 'operate/**'
+  pull_request:
+    paths:
+      - '.github/workflows/operate-*'
+      - "operate/**"
 jobs:
   run-importer-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: ./mvnw -f operate verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit

--- a/.github/workflows/operate-test-migrate-elasticsearch-data.yml
+++ b/.github/workflows/operate-test-migrate-elasticsearch-data.yml
@@ -1,11 +1,16 @@
-name: Operate Run Test Migrate Elasticsearch Data
+name: "[Legacy] Operate / Migrate Elasticsearch Data"
 on:
   push:
     branches:
-      - stable/8.7
+      - "main"
+      - "stable/**"
     paths:
       - '.github/workflows/operate-*'
       - 'operate/**'
+  pull_request:
+    paths:
+      - '.github/workflows/operate-*'
+      - "operate/**"
 jobs:
   run-migration-tests:
     uses: ./.github/workflows/operate-run-tests.yml


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Made old operate tests run for changes in the operate project and set timeout for the job to 90mins.

I will (back)port this to main, 8.6 and operate-8.5 (and see if I need to fix any tests there).

I'm not super familiar with github actions, so please let me know if there is anything that does not make sense.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/24392
