### PR TITLE
[Backport stable/8.5] feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -79,11 +79,11 @@ public class DbMigratorImpl implements DbMigrator {
 
   @Override
   public void runMigrations() {
-    var runMigrations = true;
+    var initializationOnly = false;
     switch (checkVersionCompatibility()) {
       case final Indeterminate.PreviousVersionUnknown unknown:
         LOGGER.debug("Snapshot is empty, no migrations to run");
-        runMigrations = false;
+        initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
         LOGGER.info("No migrations to run, snapshot is the same as current version");
@@ -93,19 +93,27 @@ public class DbMigratorImpl implements DbMigrator {
     }
     logPreview(migrationTasks);
 
-    final var executedMigrations = new ArrayList<MigrationTask>();
-    if (runMigrations) {
-      for (int index = 1; index <= migrationTasks.size(); index++) {
-        // one based index looks nicer in logs
-        final var migration = migrationTasks.get(index - 1);
-        final var executed = handleMigrationTask(migration, index, migrationTasks.size());
-        if (executed) {
-          executedMigrations.add(migration);
-        }
-      }
-    }
+    final var executedMigrations = runMigrations(initializationOnly);
+
     markMigrationsAsCompleted();
     logSummary(executedMigrations);
+  }
+
+  private List<MigrationTask> runMigrations(final boolean initializationOnly) {
+    final var executedMigrations = new ArrayList<MigrationTask>();
+    var migrationsToRun = migrationTasks; // no copy is needed
+    if (initializationOnly) {
+      migrationsToRun = migrationsToRun.stream().filter(MigrationTask::isInitialization).toList();
+    }
+    for (int index = 1; index <= migrationsToRun.size(); index++) {
+      // one based index looks nicer in logs
+      final var migration = migrationsToRun.get(index - 1);
+      final var executed = handleMigrationTask(migration, index, migrationsToRun.size());
+      if (executed) {
+        executedMigrations.add(migration);
+      }
+    }
+    return executedMigrations;
   }
 
   private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -60,6 +60,14 @@ public interface MigrationTask {
   boolean needsToRun(final ProcessingState processingState);
 
   /**
+   * Returns whether the migration is an initialization task, that must be executed even when the
+   * database is empty.
+   */
+  default boolean isInitialization() {
+    return false;
+  }
+
+  /**
    * Implementations of this method perform the actual migration
    *
    * @param processingState the mutable Zeebe state

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -211,7 +211,27 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
+    verify(migration).isInitialization();
     verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
+  }
+
+  @Test
+  void shouldOnlyRunInitializationMigrationsWhenDbIsEmpty() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    when(migration.isInitialization()).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration).isInitialization();
+    verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -9,33 +9,43 @@ package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.util.VersionUtil;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 public class DbMigratorImplTest {
 
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    migrations.clear();
+    sut = new DbMigratorImpl(mockProcessingState, migrations, CURRENT_VERSION);
+  }
+
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -47,14 +57,9 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
-
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -66,16 +71,12 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration1 = mock(MigrationTask.class);
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -90,18 +91,13 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- first migration fails
     doThrow(RuntimeException.class).when(mockMigration1).runMigration(mockProcessingState);
@@ -111,24 +107,19 @@ public class DbMigratorImplTest {
     // then -- second migration is not run
     verify(mockMigration2, never()).runMigration(any());
     // then -- version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- second migration fails
     doThrow(RuntimeException.class).when(mockMigration2).runMigration(mockProcessingState);
@@ -137,62 +128,53 @@ public class DbMigratorImplTest {
     assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
 
     // then -- the version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldSetVersionAfterRunningMigrations() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
     when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- running migrations
     sut.runMigrations();
 
     // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
   }
 
   @Test
-  void shouldThrowOnInvalidUpgrade() {
+  void shouldThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(mockProcessingState)).thenReturn(true);
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Snapshot is not compatible with current version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
+  }
 
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+  @Test
+  void shouldThrowOnInvalidUpgradeFromAlpha() {
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("2.0.0-alpha1");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    migrations.add(mockMigration);
 
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot upgrade to or from a pre-release version");
-    }
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot upgrade to or from a pre-release version");
 
     // then -- migration is not run
     verify(mockMigration, never()).runMigration(mockProcessingState);
@@ -201,22 +183,35 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationsIfTheSameVersion() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
     // the version is the same as the migrated version
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final String currentVersion = VersionUtil.getVersion();
-    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
 
     final var mockMigration = mock(MigrationTask.class);
 
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
 
     // then
     verify(mockMigration, never()).runMigration(mockProcessingState);
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }


### PR DESCRIPTION
# Description
Backport of #32639 to `stable/8.5`.

relates to #32419 #32388