### PR TITLE
Add update user api to java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -78,6 +78,7 @@ import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
+import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.client.api.fetch.BatchOperationGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
@@ -1612,6 +1613,23 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   DeleteUserCommandStep1 newDeleteUserCommand(String username);
+
+  /**
+   * Command to update a user.
+   *
+   * <pre>
+   * camundaClient
+   *  .newUpdateUserCommand("username")
+   *  .name("name")
+   *  .email("email@email.com")
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder for the command
+   */
+  UpdateUserCommandStep1 newUpdateUserCommand(String username);
 
   /**
    * Command to create a mapping rule.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateUserCommandStep1.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.UpdateUserResponse;
+
+public interface UpdateUserCommandStep1 extends FinalCommandStep<UpdateUserResponse> {
+
+  /**
+   * Set the name for the user to be updated.
+   *
+   * @param name the name of the user
+   * @return the builder for this command
+   */
+  UpdateUserCommandStep1 name(String name);
+
+  /**
+   * Set the email for the user to be updated.
+   *
+   * @param email the user email
+   * @return the builder for this command
+   */
+  UpdateUserCommandStep1 email(String email);
+
+  /**
+   * Set the password for the user to be updated.
+   *
+   * @param password the user password
+   * @return the builder for this command
+   */
+  UpdateUserCommandStep1 password(String password);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateUserResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface UpdateUserResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -89,6 +89,7 @@ import io.camunda.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.client.api.command.UpdateRoleCommandStep1;
 import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
+import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.client.api.fetch.BatchOperationGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
@@ -203,6 +204,7 @@ import io.camunda.client.impl.command.UpdateAuthorizationCommandImpl;
 import io.camunda.client.impl.command.UpdateGroupCommandImpl;
 import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
