### PR TITLE
fix(c8run): silent connector logs

### DIFF
--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -4,3 +4,4 @@ camunda.operate.client.url=http://localhost:8080
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 server.port=8085
+logging.level.io.camunda.client.impl.CamundaCallCredentials=ERROR


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Starting c8run, the connector logs contain a lot of messages about the unsecure connection to the Zeebe Gateway:

```
2025-05-27T17:11:24.265+02:00  WARN 45028 --- [pool-2-thread-1] i.c.client.impl.CamundaCallCredentials   : The request's security level does not guarantee that the credentials will be confidential.
2025-05-27T17:11:24.266+02:00  WARN 45028 --- [pool-2-thread-1] i.c.client.impl.CamundaCallCredentials   : The request's security level does not guarantee that the credentials will be confidential.
2025-05-27T17:11:24.267+02:00  WARN 45028 --- [pool-2-thread-1] i.c.client.impl.CamundaCallCredentials   : The request's security level does not guarantee that the credentials will be confidential.
```

This WARN output is very disturbing when you search for traces of your actions.

The pull request sets the log level for the class to `ERROR`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
