### PR TITLE
feat: sync completed partitions in engine #32512

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -67,6 +67,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -118,7 +119,8 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
-      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationExecution = value;
+      case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -68,6 +68,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -122,6 +123,7 @@ public final class TestSupport {
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -322,7 +322,8 @@ public final class EngineProcessors {
         searchClientsProxy,
         processingState,
         config,
-        partitionId);
+        partitionId,
+        routingInfo);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -42,18 +43,21 @@ public final class BatchOperationCreateProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final RoutingInfo routingInfo;
 
   public BatchOperationCreateProcessor(
       final Writers writers,
       final KeyGenerator keyGenerator,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final RoutingInfo routingInfo) {
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.keyGenerator = keyGenerator;
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.authCheckBehavior = authCheckBehavior;
+    this.routingInfo = routingInfo;
   }
 
   @Override
@@ -81,6 +85,7 @@ public final class BatchOperationCreateProcessor
     final var recordWithKey = new BatchOperationCreationRecord();
     recordWithKey.wrap(recordValue);
     recordWithKey.setBatchOperationKey(key);
+    recordWithKey.setPartitionIds(routingInfo.partitions());
 
     stateWriter.appendFollowUpEvent(key, BatchOperationIntent.CREATED, recordWithKey);
     responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -9,17 +9,24 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.BatchOperationExecutor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -37,19 +44,25 @@ public final class BatchOperationExecuteProcessor
 
   private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
+  private final CommandDistributionBehavior commandDistributionBehavior;
   private final int partitionId;
   private final BatchOperationState batchOperationState;
+  private final KeyGenerator keyGenerator;
 
   private final Map<BatchOperationType, BatchOperationExecutor> handlers;
 
   public BatchOperationExecuteProcessor(
       final Writers writers,
       final ProcessingState processingState,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final KeyGenerator keyGenerator,
       final int partitionId,
       final Map<BatchOperationType, BatchOperationExecutor> handlers) {
     commandWriter = writers.command();
     stateWriter = writers.state();
     batchOperationState = processingState.getBatchOperationState();
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    this.keyGenerator = keyGenerator;
     this.partitionId = partitionId;
     this.handlers = handlers;
   }