+import io.camunda.client.impl.command.UpdateUserCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.client.impl.fetch.BatchOperationGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetRequestImpl;
@@ -966,6 +968,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public DeleteUserCommandStep1 newDeleteUserCommand(final String username) {
     return new DeleteUserCommandImpl(httpClient, username);
+  }
+
+  @Override
+  public UpdateUserCommandStep1 newUpdateUserCommand(final String username) {
+    return new UpdateUserCommandImpl(httpClient, username, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.UpdateUserCommandStep1;
+import io.camunda.client.api.response.UpdateUserResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.protocol.rest.UserUpdateRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UpdateUserCommandImpl implements UpdateUserCommandStep1 {
+
+  private final String username;
+  private final UserUpdateRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public UpdateUserCommandImpl(
+      final HttpClient httpClient, final String username, final JsonMapper jsonMapper) {
+    this.username = username;
+    request = new UserUpdateRequest();
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public UpdateUserCommandStep1 name(final String name) {
+    request.setName(name);
+    return this;
+  }
+
+  @Override
+  public UpdateUserCommandStep1 email(final String email) {
+    request.setEmail(email);
+    return this;
+  }
+
+  @Override
+  public UpdateUserCommandStep1 password(final String password) {
+    request.setPassword(password);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UpdateUserResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<UpdateUserResponse> send() {
+    final HttpCamundaFuture<UpdateUserResponse> result = new HttpCamundaFuture<>();
+    httpClient.put(
+        "/users/" + username, jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateUserCommandImpl.java
@@ -70,6 +70,8 @@ public class UpdateUserCommandImpl implements UpdateUserCommandStep1 {
 
   @Override
   public CamundaFuture<UpdateUserResponse> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("name", request.getName());
+    ArgumentUtil.ensureNotNullNorEmpty("email", request.getEmail());
     final HttpCamundaFuture<UpdateUserResponse> result = new HttpCamundaFuture<>();
     httpClient.put(
         "/users/" + username, jsonMapper.toJson(request), httpRequestConfig.build(), result);

--- a/clients/java/src/test/java/io/camunda/client/role/UpdateRoleTest.java
+++ b/clients/java/src/test/java/io/camunda/client/role/UpdateRoleTest.java
@@ -18,7 +18,7 @@ package io.camunda.client.role;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.client.protocol.rest.GroupUpdateRequest;
+import io.camunda.client.protocol.rest.RoleUpdateRequest;
 import io.camunda.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ public class UpdateRoleTest extends ClientRestTest {
         .join();
 
     // then
-    final GroupUpdateRequest request = gatewayService.getLastRequest(GroupUpdateRequest.class);
+    final RoleUpdateRequest request = gatewayService.getLastRequest(RoleUpdateRequest.class);
     assertThat(request.getName()).isEqualTo(UPDATED_NAME);
     assertThat(request.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
   }

--- a/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
@@ -16,6 +16,7 @@
 package io.camunda.client.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.protocol.rest.UserUpdateRequest;
 import io.camunda.client.util.ClientRestTest;
@@ -37,5 +38,53 @@ public class UpdateUserTest extends ClientRestTest {
     assertThat(request.getName()).isEqualTo(NAME);
     assertThat(request.getEmail()).isEqualTo(EMAIL);
     assertThat(request.getPassword()).isEqualTo(PASSWORD);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateUserCommand(USERNAME)
+                    .name(null)
+                    .email("new_email@email.com")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyName() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateUserCommand(USERNAME)
+                    .name("")
+                    .email("new_email@email.com")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullEmail() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newUpdateUserCommand(USERNAME).name(NAME).email(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("email must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyEmail() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newUpdateUserCommand(USERNAME).name(NAME).email("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("email must not be empty");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/UpdateUserTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.protocol.rest.UserUpdateRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class UpdateUserTest extends ClientRestTest {
+  private static final String USERNAME = "username";
+  private static final String NAME = "updated user name";
+  private static final String EMAIL = "updated_email@email.com";
+  private static final String PASSWORD = "updated password";
+
+  @Test
+  void shouldUpdateUser() {
+    // when
+    client.newUpdateUserCommand(USERNAME).name(NAME).email(EMAIL).password(PASSWORD).send().join();
+
+    // then
+    final UserUpdateRequest request = gatewayService.getLastRequest(UserUpdateRequest.class);
+    assertThat(request.getName()).isEqualTo(NAME);
+    assertThat(request.getEmail()).isEqualTo(EMAIL);
+    assertThat(request.getPassword()).isEqualTo(PASSWORD);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -23,13 +24,14 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-class UserSearchingAuthorizationIT {
+class UserAuthorizationIT {
 
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
@@ -39,7 +41,6 @@ class UserSearchingAuthorizationIT {
   private static final String RESTRICTED = "restrictedUser";
   private static final String RESTRICTED_WITH_READ = "restrictedUser2";
   private static final String FIRST_USER = "user1";
-  private static final String SECOND_USER = "user2";
   private static final String DEFAULT_PASSWORD = "password";
 
   @UserDefinition
@@ -68,9 +69,6 @@ class UserSearchingAuthorizationIT {
   @UserDefinition
   private static final TestUser USER_1 = new TestUser(FIRST_USER, DEFAULT_PASSWORD, List.of());
 
-  @UserDefinition
-  private static final TestUser USER_2 = new TestUser(SECOND_USER, DEFAULT_PASSWORD, List.of());
-
   @Test
   void searchShouldReturnAuthorizedUsers(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient userClient) {
@@ -80,7 +78,7 @@ class UserSearchingAuthorizationIT {
     // then
     assertThat(result.items())
         .map(io.camunda.client.api.search.response.User::getUsername)
-        .containsExactly("demo", "admin", "restrictedUser", "restrictedUser2", "user1", "user2");
+        .containsExactly("demo", "admin", "restrictedUser", "restrictedUser2", "user1");
   }
 
   @Test
@@ -117,6 +115,51 @@ class UserSearchingAuthorizationIT {
   void deleteUserShouldReturnForbiddenIfUnauthorized(
       @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
     assertThatThrownBy(() -> camundaClient.newDeleteUserCommand(RESTRICTED).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("403: 'Forbidden'");
+  }
+
+  @Test
+  void shouldUpdateUserByUsernameIfAuthorized(
+      @Authenticated(ADMIN) final CamundaClient adminClient) {
+    final String updatedName = "updated_name";
+    final String updatedEmail = "updated_email@email.com";
+
+    adminClient
+        .newUpdateUserCommand(USER_1.username())
+        .name(updatedName)
+        .email(updatedEmail)
+        .send()
+        .join();
+
+    Awaitility.await("User is updated")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminClient
+                            .newUsersSearchRequest()
+                            .filter(fn -> fn.username(USER_1.username()))
+                            .send()
+                            .join()
+                            .items()
+                            .getFirst())
+                    .matches(u -> u.getUsername().equals(USER_1.username()))
+                    .matches(u -> u.getEmail().equals(updatedEmail))
+                    .matches(u -> u.getName().equals(updatedName)));
+  }
+
+  @Test
+  void updateUserShouldReturnForbiddenIfUnauthorized(
+      @Authenticated(RESTRICTED_WITH_READ) final CamundaClient camundaClient) {
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateUserCommand(USER_1.username())
+                    .name("updated_name")
+                    .email("updated_email@email.com")
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("403: 'Forbidden'");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.response.User;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class UsersUpdateIntegrationTest {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldUpdateUser() {
+    // given
+    final var username = "AUserName";
+    final var name = "User Name";
+    final var email = "email@email.com";
+
+    final var updatedName = "Updated User Name";
+    final var updatedEmail = "updated_email@email.com";
+
+    camundaClient
+        .newUserCreateCommand()
+        .username(username)
+        .password("password")
+        .name(name)
+        .email(email)
+        .send()
+        .join();
+    assertUserCreated(username);
+
+    // when
+    camundaClient
+        .newUpdateUserCommand(username)
+        .name(updatedName)
+        .email(updatedEmail)
+        .send()
+        .join();
+
+    // then
+    Awaitility.await("User is updated")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<User> response =
+                  camundaClient
+                      .newUsersSearchRequest()
+                      .filter(fn -> fn.username(username))
+                      .send()
+                      .join();
+              assertThat(response.items().getFirst().getUsername()).isEqualTo(username);
+              assertThat(response.items().getFirst().getName()).isEqualTo(updatedName);
+              assertThat(response.items().getFirst().getEmail()).isEqualTo(updatedEmail);
+            });
+  }
+
+  private static void assertUserCreated(final String userName) {
+    Awaitility.await("User is created and exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .untilAsserted(
+            () -> {
+              final SearchResponse<User> usersSearchResponse =
+                  camundaClient
+                      .newUsersSearchRequest()
+                      .filter(fn -> fn.username(userName))
+                      .send()
+                      .join();
+              assertThat(usersSearchResponse.items()).hasSize(1);
+              final User user = usersSearchResponse.items().getFirst();
+              assertThat(user.getUsername()).isEqualTo(userName);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -65,6 +66,25 @@ public class UsersUpdateIntegrationTest {
               assertThat(response.items().getFirst().getName()).isEqualTo(updatedName);
               assertThat(response.items().getFirst().getEmail()).isEqualTo(updatedEmail);
             });
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenUpdatingIfUserDoesNotExist() {
+    // when / then
+    final var nonExistingUserName = "nonExistingUserName";
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newUpdateUserCommand(nonExistingUserName)
+                    .name("Role Name")
+                    .email("new_email@email.com")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Expected to update user with username %s, but a user with this username does not exist"
+                .formatted(nonExistingUserName));
   }
 
   private static void assertUserCreated(final String userName) {


### PR DESCRIPTION
## Description

Adding update user API to Java Client.

There are some open questions, please check PR commits or code comments (I duplicated them into both places)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32515
