### PR TITLE
feat: add broker version to PartitionTransitionContext to simplify testing

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.List;
 
@@ -82,4 +83,8 @@ public interface PartitionContext {
    * does not update during scale up.
    */
   int getPartitionCount();
+
+  default String getBrokerVersion() {
+    return VersionUtil.getVersion();
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -54,7 +54,8 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
         new DbMigratorImpl(
             context.getBrokerCfg().getExperimental().isVersionCheckRestrictionEnabled(),
             new ClusterContextImpl(context.getPartitionCount()),
-            processingState);
+            processingState,
+            context.getBrokerVersion());
     try {
       dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -83,6 +83,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ControllableStreamClock clock;
   private SecurityConfiguration securityConfig;
   private MeterRegistry transitionMeterRegistry;
+  private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
@@ -194,6 +195,15 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public int getPartitionCount() {
     return 1;
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  public void setBrokerVersion(final String version) {
+    brokerVersion = version;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -75,18 +75,13 @@ public class DbMigratorImpl implements DbMigrator {
   public DbMigratorImpl(
       final boolean versionCheckRestrictionEnabled,
       final ClusterContext clusterContext,
-      final MutableProcessingState processingState) {
+      final MutableProcessingState processingState,
+      final String version) {
     this(
         versionCheckRestrictionEnabled,
         new MigrationTaskContextImpl(clusterContext, processingState),
         MIGRATION_TASKS,
-        null);
-  }
-
-  public DbMigratorImpl(
-      final MutableMigrationTaskContext migrationTaskContext,
-      final List<MigrationTask> migrationTasks) {
-    this(true, migrationTaskContext, migrationTasks, null);
+        version);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## Description
The version is added to the `PartitionTransitionContext` but it always equals `VersionUtil.getVersion`.
In `TestPartitionContext` it's mutable and can simplify testing when a specific version must be set.

Used in PR #32388
