### PR TITLE
[Backport stable/8.6] feat: add broker version to PartitionTransitionContext to simplify testing

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.List;
 
@@ -82,4 +83,8 @@ public interface PartitionContext {
    * does not update during scale up.
    */
   int getPartitionCount();
+
+  default String getBrokerVersion() {
+    return VersionUtil.getVersion();
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -51,7 +51,10 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             InstantSource.system());
 
     final var dbMigrator =
-        new DbMigratorImpl(new ClusterContextImpl(context.getPartitionCount()), processingState);
+        new DbMigratorImpl(
+            new ClusterContextImpl(context.getPartitionCount()),
+            processingState,
+            context.getBrokerVersion());
     try {
       dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -82,6 +82,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private ControllableStreamClock clock;
   private MeterRegistry partitionMeterRegistry;
   private MeterRegistry transitionMeterRegistry;
+  private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
@@ -193,6 +194,15 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public int getPartitionCount() {
     return 1;
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  public void setBrokerVersion(final String version) {
+    brokerVersion = version;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -68,8 +68,13 @@ public class DbMigratorImpl implements DbMigrator {
   private final String currentVersion;
 
   public DbMigratorImpl(
-      final ClusterContext clusterContext, final MutableProcessingState processingState) {
-    this(new MigrationTaskContextImpl(clusterContext, processingState), MIGRATION_TASKS, null);
+      final ClusterContext clusterContext,
+      final MutableProcessingState processingState,
+      final String currentVersion) {
+    this(
+        new MigrationTaskContextImpl(clusterContext, processingState),
+        MIGRATION_TASKS,
+        currentVersion);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
# Description
Backport of #32640 to `stable/8.6`.

Depends on 
- [x] #32657

relates to #32388