### PR TITLE
feat: display denied reason for listeners in tasklist

### DIFF
--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -14,7 +14,7 @@
     "@tanstack/eslint-plugin-query": "5.74.7",
     "@tanstack/react-query": "5.75.5",
     "@uidotdev/usehooks": "2.4.1",
-    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.48",
+    "@vzeta/camunda-api-zod-schemas": "0.0.2-beta.53",
     "bpmn-js": "18.6.1",
     "classnames": "2.5.1",
     "date-fns": "4.1.0",

--- a/tasklist/client/src/common/api/request.ts
+++ b/tasklist/client/src/common/api/request.ts
@@ -8,6 +8,7 @@
 
 import {reactQueryClient} from 'common/react-query/reactQueryClient';
 import {authenticationStore} from 'common/auth/authentication';
+import {z} from 'zod';
 
 type RequestError =
   | {
@@ -97,18 +98,18 @@ async function request(
   }
 }
 
-function isRequestError(error: unknown): error is {
-  variant: 'network-error';
-  response: null;
-  networkError: Error;
-} {
-  return (
-    error !== null &&
-    typeof error === 'object' &&
-    'variant' in error &&
-    error.variant === 'network-error'
-  );
-}
+const requestErrorSchema = z.union([
+  z.object({
+    variant: z.literal('network-error'),
+    response: z.literal(null),
+    networkError: z.instanceof(Error),
+  }),
+  z.object({
+    variant: z.literal('failed-response'),
+    response: z.instanceof(Response),
+    networkError: z.literal(null),
+  }),
+]);
 
-export {request, isRequestError};
+export {request, requestErrorSchema};
 export type {RequestError};

--- a/tasklist/client/src/common/i18n/locales/de.json
+++ b/tasklist/client/src/common/i18n/locales/de.json
@@ -336,6 +336,7 @@
     "relativeDateUnknown": "'Unbekannt'",
     "processesTabPreviousPageButtonLabel": "Vorherige Seite",
     "processesTabNextPageButtonLabel": "Nächste Seite",
-    "processesTabPaginationOfLabel": "{{currentPage}} von {{totalPages}}"
+    "processesTabPaginationOfLabel": "{{currentPage}} von {{totalPages}}",
+    "deniedReason": "Die Aufgabe {{type}} wurde vom System abgelehnt."
   }
 }

--- a/tasklist/client/src/common/i18n/locales/en.json
+++ b/tasklist/client/src/common/i18n/locales/en.json
@@ -348,6 +348,7 @@
     "relativeDateUnknown": "'Unknown'",
     "processesTabPreviousPageButtonLabel": "Previous page",
     "processesTabNextPageButtonLabel": "Next page",
-    "processesTabPaginationOfLabel": "{{currentPage}} of {{totalPages}}"
+    "processesTabPaginationOfLabel": "{{currentPage}} of {{totalPages}}",
+    "deniedReason": "The task {{type}} was rejected by the system."
   }
 }

--- a/tasklist/client/src/common/i18n/locales/es.json
+++ b/tasklist/client/src/common/i18n/locales/es.json
@@ -336,6 +336,7 @@
     "relativeDateUnknown": "'Desconocido'",
     "processesTabPreviousPageButtonLabel": "Página anterior",
     "processesTabNextPageButtonLabel": "Página siguiente",
-    "processesTabPaginationOfLabel": "{{currentPage}} de {{totalPages}}"
+    "processesTabPaginationOfLabel": "{{currentPage}} de {{totalPages}}",
+    "deniedReason": "La tarea {{type}} fue rechazada por el sistema."
   }
 }

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -339,6 +339,7 @@
     "relativeDateUnknown": "'Inconnu'",
     "processesTabPreviousPageButtonLabel": "Page précédente",
     "processesTabNextPageButtonLabel": "Page suivante",
-    "processesTabPaginationOfLabel": "{{currentPage}} de {{totalPages}}"
+    "processesTabPaginationOfLabel": "{{currentPage}} de {{totalPages}}",
+    "deniedReason": "La tâche {{type}} a été rejetée par le système."
   }
 }

--- a/tasklist/client/src/common/mocks/current-user.tsx
+++ b/tasklist/client/src/common/mocks/current-user.tsx
@@ -17,7 +17,7 @@ const currentUser: CurrentUser = {
   tenants: [],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   userKey: 2251799813685250,
 };
@@ -52,7 +52,7 @@ const currentUserWithC8Links: CurrentUser = {
   tenants: [],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   userKey: 2251799813685250,
 };
@@ -75,7 +75,7 @@ const currentUserWithTenants: CurrentUser = {
   ],
   groups: [],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   userKey: 2251799813685250,
 };
