### PR TITLE
feat: when a SCALE_UP command is processed, persist the event key in state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -60,6 +60,7 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
     }
 
     final var scalingKey = keyGenerator.nextKey();
+    scaleUp.setBootstrappedAt(command.getKey());
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
     responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
     commandWriter.appendFollowUpCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpStatusProcessor.java
@@ -47,7 +47,8 @@ public class ScaleUpStatusProcessor implements TypedRecordProcessor<ScaleRecord>
       final var response = new ScaleRecord();
       response
           .setDesiredPartitionCount(desiredPartitions.size())
-          .setRedistributedPartitions(routingState.currentPartitions());
+          .setRedistributedPartitions(routingState.currentPartitions())
+          .setBootstrappedAt(routingState.bootstrappedAt(request.getDesiredPartitionCount()));
       writers.state().appendFollowUpEvent(key, ScaleIntent.STATUS_RESPONSE, response);
       writers.response().writeEventOnCommand(key, ScaleIntent.STATUS_RESPONSE, response, command);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
@@ -25,6 +25,6 @@ public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRec
     final var partitionCount = value.getDesiredPartitionCount();
     final var partitions = PartitionUtil.allPartitions(partitionCount);
 
-    routingState.setDesiredPartitions(partitions);
+    routingState.setDesiredPartitions(partitions, key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -18,6 +18,16 @@ public interface RoutingState {
 
   boolean isInitialized();
 
+  /**
+   * Retrieves the event key of the SCALING_UP event for a specific partition count.
+   *
+   * @param partitionCount the target number of partitions for the scaling operation
+   * @return the event key of the SCALING_UP event that scaled to the specified partition count.
+   *     Returns 0 for the initial partition count, or -1 if the system has never scaled to the
+   *     specified number of partitions
+   */
+  long bootstrappedAt(int partitionCount);
+
   sealed interface MessageCorrelation {
     record HashMod(int partitionCount) implements MessageCorrelation {
       public HashMod {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
@@ -21,12 +21,17 @@ public interface MutableRoutingState extends RoutingState {
   /**
    * Creates a new desired state by copying the current state and using the given partitions.
    * Message correlation is not modified and only copied from the current state.
+   *
+   * @param partitions the set of partition IDs to be used as the desired state. The set must
+   *     include current partitions and the new partitions.
+   * @param key the event key associated with this scaling operation, which will be stored for
+   *     tracking the scaling history via {@link RoutingState#bootstrappedAt(int)}
    */
-  void setDesiredPartitions(Set<Integer> partitions);
+  void setDesiredPartitions(Set<Integer> partitions, long key);
 
   /**
    * Copies the desired state to the current state. The desired state must be set via {@link
-   * #setDesiredPartitions(Set)} before calling this method.
+   * #setDesiredPartitions(Set, long)} before calling this method.
    */
   void arriveAtDesiredState();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -81,7 +81,7 @@ public class CommandDistributionScalingTest {
 
     // given a scale operation ongoing to transition to 3 partitions
     state.getRoutingState().initializeRoutingInfo(2);
-    state.getRoutingState().setDesiredPartitions(Set.of(1, 2, 3));
+    state.getRoutingState().setDesiredPartitions(Set.of(1, 2, 3), 1L);
     behavior =
         new CommandDistributionBehavior(
             distributionState,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
@@ -131,7 +131,7 @@ public class CommandRedistributorTest {
     @BeforeEach
     void setUp() {
       // Simulate scaling up partition 3
-      routingState.setDesiredPartitions(Set.of(1, 2, 3));
+      routingState.setDesiredPartitions(Set.of(1, 2, 3), 111L);
 
       distributionState.addRetriableDistribution(distributionKey, 3);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -161,7 +161,7 @@ public class ScaleUpTest {
   public void shouldRejectRedundantScaleUp() {
     // given - a scale up from 2 to 3 was already requested
     ((MutableRoutingState) engine.getProcessingState(1).getRoutingState())
-        .setDesiredPartitions(Set.of(1, 2, 3));
+        .setDesiredPartitions(Set.of(1, 2, 3), 999L);
 
     // when
     engine.writeRecords(
@@ -219,7 +219,7 @@ public class ScaleUpTest {
                     .setDesiredPartitionCount(4)
                     .setRedistributedPartitions(List.of(4)));
     // when
-    engine.writeRecords(scaleUpCommand, getStatusCommand);
+    final var key = engine.writeRecords(scaleUpCommand, getStatusCommand);
 
     // then
 
@@ -232,6 +232,7 @@ public class ScaleUpTest {
         // In the future, the expected number of partitions should be (1,2,3)
         // until redistribution is completed
         .containsExactlyInAnyOrder(1, 2, 3, 4);
+    assertThat(record.getValue().getBootstrappedAt()).isGreaterThanOrEqualTo(key);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
@@ -62,7 +62,7 @@ public class DeploymentRedistributorTest {
     final var deploymentState = processingState.getDeploymentState();
     routingState = processingState.getRoutingState();
     routingState.initializeRoutingInfo(2);
-    routingState.setDesiredPartitions(Set.of(1, 2, 3));
+    routingState.setDesiredPartitions(Set.of(1, 2, 3), 239123L);
 
     final RoutingInfo routingInfo =
         RoutingInfo.dynamic(routingState, new StaticRoutingInfo(Set.of(1, 2), 2));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -55,7 +55,8 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.TENANTS,
           ZbColumnFamilies.AUTHORIZATIONS,
           ZbColumnFamilies.AUTHORIZATION_KEYS_BY_OWNER,
-          ZbColumnFamilies.ROUTING);
+          ZbColumnFamilies.ROUTING,
+          ZbColumnFamilies.BOOTSTRAPPED_AT);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
@@ -41,6 +41,23 @@ final class DbRoutingStateTest {
     assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(routingState.messageCorrelation())
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(3));
+    assertThat(routingState.bootstrappedAt(3)).isEqualTo(0);
+  }
+
+  @Test
+  void shouldFillBootstrappedAtCorrectly() {
+    // given
+    final var routingState = processingState.getRoutingState();
+    routingState.initializeRoutingInfo(1);
+    final long eventKey = 1231923L;
+
+    // when
+    routingState.setDesiredPartitions(Set.of(1, 2, 3), eventKey);
+
+    // then
+    assertThat(routingState.bootstrappedAt(1)).isEqualTo(0L);
+    assertThat(routingState.bootstrappedAt(3)).isEqualTo(eventKey);
+    assertThat(routingState.bootstrappedAt(2)).isEqualTo(-1L);
   }
 
   @Test
@@ -49,9 +66,10 @@ final class DbRoutingStateTest {
     final var routingState = processingState.getRoutingState();
     routingState.initializeRoutingInfo(1);
     assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1);
+    final long eventKey = 1231923L;
 
     // when
-    routingState.setDesiredPartitions(Set.of(1, 2, 3));
+    routingState.setDesiredPartitions(Set.of(1, 2, 3), eventKey);
 
     // then
     assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -495,8 +495,8 @@ public final class EngineRule extends ExternalResource {
         .getFirst();
   }
 
-  public void writeRecords(final RecordToWrite... records) {
-    environmentRule.writeBatch(records);
+  public long writeRecords(final RecordToWrite... records) {
+    return environmentRule.writeBatch(records);
   }
 
   public CommandResponseWriter getCommandResponseWriter() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.scaling;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
@@ -27,11 +28,14 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   private final ArrayProperty<IntegerValue> relocatedPartitions =
       new ArrayProperty<>("relocatedPartitions", IntegerValue::new);
 
+  private final LongProperty bootstrappedAt = new LongProperty("bootstrappedAt", -1L);
+
   public ScaleRecord() {
-    super(3);
+    super(4);
     declareProperty(desiredPartitionCountProp)
         .declareProperty(redistributedPartitions)
-        .declareProperty(relocatedPartitions);
+        .declareProperty(relocatedPartitions)
+        .declareProperty(bootstrappedAt);
   }
 
   @Override
@@ -59,6 +63,16 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
     for (final int partition : partitions) {
       relocatedPartitions.add().setValue(partition);
     }
+    return this;
+  }
+
+  @Override
+  public long getBootstrappedAt() {
+    return bootstrappedAt.getValue();
+  }
+
+  public ScaleRecord setBootstrappedAt(final long bootstrappedAt) {
+    this.bootstrappedAt.setValue(bootstrappedAt);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2923,7 +2923,8 @@ final class JsonSerializableToJsonTest {
         {
           "desiredPartitionCount": -1,
           "redistributedPartitions": [],
-          "relocatedPartitions": []
+          "relocatedPartitions": [],
+          "bootstrappedAt": -1
         }
         """
       },
@@ -2934,23 +2935,26 @@ final class JsonSerializableToJsonTest {
         {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [],
-          "relocatedPartitions": []
+          "relocatedPartitions": [],
+          "bootstrappedAt": -1
         }
         """
       },
       {
-        "ScaleRecord w/ redistributedPartitions & relocatedPartitions",
+        "ScaleRecord w/ redistributedPartitions & relocatedPartitions & bootstrappedAt",
         (Supplier<ScaleRecord>)
             () ->
                 new ScaleRecord()
                     .setDesiredPartitionCount(5)
                     .setRelocatedPartitions(List.of(4, 5))
-                    .setRedistributedPartitions(List.of(4, 5)),
+                    .setRedistributedPartitions(List.of(4, 5))
+                    .setBootstrappedAt(123L),
         """
         {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [4,5],
-          "relocatedPartitions": [4,5]
+          "relocatedPartitions": [4,5],
+          "bootstrappedAt": 123
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -238,7 +238,8 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
 
   USER_TASK_INITIAL_ASSIGNEE(121),
 
-  RPI_USAGE_METRICS(122);
+  RPI_USAGE_METRICS(122),
+  BOOTSTRAPPED_AT(123);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -28,4 +28,6 @@ public interface ScaleRecordValue extends RecordValue {
   Collection<Integer> getRedistributedPartitions();
 
   Collection<Integer> getRelocatedPartitions();
+
+  long getBootstrappedAt();
 }


### PR DESCRIPTION
## Description
Save the key of the event SCALING_UP into the state.
The event key can be retrieved later on to verify that the snapshot has been done past that event key.
## Related issues

closes #32701 
