### PR TITLE
test: add feat flag overrides

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/FlowNodeStates.test.tsx
@@ -40,6 +40,11 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 const getWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -32,6 +32,11 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 const editNameFromTextfieldAndBlur = async (user: UserEvent, value: string) => {
   const [nameField] = screen.getAllByTestId('new-variable-name');
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -53,6 +53,11 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 const getWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/notification.test.tsx
@@ -53,6 +53,11 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 const getWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/placeholder.test.tsx
@@ -38,6 +38,10 @@ jest.mock('modules/stores/notifications', () => ({
     displayNotification: jest.fn(() => () => {}),
   },
 }));
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
 
 const getWrapper = (
   initialEntries: React.ComponentProps<

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/readonly.test.tsx
@@ -41,6 +41,11 @@ jest.mock('modules/stores/notifications', () => ({
   },
 }));
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 const getWrapper = (
   initialEntries: React.ComponentProps<
     typeof MemoryRouter

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/spinner.test.tsx
@@ -42,6 +42,10 @@ jest.mock('modules/stores/notifications', () => ({
     displayNotification: jest.fn(() => () => {}),
   },
 }));
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
 
 const getWrapper = (
   initialEntries: React.ComponentProps<

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -6,13 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  render,
-  screen,
-  within,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, within, waitFor} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -49,7 +43,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(
       screen.queryByRole('textbox', {
@@ -103,7 +97,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -151,7 +145,7 @@ describe('Add variable', () => {
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
 
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -252,7 +246,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -342,7 +336,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -405,7 +399,7 @@ describe('Add variable', () => {
     variablesStore.fetchVariables('1');
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -432,7 +426,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(
       screen.queryByRole('textbox', {
@@ -486,7 +480,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
     expect(
@@ -514,7 +508,7 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(
       await screen.findByRole('button', {name: /add variable/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/addVariable.test.tsx
@@ -43,7 +43,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(
       screen.queryByRole('textbox', {
@@ -97,7 +99,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -145,7 +149,9 @@ describe('Add variable', () => {
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
 
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -246,7 +252,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -336,7 +344,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
@@ -399,7 +409,9 @@ describe('Add variable', () => {
     variablesStore.fetchVariables('1');
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByRole('button', {name: /add variable/i}));
@@ -426,7 +438,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(
       screen.queryByRole('textbox', {
@@ -480,7 +494,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
     expect(
@@ -508,7 +524,9 @@ describe('Add variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(
       await screen.findByRole('button', {name: /add variable/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
@@ -60,7 +60,7 @@ describe('Edit variable', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     const [activeOperationVariable] = variablesStore.state.items.filter(
       ({hasActiveOperation}) => hasActiveOperation,
@@ -99,7 +99,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
 
@@ -149,7 +149,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
 
@@ -189,7 +189,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
 
@@ -246,7 +246,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
 
@@ -301,7 +301,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
 
@@ -342,7 +342,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.getByText('"full-value"')).toBeInTheDocument();
 
@@ -385,7 +385,7 @@ describe('Edit variable', () => {
     const {user} = render(<Variables isVariableModificationAllowed />, {
       wrapper: getWrapper(),
     });
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
 
@@ -427,7 +427,7 @@ describe('Edit variable', () => {
     const {user} = render(<Variables isVariableModificationAllowed />, {
       wrapper: getWrapper(),
     });
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
 
@@ -458,7 +458,7 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(await screen.findByRole('button', {name: /edit variable/i}));
     mockFetchProcessDefinitionXml().withSuccess('');

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/editVariable.test.tsx
@@ -60,7 +60,9 @@ describe('Edit variable', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     const [activeOperationVariable] = variablesStore.state.items.filter(
       ({hasActiveOperation}) => hasActiveOperation,
@@ -99,7 +101,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
 
@@ -149,7 +153,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.queryByTestId('add-variable-value')).not.toBeInTheDocument();
 
@@ -189,7 +195,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.queryByTestId('edit-variable-value')).not.toBeInTheDocument();
 
@@ -246,7 +254,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
 
@@ -301,7 +311,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.getByText('"value-preview"')).toBeInTheDocument();
 
@@ -342,7 +354,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.getByText('"full-value"')).toBeInTheDocument();
 
@@ -385,7 +399,9 @@ describe('Edit variable', () => {
     const {user} = render(<Variables isVariableModificationAllowed />, {
       wrapper: getWrapper(),
     });
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
 
@@ -427,7 +443,9 @@ describe('Edit variable', () => {
     const {user} = render(<Variables isVariableModificationAllowed />, {
       wrapper: getWrapper(),
     });
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId('edit-variable-value')).toHaveValue('123');
 
@@ -458,7 +476,9 @@ describe('Edit variable', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(await screen.findByRole('button', {name: /edit variable/i}));
     mockFetchProcessDefinitionXml().withSuccess('');

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/footer.test.tsx
@@ -6,12 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -37,10 +32,13 @@ const instanceMock = createInstance({id: '1'});
 
 describe('Footer', () => {
   beforeEach(() => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchProcessDefinitionXml().withSuccess(
       mockProcessWithInputOutputMappingsXML,
     );
     mockProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockFetchVariables().withSuccess(mockVariables);
     mockFetchFlownodeInstancesStatistics().withSuccess({
       items: [
         {
@@ -97,8 +95,6 @@ describe('Footer', () => {
 
     render(<Variables />, {wrapper: getWrapper()});
 
-    expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
     await waitFor(() =>
       expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled(),
     );
@@ -123,7 +119,6 @@ describe('Footer', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await waitFor(() =>
       expect(
@@ -150,7 +145,9 @@ describe('Footer', () => {
     });
 
     const {user} = render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', {name: /add variable/i}));
     await waitFor(() =>
@@ -205,7 +202,6 @@ describe('Footer', () => {
     );
 
     render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     await waitFor(() =>
       expect(

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
@@ -6,12 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  render,
-  screen,
-  within,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen, within} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -21,18 +16,23 @@ import {createInstance, createVariable} from 'modules/testUtils';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 import {getWrapper, mockProcessInstance} from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessInstance as mockProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 const instanceMock = createInstance({id: '1'});
 
 describe('Variables', () => {
   beforeEach(() => {
     flowNodeSelectionStore.init();
+
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockFetchProcessDefinitionXml().withSuccess('');
   });
 
   describe('Variables', () => {
     it('should render variables table', async () => {
       processInstanceDetailsStore.setProcessInstance(instanceMock);
-
       mockFetchVariables().withSuccess(mockVariables);
 
       variablesStore.fetchVariables({
@@ -42,7 +42,7 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+      expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
       expect(screen.getByText('Name')).toBeInTheDocument();
       expect(screen.getByText('Value')).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-      await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+      expect(await screen.findByTestId('variables-list')).toBeTruthy();
       const {items} = variablesStore.state;
       const [activeOperationVariable] = items.filter(
         ({hasActiveOperation}) => hasActiveOperation,
@@ -114,10 +114,7 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-
-      await waitForElementToBeRemoved(() =>
-        screen.getByTestId('variables-skeleton'),
-      );
+      expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
       expect(
         screen.getByRole('button', {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, within} from 'modules/testing-library';
+import {render, screen, waitFor, within} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -42,7 +42,9 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-      expect(await screen.findByTestId('variables-list')).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+      });
 
       expect(screen.getByText('Name')).toBeInTheDocument();
       expect(screen.getByText('Value')).toBeInTheDocument();
@@ -70,7 +72,9 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-      expect(await screen.findByTestId('variables-list')).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+      });
       const {items} = variablesStore.state;
       const [activeOperationVariable] = items.filter(
         ({hasActiveOperation}) => hasActiveOperation,
@@ -114,7 +118,9 @@ describe('Variables', () => {
       });
 
       render(<Variables />, {wrapper: getWrapper()});
-      expect(await screen.findByTestId('variables-list')).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+      });
 
       expect(
         screen.getByRole('button', {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -79,7 +79,9 @@ describe('Restricted user with resource based permissions', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -120,7 +122,9 @@ describe('Restricted user with resource based permissions', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    expect(await screen.findByTestId('variables-list')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
 
     expect(
       await screen.findByRole('button', {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/v2/restrictedUserWithResourceBasedPermissions.test.tsx
@@ -6,11 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from 'modules/testing-library';
+import {render, screen} from 'modules/testing-library';
 import {variablesStore} from 'modules/stores/variables';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import Variables from './index';
@@ -20,14 +16,26 @@ import {authenticationStore} from 'modules/stores/authentication';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 import {mockFetchProcessInstance as mockFetchProcessInstanceDeprecated} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 
 const instanceMock = createInstance({id: '1'});
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
+}));
 
 describe('Restricted user with resource based permissions', () => {
   beforeEach(() => {
     window.clientConfig = {
       resourcePermissionsEnabled: true,
     };
+
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockFetchProcessInstanceDeprecated().withSuccess(instanceMock);
+    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess('');
   });
 
   afterEach(() => {
@@ -71,7 +79,7 @@ describe('Restricted user with resource based permissions', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(
       screen.getByRole('button', {name: /add variable/i}),
@@ -91,7 +99,6 @@ describe('Restricted user with resource based permissions', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-    await waitForElementToBeRemoved(screen.getByTestId('variables-skeleton'));
 
     expect(
       screen.queryByRole('button', {name: /add variable/i}),
@@ -113,13 +120,12 @@ describe('Restricted user with resource based permissions', () => {
     });
 
     render(<Variables />, {wrapper: getWrapper()});
-
-    await waitForElementToBeRemoved(() =>
-      screen.getByTestId('variables-skeleton'),
-    );
+    expect(await screen.findByTestId('variables-list')).toBeTruthy();
 
     expect(
-      screen.getByRole('button', {name: 'View full value of testVariableName'}),
+      await screen.findByRole('button', {
+        name: 'View full value of testVariableName',
+      }),
     ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/v2/index.test.tsx
@@ -36,6 +36,10 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 
 jest.mock('modules/utils/bpmn');
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: true,
+}));
 
 const processInstancesMock = createMultiInstanceFlowNodeInstances('1');
 const mockProcessInstance: ProcessInstance = {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/index.test.tsx
@@ -12,6 +12,11 @@ import {mockIncidents, Wrapper} from './mocks';
 import {incidentsStore} from 'modules/stores/incidents';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
+
 describe('IncidentsFilter', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);

--- a/operate/client/src/App/ProcessInstance/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/index.test.tsx
@@ -28,6 +28,10 @@ import {getProcessName} from 'modules/utils/instance';
 import {getWrapper, mockRequests, waitForPollingsToBeComplete} from './mocks';
 
 jest.mock('modules/utils/bpmn');
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
 
 const clearPollingStates = () => {
   variablesStore.isPollRequestRunning = false;

--- a/operate/client/src/App/ProcessInstance/modifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/modifications.test.tsx
@@ -40,6 +40,10 @@ jest.mock('modules/utils/bpmn');
 jest.mock('modules/stores/process', () => ({
   processStore: {state: {process: {}}, fetchProcess: jest.fn()},
 }));
+jest.mock('modules/feature-flags', () => ({
+  ...jest.requireActual('modules/feature-flags'),
+  IS_PROCESS_INSTANCE_V2_ENABLED: false,
+}));
 
 describe('ProcessInstance - modification mode', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Description

This PR is overriding feature flag values in tests where some child components are using v1 code. Explicitly setting the flag makes sure of consistency in integration tests. At this point, we can enable the feature flag for PI details and tests will give the same results

## Related issues

related to https://github.com/camunda/camunda/issues/31203
