### PR TITLE
fix: reset internal engine clock between tests

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -118,7 +118,9 @@ public class ActorClockEndpoint {
           "Expected to reset the clock, but the clock is immutable", 403);
     }
 
-    clock.get().resetTime();
+    final var mutableClock = clock.get();
+    mutableClock.resetTime();
+    mutableClock.update();
     return getCurrentClock();
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -210,9 +210,11 @@ public class CamundaProcessTestExtension
     }
     CamundaAssert.reset();
     closeCreatedClients();
-    // final steps: delete data and reset the time
-    deleteRuntimeData();
+    // final steps: reset the time and delete data
+    // It's important that the runtime clock is reset before the purge is started, as doing it
+    // the other way around leads to race conditions and inconsistencies in the tests
     resetRuntimeClock();
+    deleteRuntimeData();
   }
 
   private void printTestResults() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -210,8 +210,9 @@ public class CamundaProcessTestExtension
     }
     CamundaAssert.reset();
     closeCreatedClients();
-    // final step: delete data
+    // final steps: delete data and reset the time
     deleteRuntimeData();
+    resetRuntimeClock();
   }
 
   private void printTestResults() {
@@ -238,6 +239,19 @@ public class CamundaProcessTestExtension
     } catch (final Throwable t) {
       LOG.warn(
           "Failed to delete the runtime data, skipping. Check the runtime for details. "
+              + "Note that a dirty runtime may cause failures in other test cases.",
+          t);
+    }
+  }
+
+  private void resetRuntimeClock() {
+    try {
+      LOG.debug("Resetting the time");
+      camundaManagementClient.resetTime();
+      LOG.debug("Time reset");
+    } catch (final Throwable t) {
+      LOG.warn(
+          "Failed to reset the time, skipping. Check the runtime for details. "
               + "Note that a dirty runtime may cause failures in other test cases.",
           t);
     }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaManagementClient.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -57,7 +58,6 @@ public class CamundaManagementClient {
   }
 
   public Instant getCurrentTime() {
-
     try {
       final HttpGet request = new HttpGet(camundaManagementApi + CLOCK_ENDPOINT);
       final CamundaClockResponseDto clockResponseDto =
@@ -70,7 +70,6 @@ public class CamundaManagementClient {
   }
 
   public void increaseTime(final Duration timeToAdd) {
-
     final HttpPost request = new HttpPost(camundaManagementApi + CLOCK_ADD_ENDPOINT);
 
     final CamundaAddClockRequestDto requestDto = new CamundaAddClockRequestDto();
@@ -81,9 +80,18 @@ public class CamundaManagementClient {
       request.setEntity(HttpEntities.create(requestBody, ContentType.APPLICATION_JSON));
 
       sendRequest(request);
-
     } catch (final Exception e) {
       throw new RuntimeException("Failed to increase the time", e);
+    }
+  }
+
+  public void resetTime() {
+    final HttpDelete request = new HttpDelete(camundaManagementApi + CLOCK_ENDPOINT);
+
+    try {
+      sendRequest(request);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to reset the time", e);
     }
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestClockResetIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestClockResetIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class CamundaProcessTestClockResetIT {
+
+  private static final Duration TIMER_DURATION = Duration.ofHours(1);
+
+  private static Instant testStartTime;
+
+  // to be injected
+  private CamundaClient client;
+  private CamundaProcessTestContext processTestContext;
+
+  @BeforeAll
+  static void setUp() {
+    testStartTime = Instant.now();
+  }
+
+  @Test
+  @Order(1)
+  void setupTestThatManipulatesTheClock() {
+    // when
+    final Instant timeBefore = processTestContext.getCurrentTime();
+    processTestContext.increaseTime(TIMER_DURATION);
+    final Instant timeAfter = processTestContext.getCurrentTime();
+
+    // then
+    assertThat(Duration.between(timeBefore, timeAfter))
+        .isCloseTo(TIMER_DURATION, Duration.ofSeconds(10));
+  }
+
+  @Test
+  @Order(2)
+  void ensureClockHasBeenReset() {
+    final Instant currentTime = processTestContext.getCurrentTime();
+
+    assertThat(Duration.between(testStartTime, currentTime))
+        .isCloseTo(Duration.ofSeconds(10), Duration.ofMinutes(1));
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -166,7 +166,10 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
         .getBean(CamundaProcessTestContextProxy.class)
         .removeContext();
 
-    // final step: delete data
+    // final steps: reset the time and delete data
+    // It's important that the runtime clock is reset before the purge is started, as doing it
+    // the other way around leads to race conditions and inconsistencies in the tests
+    resetRuntimeClock();
     deleteRuntimeData();
   }
 
@@ -203,6 +206,19 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     } catch (final Throwable t) {
       LOG.warn(
           "Failed to delete the runtime data, skipping. Check the runtime for details. "
+              + "Note that a dirty runtime may cause failures in other test cases.",
+          t);
+    }
+  }
+
+  private void resetRuntimeClock() {
+    try {
+      LOG.info("Resetting the time");
+      camundaManagementClient.resetTime();
+      LOG.info("Time reset");
+    } catch (final Throwable t) {
+      LOG.warn(
+          "Failed to reset the time, skipping. Check the runtime for details. "
               + "Note that a dirty runtime may cause failures in other test cases.",
           t);
     }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestClockResetIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestClockResetIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {CamundaSpringProcessTestListenerIT.class})
+@CamundaSpringProcessTest
+public class CamundaSpringProcessTestClockResetIT {
+
+  private static final Duration TIMER_DURATION = Duration.ofHours(1);
+
+  private static Instant testStartTime;
+
+  @Autowired private CamundaClient client;
+  @Autowired private CamundaProcessTestContext processTestContext;
+
+  @BeforeAll
+  static void setUp() {
+    testStartTime = Instant.now();
+  }
+
+  @Test
+  @Order(1)
+  void setupTestThatManipulatesTheClock() {
+    // when
+    final Instant timeBefore = processTestContext.getCurrentTime();
+    processTestContext.increaseTime(TIMER_DURATION);
+    final Instant timeAfter = processTestContext.getCurrentTime();
+
+    // then
+    assertThat(Duration.between(timeBefore, timeAfter))
+        .isCloseTo(TIMER_DURATION, Duration.ofSeconds(10));
+  }
+
+  @Test
+  @Order(2)
+  void ensureClockHasBeenReset() {
+    final Instant currentTime = processTestContext.getCurrentTime();
+
+    assertThat(Duration.between(testStartTime, currentTime))
+        .isCloseTo(Duration.ofSeconds(10), Duration.ofMinutes(1));
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
@@ -95,6 +95,9 @@ public interface ActorClockActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Response addTime(@RequestBody AddTimeRequest request);
 
+  @RequestLine("DELETE")
+  Response resetTime();
+
   record Response(long epochMilli, Instant instant) {}
 
   record AddTimeRequest(Long offsetMilli) {}


### PR DESCRIPTION
## Description

In Camunda Process Test, I can manipulate the time in a test case:
```java
processTestContext.increaseTime(Duration.ofHours(1));
```
After the test case, the time should be reset to the original time (i.e., the current time). This PR fixes this behavior so that the time is correctly reset between tests cases.

## Related issues

closes https://github.com/camunda/camunda/issues/32323
