### PR TITLE
[Backport stable/8.5] feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -9,33 +9,57 @@ package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+<<<<<<< HEAD
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.Collections;
+=======
+import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import java.util.ArrayList;
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 public class DbMigratorImplTest {
 
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  MigrationTaskContextImpl context;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    migrations.clear();
+    sut = new DbMigratorImpl(true, context, migrations, CURRENT_VERSION);
+  }
+
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var sut =
         new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+=======
+    when(mockMigration.needsToRun(context)).thenReturn(true);
+    migrations.add(mockMigration);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when
     sut.runMigrations();
@@ -47,14 +71,16 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
 
     final var sut =
         new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+=======
+    when(mockMigration.needsToRun(context)).thenReturn(false);
+    migrations.add(mockMigration);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when
     sut.runMigrations();
@@ -66,16 +92,21 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration1 = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+=======
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
+<<<<<<< HEAD
     final var sut =
         new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+=======
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when
     sut.runMigrations();
@@ -90,18 +121,22 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+=======
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
+<<<<<<< HEAD
     final var sut =
         new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+=======
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when -- first migration fails
     doThrow(RuntimeException.class).when(mockMigration1).runMigration(mockProcessingState);
@@ -111,24 +146,28 @@ public class DbMigratorImplTest {
     // then -- second migration is not run
     verify(mockMigration2, never()).runMigration(any());
     // then -- version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+=======
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
+<<<<<<< HEAD
     final var sut =
         new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+=======
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when -- second migration fails
     doThrow(RuntimeException.class).when(mockMigration2).runMigration(mockProcessingState);
@@ -137,86 +176,150 @@ public class DbMigratorImplTest {
     assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
 
     // then -- the version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldSetVersionAfterRunningMigrations() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+=======
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
+<<<<<<< HEAD
     final var sut =
         new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+=======
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when -- running migrations
     sut.runMigrations();
 
     // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
   }
 
   @Test
-  void shouldThrowOnInvalidUpgrade() {
+  void shouldThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
+<<<<<<< HEAD
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
     final var sut =
         new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+=======
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Snapshot is not compatible with current version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
+  }
 
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+  @Test
+  void shouldThrowOnInvalidUpgradeFromAlpha() {
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(true, context, migrations, "2.0.0-alpha1");
 
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot upgrade to or from a pre-release version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot upgrade to or from a pre-release version");
 
     // then -- migration is not run
+<<<<<<< HEAD
     verify(mockMigration, never()).runMigration(mockProcessingState);
+=======
+    verify(mockMigration, never())
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromMinor() {
+    // given -- state that was migrated by version 1.0.0
+    final boolean versionCheckEnabled = false; // disable version check
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromAlphas() {
+    // given - upgrading to a pre-release version
+    final boolean versionCheckEnabled = false; // disable version check
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0-alpha1");
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    // then -- migration is run
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
   }
 
   @Test
   void shouldNotRunMigrationsIfTheSameVersion() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
     // the version is the same as the migrated version
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final String currentVersion = VersionUtil.getVersion();
-    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
 
     final var mockMigration = mock(MigrationTask.class);
 
+<<<<<<< HEAD
     final var sut =
         new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+=======
+    migrations.add(mockMigration);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
 
     // when
     sut.runMigrations();
 
     // then
     verify(mockMigration, never()).runMigration(mockProcessingState);
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }


### PR DESCRIPTION
# Description
Backport of #32419 to `stable/8.5`.

relates to #32388