### PR TITLE
feat: add RawTransactionalColumnFamily to copy generically CFs from one DB to another

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -7,11 +7,23 @@
  */
 package io.camunda.zeebe.db;
 
+import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
 
 public interface SnapshotCopy {
-  void copySnapshot(Path fromPath, Path toPath, Path toSnapshotPath, Set<ColumnFamilyScope> scope)
-      throws Exception;
+
+  void withContexts(final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer);
+
+  void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope) throws Exception;
+
+  interface CopyContextConsumer {
+    void accept(
+        ZeebeTransactionDb<ZbColumnFamilies> fromDB,
+        TransactionContext fromCtx,
+        ZeebeTransactionDb<ZbColumnFamilies> toDB,
+        TransactionContext toCtx);
+  }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db;
+
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
+import java.nio.file.Path;
+import java.util.Set;
+
+public interface SnapshotCopy {
+  void copySnapshot(Path fromPath, Path toPath, Path toSnapshotPath, Set<ColumnFamilyScope> scope)
+      throws Exception;
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -13,13 +13,45 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
 
+/**
+ * Component that allows to copy a set of columns from one snapshot to another snapshot. It contains
+ * also method to compare two snapshots that can be useful when testing.
+ */
 public interface SnapshotCopy {
 
+  /**
+   * Helper function that can be used to compare or copy two snapshots. Particularly useful for
+   * testing.
+   *
+   * @param fromPath path of the readonly snapshot that will be associated to "from" arguments in
+   *     {@link CopyContextConsumer}
+   * @param toDBPath path of the snapshot that will be associated to "to" arguments in {@link
+   *     CopyContextConsumer}
+   * @param consumer that can access both DB instances.
+   */
   void withContexts(final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer);
 
+  /**
+   * Copies the content of a snapshot from a path to another path, copying only the columns with a
+   * certain scope
+   *
+   * @param fromPath the path of the snapshot to copy from
+   * @param toPath the path where the copied snapshot will be located
+   * @param scope the scope of the columns to copy
+   */
   void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope) throws Exception;
 
   interface CopyContextConsumer {
+
+    /**
+     * Callback that will be invoked when the two DBs are opened. The arguments of this function
+     * cannot escape this method, as they will be closed once this method returns.
+     *
+     * @param fromDB DB located at fromPath
+     * @param fromCtx transaction context at fromPath
+     * @param toDB DB located at toPath
+     * @param toCtx transaction context at toPath
+     */
     void accept(
         ZeebeTransactionDb<ZbColumnFamilies> fromDB,
         TransactionContext fromCtx,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import io.camunda.zeebe.db.SnapshotCopy;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.transaction.RawTransactionalColumnFamily;
+import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction;
+import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBSnapshotCopy implements SnapshotCopy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotCopy.class);
+  private final ZeebeDbFactory<ZbColumnFamilies> factory;
+
+  public RocksDBSnapshotCopy(final ZeebeDbFactory<ZbColumnFamilies> factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public void copySnapshot(
+      final Path fromPath,
+      final Path toDBPath,
+      final Path toSnapshotPath,
+      final Set<ColumnFamilyScope> scopes) {
+
+    try (final var toDB =
+        (ZeebeTransactionDb<ZbColumnFamilies>) factory.createDb(toDBPath.toFile())) {
+      try (final var fromDB =
+          (ZeebeTransactionDb<ZbColumnFamilies>) factory.createDb(fromPath.toFile())) {
+        final var fromCtx = fromDB.createContext();
+        final var toCtx = toDB.createContext();
+        final var abort = new AtomicBoolean(false);
+        toCtx.runInTransaction(
+            () -> {
+              final var toTransaction = (ZeebeTransaction) toCtx.getCurrentTransaction();
+              for (final var cf : ZbColumnFamilies.values()) {
+                if (!scopes.contains(cf.partitionScope()) || abort.get()) {
+                  continue;
+                }
+                LOG.debug("Copying column family '{}'", cf);
+                final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
+                final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
+                fromCf.forEach(
+                    (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
+                      try {
+                        toCf.put(
+                            toTransaction, key, keyOffset, keyLen, value, valueOffset, valueLen);
+                        return true;
+                      } catch (final Exception e) {
+                        LOG.error(
+                            "Failed to copy column family '{}' on key {} and value with length {} terminating.",
+                            cf,
+                            new String(key),
+                            value.length);
+                        LOG.error("Exception", e);
+                        abort.set(true);
+                        return false;
+                      }
+                    });
+              }
+              toTransaction.commit();
+            });
+      }
+      toDB.createSnapshot(toSnapshotPath.toFile());
+    }
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb.transaction;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.startsWith;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RawTransactionalColumnFamily {
+  private static final Logger LOG = LoggerFactory.getLogger(RawTransactionalColumnFamily.class);
+
+  private static final int INITIAL_KEY_LENGTH = 256;
+  private static final int INITIAL_VALUE_LENGTH = 4 * 1024;
+
+  protected final ZeebeTransactionDb<ZbColumnFamilies> transactionDb;
+  protected final ZbColumnFamilies columnFamily;
+  protected final ColumnFamilyContext columnFamilyContext;
+  protected final TransactionContext context;
+
+  public RawTransactionalColumnFamily(
+      final ZeebeTransactionDb<ZbColumnFamilies> transactionDb,
+      final ZbColumnFamilies columnFamily,
+      final TransactionContext context) {
+    this.transactionDb = transactionDb;
+    this.columnFamily = columnFamily;
+    columnFamilyContext = new ColumnFamilyContext(columnFamily.getValue());
+    this.context = context;
+  }
+
+  public void forEach(final Visitor visitor) {
+    context.runInTransaction(
+        () -> {
+          columnFamilyContext.withPrefixKey(
+              new DbNullKey(),
+              (prefixKey, prefixLength) -> {
+                try (final RocksIterator iterator =
+                    newIterator(context, transactionDb.getPrefixReadOptions())) {
+
+                  byte[] keyBytes = new byte[INITIAL_KEY_LENGTH];
+                  byte[] valueBytes = new byte[INITIAL_VALUE_LENGTH];
+                  final var seekTarget = new DbNullKey();
+                  boolean shouldVisitNext = true;
+
+                  for (iterator.seek(columnFamilyContext.keyWithColumnFamily(seekTarget));
+                      iterator.isValid() && shouldVisitNext;
+                      iterator.next()) {
+                    final int keyLen = iterator.key(keyBytes, 0, keyBytes.length);
+                    if (keyLen > keyBytes.length) {
+                      final var previousLen = keyBytes.length;
+                      keyBytes = iterator.key();
+                      LOG.debug(
+                          "Reallocating keyBytes from {} to {}", previousLen, keyBytes.length);
+                    }
+                    final int valueLen = iterator.value(valueBytes, 0, valueBytes.length);
+                    if (valueLen > valueBytes.length) {
+                      final var previousLen = valueBytes.length;
+                      valueBytes = iterator.value();
+                      LOG.debug(
+                          "Reallocating valueBytes from {} to {}", previousLen, valueBytes.length);
+                    }
+
+                    if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyLen)) {
+                      break;
+                    }
+                    shouldVisitNext = visitor.visit(keyBytes, 0, keyLen, valueBytes, 0, valueLen);
+                  }
+                }
+              });
+        });
+  }
+
+  public void put(
+      final ZeebeTransaction transaction,
+      final byte[] key,
+      final int keyOffset,
+      final int keyLen,
+      final byte[] value,
+      final int valueOffset,
+      final int valueLen)
+      throws Exception {
+    transaction.put(
+        transactionDb.getDefaultNativeHandle(),
+        key,
+        keyOffset,
+        keyLen,
+        value,
+        valueOffset,
+        valueLen);
+  }
+
+  public byte[] get(
+      final ZeebeTransaction transaction, final byte[] key, final int keyOffset, final int keyLen)
+      throws Exception {
+    return transaction.get(
+        transactionDb.getDefaultNativeHandle(),
+        transactionDb.getReadOptionsNativeHandle(),
+        key,
+        keyOffset,
+        keyLen);
+  }
+
+  RocksIterator newIterator(final TransactionContext context, final ReadOptions options) {
+    final var currentTransaction = (ZeebeTransaction) context.getCurrentTransaction();
+    return currentTransaction.newIterator(options, transactionDb.getDefaultHandle());
+  }
+
+  public interface Visitor {
+    boolean visit(
+        byte[] key, int keyOffset, int keyLen, byte[] value, int valueOffset, int valueLen);
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -41,13 +41,13 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   public void put(
       final long columnFamilyHandle,
       final byte[] key,
+      final int keyOffset,
       final int keyLength,
       final byte[] value,
+      final int valueOffset,
       final int valueLength)
       throws Exception {
     try {
-      final int keyOffset = 0;
-      final int valueOffset = 0;
       RocksDbInternal.putWithHandle.invokeExact(
           nativeHandle,
           key,
@@ -63,14 +63,33 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
     }
   }
 
+  public void put(
+      final long columnFamilyHandle,
+      final byte[] key,
+      final int keyLength,
+      final byte[] value,
+      final int valueLength)
+      throws Exception {
+    put(columnFamilyHandle, key, 0, keyLength, value, 0, valueLength);
+  }
+
   public byte[] get(
       final long columnFamilyHandle,
       final long readOptionsHandle,
       final byte[] key,
       final int keyLength)
       throws Exception {
+    return get(columnFamilyHandle, readOptionsHandle, key, 0, keyLength);
+  }
+
+  public byte[] get(
+      final long columnFamilyHandle,
+      final long readOptionsHandle,
+      final byte[] key,
+      final int keyOffset,
+      final int keyLength)
+      throws Exception {
     try {
-      final int keyOffset = 0;
       return (byte[])
           RocksDbInternal.getWithHandle.invokeExact(
               nativeHandle, readOptionsHandle, key, keyOffset, keyLength, columnFamilyHandle);

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
@@ -21,96 +21,117 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class RocksDBSnapshotCopyTest {
   @TempDir Path destinationPath;
-  @TempDir Path destinationSnapshotPath;
-  private final Path sourcePath =
-      Path.of("/home/carlosana/incidents/game-day/2/snapshots/6734951-1-72656096-72655064-2");
+  @TempDir Path sourcePath;
+  private RocksDBSnapshotCopy copy;
+  private Random random;
 
-  @Test
-  public void shouldCopyOnlySomeColumns() throws Exception {
-    // given
-    final var factory =
-        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+  @BeforeEach
+  void setup() {
+    final ZeebeRocksDbFactory<ZbColumnFamilies> factory =
+        new ZeebeRocksDbFactory<>(
             new RocksDbConfiguration(),
             new ConsistencyChecksSettings(),
             new AccessMetricsConfiguration(Kind.NONE, 1),
             SimpleMeterRegistry::new);
-    final var copy = new RocksDBSnapshotCopy(factory);
-    final var snapshotPath = destinationSnapshotPath.resolve("snapshot");
-    // when
-    copy.copySnapshot(sourcePath, destinationPath, snapshotPath, Set.of(ColumnFamilyScope.GLOBAL));
-
-    // then
-    assertThat(snapshotPath.toFile()).exists();
-    final var sourceSize = printSnapshotFiles(sourcePath);
-    final var copySize = printSnapshotFiles(destinationPath);
-    assertThat(copySize).isLessThan(sourceSize);
-
-    final var numOfRows = new AtomicLong();
-    final var numOfColumnFamilies = new AtomicLong();
-
-    try (final var toDB = factory.createDb(snapshotPath.toFile())) {
-      try (final var fromDB = factory.createDb(sourcePath.toFile())) {
-        final var fromCtx = fromDB.createContext();
-        final var toCtx = toDB.createContext();
-
-        toCtx.runInTransaction(
-            () -> {
-              final var toTx = (ZeebeTransaction) toCtx.getCurrentTransaction();
-              for (final var cf : ZbColumnFamilies.values()) {
-                if (cf.partitionScope() == ColumnFamilyScope.GLOBAL) {
-                  numOfColumnFamilies.incrementAndGet();
-                  final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
-                  final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
-                  fromCf.forEach(
-                      (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
-                        final byte[] toValue;
-                        try {
-                          toValue = toCf.get(toTx, key, keyOffset, keyLen);
-                        } catch (final Exception e) {
-                          throw new RuntimeException(e);
-                        }
-                        assertThat(toValue).isNotNull();
-                        final var original = new byte[valueLen - valueOffset];
-                        System.arraycopy(value, valueOffset, original, 0, valueLen - valueOffset);
-                        assertThat(toValue).isEqualTo(original);
-                        numOfRows.incrementAndGet();
-                        return true;
-                      });
-                }
-              }
-            });
-      }
-    }
-    System.out.println(
-        numOfRows.get() + " rows copied, " + numOfColumnFamilies.get() + " column families");
-    assertThat(numOfRows.get()).isGreaterThan(0L);
-    assertThat(numOfColumnFamilies.get())
-        .isEqualTo(
-            Arrays.stream(ZbColumnFamilies.values())
-                .filter(cf -> cf.partitionScope() == ColumnFamilyScope.GLOBAL)
-                .count());
+    copy = new RocksDBSnapshotCopy(factory);
+    random = new Random(1212331);
   }
 
-  private long printSnapshotFiles(final Path snapshotPath) throws IOException {
+  @Test
+  public void shouldCopyOnlySomeColumns() throws Exception {
+    // given
+    final long rowsPerCF = 100;
+    final Map<ZbColumnFamilies, Long> expectedRowsPerCF = initCounterMap();
+    copy.withContexts(
+        sourcePath,
+        destinationPath,
+        (fromDB, fromCtx, toDB, toCtx) -> {
+          fromCtx.runInTransaction(
+              () -> {
+                final var ctx = (ZeebeTransaction) fromCtx.getCurrentTransaction();
+                for (final ZbColumnFamilies cf : ZbColumnFamilies.values()) {
+                  final var transactionalColumnFamily =
+                      new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
+                  for (int i = 0; i < rowsPerCF; i++) {
+                    // the key must be big enough to avoid generating duplicates.
+                    // with 1024 and the seed in the setup no duplicates are created.
+                    // otherwise, the number of rows per cf can be reduced to reduce the amount of
+                    // collisions
+                    final var key = new byte[random.nextInt(1024)];
+                    random.nextBytes(key);
+
+                    final var value = new byte[random.nextInt(64 * 1024)];
+                    random.nextBytes(value);
+                    transactionalColumnFamily.put(ctx, key, 0, key.length, value, 0, value.length);
+                    if (cf.partitionScope() == ColumnFamilyScope.GLOBAL) {
+                      expectedRowsPerCF.compute(cf, (k, v) -> v + 1);
+                    }
+                  }
+                  ctx.commit();
+                }
+              });
+        });
+    // when
+    copy.copySnapshot(sourcePath, destinationPath, Set.of(ColumnFamilyScope.GLOBAL));
+
+    // then
+    final var sourceSize = computeDBSpace(sourcePath);
+    final var copySize = computeDBSpace(destinationPath);
+    assertThat(copySize).isLessThan(sourceSize);
+
+    final var copiedRows = initCounterMap();
+    copy.withContexts(
+        sourcePath,
+        destinationPath,
+        (fromDB, fromCtx, toDB, toCtx) -> {
+          toCtx.runInTransaction(
+              () -> {
+                final var toTx = (ZeebeTransaction) toCtx.getCurrentTransaction();
+                for (final var cf : ZbColumnFamilies.values()) {
+                  if (cf.partitionScope() == ColumnFamilyScope.GLOBAL) {
+                    final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
+                    final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
+                    fromCf.forEach(
+                        (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
+                          final byte[] toValue;
+                          try {
+                            toValue = toCf.get(toTx, key, keyOffset, keyLen);
+                          } catch (final Exception e) {
+                            throw new RuntimeException(e);
+                          }
+                          assertThat(toValue).isNotNull();
+                          final var original = new byte[valueLen - valueOffset];
+                          System.arraycopy(value, valueOffset, original, 0, valueLen - valueOffset);
+                          assertThat(toValue).isEqualTo(original);
+                          copiedRows.compute(cf, (k, v) -> v + 1);
+                          return true;
+                        });
+                  }
+                }
+              });
+        });
+    assertThat(copiedRows).containsExactlyInAnyOrderEntriesOf(expectedRowsPerCF);
+  }
+
+  private long computeDBSpace(final Path snapshotPath) throws IOException {
     final var totalSize = new AtomicLong();
-    Files.walk(snapshotPath, 10)
-        .forEach(
-            f -> {
-              try {
-                totalSize.addAndGet(f.toFile().length());
-                System.out.printf("%s -> %s\n", f, Files.size(f));
-              } catch (final IOException e) {
-                throw new RuntimeException(e);
-              }
-            });
-    System.out.println("Total space used: " + totalSize.get());
+    Files.walk(snapshotPath, 10).forEach(f -> totalSize.addAndGet(f.toFile().length()));
     return totalSize.get();
+  }
+
+  private Map<ZbColumnFamilies, Long> initCounterMap() {
+    final var map = new java.util.EnumMap<ZbColumnFamilies, Long>(ZbColumnFamilies.class);
+    Arrays.stream(ZbColumnFamilies.values()).forEach(cf -> map.put(cf, 0L));
+    return map;
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.impl.rocksdb.transaction.RawTransactionalColumnFamily;
+import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction;
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class RocksDBSnapshotCopyTest {
+  @TempDir Path destinationPath;
+  @TempDir Path destinationSnapshotPath;
+  private final Path sourcePath =
+      Path.of("/home/carlosana/incidents/game-day/2/snapshots/6734951-1-72656096-72655064-2");
+
+  @Test
+  public void shouldCopyOnlySomeColumns() throws Exception {
+    // given
+    final var factory =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+            new RocksDbConfiguration(),
+            new ConsistencyChecksSettings(),
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            SimpleMeterRegistry::new);
+    final var copy = new RocksDBSnapshotCopy(factory);
+    final var snapshotPath = destinationSnapshotPath.resolve("snapshot");
+    // when
+    copy.copySnapshot(sourcePath, destinationPath, snapshotPath, Set.of(ColumnFamilyScope.GLOBAL));
+
+    // then
+    assertThat(snapshotPath.toFile()).exists();
+    final var sourceSize = printSnapshotFiles(sourcePath);
+    final var copySize = printSnapshotFiles(destinationPath);
+    assertThat(copySize).isLessThan(sourceSize);
+
+    final var numOfRows = new AtomicLong();
+    final var numOfColumnFamilies = new AtomicLong();
+
+    try (final var toDB = factory.createDb(snapshotPath.toFile())) {
+      try (final var fromDB = factory.createDb(sourcePath.toFile())) {
+        final var fromCtx = fromDB.createContext();
+        final var toCtx = toDB.createContext();
+
+        toCtx.runInTransaction(
+            () -> {
+              final var toTx = (ZeebeTransaction) toCtx.getCurrentTransaction();
+              for (final var cf : ZbColumnFamilies.values()) {
+                if (cf.partitionScope() == ColumnFamilyScope.GLOBAL) {
+                  numOfColumnFamilies.incrementAndGet();
+                  final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
+                  final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
+                  fromCf.forEach(
+                      (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
+                        final byte[] toValue;
+                        try {
+                          toValue = toCf.get(toTx, key, keyOffset, keyLen);
+                        } catch (final Exception e) {
+                          throw new RuntimeException(e);
+                        }
+                        assertThat(toValue).isNotNull();
+                        final var original = new byte[valueLen - valueOffset];
+                        System.arraycopy(value, valueOffset, original, 0, valueLen - valueOffset);
+                        assertThat(toValue).isEqualTo(original);
+                        numOfRows.incrementAndGet();
+                        return true;
+                      });
+                }
+              }
+            });
+      }
+    }
+    System.out.println(
+        numOfRows.get() + " rows copied, " + numOfColumnFamilies.get() + " column families");
+    assertThat(numOfRows.get()).isGreaterThan(0L);
+    assertThat(numOfColumnFamilies.get())
+        .isEqualTo(
+            Arrays.stream(ZbColumnFamilies.values())
+                .filter(cf -> cf.partitionScope() == ColumnFamilyScope.GLOBAL)
+                .count());
+  }
+
+  private long printSnapshotFiles(final Path snapshotPath) throws IOException {
+    final var totalSize = new AtomicLong();
+    Files.walk(snapshotPath, 10)
+        .forEach(
+            f -> {
+              try {
+                totalSize.addAndGet(f.toFile().length());
+                System.out.printf("%s -> %s\n", f, Files.size(f));
+              } catch (final IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+    System.out.println("Total space used: " + totalSize.get());
+    return totalSize.get();
+  }
+}

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
@@ -7,4 +7,97 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb.transaction;
 
-public class RawTransactionalColumnFamilyTest {}
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.agrona.collections.MutableReference;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class RawTransactionalColumnFamilyTest {
+  @TempDir static Path path;
+  @AutoClose static ZeebeTransactionDb<ZbColumnFamilies> db;
+  static Map<ZbColumnFamilies, RawTransactionalColumnFamily> columnFamilies = new HashMap<>();
+  private static TransactionContext context;
+
+  @BeforeAll
+  static void setup() {
+    final ZeebeRocksDbFactory<ZbColumnFamilies> factory =
+        new ZeebeRocksDbFactory<>(
+            new RocksDbConfiguration(),
+            new ConsistencyChecksSettings(),
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            SimpleMeterRegistry::new);
+    db = factory.createDb(path.toFile());
+    context = db.createContext();
+
+    for (final var cf : ZbColumnFamilies.values()) {
+      final var rawCF = new RawTransactionalColumnFamily(db, cf, context);
+      columnFamilies.put(cf, rawCF);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(ZbColumnFamilies.class)
+  public void shouldIterateOverAllValues(final ZbColumnFamilies cf) {
+    // given
+    final int numEntries = 100;
+    final var rawCF = columnFamilies.get(cf);
+    final var expected = new HashMap<Integer, byte[]>();
+    context.runInTransaction(
+        () -> {
+          for (int i = 0; i < numEntries; i++) {
+            // Convert the integer to a byte array so that ordering is preserved in rocksDB.
+            // if it's converted to a string, the order is broken (e.g. 10 < 2).
+            final var bytes =
+                ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(i).array();
+            expected.put(i, bytes);
+            rawCF.put(
+                (ZeebeTransaction) context.getCurrentTransaction(),
+                bytes,
+                0,
+                bytes.length,
+                bytes,
+                0,
+                bytes.length);
+          }
+        });
+    // when
+    final var i = new MutableReference<>(0);
+    rawCF.forEach(
+        ((rawKey, keyOffset, keyLen, value, valueOffset, valueLen) -> {
+          final var cfContext = new ColumnFamilyContext(cf.getValue());
+          assertThat(keyOffset).isZero();
+          assertThat(valueOffset).isZero();
+
+          cfContext.wrapKeyView(rawKey);
+          final var key = new byte[cfContext.getKeyView().capacity()];
+          cfContext.getKeyView().getBytes(0, key);
+
+          // then
+          assertThat(key).isEqualTo(expected.get(i.get()));
+          assertThat(value).isEqualTo(expected.get(i.get()));
+
+          i.set(i.get() + 1);
+          return true;
+        }));
+
+    // then
+    assertThat(i.get()).isEqualTo(numEntries);
+  }
+}

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb.transaction;
+
+public class RawTransactionalColumnFamilyTest {}


### PR DESCRIPTION
## Description
TransactionalColumnFamily requires knowing the types of each column, which unfortunately is an information which is not available generically.
RawTransactionalColumnFamily exposes some basic functionalities of a CF with only byte[] which is ideal for copying from one RocksDB instance to another.
RocksSnapshotDBCopy is able to open a snapshot folder, iterate over all columns with the provided scope and insert them in another instance of RocksDB.
At the end, it will take a snapshot in another folder.


## Checklist

- [ ] Use `RawTransactionalColumnFamily`  in `TransactionalColumnFamily` to avoid duplication. It may be done in a follow up PR. 

## Related  issues
relates #31992
