### PR TITLE
Add tenant delete authorization tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.tenant;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteTenantAuthorizationTest {
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getMultiTenancy().setEnabled(true);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToDeleteAssignedTenantWithPermissions() {
+    // given
+    final var user = createUser();
+    final var tenantId = UUID.randomUUID().toString();
+    createTenant(tenantId);
+    addPermissionsToUser(user, AuthorizationResourceType.TENANT, PermissionType.DELETE, tenantId);
+    assignUserToTenant(user.getUsername(), tenantId);
+
+    // when
+    engine.tenant().deleteTenant(tenantId).delete(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.tenantRecords()
+                .withTenantId(tenantId)
+                .withIntent(TenantIntent.DELETED)
+                .count())
+        .isOne();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToDeleteUnassignedTenantWithPermissions() {
+    // given
+    final var user = createUser();
+    final var tenantId = UUID.randomUUID().toString();
+    createTenant(tenantId);
+
+    // when / then
+    final var rejectedDeleteRecord =
+        engine.tenant().deleteTenant(tenantId).expectRejection().delete(user.getUsername());
+
+    // then
+    assertThat(rejectedDeleteRecord)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'DELETE' on resource 'TENANT', required resource identifiers are one of '[*, %s]'"
+                .formatted(tenantId));
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(DEFAULT_USER.getUsername())
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private TenantRecordValue createTenant(final String tenantId) {
+    return engine.tenant().newTenant().withTenantId(tenantId).create().getValue();
+  }
+
+  private void assignUserToTenant(final String username, final String tenantId) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -336,6 +336,7 @@ public class TenantClient {
     private final CommandWriter writer;
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
+    private final boolean expectRejection = false;
 
     public TenantDeleteClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;
@@ -350,6 +351,16 @@ public class TenantClient {
      */
     public Record<TenantRecordValue> delete() {
       final long position = writer.writeCommand(TenantIntent.DELETE, tenantRecord);
+      return expectation.apply(position);
+    }
+
+    /**
+     * Submits a user-requested delete command for the tenant and returns the resulting record.
+     *
+     * @return the deleted tenant record
+     */
+    public Record<TenantRecordValue> delete(final String username) {
+      final long position = writer.writeCommand(TenantIntent.DELETE, username, tenantRecord);
       return expectation.apply(position);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ensure that only authorized tenants may delete
tenants.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31623 
