### PR TITLE
fix: visual regression mocks for PI details

### DIFF
--- a/operate/client/e2e-playwright/a11y/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/processInstance.spec.ts
@@ -29,6 +29,8 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -74,8 +76,10 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
-          statisticsV2: runningInstance.statisticsV2,
+          statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
           sequenceFlowsV2: instanceWithIncident.sequenceFlowsV2,
           variables: instanceWithIncident.variables,
@@ -141,6 +145,8 @@ test.describe('process detail', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/delete-finished-instances.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/delete-finished-instances.spec.ts
@@ -162,6 +162,8 @@ test.describe('delete finished instances', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: completedOrderProcessInstance.detail,
+        processInstanceDetailV2: completedOrderProcessInstance.detailV2,
+        callHierarchy: completedOrderProcessInstance.callHierarchy,
         flowNodeInstances: completedOrderProcessInstance.flowNodeInstances,
         statisticsV2: completedOrderProcessInstance.statisticsV2,
         sequenceFlows: completedOrderProcessInstance.sequenceFlows,
@@ -202,6 +204,16 @@ test.describe('delete finished instances', () => {
 
     await page.route(URL_API_PATTERN, (route) => {
       if (route.request().url().includes('/api/process-instances/')) {
+        return route.fulfill({
+          status: 404,
+          body: JSON.stringify(''),
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      }
+
+      if (route.request().url().includes('/v2/process-instances/')) {
         return route.fulfill({
           status: 404,
           body: JSON.stringify(''),

--- a/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/get-familiar-with-operate.spec.ts
@@ -118,6 +118,8 @@ test.describe('get familiar with operate', () => {
       URL_API_PATTERN,
       mockProcessInstanceDetailResponses({
         processInstanceDetail: runningOrderProcessInstance.detail,
+        processInstanceDetailV2: runningOrderProcessInstance.detailV2,
+        callHierarchy: runningOrderProcessInstance.callHierarchy,
         flowNodeInstances: runningOrderProcessInstance.flowNodeInstances,
         statisticsV2: runningOrderProcessInstance.statisticsV2,
         sequenceFlows: runningOrderProcessInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-modification.spec.ts
@@ -30,6 +30,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -132,6 +134,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -250,6 +254,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,
@@ -392,6 +398,8 @@ test.describe('process instance modification', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: eventBasedGatewayProcessInstance.detail,
+        processInstanceDetailV2: eventBasedGatewayProcessInstance.detailV2,
+        callHierarchy: eventBasedGatewayProcessInstance.callHierarchy,
         flowNodeInstances: eventBasedGatewayProcessInstance.flowNodeInstances,
         statisticsV2: eventBasedGatewayProcessInstance.statisticsV2,
         sequenceFlows: eventBasedGatewayProcessInstance.sequenceFlows,

--- a/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
@@ -106,6 +106,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.incidentState.detail,
+        processInstanceDetailV2: orderProcessInstance.incidentState.detailV2,
+        callHierarchy: orderProcessInstance.incidentState.callHierarchy,
         flowNodeInstances: orderProcessInstance.incidentState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentState.statisticsV2,
         sequenceFlows: orderProcessInstance.incidentState.sequenceFlows,
@@ -186,6 +188,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.incidentState.detail,
+        processInstanceDetailV2: orderProcessInstance.incidentState.detailV2,
+        callHierarchy: orderProcessInstance.incidentState.callHierarchy,
         flowNodeInstances: orderProcessInstance.incidentState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentState.statisticsV2,
         sequenceFlows: orderProcessInstance.incidentState.sequenceFlows,
@@ -247,6 +251,9 @@ test.describe('variables and incidents', () => {
       mockProcessDetailResponses({
         processInstanceDetail:
           orderProcessInstance.incidentResolvedState.detail,
+        processInstanceDetailV2:
+          orderProcessInstance.incidentResolvedState.detailV2,
+        callHierarchy: orderProcessInstance.incidentResolvedState.callHierarchy,
         flowNodeInstances:
           orderProcessInstance.incidentResolvedState.flowNodeInstances,
         statisticsV2: orderProcessInstance.incidentResolvedState.statisticsV2,
@@ -273,6 +280,8 @@ test.describe('variables and incidents', () => {
       URL_API_PATTERN,
       mockProcessDetailResponses({
         processInstanceDetail: orderProcessInstance.completedState.detail,
+        processInstanceDetailV2: orderProcessInstance.completedState.detailV2,
+        callHierarchy: orderProcessInstance.completedState.callHierarchy,
         flowNodeInstances:
           orderProcessInstance.completedState.flowNodeInstances,
         statisticsV2: orderProcessInstance.completedState.statisticsV2,

--- a/operate/client/e2e-playwright/mocks/processInstance/compensationProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/compensationProcessInstance.mocks.ts
@@ -39,6 +39,7 @@ const compensationProcessInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: false,
   },
+  callHierarchy: [],
   flowNodeInstances: {
     '9007199254744341': {
       children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/completedInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/completedInstance.mocks.ts
@@ -38,6 +38,7 @@ const completedInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: false,
   },
+  callHierarchy: [],
   flowNodeInstances: {
     '2551799813954282': {
       children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/completedOrderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/completedOrderProcessInstance.mocks.ts
@@ -26,6 +26,7 @@ const completedOrderProcessInstance: InstanceMock = {
     processDefinitionVersion: 1,
     processDefinitionId: 'orderProcess',
   },
+  callHierarchy: [],
   xml: open('orderProcess.bpmn'),
   statisticsV2: {
     items: [

--- a/operate/client/e2e-playwright/mocks/processInstance/eventBasedGatewayProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/eventBasedGatewayProcessInstance.mocks.ts
@@ -38,6 +38,7 @@ const eventBasedGatewayProcessInstance: InstanceMock = {
     tenantId: '<default>',
     hasIncident: true,
   },
+  callHierarchy: [],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_13jk2qx" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.5.0">
       <bpmn:process id="eventBasedGatewayProcess" name="Event based gateway with timer start" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/index.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/index.ts
@@ -9,6 +9,7 @@
 import {Route} from '@playwright/test';
 import {
   GetProcessDefinitionStatisticsResponseBody,
+  GetProcessInstanceCallHierarchyResponseBody,
   GetProcessSequenceFlowsResponseBody,
   ProcessInstance,
 } from '@vzeta/camunda-api-zod-schemas/operate';
@@ -24,6 +25,7 @@ type InstanceMock = {
   xml: string;
   detail: ProcessInstanceEntity;
   detailV2: ProcessInstance;
+  callHierarchy: GetProcessInstanceCallHierarchyResponseBody;
   flowNodeInstances: FlowNodeInstancesDto<FlowNodeInstanceDto>;
   statisticsV2: GetProcessDefinitionStatisticsResponseBody;
   sequenceFlows: SequenceFlowsDto;
@@ -36,6 +38,7 @@ type InstanceMock = {
 function mockResponses({
   processInstanceDetail,
   processInstanceDetailV2,
+  callHierarchy,
   flowNodeInstances,
   statisticsV2,
   sequenceFlows,
@@ -47,6 +50,7 @@ function mockResponses({
 }: {
   processInstanceDetail?: ProcessInstanceEntity;
   processInstanceDetailV2?: ProcessInstance;
+  callHierarchy?: GetProcessInstanceCallHierarchyResponseBody;
   flowNodeInstances?: FlowNodeInstancesDto<FlowNodeInstanceDto>;
   statisticsV2?: GetProcessDefinitionStatisticsResponseBody;
   sequenceFlows?: SequenceFlowsDto;
@@ -163,6 +167,16 @@ function mockResponses({
       return route.fulfill({
         status: metaData === undefined ? 400 : 200,
         body: JSON.stringify(metaData),
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    if (route.request().url().includes('call-hierarchy')) {
+      return route.fulfill({
+        status: callHierarchy === undefined ? 400 : 200,
+        body: JSON.stringify(callHierarchy),
         headers: {
           'content-type': 'application/json',
         },

--- a/operate/client/e2e-playwright/mocks/processInstance/instanceWithIncident.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/instanceWithIncident.mocks.ts
@@ -50,12 +50,30 @@ const instanceWithIncident: InstanceMock = {
     processDefinitionKey: '2251799813687188',
     processDefinitionName: 'Order process',
     processDefinitionVersion: 2,
+    parentProcessInstanceKey: '6755399441062817',
     startDate: '2023-08-14T05:47:07.376+0000',
     state: 'ACTIVE',
     processDefinitionId: 'orderProcess',
     tenantId: '',
     hasIncident: true,
   },
+  callHierarchy: [
+    {
+      processInstanceKey: '6755399441062811',
+      processDefinitionName: 'Call Activity Process',
+      processDefinitionKey: '2251799813686145',
+    },
+    {
+      processInstanceKey: '6755399441062817',
+      processDefinitionName: 'called-process',
+      processDefinitionKey: '2251799813687891',
+    },
+    {
+      processInstanceKey: '6755399441062827',
+      processDefinitionName: 'Order process',
+      processDefinitionKey: '2251799813687188',
+    },
+  ],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
   <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
     <bpmn:process id="orderProcess" name="Order process" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/orderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/orderProcessInstance.mocks.ts
@@ -189,6 +189,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: true,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [
@@ -417,6 +418,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: false,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [
@@ -637,6 +639,7 @@ const orderProcessInstance: {
       tenantId: '<default>',
       hasIncident: false,
     },
+    callHierarchy: [],
     flowNodeInstances: {
       '2251799813725328': {
         children: [

--- a/operate/client/e2e-playwright/mocks/processInstance/runningInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/runningInstance.mocks.ts
@@ -38,6 +38,7 @@ const runningInstance: InstanceMock = {
     tenantId: '',
     hasIncident: false,
   },
+  callHierarchy: [],
   xml: `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w68912" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
       <bpmn:process id="signalEventProcess" name="Signal event" isExecutable="true">

--- a/operate/client/e2e-playwright/mocks/processInstance/runningOrderProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/runningOrderProcessInstance.mocks.ts
@@ -24,6 +24,7 @@ const runningOrderProcessInstance: InstanceMock = {
     processDefinitionName: 'Order process',
     processDefinitionId: 'orderProcess',
   },
+  callHierarchy: [],
   xml: open('orderProcess.bpmn'),
   statisticsV2: {
     items: [

--- a/operate/client/e2e-playwright/visual/modifications.spec.ts
+++ b/operate/client/e2e-playwright/visual/modifications.spec.ts
@@ -41,6 +41,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -77,6 +79,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -121,6 +125,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
@@ -189,6 +195,8 @@ test.describe('modifications', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,

--- a/operate/client/e2e-playwright/visual/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstance.spec.ts
@@ -43,6 +43,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           xml: runningInstance.xml,
         }),
       );
@@ -68,6 +70,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -98,6 +102,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -129,6 +135,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: runningInstance.detail,
+          processInstanceDetailV2: runningInstance.detailV2,
+          callHierarchy: runningInstance.callHierarchy,
           flowNodeInstances: runningInstance.flowNodeInstances,
           statisticsV2: runningInstance.statisticsV2,
           sequenceFlows: runningInstance.sequenceFlows,
@@ -165,6 +173,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: instanceWithIncident.detail,
+          processInstanceDetailV2: instanceWithIncident.detailV2,
+          callHierarchy: instanceWithIncident.callHierarchy,
           flowNodeInstances: instanceWithIncident.flowNodeInstances,
           statisticsV2: instanceWithIncident.statisticsV2,
           sequenceFlows: instanceWithIncident.sequenceFlows,
@@ -181,6 +191,12 @@ test.describe('process instance page', () => {
           waitUntil: 'networkidle',
         },
       });
+
+      await page
+        .getByRole('button', {
+          name: /reset diagram zoom/i,
+        })
+        .click();
 
       await page
         .getByRole('button', {
@@ -202,6 +218,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: completedInstance.detail,
+          processInstanceDetailV2: completedInstance.detailV2,
+          callHierarchy: completedInstance.callHierarchy,
           flowNodeInstances: completedInstance.flowNodeInstances,
           statisticsV2: completedInstance.statisticsV2,
           sequenceFlows: completedInstance.sequenceFlows,
@@ -237,6 +255,8 @@ test.describe('process instance page', () => {
         URL_API_PATTERN,
         mockResponses({
           processInstanceDetail: compensationProcessInstance.detail,
+          processInstanceDetailV2: compensationProcessInstance.detailV2,
+          callHierarchy: compensationProcessInstance.callHierarchy,
           flowNodeInstances: compensationProcessInstance.flowNodeInstances,
           statisticsV2: compensationProcessInstance.statisticsV2,
           sequenceFlows: compensationProcessInstance.sequenceFlows,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/VariablesTable.tsx
@@ -22,9 +22,9 @@ import {useProcessInstancePageParams} from '../../../useProcessInstancePageParam
 import {Edit} from '@carbon/react/icons';
 import {VariableFormValues} from 'modules/types/variables';
 import {EditButtons} from '../EditButtons';
-import {ExistingVariableValue} from '../ExistingVariableValue';
-import {Name} from '../NewVariableModification/Name';
-import {Value} from '../NewVariableModification/Value';
+import {ExistingVariableValue} from './ExistingVariableValue';
+import {Name} from '../NewVariableModification/v2/Name';
+import {Value} from '../NewVariableModification/v2/Value';
 import {Operation as OperationV2} from '../NewVariableModification/v2/Operation';
 import {ViewFullVariableButton} from '../ViewFullVariableButton';
 import {MAX_VARIABLES_STORED} from 'modules/constants/variables';

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -47,7 +47,7 @@ const mockProcessInstance: ProcessInstance = {
   processDefinitionId: 'processName',
   tenantId: '<default>',
   processDefinitionName: 'Multi-Instance Process',
-  hasIncident: true,
+  hasIncident: false,
 };
 const mockDeprecatedProcessInstance = createInstance({
   id: '1',

--- a/operate/client/src/App/ProcessInstance/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/v2/index.tsx
@@ -204,7 +204,7 @@ const ProcessInstance: React.FC = observer(() => {
             breadcrumb={
               isBreadcrumbVisible && callHierarchy ? (
                 <Breadcrumb
-                  callHierarchy={callHierarchy}
+                  callHierarchy={callHierarchy.slice(0, -1)}
                   processInstance={processInstance}
                 />
               ) : undefined

--- a/operate/client/src/modules/hooks/flowNodeInstance.ts
+++ b/operate/client/src/modules/hooks/flowNodeInstance.ts
@@ -34,7 +34,7 @@ const useInstanceExecutionHistory = (): FlowNodeInstance | null => {
   return {
     id: processInstance.processInstanceKey,
     type: 'PROCESS',
-    state: processInstance.state,
+    state: processInstance.hasIncident ? 'INCIDENT' : processInstance.state,
     treePath: processInstance.processInstanceKey,
     endDate: null,
     startDate: '',


### PR DESCRIPTION
## Description

This PR adds missing mocks for visual regression tests. Along the way I also fixed some v2 imports, a bug with flow node states and another bug with variables modification scope

## Related issues

related to #31203
