### PR TITLE
[Backport stable/8.4] [Backport stable/8.7] feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_2.DecisionRequirementsMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyDecisionStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyJobStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyMessageStartEventSubscriptionStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyMessageStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyMessageSubscriptionStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyProcessMessageSubscriptionStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyProcessStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.stream.api.ClusterContext;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DbMigratorImpl implements DbMigrator {
+
+  // add new migration tasks here, migrations are executed in the order they appear in the list
+  public static final List<MigrationTask> MIGRATION_TASKS =
+      List.of(
+          new ProcessMessageSubscriptionSentTimeMigration(),
+          new MessageSubscriptionSentTimeMigration(),
+          new TemporaryVariableMigration(),
+          new DecisionMigration(),
+          new DecisionRequirementsMigration(),
+          new ProcessInstanceByProcessDefinitionMigration(),
+          new JobTimeoutCleanupMigration(),
+          new JobBackoffCleanupMigration(),
+          new MultiTenancyProcessStateMigration(),
+          new MultiTenancyDecisionStateMigration(),
+          new MultiTenancyMessageStateMigration(),
+          new MultiTenancyMessageStartEventSubscriptionStateMigration(),
+          new MultiTenancyMessageSubscriptionStateMigration(),
+          new MultiTenancyProcessMessageSubscriptionStateMigration(),
+          new MultiTenancyJobStateMigration(),
+          new ColumnFamilyPrefixCorrectionMigration(),
+          new MultiTenancySignalSubscriptionStateMigration(),
+          new JobBackoffRestoreMigration(),
+          new RoutingInfoMigration(),
+          new OrderedCommandDistributionMigration());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
+  // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue
+  // should be solved first, before adding any migration that can take a long time
+  private final MutableMigrationTaskContext migrationTaskContext;
+  private final List<MigrationTask> migrationTasks;
+  private final String currentVersion;
+  private final boolean versionCheckRestrictionEnabled;
+
+  public DbMigratorImpl(
+      final ClusterContext clusterContext, final MutableProcessingState processingState) {
+    this(
+        true, new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS, null);
+  }
+
+  public DbMigratorImpl(
+      final boolean versionCheckRestrictionEnabled,
+      final ClusterContext clusterContext,
+      final MutableProcessingState processingState) {
+    this(
+        versionCheckRestrictionEnabled,
+        new MigrationTaskContextImpl(clusterContext, processingState),
+        MIGRATION_TASKS,
+        null);
+  }
+
+  public DbMigratorImpl(
+      final MutableMigrationTaskContext migrationTaskContext,
+      final List<MigrationTask> migrationTasks) {
+    this(true, migrationTaskContext, migrationTasks, null);
+  }
+
+  @VisibleForTesting
+  public DbMigratorImpl(
+      final boolean versionCheckRestrictionEnabled,
+      final MutableMigrationTaskContext migrationTaskContext,
+      final List<MigrationTask> migrationTasks,
+      final String currentVersion) {
+    this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+    this.migrationTaskContext = migrationTaskContext;
+    this.migrationTasks = migrationTasks;
+    this.currentVersion = currentVersion != null ? currentVersion : VersionUtil.getVersion();
+  }
+
+  @Override
+  public void runMigrations() {
+    var runMigrations = true;
+    switch (checkVersionCompatibility()) {
+      case final Indeterminate.PreviousVersionUnknown unknown:
+        LOGGER.debug("Snapshot is empty, no migrations to run");
+        runMigrations = false;
+        break;
+      case final Compatible.SameVersion compatible:
+        LOGGER.info("No migrations to run, snapshot is the same as current version");
+        return;
+      default:
+        break;
+    }
+    logPreview(migrationTasks);
+
+    final var executedMigrations = new ArrayList<MigrationTask>();
+    if (runMigrations) {
+      for (int index = 1; index <= migrationTasks.size(); index++) {
+        // one based index looks nicer in logs
+        final var migration = migrationTasks.get(index - 1);
+        final var executed = handleMigrationTask(migration, index, migrationTasks.size());
+        if (executed) {
+          executedMigrations.add(migration);
+        }
+      }
+    }
+    markMigrationsAsCompleted();
+    logSummary(executedMigrations);
+  }
+
+  private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {
+    final var migratedByVersion =
+        migrationTaskContext.processingState().getMigrationState().getMigratedByVersion();
+    final CheckResult checkResult =
+        VersionCompatibilityCheck.check(migratedByVersion, currentVersion);
+    switch (checkResult) {
+      case final Indeterminate.PreviousVersionUnknown previousVersionUnknown ->
+          LOGGER.trace(
+              "Snapshot is from an unknown version, not checking compatibility with current version: {}",
+              previousVersionUnknown);
+      case final Indeterminate indeterminate ->
+          LOGGER.warn(
+              "Could not check compatibility of snapshot with current version: {}", indeterminate);
+      case final Incompatible.UseOfPreReleaseVersion preRelease -> {
+        final String errorMsg =
+            "Cannot upgrade to or from a pre-release version: %s".formatted(preRelease);
+        if (versionCheckRestrictionEnabled) {
+          throw new IllegalStateException(errorMsg);
+        } else {
+          LOGGER.warn(
+              "Detected issue with migration, but ignoring as configured. Details: '{}'", errorMsg);
+        }
+      }
+      case final Incompatible incompatible -> {
+        final String errorMsg =
+            "Snapshot is not compatible with current version: %s".formatted(incompatible);
+        if (versionCheckRestrictionEnabled) {
+          throw new IllegalStateException(errorMsg);
+        } else {
+          LOGGER.warn(
+              "Detected issue with migration, but ignoring as configured. Details: '{}'", errorMsg);
+        }
+      }
+      case final Compatible.SameVersion sameVersion ->
+          LOGGER.trace("Snapshot is from the same version as the current version: {}", sameVersion);
+      case final Compatible compatible ->
+          LOGGER.debug("Snapshot is compatible with current version: {}", compatible);
+    }
+    return checkResult;
+  }
+
+  private void markMigrationsAsCompleted() {
+    migrationTaskContext.processingState().getMigrationState().setMigratedByVersion(currentVersion);
+  }
+
+  private void logPreview(final List<MigrationTask> migrationTasks) {
+    LOGGER.info(
+        "Starting processing {} migration tasks (use LogLevel.DEBUG for more details) ... ",
+        migrationTasks.size());
+    LOGGER.debug(
+        "Found {} migration tasks: {}",
+        migrationTasks.size(),
+        migrationTasks.stream()
+            .map(MigrationTask::getIdentifier)
+            .collect(Collectors.joining(", ")));
+  }
+
+  private void logSummary(final List<MigrationTask> migrationTasks) {
+    LOGGER.info(
+        "Completed processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
+    LOGGER.debug(
+        "Executed {} migration tasks: {}",
+        migrationTasks.size(),
+        migrationTasks.stream()
+            .map(MigrationTask::getIdentifier)
+            .collect(Collectors.joining(", ")));
+  }
+
+  private boolean handleMigrationTask(
+      final MigrationTask migrationTask, final int index, final int total) {
+    if (migrationTask.needsToRun(migrationTaskContext)) {
+      runMigration(migrationTask, index, total);
+      return true;
+    } else {
+      logMigrationSkipped(migrationTask, index, total);
+      return false;
+    }
+  }
+
+  private void logMigrationSkipped(
+      final MigrationTask migrationTask, final int index, final int total) {
+    LOGGER.info(
+        "Skipping {} migration ({}/{}).  It was determined it does not need to run right now.",
+        migrationTask.getIdentifier(),
+        index,
+        total);
+  }
+
+  private void runMigration(final MigrationTask migrationTask, final int index, final int total) {
+    LOGGER.info("Starting {} migration ({}/{})", migrationTask.getIdentifier(), index, total);
+    final var startTime = System.currentTimeMillis();
+    migrationTask.runMigration(migrationTaskContext);
+    final var duration = System.currentTimeMillis() - startTime;
+
+    LOGGER.debug("{} migration completed in {} ms.", migrationTask.getIdentifier(), duration);
+    LOGGER.info("Finished {} migration ({}/{})", migrationTask.getIdentifier(), index, total);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+public class DbMigratorImplTest {
+
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  MigrationTaskContextImpl context;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    migrations.clear();
+    sut = new DbMigratorImpl(true, context, migrations, CURRENT_VERSION);
+  }
+
+  @Test
+  void shouldRunMigrationThatNeedsToBeRun() {
+    // given
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(context)).thenReturn(true);
+    migrations.add(mockMigration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration).runMigration(context);
+  }
+
+  @Test
+  void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
+    // given
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(context)).thenReturn(false);
+    migrations.add(mockMigration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration, never()).runMigration(context);
+  }
+
+  @Test
+  void shouldRunMigrationsInOrder() {
+    // given
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(context)).thenReturn(true);
+
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+
+    // when
+    sut.runMigrations();
+
+    // then
+    final var inOrder = Mockito.inOrder(mockMigration1, mockMigration2);
+
+    inOrder.verify(mockMigration1).runMigration(context);
+    inOrder.verify(mockMigration2).runMigration(context);
+  }
+
+  @Test
+  void shouldNotSetVersionIfFirstMigrationFails() {
+    // given -- two migrations that both need to be run
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(context)).thenReturn(true);
+
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+
+    // when -- first migration fails
+    doThrow(RuntimeException.class).when(mockMigration1).runMigration(context);
+
+    // then -- running migrations fails
+    assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
+    // then -- second migration is not run
+    verify(mockMigration2, never()).runMigration(any());
+    // then -- version is not set
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
+  }
+
+  @Test
+  void shouldNotSetVersionIfSecondMigrationFails() {
+    // given -- two migrations that both need to be run
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(context)).thenReturn(true);
+
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+
+    // when -- second migration fails
+    doThrow(RuntimeException.class).when(mockMigration2).runMigration(context);
+
+    // then -- running migrations fails
+    assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
+
+    // then -- the version is not set
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
+  }
+
+  @Test
+  void shouldSetVersionAfterRunningMigrations() {
+    // given -- two migrations that both need to be run
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(context)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(context)).thenReturn(true);
+
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
+
+    // when -- running migrations
+    sut.runMigrations();
+
+    // then -- the version is set
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
+  }
+
+  @Test
+  void shouldThrowOnInvalidUpgradeFromMinor() {
+    // given -- state that was migrated by version 1.0.0
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+
+    // when -- upgrading to a version that is not compatible
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
+  }
+
+  @Test
+  void shouldThrowOnInvalidUpgradeFromAlpha() {
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(true, context, migrations, "2.0.0-alpha1");
+
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot upgrade to or from a pre-release version");
+
+    // then -- migration is not run
+    verify(mockMigration, never())
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromMinor() {
+    // given -- state that was migrated by version 1.0.0
+    final boolean versionCheckEnabled = false; // disable version check
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgradeFromAlphas() {
+    // given - upgrading to a pre-release version
+    final boolean versionCheckEnabled = false; // disable version check
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
+    sut = new DbMigratorImpl(versionCheckEnabled, context, migrations, "2.0.0-alpha1");
+    // when/then -- running migrations throws
+    assertThatNoException().isThrownBy(sut::runMigrations);
+
+    // then -- migration is run
+    verify(mockMigration, times(1))
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotRunMigrationsIfTheSameVersion() {
+    // given
+    // the version is the same as the migrated version
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
+
+    final var mockMigration = mock(MigrationTask.class);
+
+    migrations.add(mockMigration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration, never()).runMigration(any());
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
+  }
+}


### PR DESCRIPTION
# Description
Backport of #32639 to `stable/8.4`.

relates to #32419 #32388