### PR TITLE
Add delete user command to java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -51,6 +51,7 @@ import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
+import io.camunda.client.api.command.DeleteUserCommandStep1;
 import io.camunda.client.api.command.DeployProcessCommandStep1;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
@@ -1594,6 +1595,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CreateUserCommandStep1 newUserCreateCommand();
+
+  /**
+   * Command to delete a user by username
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newDeleteUserCommand("username")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder for the command
+   */
+  DeleteUserCommandStep1 newDeleteUserCommand(String username);
 
   /**
    * Command to create a mapping rule.

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteUserCommandStep1.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.DeleteUserResponse;
+
+public interface DeleteUserCommandStep1 extends FinalCommandStep<DeleteUserResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/DeleteUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DeleteUserResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface DeleteUserResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -59,6 +59,7 @@ import io.camunda.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.client.api.command.DeleteRoleCommandStep1;
 import io.camunda.client.api.command.DeleteTenantCommandStep1;
+import io.camunda.client.api.command.DeleteUserCommandStep1;
 import io.camunda.client.api.command.DeployProcessCommandStep1;
 import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.command.EvaluateDecisionCommandStep1;
@@ -174,6 +175,7 @@ import io.camunda.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.client.impl.command.DeleteRoleCommandImpl;
 import io.camunda.client.impl.command.DeleteTenantCommandImpl;
+import io.camunda.client.impl.command.DeleteUserCommandImpl;
 import io.camunda.client.impl.command.DeployProcessCommandImpl;
 import io.camunda.client.impl.command.DeployResourceCommandImpl;
 import io.camunda.client.impl.command.EvaluateDecisionCommandImpl;
@@ -959,6 +961,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateUserCommandStep1 newUserCreateCommand() {
     return new CreateUserCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public DeleteUserCommandStep1 newDeleteUserCommand(final String username) {
+    return new DeleteUserCommandImpl(httpClient, username);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteUserCommandImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.DeleteUserCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.DeleteUserResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteUserCommandImpl implements DeleteUserCommandStep1 {
+
+  private final String username;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteUserCommandImpl(final HttpClient httpClient, final String username) {
+    this.username = username;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<DeleteUserResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<DeleteUserResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("username", username);
+    final HttpCamundaFuture<DeleteUserResponse> result = new HttpCamundaFuture<>();
+    httpClient.delete("/users/" + username, httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/user/DeleteUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/DeleteUserTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.user;
+
+import static io.camunda.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class DeleteUserTest extends ClientRestTest {
+
+  private static final String USERNAME = "username";
+
+  @Test
+  void shouldDeleteUser() {
+    // when
+    client.newDeleteUserCommand(USERNAME).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/users/" + USERNAME);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullUsername() {
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteUserCommand(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyUsername() {
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteUserCommand("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be empty");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RoleIntegrationTest.java
@@ -17,7 +17,6 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
-import io.camunda.client.protocol.rest.RoleResult;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.io.IOException;
@@ -374,6 +373,4 @@ public class RoleIntegrationTest {
       String resourceId,
       List<PermissionType> permissionTypes,
       String authorizationKey) {}
-
-  private record RoleSearchResponse(List<RoleResult> items) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.User;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class UserIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldCreateUser() {
+    // given
+    final var username = "someUsername";
+    final var name = "someName";
+    final var email = "some_email@email.com";
+
+    // when
+    camundaClient
+        .newUserCreateCommand()
+        .username(username)
+        .name(name)
+        .password("some password")
+        .email(email)
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("User is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<User> response =
+                  camundaClient
+                      .newUsersSearchRequest()
+                      .filter(fn -> fn.username(username))
+                      .send()
+                      .join();
+              assertThat(response.items().size()).isEqualTo(1);
+              assertThat(response.items().getFirst().getUsername()).isEqualTo(username);
+              assertThat(response.items().getFirst().getName()).isEqualTo(name);
+              assertThat(response.items().getFirst().getEmail()).isEqualTo(email);
+            });
+  }
+
+  @Test
+  void shouldDeleteUser() {
+    // given
+    final var username = "username";
+
+    camundaClient
+        .newUserCreateCommand()
+        .username(username)
+        .name("name")
+        .password("some password")
+        .email("email@email.com")
+        .send()
+        .join();
+
+    // when
+    camundaClient.newDeleteUserCommand(username).send().join();
+
+    // then
+    Awaitility.await("User is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<User> response =
+                  camundaClient
+                      .newUsersSearchRequest()
+                      .filter(fn -> fn.username(username))
+                      .send()
+                      .join();
+              assertThat(response.items()).isEmpty();
+            });
+  }
+
+  @Test
+  void shouldReturnNotFoundOnDeleteWhenUsernameDoesNotExist() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newDeleteUserCommand(Strings.newRandomValidIdentityId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining("a user with this username does not exist");
+  }
+}


### PR DESCRIPTION
## Description

Add Delete User API to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32517 