### PR TITLE
feat: expose get token related to the logged in user endpoint

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.service;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOAuthPrincipal;
+import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -61,6 +62,12 @@ public class OidcCamundaUserService implements CamundaUserService {
 
   @Override
   public String getUserToken() {
-    return "";
+    return getCamundaUser()
+        .map(
+            user -> {
+              final var oidcUser = (CamundaOidcUser) user;
+              return oidcUser.getIdToken().getTokenValue();
+            })
+        .orElse(null);
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/OidcCamundaUserService.java
@@ -65,8 +65,11 @@ public class OidcCamundaUserService implements CamundaUserService {
     return getCamundaUser()
         .map(
             user -> {
-              final var oidcUser = (CamundaOidcUser) user;
-              return oidcUser.getIdToken().getTokenValue();
+              if (user instanceof final CamundaOidcUser camundaOAuthPrincipal) {
+                return camundaOAuthPrincipal.getIdToken().getTokenValue();
+              }
+
+              return null;
             })
         .orElse(null);
   }

--- a/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/OidcCamundaUserServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.entity.CamundaOidcUser;
+import io.camunda.authentication.service.OidcCamundaUserService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+public class OidcCamundaUserServiceTest {
+  private static final String TOKEN_VALUE =
+      "{\"access_token\":\"test-access-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}";
+  private static final Instant TOKEN_ISSUED_AT = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+  private static final Instant TOKEN_EXPIRES_AT = TOKEN_ISSUED_AT.plus(1, ChronoUnit.DAYS);
+
+  private Authentication mockAuthentication;
+  private CamundaOidcUser mockCamundaOidcUser;
+  private SecurityContext mockSecurityContext;
+  private OidcCamundaUserService oidcCamundaUserService;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    oidcCamundaUserService = new OidcCamundaUserService();
+  }
+
+  @Test
+  public void givenCamundaOidcUserWhenGetUserTokenThenTokenIsCalled() {
+    final var principal =
+        new CamundaOidcUser(
+            new DefaultOidcUser(
+                Collections.emptyList(),
+                new OidcIdToken(
+                    TOKEN_VALUE,
+                    Instant.now(),
+                    Instant.now().plusSeconds(3600),
+                    Map.of("sub", "not-tested"))),
+            Collections.emptySet(),
+            null);
+
+    final var auth = new OAuth2AuthenticationToken(principal, List.of(), "oidc");
+    SecurityContextHolder.getContext().setAuthentication(auth);
+
+    assertThat(oidcCamundaUserService.getUserToken()).isEqualTo(TOKEN_VALUE);
+  }
+}

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -20,6 +20,10 @@
   <dependencies>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -19,6 +19,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/security/security-core/src/main/java/io/camunda/security/ConditionalOnSaaSConfigured.java
+++ b/security/security-core/src/main/java/io/camunda/security/ConditionalOnSaaSConfigured.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security;
+
+import io.camunda.security.ConditionalOnSaaSConfigured.SaaSConfiguredCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(SaaSConfiguredCondition.class)
+public @interface ConditionalOnSaaSConfigured {
+  final class SaaSConfiguredCondition implements Condition {
+
+    private final List<String> properties =
+        Arrays.asList("camunda.security.saas.organizationId", "camunda.security.saas.clusterId");
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      return properties.stream()
+          .map(key -> context.getEnvironment().getProperty(key))
+          .allMatch(value -> value != null && !value.isEmpty());
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SaaSTokenController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SaaSTokenController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.authentication.service.CamundaUserService;
+import io.camunda.security.ConditionalOnSaaSConfigured;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Profile("consolidated-auth")
+@ConditionalOnSaaSConfigured
+@CamundaRestController
+@RequestMapping("/v2/authentication")
+public class SaaSTokenController {
+  private final CamundaUserService camundaUserService;
+
+  public SaaSTokenController(final CamundaUserService camundaUserService) {
+    this.camundaUserService = camundaUserService;
+  }
+
+  @CamundaGetMapping(path = "/me/token")
+  public ResponseEntity<String> getCurrentToken() {
+    final var idToken = camundaUserService.getUserToken();
+
+    return idToken == null
+        ? ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        : ResponseEntity.ok(idToken);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As per the linked issue this PR introduces a new (undocumented endpoint) that returns the token linked to the currently logged in user. Some things to note:
1. I have used inspiration from the old implementations regarding the return structure (a String) although I'm happy to change this I felt it was best to reduce the effort/change set in the calling code
2. I have extended the concept we have for `/authentication/me` to add `/token` to the end so its aligned
3. As requested, this controller/endpoint is only loaded when the configurations are in place for SaaS.

## Related issues

closes https://github.com/camunda/camunda/issues/32452
