### PR TITLE
feat: add a temporary partition folder to receive the snapshot

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -175,7 +175,8 @@ public final class PartitionManagerImpl
             brokerCfg,
             initialPartitionConfig,
             initializeFromSnapshot,
-            brokerMeterRegistry);
+            brokerMeterRegistry,
+            brokerClient);
     final var partition = Partition.bootstrapping(context);
     partitions.put(id, partition);
 
@@ -203,7 +204,8 @@ public final class PartitionManagerImpl
             brokerCfg,
             initialPartitionConfig,
             false,
-            brokerMeterRegistry);
+            brokerMeterRegistry,
+            brokerClient);
     final var partition = Partition.joining(context);
     final var previousPartition = partitions.putIfAbsent(id, partition);
     if (previousPartition != null) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning.startup;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -37,6 +38,7 @@ public final class PartitionStartupContext {
   private final DynamicPartitionConfig initialPartitionConfig;
   private final boolean initializeFromSnapshot;
   private final MeterRegistry brokerMeterRegistry;
+  private final BrokerClient brokerClient;
 
   private Path partitionDirectory;
 
@@ -44,6 +46,7 @@ public final class PartitionStartupContext {
   private FileBasedSnapshotStore snapshotStore;
   private RaftPartition raftPartition;
   private ZeebePartition zeebePartition;
+  private Path temporaryPartitionDirectory;
 
   public PartitionStartupContext(
       final ActorSchedulingService schedulingService,
@@ -58,7 +61,8 @@ public final class PartitionStartupContext {
       final BrokerCfg brokerConfig,
       final DynamicPartitionConfig initialPartitionConfig,
       final boolean initializeFromSnapshot,
-      final MeterRegistry brokerMeterRegistry) {
+      final MeterRegistry brokerMeterRegistry,
+      final BrokerClient brokerClient) {
     this.schedulingService = schedulingService;
     this.topologyManager = topologyManager;
     this.concurrencyControl = concurrencyControl;
@@ -72,11 +76,16 @@ public final class PartitionStartupContext {
     this.initialPartitionConfig = initialPartitionConfig;
     this.initializeFromSnapshot = initializeFromSnapshot;
     this.brokerMeterRegistry = brokerMeterRegistry;
+    this.brokerClient = brokerClient;
   }
 
   @Override
   public String toString() {
     return "PartitionStartupContext{" + "partition=" + partitionMetadata.id().id() + '}';
+  }
+
+  public Integer partitionId() {
+    return partitionMetadata.id().id();
   }
 
   public ActorSchedulingService schedulingService() {
@@ -119,6 +128,10 @@ public final class PartitionStartupContext {
     return partitionDirectory;
   }
 
+  public Path temporaryPartitionDirectory() {
+    return temporaryPartitionDirectory;
+  }
+
   public FileBasedSnapshotStore snapshotStore() {
     return snapshotStore;
   }
@@ -155,6 +168,12 @@ public final class PartitionStartupContext {
     return this;
   }
 
+  public PartitionStartupContext temporaryPartitionDirectory(
+      final Path temporaryPartitionDirectory) {
+    this.temporaryPartitionDirectory = temporaryPartitionDirectory;
+    return this;
+  }
+
   public DynamicPartitionConfig initialPartitionConfig() {
     return initialPartitionConfig;
   }
@@ -175,5 +194,9 @@ public final class PartitionStartupContext {
 
   public boolean isInitializeFromSnapshot() {
     return initializeFromSnapshot;
+  }
+
+  public BrokerClient getBrokerClient() {
+    return brokerClient;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStepTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.startup.steps;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+public class PartitionDirectoryStepTest {
+  @TempDir Path path;
+  PartitionStartupContext context = mock(PartitionStartupContext.class, Answers.RETURNS_DEEP_STUBS);
+  TestConcurrencyControl concurrency = new TestConcurrencyControl();
+  PartitionDirectoryStep step = new PartitionDirectoryStep();
+  Path expectedPartitionPath;
+  Path expectedTempPath;
+
+  @BeforeEach
+  void setup() {
+    when(context.brokerConfig().getData().getDirectory()).thenReturn(path.toString());
+    when(context.partitionId()).thenReturn(1);
+    when(context.concurrencyControl()).thenReturn(concurrency);
+    // to make fluent api work
+    when(context.partitionDirectory(any())).thenReturn(context);
+    expectedPartitionPath = path.resolve("raft-partition/partitions/1");
+    expectedTempPath = path.resolve("raft-partition/temporary-partitions/1");
+  }
+
+  @Test
+  void shouldCreatePartitionDirectories() {
+    // when
+    assertThat(step.startup(context)).succeedsWithin(Duration.ofSeconds(10));
+    // then
+    verify(context).partitionDirectory(argThat(p -> p.equals(expectedPartitionPath)));
+    verify(context).temporaryPartitionDirectory(argThat(p -> p.equals(expectedTempPath)));
+
+    assertThat(expectedPartitionPath).exists();
+    assertThat(expectedTempPath).exists();
+  }
+
+  @Test
+  void shouldDeleteTempPartitionWhenShuttingDown() {
+    // when
+    assertThat(step.startup(context)).succeedsWithin(Duration.ofSeconds(10));
+    when(context.temporaryPartitionDirectory()).thenReturn(expectedTempPath);
+    assertThat(step.shutdown(context)).succeedsWithin(Duration.ofSeconds(10));
+
+    // then
+    assertThat(expectedTempPath).doesNotExist();
+    verify(context).temporaryPartitionDirectory(null);
+    verify(context).partitionDirectory(null);
+  }
+}


### PR DESCRIPTION
## Description
In order to keep things clean, the snapshot received from partition 1 when bootstrapping a new partition will be received in a separate `SnapshotStore`, which will use a different folder.

Apart from that, I added flushing directories to be sure that these exists before completing the future.

Whenever the broker is stopping, the folder will be removed. 


## Related issues

relates #32041
