### PR TITLE
perf: increase scroll page size in getProcessInstanceIdsWithMatchingVars

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -311,7 +311,10 @@ public class VariableStoreElasticSearch implements VariableStore {
       boolQuery.must(QueryBuilders.termQuery(VALUE, varValues.get(i)));
 
       final SearchSourceBuilder searchSourceBuilder =
-          new SearchSourceBuilder().query(boolQuery).fetchSource(PROCESS_INSTANCE_ID, null);
+          new SearchSourceBuilder()
+              .query(boolQuery)
+              .fetchSource(PROCESS_INSTANCE_ID, null)
+              .size(tasklistProperties.getElasticsearch().getBatchSize());
 
       final SearchRequest searchRequest =
           new SearchRequest(variableIndex.getAlias()).source(searchSourceBuilder);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -331,7 +331,9 @@ public class VariableStoreOpenSearch implements VariableStore {
       final SearchRequest.Builder searchRequestBuilder = new SearchRequest.Builder();
       searchRequestBuilder
           .index(variableIndex.getAlias())
-          .query(q -> q.constantScore(cs -> cs.filter(boolQuery)));
+          .query(q -> q.constantScore(cs -> cs.filter(boolQuery)))
+          .source(s -> s.filter(f -> f.includes(PROCESS_INSTANCE_ID)))
+          .size(tasklistProperties.getOpenSearch().getBatchSize());
       final Set<String> currentIds;
       try {
         currentIds =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When scrolling, fetching ids by batchSize tasklist property (default 200) instead of the default 10 of elasticsearch

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/32336
