### PR TITLE
[Backport stable/8.5] feat: add broker version to PartitionTransitionContext to simplify testing

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.List;
 
@@ -66,4 +67,8 @@ public interface PartitionContext {
   PartitionAdminAccess getAdminAccess();
 
   void setAdminAccess(PartitionAdminAccess adminAccess);
+
+  default String getBrokerVersion() {
+    return VersionUtil.getVersion();
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -47,7 +47,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             transientProcessMessageSubscriptionState,
             context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration());
 
-    final var dbMigrator = new DbMigratorImpl(processingState);
+    final var dbMigrator = new DbMigratorImpl(processingState, context.getBrokerVersion());
     try {
       dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -81,6 +81,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private CheckpointRecordsProcessor checkpointRecordsProcessor;
   private BackupStore backupStore;
   private MeterRegistry transitionMeterRegistry;
+  private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
 
   public TestPartitionTransitionContext() {
     startupMeterRegistry.config().commonTags(PartitionKeyNames.tags(1));
@@ -169,6 +170,15 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public void setAdminAccess(final PartitionAdminAccess adminAccess) {}
+
+  @Override
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  public void setBrokerVersion(final String version) {
+    brokerVersion = version;
+  }
 
   @Override
   public void setExporterDirector(final ExporterDirector exporterDirector) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -82,7 +82,7 @@ public class DbMigratorImpl implements DbMigrator {
     var initializationOnly = false;
     switch (checkVersionCompatibility()) {
       case final Indeterminate.PreviousVersionUnknown unknown:
-        LOGGER.debug("Snapshot is empty, no migrations to run");
+        LOGGER.debug("Snapshot is empty, only initialization migrations will be run.");
         initializationOnly = true;
         break;
       case final Compatible.SameVersion compatible:
@@ -91,7 +91,7 @@ public class DbMigratorImpl implements DbMigrator {
       default:
         break;
     }
-    logPreview(migrationTasks);
+    logPreview(migrationTasks, initializationOnly);
 
     final var executedMigrations = runMigrations(initializationOnly);
 
@@ -146,7 +146,8 @@ public class DbMigratorImpl implements DbMigrator {
     processingState.getMigrationState().setMigratedByVersion(currentVersion);
   }
 
-  private void logPreview(final List<MigrationTask> migrationTasks) {
+  private void logPreview(
+      final List<MigrationTask> migrationTasks, final boolean initializationOnly) {
     LOGGER.info(
         "Starting processing {} migration tasks (use LogLevel.DEBUG for more details) ... ",
         migrationTasks.size());
@@ -154,6 +155,7 @@ public class DbMigratorImpl implements DbMigrator {
         "Found {} migration tasks: {}",
         migrationTasks.size(),
         migrationTasks.stream()
+            .filter(task -> !initializationOnly || task.isInitialization())
             .map(MigrationTask::getIdentifier)
             .collect(Collectors.joining(", ")));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -64,8 +64,8 @@ public class DbMigratorImpl implements DbMigrator {
   private final List<MigrationTask> migrationTasks;
   private final String currentVersion;
 
-  public DbMigratorImpl(final MutableProcessingState processingState) {
-    this(processingState, MIGRATION_TASKS, null);
+  public DbMigratorImpl(final MutableProcessingState processingState, String version) {
+    this(processingState, MIGRATION_TASKS, version);
   }
 
   public DbMigratorImpl(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.migration;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -211,7 +212,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration, never()).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }
@@ -230,7 +231,7 @@ public class DbMigratorImplTest {
     sut.runMigrations();
 
     // then
-    verify(migration).isInitialization();
+    verify(migration, atLeastOnce()).isInitialization();
     verify(migration).runMigration(any());
     verify(mockProcessingState.getMigrationState()).setMigratedByVersion(eq(CURRENT_VERSION));
   }


### PR DESCRIPTION
# Description
Backport of #32640 to `stable/8.5`.

Depends on 
- [x] #32656

relates to #32388