### PR TITLE
Fix default user delete default tenant

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -147,23 +147,17 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     final var tenant = tenantState.getTenantById(record.getTenantId()).orElseThrow();
     final var tenantId = tenant.getTenantId();
     final var tenantKey = tenant.getTenantKey();
-
     membershipState.forEachMember(
         RelationType.TENANT,
         tenantId,
-        (type, id) -> {
-          switch (type) {
-            case USER ->
-                stateWriter.appendFollowUpEvent(
-                    tenantKey,
-                    TenantIntent.ENTITY_REMOVED,
-                    new TenantRecord().setTenantId(tenantId).setEntityId(id).setEntityType(type));
-            default ->
-                throw new UnsupportedOperationException(
-                    String.format(
-                        "Expected to remove entity with id %s and type %s from tenant %s, but the type is not supported.",
-                        id, type, tenantId));
-          }
+        (entityType, entityId) -> {
+          stateWriter.appendFollowUpEvent(
+              tenantKey,
+              TenantIntent.ENTITY_REMOVED,
+              new TenantRecord()
+                  .setTenantId(tenantId)
+                  .setEntityType(entityType)
+                  .setEntityId(entityId));
         });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.tenant;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteTenantAuthorizationTest {
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(
+              cfg -> {
+                cfg.getAuthorizations().setEnabled(true);
+                cfg.getInitialization().setUsers(List.of(DEFAULT_USER));
+                cfg.getInitialization()
+                    .getDefaultRoles()
+                    .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getMultiTenancy().setEnabled(true);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToDeleteAssignedTenantWithPermissions() {
+    // given
+    final var user = createUser();
+    final var tenantId = UUID.randomUUID().toString();
+    createTenant(tenantId);
+    addPermissionsToUser(user, AuthorizationResourceType.TENANT, PermissionType.DELETE, tenantId);
+    assignUserToTenant(user.getUsername(), tenantId);
+
+    // when
+    engine.tenant().deleteTenant(tenantId).delete(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.tenantRecords()
+                .withTenantId(tenantId)
+                .withIntent(TenantIntent.DELETED)
+                .count())
+        .isOne();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToDeleteUnassignedTenantWithPermissions() {
+    // given
+    final var user = createUser();
+    final var tenantId = UUID.randomUUID().toString();
+    createTenant(tenantId);
+
+    // when / then
+    final var rejectedDeleteRecord =
+        engine.tenant().deleteTenant(tenantId).expectRejection().delete(user.getUsername());
+
+    // then
+    assertThat(rejectedDeleteRecord)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'DELETE' on resource 'TENANT', required resource identifiers are one of '[*, %s]'"
+                .formatted(tenantId));
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(DEFAULT_USER.getUsername())
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private TenantRecordValue createTenant(final String tenantId) {
+    return engine.tenant().newTenant().withTenantId(tenantId).create().getValue();
+  }
+
+  private void assignUserToTenant(final String username, final String tenantId) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -53,6 +54,19 @@ public class DeleteTenantAuthorizationTest {
               });
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedAsDefaultUserToDeleteDefaultTenant() {
+    // given
+    final var defaultUsername = DEFAULT_USER.getUsername();
+
+    // when
+    final var tenantRecord =
+        engine.tenant().deleteTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER).delete(defaultUsername);
+
+    // then
+    assertThat(tenantRecord).isNotNull();
+  }
 
   @Test
   public void shouldBeAuthorizedToDeleteAssignedTenantWithPermissions() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -85,8 +85,8 @@ public class DeleteTenantAuthorizationTest {
             RecordingExporter.tenantRecords()
                 .withTenantId(tenantId)
                 .withIntent(TenantIntent.DELETED)
-                .count())
-        .isOne();
+                .exists())
+        .isTrue();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -336,6 +336,7 @@ public class TenantClient {
     private final CommandWriter writer;
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
+    private final boolean expectRejection = false;
 
     public TenantDeleteClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;
@@ -350,6 +351,16 @@ public class TenantClient {
      */
     public Record<TenantRecordValue> delete() {
       final long position = writer.writeCommand(TenantIntent.DELETE, tenantRecord);
+      return expectation.apply(position);
+    }
+
+    /**
+     * Submits a user-requested delete command for the tenant and returns the resulting record.
+     *
+     * @return the deleted tenant record
+     */
+    public Record<TenantRecordValue> delete(final String username) {
+      final long position = writer.writeCommand(TenantIntent.DELETE, username, tenantRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -336,7 +336,6 @@ public class TenantClient {
     private final CommandWriter writer;
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
-    private final boolean expectRejection = false;
 
     public TenantDeleteClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Allow the TenantDeleteProcessor to be able to delete all member entities from its membership list.

ℹ️ Note: this PR is based on https://github.com/camunda/camunda/pull/32647. However, the related issue seems to be fixed already, so we can merge this PR without waiting on the base one.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32340
