### PR TITLE
[Backport stable/8.7] Extend exporter context to filter based on intent

### DIFF
--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.exporter.api.context;
 
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import org.slf4j.Logger;
@@ -80,5 +81,16 @@ public interface Context {
      * @return {@code true} if records with this type of value should be exported.
      */
     boolean acceptValue(ValueType valueType);
+
+    /**
+     * Should export records with the given intent?
+     *
+     * @param intent the intent of the record.
+     * @return {@code true} if records with this intent should be exported.
+     */
+    default boolean acceptIntent(final Intent intent) {
+      // default implementation accepts all intents
+      return true;
+    }
   }
 }

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -60,7 +60,7 @@ public final class ExporterTest {
   }
 
   @Test
-  public void shouldAllowFilteringOnIntent() throws Exception {
+  public void shouldAllowFilteringOnIntent() {
     // given
     final TestExporterContainer exporter = new TestExporterContainer();
     final var record = new TestMessageRecord(MessageIntent.EXPIRED);
@@ -71,7 +71,7 @@ public final class ExporterTest {
   }
 
   @Test
-  public void shouldRejectDisallowedIntent() throws Exception {
+  public void shouldRejectDisallowedIntent() {
     // given
     final TestExporterContainer exporter = new TestExporterContainer();
     final var record = new TestMessageRecord(MessageIntent.PUBLISHED);
@@ -80,7 +80,7 @@ public final class ExporterTest {
     assertThat(exporter.isExported(record)).isFalse();
   }
 
-  static class TestExporterContainer {
+  private static final class TestExporterContainer {
     private final MessageExpiredSupportingExporter exporter;
     private final TestContext context;
 
@@ -88,14 +88,6 @@ public final class ExporterTest {
       context = new TestContext();
       exporter = new MessageExpiredSupportingExporter();
       exporter.configure(context);
-    }
-
-    public Exporter getExporter() {
-      return exporter;
-    }
-
-    public Context getContext() {
-      return context;
     }
 
     public void exportRecord(final Record<?> record) {
@@ -111,7 +103,7 @@ public final class ExporterTest {
     }
   }
 
-  static class MessageExpiredSupportingExporter implements Exporter {
+  private static final class MessageExpiredSupportingExporter implements Exporter {
     private final List<Record<?>> records = new ArrayList<>();
 
     public boolean isExported(final Record<?> record) {
@@ -129,7 +121,7 @@ public final class ExporterTest {
     }
   }
 
-  static class TestContext implements Context {
+  private static final class TestContext implements Context {
     private RecordFilter filter;
 
     @Override
@@ -167,7 +159,7 @@ public final class ExporterTest {
     }
   }
 
-  static class MessageExpiredFilter implements RecordFilter {
+  private static final class MessageExpiredFilter implements RecordFilter {
     @Override
     public boolean acceptType(final RecordType recordType) {
       return true;
@@ -187,7 +179,7 @@ public final class ExporterTest {
     }
   }
 
-  record TestMessageRecord(Intent intent) implements Record<MessageRecordValue> {
+  private record TestMessageRecord(Intent intent) implements Record<MessageRecordValue> {
     @Override
     public long getPosition() {
       return 0;

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -15,12 +15,27 @@
  */
 package io.camunda.zeebe.exporter.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.time.InstantSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 public final class ExporterTest {
 
@@ -42,5 +57,210 @@ public final class ExporterTest {
 
     // then
     assertThatThrownBy(() -> exporter.configure(null)).isEqualTo(expectedException);
+  }
+
+  @Test
+  public void shouldAllowFilteringOnIntent() throws Exception {
+    // given
+    final TestExporterContainer exporter = new TestExporterContainer();
+    final var record = new TestMessageRecord(MessageIntent.EXPIRED);
+    exporter.exportRecord(record);
+
+    // then
+    assertThat(exporter.isExported(record)).isTrue();
+  }
+
+  @Test
+  public void shouldRejectDisallowedIntent() throws Exception {
+    // given
+    final TestExporterContainer exporter = new TestExporterContainer();
+    final var record = new TestMessageRecord(MessageIntent.PUBLISHED);
+
+    // then
+    assertThat(exporter.isExported(record)).isFalse();
+  }
+
+  static class TestExporterContainer {
+    private final MessageExpiredSupportingExporter exporter;
+    private final TestContext context;
+
+    public TestExporterContainer() {
+      context = new TestContext();
+      exporter = new MessageExpiredSupportingExporter();
+      exporter.configure(context);
+    }
+
+    public Exporter getExporter() {
+      return exporter;
+    }
+
+    public Context getContext() {
+      return context;
+    }
+
+    public void exportRecord(final Record<?> record) {
+      if (context.getFilter().acceptValue(record.getValueType())
+          && context.getFilter().acceptType(record.getRecordType())
+          && context.getFilter().acceptIntent(record.getIntent())) {
+        exporter.export(record);
+      }
+    }
+
+    public boolean isExported(final Record<?> record) {
+      return exporter.isExported(record);
+    }
+  }
+
+  static class MessageExpiredSupportingExporter implements Exporter {
+    private final List<Record<?>> records = new ArrayList<>();
+
+    public boolean isExported(final Record<?> record) {
+      return records.contains(record);
+    }
+
+    @Override
+    public void configure(final Context context) {
+      context.setFilter(new MessageExpiredFilter());
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      records.add(record);
+    }
+  }
+
+  static class TestContext implements Context {
+    private RecordFilter filter;
+
+    @Override
+    public MeterRegistry getMeterRegistry() {
+      return null;
+    }
+
+    @Override
+    public Logger getLogger() {
+      return null;
+    }
+
+    @Override
+    public InstantSource clock() {
+      return null;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+      return null;
+    }
+
+    @Override
+    public int getPartitionId() {
+      return 0;
+    }
+
+    public RecordFilter getFilter() {
+      return filter;
+    }
+
+    @Override
+    public void setFilter(final RecordFilter filter) {
+      this.filter = filter;
+    }
+  }
+
+  static class MessageExpiredFilter implements RecordFilter {
+    @Override
+    public boolean acceptType(final RecordType recordType) {
+      return true;
+    }
+
+    @Override
+    public boolean acceptValue(final ValueType valueType) {
+      return true;
+    }
+
+    @Override
+    public boolean acceptIntent(final Intent intent) {
+      if (intent instanceof MessageIntent) {
+        return intent == MessageIntent.EXPIRED;
+      }
+      return true;
+    }
+  }
+
+  record TestMessageRecord(Intent intent) implements Record<MessageRecordValue> {
+    @Override
+    public long getPosition() {
+      return 0;
+    }
+
+    @Override
+    public long getSourceRecordPosition() {
+      return 0;
+    }
+
+    @Override
+    public long getKey() {
+      return 0;
+    }
+
+    @Override
+    public long getTimestamp() {
+      return 0;
+    }
+
+    @Override
+    public Intent getIntent() {
+      return intent;
+    }
+
+    @Override
+    public int getPartitionId() {
+      return 0;
+    }
+
+    @Override
+    public RecordType getRecordType() {
+      return null;
+    }
+
+    @Override
+    public RejectionType getRejectionType() {
+      return null;
+    }
+
+    @Override
+    public String getRejectionReason() {
+      return "";
+    }
+
+    @Override
+    public String getBrokerVersion() {
+      return "";
+    }
+
+    @Override
+    public Map<String, Object> getAuthorizations() {
+      return Map.of();
+    }
+
+    @Override
+    public int getRecordVersion() {
+      return 0;
+    }
+
+    @Override
+    public ValueType getValueType() {
+      return null;
+    }
+
+    @Override
+    public MessageRecordValue getValue() {
+      return null;
+    }
+
+    @Override
+    public long getOperationReference() {
+      return 0;
+    }
   }
 }


### PR DESCRIPTION
# Description
Backport of #32456 to `stable/8.7`.

relates to #32232