### PR TITLE
[Backport stable/8.6]  feat: skip running all migrations when zeebe is run for the first time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -87,7 +87,7 @@ public class DbMigratorImpl implements DbMigrator {
     var initializationOnly = false;
     switch (checkVersionCompatibility()) {
       case final Indeterminate.PreviousVersionUnknown unknown:
-        LOGGER.debug("Snapshot is empty, no migrations to run");
+        LOGGER.debug("Snapshot is empty, only initialization migrations will be run.");
         initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
@@ -96,7 +96,7 @@ public class DbMigratorImpl implements DbMigrator {
       default:
         break;
     }
-    logPreview(migrationTasks);
+    logPreview(migrationTasks, initializationOnly);
 
     final var executedMigrations = runMigrations(initializationOnly);
 
@@ -152,7 +152,8 @@ public class DbMigratorImpl implements DbMigrator {
     migrationTaskContext.processingState().getMigrationState().setMigratedByVersion(currentVersion);
   }
 
-  private void logPreview(final List<MigrationTask> migrationTasks) {
+  private void logPreview(
+      final List<MigrationTask> migrationTasks, final boolean initializationOnly) {
     LOGGER.info(
         "Starting processing {} migration tasks (use LogLevel.DEBUG for more details) ... ",
         migrationTasks.size());
@@ -160,6 +161,7 @@ public class DbMigratorImpl implements DbMigrator {
         "Found {} migration tasks: {}",
         migrationTasks.size(),
         migrationTasks.stream()
+            .filter(task -> !initializationOnly || task.isInitialization())
             .map(MigrationTask::getIdentifier)
             .collect(Collectors.joining(", ")));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistribution
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,34 +65,48 @@ public class DbMigratorImpl implements DbMigrator {
   // should be solved first, before adding any migration that can take a long time
   private final MutableMigrationTaskContext migrationTaskContext;
   private final List<MigrationTask> migrationTasks;
+  private final String currentVersion;
 
   public DbMigratorImpl(
       final ClusterContext clusterContext, final MutableProcessingState processingState) {
-    this(new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS);
+    this(new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS, null);
   }
 
+  @VisibleForTesting
   public DbMigratorImpl(
       final MutableMigrationTaskContext migrationTaskContext,
-      final List<MigrationTask> migrationTasks) {
+      final List<MigrationTask> migrationTasks,
+      final String currentVersion) {
     this.migrationTaskContext = migrationTaskContext;
     this.migrationTasks = migrationTasks;
+    this.currentVersion = currentVersion != null ? currentVersion : VersionUtil.getVersion();
   }
 
   @Override
   public void runMigrations() {
-    if (checkVersionCompatibility() instanceof Compatible.SameVersion) {
-      LOGGER.info("No migrations to run, snapshot is the same as current version");
-      return;
+    var runMigrations = true;
+    switch (checkVersionCompatibility()) {
+      case final Indeterminate.PreviousVersionUnknown unknown:
+        LOGGER.debug("Snapshot is empty, no migrations to run");
+        runMigrations = false;
+        break;
+      case final Compatible.SameVersion compatible:
+        LOGGER.info("No migrations to run, snapshot is the same as current version");
+        return;
+      default:
+        break;
     }
     logPreview(migrationTasks);
 
     final var executedMigrations = new ArrayList<MigrationTask>();
-    for (int index = 1; index <= migrationTasks.size(); index++) {
-      // one based index looks nicer in logs
-      final var migration = migrationTasks.get(index - 1);
-      final var executed = handleMigrationTask(migration, index, migrationTasks.size());
-      if (executed) {
-        executedMigrations.add(migration);
+    if (runMigrations) {
+      for (int index = 1; index <= migrationTasks.size(); index++) {
+        // one based index looks nicer in logs
+        final var migration = migrationTasks.get(index - 1);
+        final var executed = handleMigrationTask(migration, index, migrationTasks.size());
+        if (executed) {
+          executedMigrations.add(migration);
+        }
       }
     }
     markMigrationsAsCompleted();
@@ -101,7 +116,6 @@ public class DbMigratorImpl implements DbMigrator {
   private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {
     final var migratedByVersion =
         migrationTaskContext.processingState().getMigrationState().getMigratedByVersion();
-    final var currentVersion = VersionUtil.getVersion();
     final CheckResult checkResult =
         VersionCompatibilityCheck.check(migratedByVersion, currentVersion);
     switch (checkResult) {
@@ -121,21 +135,19 @@ public class DbMigratorImpl implements DbMigrator {
       case final Compatible.SameVersion sameVersion ->
           LOGGER.trace("Snapshot is from the same version as the current version: {}", sameVersion);
       case final Compatible compatible ->
-          LOGGER.info("Snapshot is compatible with current version: {}", compatible);
+          LOGGER.debug("Snapshot is compatible with current version: {}", compatible);
     }
     return checkResult;
   }
 
   private void markMigrationsAsCompleted() {
-    migrationTaskContext
-        .processingState()
-        .getMigrationState()
-        .setMigratedByVersion(VersionUtil.getVersion());
+    migrationTaskContext.processingState().getMigrationState().setMigratedByVersion(currentVersion);
   }
 
   private void logPreview(final List<MigrationTask> migrationTasks) {
     LOGGER.info(
-        "Starting processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
+        "Starting processing {} migration tasks (use LogLevel.DEBUG for more details) ... ",
+        migrationTasks.size());
     LOGGER.debug(
         "Found {} migration tasks: {}",
         migrationTasks.size(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -57,7 +57,7 @@ public class DbMigratorImpl implements DbMigrator {
           new ColumnFamilyPrefixCorrectionMigration(),
           new MultiTenancySignalSubscriptionStateMigration(),
           new JobBackoffRestoreMigration(),
-          new RoutingInfoMigration(),
+          new RoutingInfoInitializationMigration(),
           new OrderedCommandDistributionMigration());
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
@@ -91,7 +91,7 @@ public class DbMigratorImpl implements DbMigrator {
         initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
-        LOGGER.info("No migrations to run, snapshot is the same as current version");
+        LOGGER.debug("No migrations to run, snapshot is the same as current version");
         return;
       default:
         break;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -84,11 +84,11 @@ public class DbMigratorImpl implements DbMigrator {
 
   @Override
   public void runMigrations() {
-    var runMigrations = true;
+    var initializationOnly = false;
     switch (checkVersionCompatibility()) {
       case final Indeterminate.PreviousVersionUnknown unknown:
         LOGGER.debug("Snapshot is empty, no migrations to run");
-        runMigrations = false;
+        initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
         LOGGER.info("No migrations to run, snapshot is the same as current version");
@@ -98,19 +98,27 @@ public class DbMigratorImpl implements DbMigrator {
     }
     logPreview(migrationTasks);
 
-    final var executedMigrations = new ArrayList<MigrationTask>();
-    if (runMigrations) {
-      for (int index = 1; index <= migrationTasks.size(); index++) {
-        // one based index looks nicer in logs
-        final var migration = migrationTasks.get(index - 1);
-        final var executed = handleMigrationTask(migration, index, migrationTasks.size());
-        if (executed) {
-          executedMigrations.add(migration);
-        }
-      }
-    }
+    final var executedMigrations = runMigrations(initializationOnly);
+
     markMigrationsAsCompleted();
     logSummary(executedMigrations);
+  }
+
+  private List<MigrationTask> runMigrations(final boolean initializationOnly) {
+    final var executedMigrations = new ArrayList<MigrationTask>();
+    var migrationsToRun = migrationTasks; // no copy is needed
+    if (initializationOnly) {
+      migrationsToRun = migrationsToRun.stream().filter(MigrationTask::isInitialization).toList();
+    }
+    for (int index = 1; index <= migrationsToRun.size(); index++) {
+      // one based index looks nicer in logs
+      final var migration = migrationsToRun.get(index - 1);
+      final var executed = handleMigrationTask(migration, index, migrationsToRun.size());
+      if (executed) {
+        executedMigrations.add(migration);
+      }
+    }
+    return executedMigrations;
   }
 
   private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTask.java
@@ -51,6 +51,14 @@ public interface MigrationTask {
   /** Returns whether the migration needs to run. */
   boolean needsToRun(final MigrationTaskContext context);
 
+  /**
+   * Returns whether the migration is an initialization task, that must be executed even when the
+   * database is empty.
+   */
+  default boolean isInitialization() {
+    return false;
+  }
+
   /** Implementations of this method perform the actual migration */
   void runMigration(final MutableMigrationTaskContext context);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-public class RoutingInfoMigration implements MigrationTask {
+public class RoutingInfoInitializationMigration implements MigrationTask {
 
   @Override
   public String getIdentifier() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigration.java
@@ -20,6 +20,11 @@ public class RoutingInfoMigration implements MigrationTask {
   }
 
   @Override
+  public boolean isInitialization() {
+    return true;
+  }
+
+  @Override
   public void runMigration(final MutableMigrationTaskContext context) {
     final var routingState = context.processingState().getRoutingState();
     final var partitionCount = context.clusterContext().partitionCount();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -197,7 +197,27 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
+    verify(migration).isInitialization();
     verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
+  }
+
+  @Test
+  void shouldOnlyRunInitializationMigrationsWhenDbIsEmpty() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    when(migration.isInitialization()).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration).isInitialization();
+    verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.migration;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -197,7 +198,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration, never()).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
@@ -216,7 +217,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -29,10 +29,10 @@ import org.mockito.Mockito;
 public class DbMigratorImplTest {
 
   private static final String CURRENT_VERSION = "8.8.0";
-  MutableProcessingState mockProcessingState;
-  MigrationTaskContextImpl context;
-  ArrayList<MigrationTask> migrations = new ArrayList<>();
-  DbMigratorImpl sut;
+  private MutableProcessingState mockProcessingState;
+  private MigrationTaskContextImpl context;
+  private final ArrayList<MigrationTask> migrations = new ArrayList<>();
+  private DbMigratorImpl sut;
 
   @BeforeEach
   public void setup() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -9,35 +9,45 @@ package io.camunda.zeebe.engine.state.migration;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.impl.ClusterContextImpl;
-import io.camunda.zeebe.util.VersionUtil;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 public class DbMigratorImplTest {
 
+  private static final String CURRENT_VERSION = "8.8.0";
+  MutableProcessingState mockProcessingState;
+  MigrationTaskContextImpl context;
+  ArrayList<MigrationTask> migrations = new ArrayList<>();
+  DbMigratorImpl sut;
+
+  @BeforeEach
+  public void setup() {
+    mockProcessingState = mock(MutableProcessingState.class, Answers.RETURNS_DEEP_STUBS);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("8.7.0");
+    context = new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    migrations.clear();
+    sut = new DbMigratorImpl(context, migrations, CURRENT_VERSION);
+  }
+
   @Test
   void shouldRunMigrationThatNeedsToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(true);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -49,15 +59,9 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotRunMigrationThatDoesNotNeedToBeRun() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration.needsToRun(context)).thenReturn(false);
-
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
@@ -69,17 +73,12 @@ public class DbMigratorImplTest {
   @Test
   void shouldRunMigrationsInOrder() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();
@@ -94,19 +93,13 @@ public class DbMigratorImplTest {
   @Test
   void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- first migration fails
     doThrow(RuntimeException.class).when(mockMigration1).runMigration(context);
@@ -116,25 +109,19 @@ public class DbMigratorImplTest {
     // then -- second migration is not run
     verify(mockMigration2, never()).runMigration(any());
     // then -- version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- second migration fails
     doThrow(RuntimeException.class).when(mockMigration2).runMigration(context);
@@ -143,91 +130,74 @@ public class DbMigratorImplTest {
     assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
 
     // then -- the version is not set
-    verify(mockMigrationState, never()).setMigratedByVersion(any());
+    verify(mockProcessingState.getMigrationState(), never()).setMigratedByVersion(any());
   }
 
   @Test
   void shouldSetVersionAfterRunningMigrations() {
     // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
     final var mockMigration1 = mock(MigrationTask.class);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
     when(mockMigration1.needsToRun(context)).thenReturn(true);
 
     final var mockMigration2 = mock(MigrationTask.class);
     when(mockMigration2.needsToRun(context)).thenReturn(true);
 
-    final var sut = new DbMigratorImpl(context, List.of(mockMigration1, mockMigration2));
+    migrations.addAll(List.of(mockMigration1, mockMigration2));
 
     // when -- running migrations
     sut.runMigrations();
 
     // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(CURRENT_VERSION);
   }
 
   @Test
-  void shouldThrowOnInvalidUpgrade() {
+  void shouldThrowOnInvalidUpgradeFromMinor() {
     // given -- state that was migrated by version 1.0.0
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn("1.0.0");
     final var mockMigration = mock(MigrationTask.class);
     when(mockMigration.needsToRun(any())).thenReturn(true);
-    final var context =
-        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
-    final var sut = new DbMigratorImpl(context, Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when -- upgrading to a version that is not compatible
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Snapshot is not compatible with current version");
-    }
-
-    // when - upgrading to a pre-release version
-    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
-      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
-
-      // then -- running migrations throws
-      assertThatThrownBy(sut::runMigrations)
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Cannot upgrade to or from a pre-release version");
-    }
-
-    // then -- migration is not run
-    verify(mockMigration, never())
-        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+    // then -- running migrations throws
+    assertThatThrownBy(sut::runMigrations)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not compatible with current version");
   }
 
   @Test
   void shouldNotRunMigrationsIfTheSameVersion() {
     // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
     // the version is the same as the migrated version
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final String currentVersion = VersionUtil.getVersion();
-    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+    when(mockProcessingState.getMigrationState().getMigratedByVersion())
+        .thenReturn(CURRENT_VERSION);
 
     final var mockMigration = mock(MigrationTask.class);
 
-    final var sut =
-        new DbMigratorImpl(
-            new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState),
-            Collections.singletonList(mockMigration));
+    migrations.add(mockMigration);
 
     // when
     sut.runMigrations();
 
     // then
     verify(mockMigration, never()).runMigration(any());
+  }
+
+  @Test
+  void shouldNotRunMigrationsWhenNoVersionIsSavedInTheState() {
+    // given
+    when(mockProcessingState.getMigrationState().getMigratedByVersion()).thenReturn(null);
+
+    final var migration = mock(MigrationTask.class);
+    when(migration.needsToRun(any())).thenReturn(true);
+    migrations.add(migration);
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(migration, never()).runMigration(any());
+    verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoInitializationMigrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
-final class RoutingInfoMigrationTest {
+final class RoutingInfoInitializationMigrationTest {
   @SuppressWarnings("unused")
   private MutableProcessingState processingState;
 
@@ -27,7 +27,7 @@ final class RoutingInfoMigrationTest {
     final var clusterContext = new ClusterContextImpl(3);
 
     // when
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
     migration.runMigration(context);
 
@@ -40,7 +40,7 @@ final class RoutingInfoMigrationTest {
   void shouldNotRunMigrationAgain() {
     // given
     final var clusterContext = new ClusterContextImpl(3);
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
 
     // when
@@ -54,7 +54,7 @@ final class RoutingInfoMigrationTest {
   void shouldInitializeRoutingInfo() {
     // given
     final var clusterContext = new ClusterContextImpl(3);
-    final var migration = new RoutingInfoMigration();
+    final var migration = new RoutingInfoInitializationMigration();
     final var context = new MigrationTaskContextImpl(clusterContext, processingState);
 
     // when
@@ -66,5 +66,14 @@ final class RoutingInfoMigrationTest {
     assertThat(updatedRoutingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(updatedRoutingState.messageCorrelation())
         .isEqualTo(new MessageCorrelation.HashMod(3));
+  }
+
+  @Test
+  void shouldBeAnInitialization() {
+    // given
+    final var migration = new RoutingInfoInitializationMigration();
+
+    // when/then
+    assertThat(migration.isInitialization()).isTrue();
   }
 }


### PR DESCRIPTION
# Description
Backport of #32639 to `stable/8.6`.

relates to #32419 #32388