### PR TITLE
[Backport stable/8.6] feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistribution
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,34 +65,81 @@ public class DbMigratorImpl implements DbMigrator {
   // should be solved first, before adding any migration that can take a long time
   private final MutableMigrationTaskContext migrationTaskContext;
   private final List<MigrationTask> migrationTasks;
+<<<<<<< HEAD
 
   public DbMigratorImpl(
       final ClusterContext clusterContext, final MutableProcessingState processingState) {
     this(new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS);
+=======
+  private final String currentVersion;
+  private final boolean versionCheckRestrictionEnabled;
+
+  private int skippedMigrations = 0;
+
+  public DbMigratorImpl(
+      final boolean versionCheckRestrictionEnabled,
+      final ClusterContext clusterContext,
+      final MutableProcessingState processingState) {
+    this(
+        versionCheckRestrictionEnabled,
+        new MigrationTaskContextImpl(clusterContext, processingState),
+        MIGRATION_TASKS,
+        null);
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
   }
 
   public DbMigratorImpl(
       final MutableMigrationTaskContext migrationTaskContext,
       final List<MigrationTask> migrationTasks) {
+<<<<<<< HEAD
+=======
+    this(true, migrationTaskContext, migrationTasks, null);
+  }
+
+  @VisibleForTesting
+  public DbMigratorImpl(
+      final boolean versionCheckRestrictionEnabled,
+      final MutableMigrationTaskContext migrationTaskContext,
+      final List<MigrationTask> migrationTasks,
+      final String currentVersion) {
+    this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
     this.migrationTaskContext = migrationTaskContext;
     this.migrationTasks = migrationTasks;
+    this.currentVersion = currentVersion != null ? currentVersion : VersionUtil.getVersion();
   }
 
   @Override
   public void runMigrations() {
+<<<<<<< HEAD
     if (checkVersionCompatibility() instanceof Compatible.SameVersion) {
       LOGGER.info("No migrations to run, snapshot is the same as current version");
       return;
+=======
+    var runMigrations = true;
+    switch (checkVersionCompatibility()) {
+      case final Indeterminate.PreviousVersionUnknown unknown:
+        LOGGER.debug("Snapshot is empty, no migrations to run");
+        runMigrations = false;
+        break;
+      case final Compatible.SameVersion compatible:
+        LOGGER.debug("No migrations to run, snapshot is the same as current version");
+        return;
+      default:
+        break;
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
     }
     logPreview(migrationTasks);
 
     final var executedMigrations = new ArrayList<MigrationTask>();
-    for (int index = 1; index <= migrationTasks.size(); index++) {
-      // one based index looks nicer in logs
-      final var migration = migrationTasks.get(index - 1);
-      final var executed = handleMigrationTask(migration, index, migrationTasks.size());
-      if (executed) {
-        executedMigrations.add(migration);
+    if (runMigrations) {
+      for (int index = 1; index <= migrationTasks.size(); index++) {
+        // one based index looks nicer in logs
+        final var migration = migrationTasks.get(index - 1);
+        final var executed = handleMigrationTask(migration, index, migrationTasks.size());
+        if (executed) {
+          executedMigrations.add(migration);
+        }
       }
     }
     markMigrationsAsCompleted();
@@ -101,7 +149,6 @@ public class DbMigratorImpl implements DbMigrator {
   private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {
     final var migratedByVersion =
         migrationTaskContext.processingState().getMigrationState().getMigratedByVersion();
-    final var currentVersion = VersionUtil.getVersion();
     final CheckResult checkResult =
         VersionCompatibilityCheck.check(migratedByVersion, currentVersion);
     switch (checkResult) {
@@ -127,10 +174,7 @@ public class DbMigratorImpl implements DbMigrator {
   }
 
   private void markMigrationsAsCompleted() {
-    migrationTaskContext
-        .processingState()
-        .getMigrationState()
-        .setMigratedByVersion(VersionUtil.getVersion());
+    migrationTaskContext.processingState().getMigrationState().setMigratedByVersion(currentVersion);
   }
 
   private void logPreview(final List<MigrationTask> migrationTasks) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -9,35 +9,45 @@ package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
-import io.camunda.zeebe.util.VersionUtil;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 public class DbMigratorImplTest {
 
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  MigrationTaskContextImpl context;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    migrations.clear();
+    sut = new DbMigratorImpl(true, context, migrations, CURRENT_VERSION);
+  }
+
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(true);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -49,15 +59,9 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(false);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -69,17 +73,12 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -94,19 +93,13 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- first migration fails
     doThrow(RuntimeException.class).when(mockMigration1).runMigration(context);
@@ -116,25 +109,19 @@ public class DbMigratorImplTest {
     // then -- second migration is not run
     verify(mockMigration2, never()).runMigration(any());
     // then -- version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- second migration fails
     doThrow(RuntimeException.class).when(mockMigration2).runMigration(context);
@@ -143,64 +130,54 @@ public class DbMigratorImplTest {
     assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
 
     // then -- the version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldSetVersionAfterRunningMigrations() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- running migrations
     sut.runMigrations();
 
     // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
   }
 
   @Test
-  void shouldThrowOnInvalidUpgrade() {
+  void shouldThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(any())).thenReturn(true);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Snapshot is not compatible with current version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
+  }
 
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+  @Test
+  void shouldThrowOnInvalidUpgradeFromAlpha() {
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(true, context, migrations, "2.0.0-alpha1");
 
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot upgrade to or from a pre-release version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot upgrade to or from a pre-release version");
 
     // then -- migration is not run
     verify(mockMigration, never())
@@ -208,26 +185,74 @@ public class DbMigratorImplTest {
   }
 
   @Test
+<<<<<<< HEAD
+=======
+  void shouldNotThrowOnInvalidUpgradeFromMinor() {
+    // given -- state that was migrated by version 1.0.0
+    final boolean versionCheckEnabled = false; // disable version check
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromAlphas() {
+    // given - upgrading to a pre-release version
+    final boolean versionCheckEnabled = false; // disable version check
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0-alpha1");
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    // then -- migration is run
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+>>>>>>> 98eca57b (feat: skip running all migrations when zeebe is run for the first time)
   void shouldNotRunMigrationsIfTheSameVersion() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
     // the version is the same as the migrated version
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final String currentVersion = VersionUtil.getVersion();
-    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
 
     final var mockMigration = mock(MigrationTask.class);
 
-    final var sut =
-        new DbMigratorImpl(
-            new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState),
-            Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
 
     // then
     verify(mockMigration, never()).runMigration(any());
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }


### PR DESCRIPTION
# Description
Backport of #32419 to `stable/8.6`.

relates to #32388