### PR TITLE
Refactor `newAssignUserToGroupCommand` to follow the agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1545,8 +1545,9 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    *
    * camundaClient
-   *  .newAssignUserToGroupCommand("groupId")
+   *  .newAssignUserToGroupCommand()
    *  .username("username")
+   *  .groupId("groupId")
    *  .send();
    * </pre>
    *
@@ -1554,7 +1555,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  AssignUserToGroupCommandStep1 newAssignUserToGroupCommand(String groupId);
+  AssignUserToGroupCommandStep1 newAssignUserToGroupCommand();
 
   /**
    * Command to unassign a user from a group.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToGroupCommandStep1.java
@@ -17,14 +17,24 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.AssignUserToGroupResponse;
 
-public interface AssignUserToGroupCommandStep1 extends FinalCommandStep<AssignUserToGroupResponse> {
+public interface AssignUserToGroupCommandStep1 {
 
   /**
    * Sets the username for the assignment.
    *
    * @param username the username of the user
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  AssignUserToGroupCommandStep1 username(String username);
+  AssignUserToGroupCommandStep2 username(String username);
+
+  interface AssignUserToGroupCommandStep2 extends FinalCommandStep<AssignUserToGroupResponse> {
+    /**
+     * Sets the group ID.
+     *
+     * @param groupId the id of the group
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignUserToGroupCommandStep2 groupId(String groupId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -947,8 +947,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignUserToGroupCommandStep1 newAssignUserToGroupCommand(final String groupId) {
-    return new AssignUserToGroupCommandImpl(groupId, httpClient);
+  public AssignUserToGroupCommandStep1 newAssignUserToGroupCommand() {
+    return new AssignUserToGroupCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToGroupCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignUserToGroupCommandStep1;
+import io.camunda.client.api.command.AssignUserToGroupCommandStep1.AssignUserToGroupCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class AssignUserToGroupCommandImpl implements AssignUserToGroupCommandStep1 {
+public class AssignUserToGroupCommandImpl
+    implements AssignUserToGroupCommandStep1, AssignUserToGroupCommandStep2 {
 
-  private final String groupId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private String username;
+  private String groupId;
 
-  public AssignUserToGroupCommandImpl(final String groupId, final HttpClient httpClient) {
-    this.groupId = groupId;
+  public AssignUserToGroupCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignUserToGroupCommandStep1 username(final String username) {
+  public AssignUserToGroupCommandStep2 username(final String username) {
     this.username = username;
+    return this;
+  }
+
+  @Override
+  public AssignUserToGroupCommandStep2 groupId(final String groupId) {
+    this.groupId = groupId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/group/AssignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/AssignMemberGroupTest.java
@@ -35,7 +35,7 @@ public class AssignMemberGroupTest extends ClientRestTest {
   @Test
   void shouldAssignUserToGroup() {
     // when
-    client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join();
+    client.newAssignUserToGroupCommand().username(USERNAME).groupId(GROUP_ID).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
@@ -50,7 +50,13 @@ public class AssignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -63,7 +69,13 @@ public class AssignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'");
   }
@@ -76,7 +88,13 @@ public class AssignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }

--- a/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
@@ -63,7 +63,13 @@ public class UnassignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }
@@ -76,7 +82,13 @@ public class UnassignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
@@ -87,7 +87,7 @@ public class UsersByGroupSearchTest {
   }
 
   private static void assignUserToGroup(final String username, final String groupId) {
-    camundaClient.newAssignUserToGroupCommand(groupId).username(username).send().join();
+    camundaClient.newAssignUserToGroupCommand().username(username).groupId(groupId).send().join();
   }
 
   private static void waitForGroupsToBeUpdated() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -196,7 +196,7 @@ public class OperateInternalApiGroupPermissionsIT {
 
   private static void addUserToGroup(
       final CamundaClient client, final String groupId, final String userId) {
-    client.newAssignUserToGroupCommand(groupId).username(userId).send().join();
+    client.newAssignUserToGroupCommand().username(userId).groupId(groupId).send().join();
   }
 
   private ResponseCount searchRunningProcessInstances(
@@ -211,7 +211,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .uri(new URI(url))
             .POST(
                 HttpRequest.BodyPublishers.ofString(
-                    """
+                        """
               {
                 "query": {
                   "bpmnProcessId": "%s",
@@ -265,7 +265,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .uri(new URI(url))
             .POST(
                 HttpRequest.BodyPublishers.ofString(
-                    """
+                        """
               {
                 "operationType": "ADD_VARIABLE",
                 "name": "addVariable",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -211,7 +211,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .uri(new URI(url))
             .POST(
                 HttpRequest.BodyPublishers.ofString(
-                        """
+                    """
               {
                 "query": {
                   "bpmnProcessId": "%s",
@@ -265,7 +265,7 @@ public class OperateInternalApiGroupPermissionsIT {
             .uri(new URI(url))
             .POST(
                 HttpRequest.BodyPublishers.ofString(
-                        """
+                    """
               {
                 "operationType": "ADD_VARIABLE",
                 "name": "addVariable",

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -204,7 +204,7 @@ public class TasklistV1ApiGroupPermissionsIT {
 
   private static void addUserToGroup(
       final CamundaClient client, final String groupId, final String userId) {
-    client.newAssignUserToGroupCommand(groupId).username(userId).send().join();
+    client.newAssignUserToGroupCommand().username(userId).groupId(groupId).send().join();
   }
 
   private int getRunningProcessInstance(
@@ -241,7 +241,7 @@ public class TasklistV1ApiGroupPermissionsIT {
             .method(
                 "PATCH",
                 BodyPublishers.ofString(
-                    """
+                        """
                           {
                             "assignee": "%s",
                             "allowOverrideAssignment": true

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/groups/TasklistV1ApiGroupPermissionsIT.java
@@ -241,7 +241,7 @@ public class TasklistV1ApiGroupPermissionsIT {
             .method(
                 "PATCH",
                 BodyPublishers.ofString(
-                        """
+                    """
                           {
                             "assignee": "%s",
                             "allowOverrideAssignment": true

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -112,8 +112,9 @@ public final class EntityManager {
           final var entityType = membership.entityType();
           if (entityType == EntityType.USER) {
             defaultClient
-                .newAssignUserToGroupCommand(groupId)
+                .newAssignUserToGroupCommand()
                 .username(membership.memberId())
+                .groupId(groupId)
                 .send()
                 .join();
           } else {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToGroupTest.java
@@ -62,7 +62,7 @@ class AssignUserToGroupTest {
   @Test
   void shouldAssignUserToGroup() {
     // when
-    client.newAssignUserToGroupCommand(groupId).username(username).send().join();
+    client.newAssignUserToGroupCommand().username(username).groupId(groupId).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityAssignedToGroup(
@@ -82,8 +82,9 @@ class AssignUserToGroupTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignUserToGroupCommand(nonExistentGroupId)
+                    .newAssignUserToGroupCommand()
                     .username(username)
+                    .groupId(nonExistentGroupId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -96,11 +97,17 @@ class AssignUserToGroupTest {
   @Test
   void shouldRejectIfAlreadyAssigned() {
     // given
-    client.newAssignUserToGroupCommand(groupId).username(username).send().join();
+    client.newAssignUserToGroupCommand().username(username).groupId(groupId).send().join();
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(groupId).username(username).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(username)
+                    .groupId(groupId)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining(
@@ -112,7 +119,13 @@ class AssignUserToGroupTest {
   void shouldRejectIfMissingGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand(null).username("username").send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username("username")
+                    .groupId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be null");
   }
@@ -121,7 +134,8 @@ class AssignUserToGroupTest {
   void shouldRejectIfEmptyGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand("").username("username").send().join())
+            () ->
+                client.newAssignUserToGroupCommand().username("username").groupId("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be empty");
   }
@@ -130,7 +144,13 @@ class AssignUserToGroupTest {
   void shouldRejectIfMissingUsername() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand("groupId").username(null).send().join())
+            () ->
+                client
+                    .newAssignUserToGroupCommand()
+                    .username(null)
+                    .groupId("groupId")
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("username must not be null");
   }
@@ -139,7 +159,8 @@ class AssignUserToGroupTest {
   void shouldRejectIfEmptyUsername() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToGroupCommand("groupId").username("").send().join())
+            () ->
+                client.newAssignUserToGroupCommand().username("").groupId("groupId").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("username must not be empty");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
@@ -56,7 +56,7 @@ public class UnassignUserFromGroupTest {
             .send()
             .join()
             .getGroupId();
-    client.newAssignUserToGroupCommand(groupId).username(username).send().join();
+    client.newAssignUserToGroupCommand().username(username).groupId(groupId).send().join();
   }
 
   @Test


### PR DESCRIPTION
## Description

Command should follow the pattern `assignXToY().x("").y("")`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32500