@@ -129,11 +142,33 @@ public final class BatchOperationExecuteProcessor
 
   private void appendBatchOperationExecutionCompletedEvent(
       final BatchOperationExecutionRecord executionRecord) {
-    final var batchExecute = new BatchOperationExecutionRecord();
-    batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
-    stateWriter.appendFollowUpEvent(
+
+    final int originPartitionId =
+        Protocol.decodePartitionId(executionRecord.getBatchOperationKey());
+    final var batchInternalComplete =
+        new BatchOperationPartitionLifecycleRecord()
+            .setBatchOperationKey(executionRecord.getBatchOperationKey())
+            .setSourcePartitionId(partitionId);
+
+    LOGGER.debug(
+        "Send internal complete command for batch operation {} to original partition {}",
         executionRecord.getBatchOperationKey(),
-        BatchOperationExecutionIntent.COMPLETED,
-        batchExecute);
+        originPartitionId);
+
+    if (originPartitionId == partitionId) {
+      commandWriter.appendFollowUpCommand(
+          executionRecord.getBatchOperationKey(),
+          BatchOperationIntent.COMPLETE_PARTITION,
+          batchInternalComplete);
+    } else {
+      commandDistributionBehavior
+          .withKey(keyGenerator.nextKey())
+          .inQueue(DistributionQueue.BATCH_OPERATION)
+          .forPartition(originPartitionId)
+          .distribute(
+              ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+              BatchOperationIntent.COMPLETE_PARTITION,
+              batchInternalComplete);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionCompleteProcessor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This processor only runs on the lead partition of a batch operation. It processes commands to
+ * mark follower partitions as completed.
+ */
+@ExcludeAuthorizationCheck
+public final class BatchOperationPartitionCompleteProcessor
+    implements DistributedTypedRecordProcessor<BatchOperationPartitionLifecycleRecord> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationPartitionCompleteProcessor.class);
+
+  private final StateWriter stateWriter;
+  private final BatchOperationState batchOperationState;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final int partitionId;
+
+  public BatchOperationPartitionCompleteProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final int partitionId) {
+    stateWriter = writers.state();
+    batchOperationState = processingState.getBatchOperationState();
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    this.partitionId = partitionId;
+  }
+
+  /**
+   * Processes a non-distributed command to mark a partition of a batch operation as completed. This
+   * occurs, when the leader marks itself as completed.
+   *
+   * @param command the command to process
+   */
+  @Override
+  public void processNewCommand(final TypedRecord<BatchOperationPartitionLifecycleRecord> command) {
+    doProcessRecord(command);
+  }
+
+  /**
+   * Processes a command from a follower partition to mark that partition of a batch operation as
+   * completed.
+   *
+   * @param command the command to process
+   */
+  @Override
+  public void processDistributedCommand(
+      final TypedRecord<BatchOperationPartitionLifecycleRecord> command) {
+    doProcessRecord(command);
+
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void doProcessRecord(final TypedRecord<BatchOperationPartitionLifecycleRecord> command) {
+    final var batchOperationKey = command.getValue().getBatchOperationKey();
+    if (Protocol.decodePartitionId(batchOperationKey) != partitionId) {
+      LOGGER.warn(
+          "Received command for batch operation {} on partition {}, but partition {} is leader for this batch operation. Ignoring command.",
+          batchOperationKey,
+          Protocol.decodePartitionId(batchOperationKey),
+          partitionId);
+      return;
+    }
+
+    LOGGER.debug(
+        "Processing command from partition {} to mark batch operation {} as completed",
+        command.getValue().getSourcePartitionId(),
+        command.getValue().getBatchOperationKey());
+
+    final var oBatchOperation = batchOperationState.get(batchOperationKey);
+    if (oBatchOperation.isPresent()) {
+      final var bo = oBatchOperation.get();
+      if (bo.getCompletedPartitions().contains(command.getValue().getSourcePartitionId())) {
+        LOGGER.debug(
+            "Batch operation {} already contains partition {}, ignoring command",
+            batchOperationKey,
+            command.getValue().getSourcePartitionId());
+      } else {
+        stateWriter.appendFollowUpEvent(
+            batchOperationKey, BatchOperationIntent.PARTITION_COMPLETED, command.getValue());
+
+        if (bo.getCompletedPartitions().containsAll(bo.getPartitions())) {
+          LOGGER.debug(
+              "All partitions completed, appending COMPLETED event for batch operation {}",
+              batchOperationKey);
+          final var batchExecute = new BatchOperationExecutionRecord();
+          batchExecute.setBatchOperationKey(batchOperationKey);
+          stateWriter.appendFollowUpEvent(
+              batchOperationKey, BatchOperationExecutionIntent.COMPLETED, batchExecute);
+        }
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -83,7 +83,12 @@ public final class BatchOperationSetupProcessors {
             ValueType.BATCH_OPERATION_EXECUTION,
             BatchOperationExecutionIntent.EXECUTE,
             new BatchOperationExecuteProcessor(
-                writers, processingState, partitionId, batchExecutionHandlers))
+                writers,
+                processingState,
+                commandDistributionBehavior,
+                keyGenerator,
+                partitionId,
+                batchExecutionHandlers))
         .onCommand(
             ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
             BatchOperationIntent.CANCEL,
@@ -111,6 +116,11 @@ public final class BatchOperationSetupProcessors {
                 processingState,
                 authorizationCheckBehavior,
                 keyGenerator))
+        .onCommand(
+            ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+            BatchOperationIntent.COMPLETE_PARTITION,
+            new BatchOperationPartitionCompleteProcessor(
+                writers, processingState, commandDistributionBehavior, partitionId))
         .withListener(
             new BatchOperationExecutionScheduler(
                 scheduledTaskStateFactory,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
@@ -40,7 +41,8 @@ public final class BatchOperationSetupProcessors {
       final SearchClientsProxy searchClientsProxy,
       final ProcessingState processingState,
       final EngineConfiguration engineConfiguration,
-      final int partitionId) {
+      final int partitionId,
+      final RoutingInfo routingInfo) {
     final var batchExecutionHandlers =
         Map.of(
             BatchOperationType.CANCEL_PROCESS_INSTANCE,
@@ -60,7 +62,11 @@ public final class BatchOperationSetupProcessors {
             ValueType.BATCH_OPERATION_CREATION,
             BatchOperationIntent.CREATE,
             new BatchOperationCreateProcessor(
-                writers, keyGenerator, commandDistributionBehavior, authorizationCheckBehavior))
+                writers,
+                keyGenerator,
+                commandDistributionBehavior,
+                authorizationCheckBehavior,
+                routingInfo))
         .onCommand(
             ValueType.BATCH_OPERATION_CREATION,
             BatchOperationIntent.START,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationPartitionCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationPartitionCompletedApplier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+
+/** This applier only runs on the lead partition of a batch operation. */
+public class BatchOperationPartitionCompletedApplier
+    implements TypedEventApplier<BatchOperationIntent, BatchOperationPartitionLifecycleRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationPartitionCompletedApplier(
+      final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(
+      final long batchOperationKey, final BatchOperationPartitionLifecycleRecord value) {
+    batchOperationState.completePartition(batchOperationKey, value.getSourcePartitionId());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -621,6 +621,9 @@ public final class EventAppliers implements EventApplier {
     register(
         BatchOperationExecutionIntent.COMPLETED,
         new BatchOperationCompletedApplier(state.getBatchOperationState()));
+    register(
+        BatchOperationIntent.PARTITION_COMPLETED,
+        new BatchOperationPartitionCompletedApplier(state.getBatchOperationState()));
   }
 
   private void registerIdentitySetupAppliers() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -191,6 +191,17 @@ public class DbBatchOperationState implements MutableBatchOperationState {
   }
 
   @Override
+  public void completePartition(final long batchOperationKey, final int partitionId) {
+    LOGGER.trace(
+        "Complete batch operation with key {} on partition {}", batchOperationKey, partitionId);
+    batchKey.wrapLong(batchOperationKey);
+
+    final var batch = batchOperationColumnFamily.get(batchKey);
+    batch.addCompletedPartition(partitionId);
+    batchOperationColumnFamily.update(batchKey, batch);
+  }
+
+  @Override
   public boolean exists(final long batchOperationKey) {
     return get(batchOperationKey).isPresent();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -35,4 +35,6 @@ public interface MutableBatchOperationState extends BatchOperationState {
   void resume(final long batchOperationKey);
 
   void complete(final long batchOperationKey);
+
+  void completePartition(final long batchOperationKey, int partitionId);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -25,13 +25,12 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementR
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Random;
-import java.util.Set;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 
 public final class BatchOperationClient {
 
-  private static final int DEFAULT_PARTITION = 1;
+  public static final int DEFAULT_PARTITION = 1;
 
   private final CommandWriter writer;
 
@@ -213,7 +212,7 @@ public final class BatchOperationClient {
 
     private final CommandWriter writer;
     private final BatchOperationExecutionRecord batchOperationExecutionRecord;
-    private final int partition = DEFAULT_PARTITION;
+    private int partition = DEFAULT_PARTITION;
 
     public BatchOperationExecutionClient(final CommandWriter writer) {
       this.writer = writer;
@@ -225,8 +224,8 @@ public final class BatchOperationClient {
       return this;
     }
 
-    public BatchOperationExecutionClient withItemKeys(final Set<Long> items) {
-      batchOperationExecutionRecord.setItemKeys(items);
+    public BatchOperationExecutionClient onPartition(final int partition) {
+      this.partition = partition;
       return this;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCompletedHandler.java
@@ -20,9 +20,13 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BatchOperationCompletedHandler
     implements ExportHandler<BatchOperationEntity, BatchOperationExecutionRecordValue> {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationCompletedHandler.class);
 
   private final String indexName;
 
@@ -64,6 +68,9 @@ public class BatchOperationCompletedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
+    LOGGER.trace(
+        "Updating batch operation {} to be COMPLETED on index {}", entity.getId(), indexName);
+
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(BatchOperationTemplate.STATE, entity.getState());
     batchRequest.update(indexName, entity.getId(), updateFields);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -214,6 +214,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean batchOperationChunk = false;
     public boolean batchOperationExecution = false;
     public boolean batchOperationLifecycleManagement = false;
+    public boolean batchOperationPartitionLifecycle = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -67,6 +67,7 @@ final class TestSupport {
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -120,7 +121,8 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_CHUNK,
             ValueType.BATCH_OPERATION_EXECUTION,
-            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -204,6 +204,7 @@ public class OpensearchExporterConfiguration {
     public boolean batchOperationChunk = false;
     public boolean batchOperationExecution = false;
     public boolean batchOperationLifecycleManagement = false;
+    public boolean batchOperationPartitionLifecycle = false;
 
     // index settings
     private Integer numberOfShards = null;

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -68,6 +68,7 @@ final class TestSupport {
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT -> config.batchOperationLifecycleManagement = value;
+      case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
       default ->
@@ -121,7 +122,8 @@ final class TestSupport {
             ValueType.BATCH_OPERATION_CREATION,
             ValueType.BATCH_OPERATION_CHUNK,
             ValueType.BATCH_OPERATION_EXECUTION,
-            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT);
+            ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
+            ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
+
+public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordValue
+    implements BatchOperationPartitionLifecycleRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_SOURCE_PARTITION_ID = "sourcePartitionId";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty sourcePartitionIdProp =
+      new IntegerProperty(PROP_SOURCE_PARTITION_ID, -1);
+
+  public BatchOperationPartitionLifecycleRecord() {
+    super(2);
+    declareProperty(batchOperationKeyProp);
+    declareProperty(sourcePartitionIdProp);
+  }
+
+  @Override
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setBatchOperationKey(final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public Integer getSourcePartitionId() {
+    return sourcePartitionIdProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setSourcePartitionId(final int sourcePartitionId) {
+    sourcePartitionIdProp.reset();
+    sourcePartitionIdProp.setValue(sourcePartitionId);
+    return this;
+  }
+
+  public BatchOperationPartitionLifecycleRecord wrap(
+      final BatchOperationPartitionLifecycleRecord record) {
+    setBatchOperationKey(record.getBatchOperationKey());
+    setSourcePartitionId(record.getSourcePartitionId());
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -63,6 +64,8 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
         BatchOperationLifecycleManagementRecord::new);
+    RECORDS_BY_TYPE.put(
+        ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE, BatchOperationPartitionLifecycleRecord::new);
   }
 
   /*

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3252,6 +3252,7 @@ final class JsonSerializableToJsonTest {
             () ->
                 new BatchOperationCreationRecord()
                     .setBatchOperationKey(12345L)
+                    .setPartitionIds(List.of(1, 2, 3))
                     .setBatchOperationType(BatchOperationType.CANCEL_PROCESS_INSTANCE),
         """
   {
@@ -3259,6 +3260,7 @@ final class JsonSerializableToJsonTest {
     "batchOperationType": "CANCEL_PROCESS_INSTANCE",
     "entityFilterBuffer": {"expandable":false},
     "entityFilter": null,
+    "partitionIds": [1, 2, 3],
     "migrationPlan":{"targetProcessDefinitionKey":-1,"mappingInstructions":[],"empty":false,"encodedLength":50},
     "modificationPlan":{"moveInstructions":[],"empty":false,"encodedLength":19},
     "authenticationBuffer": {"expandable":false}
@@ -3275,6 +3277,7 @@ final class JsonSerializableToJsonTest {
             () ->
                 new BatchOperationCreationRecord()
                     .setBatchOperationKey(12345L)
+                    .setPartitionIds(List.of(1, 2, 3))
                     .setBatchOperationType(BatchOperationType.MIGRATE_PROCESS_INSTANCE)
                     .setEntityFilter(
                         toMessagePack("{'processDefinitionKey': 67890, 'state': 'ACTIVE'}"))
@@ -3314,6 +3317,7 @@ final class JsonSerializableToJsonTest {
      "entityFilterBuffer": {
        "expandable": false
      },
+    "partitionIds": [1, 2, 3],
      "entityFilter": "{\\"processDefinitionKey\\":67890,\\"state\\":\\"ACTIVE\\"}",
      "migrationPlan": {
        "mappingInstructions": [

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -72,6 +72,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -295,6 +296,10 @@ public final class ValueTypeMapping {
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
         new Mapping<>(
             BatchOperationLifecycleManagementRecordValue.class, BatchOperationIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+        new Mapping<>(
+            BatchOperationPartitionLifecycleRecordValue.class, BatchOperationIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
@@ -27,7 +27,9 @@ public enum BatchOperationIntent implements Intent {
   SUSPEND((short) 8),
   SUSPENDED((short) 9),
   RESUME((short) 10),
-  RESUMED((short) 11);
+  RESUMED((short) 11),
+  COMPLETE_PARTITION((short) 12),
+  PARTITION_COMPLETED((short) 13);
 
   private final short value;
 
@@ -65,7 +67,10 @@ public enum BatchOperationIntent implements Intent {
         return RESUME;
       case 11:
         return RESUMED;
-
+      case 12:
+        return COMPLETE_PARTITION;
+      case 13:
+        return PARTITION_COMPLETED;
       default:
         return Intent.UNKNOWN;
     }
@@ -85,6 +90,7 @@ public enum BatchOperationIntent implements Intent {
       case SUSPENDED:
       case CANCELED:
       case RESUMED:
+      case PARTITION_COMPLETED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -192,6 +192,8 @@ public interface Intent {
         return BatchOperationChunkIntent.from(intent);
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
         return BatchOperationIntent.from(intent);
+      case BATCH_OPERATION_PARTITION_LIFECYCLE:
+        return BatchOperationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -298,6 +300,8 @@ public interface Intent {
       case BATCH_OPERATION_CHUNK:
         return BatchOperationChunkIntent.valueOf(intent);
       case BATCH_OPERATION_LIFECYCLE_MANAGEMENT:
+        return BatchOperationIntent.valueOf(intent);
+      case BATCH_OPERATION_PARTITION_LIFECYCLE:
         return BatchOperationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
@@ -46,6 +46,14 @@ public interface BatchOperationCreationRecordValue extends BatchOperationRelated
    */
   BatchOperationProcessInstanceModificationPlanValue getModificationPlan();
 
+  /**
+   * The list of partitions this batch operation is executed on. THis list will be filled by the
+   * engine.
+   *
+   * @return the list of partitions
+   */
+  List<Integer> getPartitionIds();
+
   @Value.Immutable
   @ImmutableProtocol(
       builder = ImmutableBatchOperationProcessInstanceMigrationPlanValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationPartitionLifecycleRecordValue.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/** Will be used by cluster internal communications for batch operations. */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationPartitionLifecycleRecordValue.Builder.class)
+public interface BatchOperationPartitionLifecycleRecordValue
+    extends BatchOperationRelated, RecordValue {
+
+  Integer getSourcePartitionId();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -70,6 +70,7 @@
       <validValue name="BATCH_OPERATION_CHUNK">52</validValue>
       <validValue name="AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION">53</validValue>
       <validValue name="BATCH_OPERATION_LIFECYCLE_MANAGEMENT">54</validValue>
+      <validValue name="BATCH_OPERATION_PARTITION_LIFECYCLE">55</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -130,6 +131,9 @@ public final class TypedEventRegistry {
     registry.put(
         ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT,
         BatchOperationLifecycleManagementRecord.class);
+    registry.put(
+        ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+        BatchOperationPartitionLifecycleRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationPartitionLifecycleRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationPartitionLifecycleRecordStream.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
+import java.util.stream.Stream;
+
+public class BatchOperationPartitionLifecycleRecordStream
+    extends ExporterRecordStream<
+        BatchOperationPartitionLifecycleRecordValue, BatchOperationPartitionLifecycleRecordStream> {
+
+  public BatchOperationPartitionLifecycleRecordStream(
+      final Stream<Record<BatchOperationPartitionLifecycleRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected BatchOperationPartitionLifecycleRecordStream supply(
+      final Stream<Record<BatchOperationPartitionLifecycleRecordValue>> wrappedStream) {
+    return new BatchOperationPartitionLifecycleRecordStream(wrappedStream);
+  }
+
+  public BatchOperationPartitionLifecycleRecordStream withBatchOperationKey(
+      final long batchOperationKey) {
+    return valueFilter(v -> v.getBatchOperationKey() == batchOperationKey);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationPartitionLifecycleRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -591,6 +592,19 @@ public final class RecordingExporter implements Exporter {
   public static BatchOperationLifecycleRecordStream batchOperationLifecycleRecords(
       final BatchOperationIntent intent) {
     return batchOperationLifecycleRecords().withIntent(intent);
+  }
+
+  public static BatchOperationPartitionLifecycleRecordStream
+      batchOperationPartitionLifecycleRecords() {
+    return new BatchOperationPartitionLifecycleRecordStream(
+        records(
+            ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
+            BatchOperationPartitionLifecycleRecordValue.class));
+  }
+
+  public static BatchOperationPartitionLifecycleRecordStream
+      batchOperationPartitionLifecycleRecords(final BatchOperationIntent intent) {
+    return batchOperationPartitionLifecycleRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

This PR introduces a synchronization of the COMPLETED event between all partitions, to have one final unified COMPLETED event for the exporter.
- new ValueType `BatchOperationPartitionLifecycleRecord`
- new command processor BatchOperationPartitionCompleteProcessor
- When no more elements are to be executed, instead of appending a COMPLETED event, the partition will now send a COMPLETE_PARTITION command to the leader of the batch operation. That leader will count these commands and append a final COMPLETED event

Note:
After this PR a completed batch operation will not be deleted from follower rocksDb. To keep this PR rather small, this is fixed in issue #32646 and PR #32649

## Related issues

closes #32512 
