### PR TITLE
fix: reset batch operation endDate on new chunk to trigger updateTask…

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -67,6 +67,7 @@ import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
+import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationChunkCreatedItemHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCompletedHandler;
 import io.camunda.exporter.handlers.batchoperation.BatchOperationCreatedHandler;
@@ -274,6 +275,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new BatchOperationLifecycleManagementHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationChunkCreatedItemHandler(
+                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+            new BatchOperationChunkCreatedHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
             new ProcessInstanceCancellationOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Additionally to the {@link BatchOperationChunkCreatedItemHandler}, this handler removes an
+ * existing endDate of the batch operation from the document. This way the {@link
+ * BatchOperationUpdateTask} will process this batch operation again to update all counts. <br>
+ * <br>
+ * This process is necessary because sometimes the <code>COMPLETED</code> event from one partition
+ * is exported before all <code>CHUNK_CREATED</code> events are exported from another partition. In
+ * that case the numbers would forever be wrong.
+ */
+public class BatchOperationChunkCreatedHandler
+    implements ExportHandler<BatchOperationEntity, BatchOperationChunkRecordValue> {
+
+  private final String indexName;
+
+  public BatchOperationChunkCreatedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.BATCH_OPERATION_CHUNK;
+  }
+
+  @Override
+  public Class<BatchOperationEntity> getEntityType() {
+    return BatchOperationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getIntent().equals(BatchOperationChunkIntent.CREATED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Override
+  public BatchOperationEntity createNewEntity(final String id) {
+    return new BatchOperationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<BatchOperationChunkRecordValue> record, final BatchOperationEntity entity) {
+    // set the endDate to null to ensure that the batch operation is processed again by the
+    // BatchOperationUpdateTask
+    entity.setEndDate(null);
+  }
+
+  @Override
+  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.END_DATE, entity.getState());
+    batchRequest.update(indexName, entity.getId(), updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BatchOperationChunkCreatedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-" + OperationTemplate.INDEX_NAME;
+  private final BatchOperationChunkCreatedHandler underTest =
+      new BatchOperationChunkCreatedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.BATCH_OPERATION_CHUNK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(BatchOperationEntity.class);
+  }
+
+  @Test
+  void shouldHandleChunkCreatedRecord() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final var recordValue = factory.generateObject(BatchOperationChunkRecordValue.class);
+    final Record<BatchOperationChunkRecordValue> record =
+        factory.generateRecord(
+            ValueType.BATCH_OPERATION_CHUNK,
+            r -> r.withIntent(BatchOperationChunkIntent.CREATED).withValue(recordValue));
+
+    final var entity = new BatchOperationEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getEndDate()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityOnFlush() throws PersistenceException {
+    // given
+    final var entity = new BatchOperationEntity().setId("123").setEndDate(null);
+    final var mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put("endDate", null);
+
+    // then
+    verify(mockRequest, times(1)).update(indexName, entity.getId(), updateFields);
+  }
+}


### PR DESCRIPTION
## Description

Reset the endDate of a batch operation to null when a new BatchOperation chunk is processed in the camunda exporter. Usually this basically does nothing because the endDate is still NULL. But in some cases a chunk is exported later than the earliest COMPLETED and then the statistical counts of the batch operation are wrong. Resetting the endDate will cause the BatchOperationBackgroundTask to run again and recalculate the statistics to the correct value.

## Related issues

closes #32635 
