### PR TITLE
Fix go linting ci job

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -459,9 +459,6 @@ jobs:
         with:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.55.2
-          # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
-          skip-pkg-cache: true
-          skip-build-cache: true
           working-directory: clients/go
       - name: Observe build status
         if: always()

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -455,7 +455,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.55.2


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This is an attempt to fix the Go linting CI job in the Zeebe CI workflow by bumping golangci/golangci-lint-action from v4 to v6. 

We sadly can't upgrade higher (latest currently v8) because we're using v1 of the golangci-lint tool and not the required v2.

✅ Successfully tested with: https://github.com/camunda/camunda/commit/f534975012a2420f30db1a0a5154da4686112757
- results: https://github.com/camunda/camunda/actions/runs/15306272162/job/43059724112?pr=32680

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://camunda.slack.com/archives/C071KP5BTHB/p1748448747823899
