### PR TITLE
fix: update operate docker configurations in the core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/config/docker-compose.yml
+++ b/qa/core-application-e2e-test-suite/config/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       - 8081:8080
     environment:
       - SPRING_PROFILES_ACTIVE=dev,consolidated-auth
+      - CAMUNDA_OPERATE_ZEEBE_COMPATIBILITY_ENABLED=true
     depends_on:
       - ${DATABASE}
       - zeebe


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Operate was failing to start on `SNAPSHOT` due to configurations issue, this PR address the fix as discussed [here](https://camunda.slack.com/archives/C08G19SQ1BM/p1747997185748839)

🧪 successful test run can be found [here](https://github.com/camunda/camunda/actions/runs/15348088517)
Note: This only fix the configurations issue, flaky tests will be addressed in a separate PR
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
