### PR TITLE
Bugfix/31795 respect version labels

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -49,6 +49,12 @@ public final class ContainerRuntimePropertiesUtil {
 
   private static final String VERSION_FORMAT = "%d.%d.%d";
 
+  /**
+   * Format string for versions that include additional labels (e.g., alpha, rc). This is used to
+   * format semantic versions with non-SNAPSHOT labels.
+   */
+  private static final String LABELED_VERSION_FORMAT = "%d.%d.%d%s";
+
   private final String camundaVersion;
   private final String camundaDockerImageName;
   private final String camundaDockerImageVersion;
@@ -123,11 +129,12 @@ public final class ContainerRuntimePropertiesUtil {
     if (label == null) {
       // release version
       return String.format(VERSION_FORMAT, major, minor, patch);
-
+    } else if (!label.contains(SNAPSHOT_VERSION)) {
+      // alpha, rc or other labeled version
+      return String.format(LABELED_VERSION_FORMAT, major, minor, patch, label);
     } else if (patch == 0) {
       // current dev version
       return SNAPSHOT_VERSION;
-
     } else {
       // maintenance dev version
       final int previousPatchVersion = patch - 1;

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -86,7 +86,11 @@ public class ContainerRuntimePropertiesUtilTest {
     "8.6.0-SNAPSHOT, SNAPSHOT",
     "8.5.1-SNAPSHOT, 8.5.0",
     "8.5.2-SNAPSHOT, 8.5.1",
-    "8.5.2-rc1, 8.5.1",
+    "8.5.2-rc1, 8.5.2-rc1",
+    "8.7.1-alpha4-rc1, 8.7.1-alpha4-rc1",
+    "8.8.0-alpha4.1, 8.8.0-alpha4.1",
+    "8.8.0-alpha4-optimize, 8.8.0-alpha4-optimize",
+    "8.7.1-optimize, 8.7.1-optimize",
     "custom-version, custom-version"
   })
   void shouldReturnCamundaVersion(final String propertyVersion, final String expectedVersion) {
@@ -152,8 +156,12 @@ public class ContainerRuntimePropertiesUtilTest {
     "8.6.0-SNAPSHOT, SNAPSHOT",
     "8.5.1-SNAPSHOT, 8.5.0",
     "8.5.2-SNAPSHOT, 8.5.1",
-    "8.5.2-rc1, 8.5.1",
-    "custom-version, custom-version"
+    "8.5.2-rc1, 8.5.2-rc1",
+    "8.7.1-alpha4-rc1, 8.7.1-alpha4-rc1",
+    "8.8.0-alpha4.1, 8.8.0-alpha4.1",
+    "8.8.0-alpha4-optimize, 8.8.0-alpha4-optimize",
+    "8.7.1-optimize, 8.7.1-optimize",
+    "custom-version, custom-version",
   })
   void shouldReturnCamundaDockerImageVersion(
       final String propertyVersion, final String expectedVersion) {
@@ -198,7 +206,11 @@ public class ContainerRuntimePropertiesUtilTest {
     "8.6.0-SNAPSHOT, SNAPSHOT",
     "8.5.1-SNAPSHOT, 8.5.0",
     "8.5.2-SNAPSHOT, 8.5.1",
-    "8.5.2-rc1, 8.5.1",
+    "8.5.2-rc1, 8.5.2-rc1",
+    "8.7.1-alpha4-rc1, 8.7.1-alpha4-rc1",
+    "8.8.0-alpha4.1, 8.8.0-alpha4.1",
+    "8.8.0-alpha4-optimize, 8.8.0-alpha4-optimize",
+    "8.7.1-optimize, 8.7.1-optimize",
     "custom-version, custom-version"
   })
   void shouldReturnConnectorsDockerImageVersion(


### PR DESCRIPTION
## Description

In Camunda Process Test, the runtime starts the Camunda Docker image before running the test cases. By default, the version of the Camunda Docker image should be the same as the version of the Maven dependency.

A test with the following dependency should start the Camunda Docker image in version 8.7.1:
```
<dependency>
            <groupId>io.camunda</groupId>
            <artifactId>camunda-process-test-spring</artifactId>
            <scope>test</scope>
            <version>8.7.1</version>
</dependency>
```
This works except for alpha/rc versions, such as 8.8.0-alpha4-rc1. In this case, the runtime starts the SNAPSHOT version.

This PR fixes this behavior so that 8.8.0-alpha4-rc1 is used as the dockerImageVersion. **Please note** that this also changes the logic for the connectors-bundle and camunda. If this is not the intended behavior, i.e. other versions *shouldn't* use the non-snapshot labeled releases, please let me know, thank you!

closes https://github.com/camunda/camunda/issues/31795
