### PR TITLE
Refactor `newAssignGroupToTenantCommand` to follow the agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2037,15 +2037,15 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignGroupToTenantCommand(tenantId)
-   *   .groupId(groupId)
+   *   .newAssignGroupToTenantCommand()
+   *   .groupId("groupId")
+   *   .tenantId("tenantId")
    *   .send();
    * </pre>
    *
-   * @param tenantId the unique identifier of the tenant
    * @return a builder to configure and send the assign group to tenant command
    */
-  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(String tenantId);
+  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand();
 
   /**
    * Command to unassign a group from a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignGroupToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignGroupToTenantCommandStep1.java
@@ -17,15 +17,25 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.AssignGroupToTenantResponse;
 
-public interface AssignGroupToTenantCommandStep1
-    extends FinalCommandStep<AssignGroupToTenantResponse> {
+public interface AssignGroupToTenantCommandStep1 {
 
   /**
    * Sets the group ID for the assignment.
    *
    * @param groupId the ID of the group
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  AssignGroupToTenantCommandStep1 groupId(String groupId);
+  AssignGroupToTenantCommandStep2 groupId(String groupId);
+
+  interface AssignGroupToTenantCommandStep2 extends FinalCommandStep<AssignGroupToTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the tenantId of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignGroupToTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1090,8 +1090,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final String tenantId) {
-    return new AssignGroupToTenantCommandImpl(httpClient, tenantId);
+  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand() {
+    return new AssignGroupToTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
+import io.camunda.client.api.command.AssignGroupToTenantCommandStep1.AssignGroupToTenantCommandStep2;
 import io.camunda.client.api.response.AssignGroupToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -24,27 +25,33 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class AssignGroupToTenantCommandImpl implements AssignGroupToTenantCommandStep1 {
+public final class AssignGroupToTenantCommandImpl
+    implements AssignGroupToTenantCommandStep1, AssignGroupToTenantCommandStep2 {
 
   private final HttpClient httpClient;
-  private final String tenantId;
   private final RequestConfig.Builder httpRequestConfig;
   private String groupId;
+  private String tenantId;
 
-  public AssignGroupToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public AssignGroupToTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignGroupToTenantCommandStep1 groupId(final String groupId) {
+  public AssignGroupToTenantCommandStep2 groupId(final String groupId) {
     this.groupId = groupId;
     return this;
   }
 
   @Override
-  public AssignGroupToTenantCommandStep1 requestTimeout(final Duration timeout) {
+  public AssignGroupToTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  @Override
+  public AssignGroupToTenantCommandStep2 requestTimeout(final Duration timeout) {
     httpRequestConfig.setResponseTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignGroupToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignGroupToTenantTest.java
@@ -33,7 +33,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join();
+    client.newAssignGroupToTenantCommand().groupId(GROUP_ID).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -50,7 +50,13 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -64,7 +70,13 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -78,7 +90,13 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -92,7 +110,13 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupId(GROUP_ID).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(GROUP_ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -61,7 +61,7 @@ class AssignGroupToTenantTest {
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(tenantId).groupId(groupId).send().join();
+    client.newAssignGroupToTenantCommand().groupId(groupId).tenantId(tenantId).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
@@ -79,8 +79,9 @@ class AssignGroupToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignGroupToTenantCommand(nonExistentTenantId)
+                    .newAssignGroupToTenantCommand()
                     .groupId(groupId)
+                    .tenantId(nonExistentTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -99,8 +100,9 @@ class AssignGroupToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignGroupToTenantCommand(tenantId)
+                    .newAssignGroupToTenantCommand()
                     .groupId(nonExistentGroupId)
+                    .tenantId(tenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -113,11 +115,17 @@ class AssignGroupToTenantTest {
   @Test
   void shouldRejectIfAlreadyAssigned() {
     // given
-    client.newAssignGroupToTenantCommand(tenantId).groupId(groupId).send().join();
+    client.newAssignGroupToTenantCommand().groupId(groupId).tenantId(tenantId).send().join();
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(tenantId).groupId(groupId).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(groupId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining(
@@ -129,7 +137,13 @@ class AssignGroupToTenantTest {
   void shouldRejectIfMissingTenantId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(null).groupId(groupId).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(groupId)
+                    .tenantId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be null");
   }
@@ -138,7 +152,8 @@ class AssignGroupToTenantTest {
   void shouldRejectIfEmptyTenantId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand("").groupId(groupId).send().join())
+            () ->
+                client.newAssignGroupToTenantCommand().groupId(groupId).tenantId("").send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("tenantId must not be empty");
   }
@@ -147,7 +162,13 @@ class AssignGroupToTenantTest {
   void shouldRejectIfMissingGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(tenantId).groupId(null).send().join())
+            () ->
+                client
+                    .newAssignGroupToTenantCommand()
+                    .groupId(null)
+                    .tenantId(tenantId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be null");
   }
@@ -156,7 +177,8 @@ class AssignGroupToTenantTest {
   void shouldRejectIfEmptyGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(tenantId).groupId("").send().join())
+            () ->
+                client.newAssignGroupToTenantCommand().groupId("").tenantId(tenantId).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be empty");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -56,7 +56,7 @@ class UnassignGroupFromTenantTest {
             .getGroupId();
 
     // Assign group to tenant to set up test scenario
-    client.newAssignGroupToTenantCommand(tenantId).groupId(groupId).send().join();
+    client.newAssignGroupToTenantCommand().groupId(groupId).tenantId(tenantId).send().join();
   }
 
   @Test


### PR DESCRIPTION
## Description

Command should follow the pattern `assignXToY().x("").y("")`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32501