@@ -89,7 +89,7 @@ const currentUserWithGroups: CurrentUser = {
   tenants: [],
   groups: ['admin', 'customer-support', 'guest'],
   canLogout: true,
-  authorizedApplications: ['*'],
+  authorizedComponents: ['*'],
   apiUser: false,
   userKey: 2251799813685250,
 };
@@ -103,7 +103,7 @@ const currentUnauthorizedUser: CurrentUser = {
   tenants: [],
   groups: ['admin', 'customer-support', 'guest'],
   canLogout: true,
-  authorizedApplications: ['operate'],
+  authorizedComponents: ['operate'],
   apiUser: false,
   userKey: 2251799813685250,
 };

--- a/tasklist/client/src/common/utils/isForbidden.test.ts
+++ b/tasklist/client/src/common/utils/isForbidden.test.ts
@@ -19,31 +19,31 @@ describe('isForbidden', () => {
     tenants: [],
     groups: [],
     canLogout: true,
-    authorizedApplications: [],
+    authorizedComponents: [],
     apiUser: false,
     userKey: 2251799813685250,
   };
 
-  it('should return true when authorizedApplications does not contain "tasklist" or "*"', () => {
+  it('should return true when authorizedComponents does not contain "tasklist" or "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['operate'],
+      authorizedComponents: ['operate'],
     };
     expect(isForbidden(user)).toBe(true);
   });
 
-  it('should return false when authorizedApplications contains "tasklist"', () => {
+  it('should return false when authorizedComponents contains "tasklist"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['operate', 'tasklist'],
+      authorizedComponents: ['operate', 'tasklist'],
     };
     expect(isForbidden(user)).toBe(false);
   });
 
-  it('should return false when authorizedApplications contains "*"', () => {
+  it('should return false when authorizedComponents contains "*"', () => {
     const user: CurrentUser = {
       ...baseUser,
-      authorizedApplications: ['*'],
+      authorizedComponents: ['*'],
     };
     expect(isForbidden(user)).toBe(false);
   });

--- a/tasklist/client/src/common/utils/isForbidden.ts
+++ b/tasklist/client/src/common/utils/isForbidden.ts
@@ -10,9 +10,9 @@ import type {CurrentUser} from '@vzeta/camunda-api-zod-schemas/identity';
 
 function isForbidden(user: CurrentUser | undefined) {
   return (
-    Array.isArray(user?.authorizedApplications) &&
-    !user.authorizedApplications.includes('tasklist') &&
-    !user.authorizedApplications.includes('*')
+    Array.isArray(user?.authorizedComponents) &&
+    !user.authorizedComponents.includes('tasklist') &&
+    !user.authorizedComponents.includes('*')
   );
 }
 

--- a/tasklist/client/src/v2/TaskDetails/index.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.tsx
@@ -23,6 +23,7 @@ import {Variables} from './Variables';
 import {FormJS} from './FormJS';
 import {useUploadDocuments} from 'common/api/useUploadDocuments.mutation';
 import {parseDenialReason} from 'v2/utils/parseDenialReason';
+import {isRequestError} from 'common/api/request';
 
 const TaskDetails: React.FC = observer(() => {
   const {task, currentUser} = useOutletContext<OutletContext>();
@@ -92,7 +93,11 @@ const TaskDetails: React.FC = observer(() => {
   }
 
   async function handleSubmissionFailure(error: unknown) {
-    const denialReason = await parseDenialReason(error, 'completion');
+    let denialReason: string | undefined = undefined;
+
+    if (!isRequestError(error)) {
+      denialReason = await parseDenialReason(error, 'completion');
+    }
 
     notificationsStore.displayNotification({
       kind: 'error',

--- a/tasklist/client/src/v2/TaskDetails/index.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.tsx
@@ -22,6 +22,7 @@ import type {OutletContext} from 'v2/TaskDetailsLayout';
 import {Variables} from './Variables';
 import {FormJS} from './FormJS';
 import {useUploadDocuments} from 'common/api/useUploadDocuments.mutation';
+import {parseDenialReason} from 'v2/utils/parseDenialReason';
 
 const TaskDetails: React.FC = observer(() => {
   const {task, currentUser} = useOutletContext<OutletContext>();
@@ -90,10 +91,13 @@ const TaskDetails: React.FC = observer(() => {
     }
   }
 
-  function handleSubmissionFailure() {
+  async function handleSubmissionFailure(error: unknown) {
+    const denialReason = await parseDenialReason(error, 'completion');
+
     notificationsStore.displayNotification({
       kind: 'error',
       title: t('taskCouldNotBeCompletedNotification'),
+      subtitle: denialReason,
       isDismissable: true,
     });
   }

--- a/tasklist/client/src/v2/TaskDetails/index.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.tsx
@@ -99,7 +99,7 @@ const TaskDetails: React.FC = observer(() => {
       notificationsStore.displayNotification({
         kind: 'error',
         title: t('taskCouldNotBeCompletedNotification'),
-        subtitle: await parseDenialReason(
+        subtitle: parseDenialReason(
           await parsedError?.response?.json(),
           'completion',
         ),

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -80,7 +80,7 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
         notificationsStore.displayNotification({
           kind: 'error',
           title: t('taskDetailsTaskAssignmentError'),
-          subtitle: await parseDenialReason(
+          subtitle: parseDenialReason(
             await parsedError?.response?.json(),
             'assignment',
           ),
@@ -116,7 +116,7 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
         notificationsStore.displayNotification({
           kind: 'error',
           title: t('taskDetailsTaskUnassignmentError'),
-          subtitle: await parseDenialReason(
+          subtitle: parseDenialReason(
             await parsedError?.response?.json(),
             'unassignment',
           ),

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -15,6 +15,7 @@ import {useTranslation} from 'react-i18next';
 import {useAssignTask} from 'v2/api/useAssignTask.mutation';
 import {useUnassignTask} from 'v2/api/useUnassignTask.mutation';
 import {usePollForAssignmentResult} from 'v2/api/usePollForAssignmentResult.mutation';
+import {parseDenialReason} from 'v2/utils/parseDenialReason';
 
 type AssignmentStatus =
   | 'off'
@@ -71,10 +72,13 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
       });
       setAssignmentStatus('assignmentSuccessful');
       tracking.track({eventName: 'task-assigned'});
-    } catch {
+    } catch (error) {
+      const denialReason = await parseDenialReason(error, 'assignment');
+
       notificationsStore.displayNotification({
         kind: 'error',
         title: t('taskDetailsTaskAssignmentError'),
+        subtitle: denialReason,
         isDismissable: true,
       });
 
@@ -92,10 +96,13 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
       });
       setAssignmentStatus('unassignmentSuccessful');
       tracking.track({eventName: 'task-unassigned'});
-    } catch {
+    } catch (error) {
+      const denialReason = await parseDenialReason(error, 'unassignment');
+
       notificationsStore.displayNotification({
         kind: 'error',
         title: t('taskDetailsTaskUnassignmentError'),
+        subtitle: denialReason,
         isDismissable: true,
       });
 

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -16,6 +16,7 @@ import {useAssignTask} from 'v2/api/useAssignTask.mutation';
 import {useUnassignTask} from 'v2/api/useUnassignTask.mutation';
 import {usePollForAssignmentResult} from 'v2/api/usePollForAssignmentResult.mutation';
 import {parseDenialReason} from 'v2/utils/parseDenialReason';
+import {isRequestError} from 'common/api/request';
 
 type AssignmentStatus =
   | 'off'
@@ -73,7 +74,11 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
       setAssignmentStatus('assignmentSuccessful');
       tracking.track({eventName: 'task-assigned'});
     } catch (error) {
-      const denialReason = await parseDenialReason(error, 'assignment');
+      let denialReason: string | undefined = undefined;
+
+      if (!isRequestError(error)) {
+        denialReason = await parseDenialReason(error, 'assignment');
+      }
 
       notificationsStore.displayNotification({
         kind: 'error',
@@ -97,7 +102,11 @@ const AssignButton: React.FC<Props> = ({id, assignee, currentUser}) => {
       setAssignmentStatus('unassignmentSuccessful');
       tracking.track({eventName: 'task-unassigned'});
     } catch (error) {
-      const denialReason = await parseDenialReason(error, 'unassignment');
+      let denialReason: string | undefined = undefined;
+
+      if (!isRequestError(error)) {
+        denialReason = await parseDenialReason(error, 'unassignment');
+      }
 
       notificationsStore.displayNotification({
         kind: 'error',

--- a/tasklist/client/src/v2/utils/parseDenialReason.ts
+++ b/tasklist/client/src/v2/utils/parseDenialReason.ts
@@ -14,7 +14,9 @@ export const parseDenialReason = async (
   if (!response || response.status !== 409) return undefined;
 
   const responseJson = await response?.json();
-  const detail = responseJson?.detail as string;
+
+  const detail =
+    typeof responseJson?.detail === 'string' ? responseJson?.detail : '';
 
   let deniedReason: string = `The task ${type} was rejected by the system.`;
   const match = detail.match(/Reason to deny:\s*(.*)/i);

--- a/tasklist/client/src/v2/utils/parseDenialReason.ts
+++ b/tasklist/client/src/v2/utils/parseDenialReason.ts
@@ -11,7 +11,6 @@ export const parseDenialReason = async (
   type: 'assignment' | 'unassignment' | 'completion',
 ): Promise<string | undefined> => {
   const response = (error as {response?: Response})?.response;
-
   if (!response || response.status !== 409) return undefined;
 
   const responseJson = await response?.json();
@@ -20,7 +19,7 @@ export const parseDenialReason = async (
   let deniedReason: string = `The task ${type} was rejected by the system.`;
   const match = detail.match(/Reason to deny:\s*(.*)/i);
   if (match && match[1]) {
-    deniedReason = match[1].trim();
+    deniedReason = match[1].trim().replace(/^["'](.*)["']$/, '$1');
   }
 
   return deniedReason;

--- a/tasklist/client/src/v2/utils/parseDenialReason.ts
+++ b/tasklist/client/src/v2/utils/parseDenialReason.ts
@@ -7,18 +7,16 @@
  */
 
 import {t} from 'i18next';
+import {type ProblemDetailsResponse} from '@vzeta/camunda-api-zod-schemas';
 
 export const parseDenialReason = async (
-  error: unknown,
+  errorPayload: ProblemDetailsResponse,
   type: 'assignment' | 'unassignment' | 'completion',
 ): Promise<string | undefined> => {
-  const response = (error as {response?: Response})?.response;
-  if (!response || response.status !== 409) return undefined;
-
-  const responseJson = await response?.json();
+  if (!errorPayload || errorPayload.status !== 409) return undefined;
 
   const detail =
-    typeof responseJson?.detail === 'string' ? responseJson?.detail : '';
+    typeof errorPayload?.detail === 'string' ? errorPayload?.detail : '';
 
   let deniedReason: string = t('deniedReason', {type});
   const match = detail.match(/Reason to deny:\s*(.*)/i);

--- a/tasklist/client/src/v2/utils/parseDenialReason.ts
+++ b/tasklist/client/src/v2/utils/parseDenialReason.ts
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {t} from 'i18next';
+
 export const parseDenialReason = async (
   error: unknown,
   type: 'assignment' | 'unassignment' | 'completion',
@@ -18,7 +20,7 @@ export const parseDenialReason = async (
   const detail =
     typeof responseJson?.detail === 'string' ? responseJson?.detail : '';
 
-  let deniedReason: string = `The task ${type} was rejected by the system.`;
+  let deniedReason: string = t('deniedReason', {type});
   const match = detail.match(/Reason to deny:\s*(.*)/i);
   if (match && match[1]) {
     deniedReason = match[1].trim().replace(/^["'](.*)["']$/, '$1');

--- a/tasklist/client/src/v2/utils/parseDenialReason.ts
+++ b/tasklist/client/src/v2/utils/parseDenialReason.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const parseDenialReason = async (
+  error: unknown,
+  type: 'assignment' | 'unassignment' | 'completion',
+): Promise<string | undefined> => {
+  const response = (error as {response?: Response})?.response;
+
+  if (!response || response.status !== 409) return undefined;
+
+  const responseJson = await response?.json();
+  const detail = responseJson?.detail as string;
+
+  let deniedReason: string = `The task ${type} was rejected by the system.`;
+  const match = detail.match(/Reason to deny:\s*(.*)/i);
+  if (match && match[1]) {
+    deniedReason = match[1].trim();
+  }
+
+  return deniedReason;
+};

--- a/tasklist/client/yarn.lock
+++ b/tasklist/client/yarn.lock
@@ -1966,10 +1966,10 @@
     loupe "^3.1.3"
     tinyrainbow "^2.0.0"
 
-"@vzeta/camunda-api-zod-schemas@0.0.2-beta.48":
-  version "0.0.2-beta.48"
-  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.48.tgz#aaf2c59f3aeef09ade46302f2b1a9f714b1c9322"
-  integrity sha512-HkYxfpWU4nR76WpKCIcrNPP4UrYyyrlNMKS/KO7wx7Ha5HxBMB/czTrxoOoss0KJvh053xouiez43cVmOEsL0Q==
+"@vzeta/camunda-api-zod-schemas@0.0.2-beta.53":
+  version "0.0.2-beta.53"
+  resolved "https://registry.yarnpkg.com/@vzeta/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.2-beta.53.tgz#99342ad0800d71ced006e46718c00ada683172b1"
+  integrity sha512-m1GZGO+qG1qhIzoNEOmshwFrdw5fGjgkidBWAU9dJAS+whgR4rGqguLwcCkAA+R16PSIlpKRVtbunJk/VqOodQ==
 
 "@vzeta/rollup-plugin-sbom@2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Description

Display denied reason for a task operation by a User Task Listener (present in the `detail` property of the `409` responses [on the API](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/assign-user-task/)).

Currently we can have a denied reason for:
- Assignment of a task
- Unassignment of a task
- Completion of a task

Each of those will show either the denied reason (if it is present in the response) or a generic error message (you can see it on the issue linked to this PR)

* This is only available for the v2 API and will not work on v1, that is intended due to the amount of extra work that would be necessary to make this data available on the backend for the v1.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27274 
