### PR TITLE
fix: hasVariables only checks global variables

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -59,8 +59,9 @@ public class CamundaDataSource {
         .items();
   }
 
-  public List<Variable> findVariablesByProcessInstanceKey(final long processInstanceKey) {
-    return findVariables(filter -> filter.processInstanceKey(processInstanceKey));
+  public List<Variable> findGlobalVariablesByProcessInstanceKey(final long processInstanceKey) {
+    return findVariables(
+        filter -> filter.processInstanceKey(processInstanceKey).scopeKey(processInstanceKey));
   }
 
   public List<Variable> findVariables(final Consumer<VariableFilter> filter) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -173,7 +173,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   }
 
   private Map<String, String> getProcessInstanceVariables(final long processInstanceKey) {
-    return dataSource.findVariablesByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource.findGlobalVariablesByProcessInstanceKey(processInstanceKey).stream()
         // We're deliberately switching from the Collectors.toMap collector to a custom
         // implementation because it's allowed to have Camunda Variables with null values
         // However, the toMap collector does not allow null values and would throw an exception.

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -598,7 +598,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertStateAndVariables() {
       // given
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -624,7 +624,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertVariablesAndState() {
       // given
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -640,7 +640,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(activeElementInstance));
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -656,7 +656,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findElementInstances(any()))
           .thenReturn(Collections.singletonList(activeElementInstance));
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -106,7 +106,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -122,7 +122,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", null);
       final Variable variableB = newVariable("b", null);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -138,7 +138,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -148,7 +148,8 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
 
-      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -157,7 +158,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -197,7 +198,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when
@@ -213,7 +214,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableB))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -223,7 +224,8 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 1);
 
-      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -231,7 +233,7 @@ public class VariableAssertTest {
       // given
       final Variable variableWithNull = newVariable("a", null);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableWithNull));
 
       // when
@@ -247,7 +249,7 @@ public class VariableAssertTest {
       final Variable variableValue1 = newVariable("a", "1");
       final Variable variableValue2 = newVariable("a", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableValue1))
           .thenReturn(Collections.singletonList(variableValue2));
 
@@ -257,7 +259,8 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 2);
 
-      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -266,7 +269,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -286,7 +289,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -306,7 +309,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when
@@ -345,7 +348,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", variableValue);
       final Variable variableB = newVariable("b", "100");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -365,7 +368,7 @@ public class VariableAssertTest {
       final Variable nullVariableB = newVariable("b", null);
       final Variable nullVariableC = newVariable("c", null);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, nullVariableB, nullVariableC));
 
       // when
@@ -385,7 +388,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -398,7 +401,8 @@ public class VariableAssertTest {
       expectedVariables.put("b", 2);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
 
-      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -408,7 +412,7 @@ public class VariableAssertTest {
       final Variable variableValue2 = newVariable("a", "2");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableValue1, variableB))
           .thenReturn(Arrays.asList(variableValue2, variableB));
 
@@ -421,7 +425,8 @@ public class VariableAssertTest {
       expectedVariables.put("b", 2);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
 
-      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -430,7 +435,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -455,7 +460,7 @@ public class VariableAssertTest {
       final Variable variableB = newVariable("b", "2");
       final Variable variableC = newVariable("c", "3");
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB, variableC));
 
       // when
@@ -479,7 +484,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -80,7 +80,10 @@ public class CamundaProcessTestContextIT {
 
     // Then
     assertThat(processInstanceEvent).hasCompletedElements("error-end");
-    assertThat(processInstanceEvent).hasVariables(variables);
+
+    final Map<String, Object> expectedVariables = new HashMap<>();
+    expectedVariables.put("error_code", 123);
+    assertThat(processInstanceEvent).hasVariables(expectedVariables);
   }
 
   @Test
@@ -219,7 +222,10 @@ public class CamundaProcessTestContextIT {
     // Then
     assertThat(processInstanceEvent).isCompleted();
     assertThat(processInstanceEvent).hasCompletedElements("error-end");
-    assertThat(processInstanceEvent).hasVariables(variables);
+
+    final Map<String, Object> expectedVariables = new HashMap<>();
+    expectedVariables.put("error_code", 123);
+    assertThat(processInstanceEvent).hasVariables(expectedVariables);
   }
 
   @Test
@@ -679,6 +685,7 @@ public class CamundaProcessTestContextIT {
         .zeebeJobType("test")
         .boundaryEvent("error-boundary-event")
         .error("bpmn-error")
+        .zeebeOutputExpression("abc", "error_code")
         .endEvent("error-end")
         .moveToActivity("service-task-1")
         .endEvent("success-end")


### PR DESCRIPTION
## Description

In Camunda Process Test, I can verify that a process instance has a given variable: https://docs.camunda.io/docs/next/apis-tools/testing/assertions/#hasvariable.
```java
assertThat(processInstance).hasVariable("var1", 100);
```
The documentation mentions that the assertions check only global and not local process instance variables.
```
    You can verify the process instance variables using CamundaAssert.assertThat(processInstance). Local variables of BPMN elements are ignored.
```
However, the assertions behave differently. The assertion passes if the given variable is a local variable of a BPMN element.

This PR fixes that issue by adding a scope parameter on the variable filter so that only globally-accessible variables are checked.

closes https://github.com/camunda/camunda/issues/31649
