### PR TITLE
feat: Cover entire user task lifecycle in secondary storage

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/UserTaskState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/UserTaskState.java
@@ -16,8 +16,13 @@
 package io.camunda.client.api.search.enums;
 
 public enum UserTaskState {
+  CREATING,
   CREATED,
+  ASSIGNING,
+  UPDATING,
+  COMPLETING,
   COMPLETED,
+  CANCELING,
   CANCELED,
   FAILED,
   UNKNOWN_ENUM_VALUE;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -99,8 +99,7 @@ public class JobSearchTest {
 
     camundaClient.newCompleteCommand(executionEndListenerJob.getJobKey()).send().join();
 
-    waitUntilNewUserTaskHasBeenCreated();
-
+    waitForSingleUserTaskWithCreatedState();
     final var userTask =
         camundaClient
             .newUserTaskSearchRequest()
@@ -134,12 +133,11 @@ public class JobSearchTest {
         .send()
         .join();
 
+    waitForSingleUserTaskWithCreatedState();
     camundaClient
         .newUserTaskAssignCommand(userTask.getUserTaskKey())
         .assignee("testAssignee")
         .send();
-
-    waitUntilNewUserTaskHasBeenCreated();
 
     // Wait until the total number of jobs in the system reaches 5
     waitUntilNewJobHasBeenCreated(6);
@@ -159,17 +157,9 @@ public class JobSearchTest {
 
     camundaClient.newCompleteCommand(userTaskListenerAssigningJob2.getJobKey()).send().join();
 
-    final var userTaskB =
-        camundaClient
-            .newUserTaskSearchRequest()
-            .filter(f -> f.state(UserTaskState.CREATED))
-            .send()
-            .join()
-            .items()
-            .getFirst();
-
+    waitForSingleUserTaskWithCreatedState();
     camundaClient
-        .newUserTaskCompleteCommand(userTaskB.getUserTaskKey())
+        .newUserTaskCompleteCommand(userTask.getUserTaskKey())
         .variable("name", "test")
         .send();
 
@@ -1136,8 +1126,8 @@ public class JobSearchTest {
             });
   }
 
-  private static void waitUntilNewUserTaskHasBeenCreated() {
-    await("should wait until user task has been created")
+  private static void waitForSingleUserTaskWithCreatedState() {
+    await("should wait until user task with state='CREATED' found")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskIT.java
@@ -391,7 +391,8 @@ public class UserTaskIT {
             () ->
                 !client
                     .newUserTaskSearchRequest()
-                    .filter(f -> f.processInstanceKey(processInstanceKey))
+                    .filter(
+                        f -> f.processInstanceKey(processInstanceKey).state(UserTaskState.CREATED))
                     .send()
                     .join()
                     .items()

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
@@ -47,8 +47,13 @@ public class UserTaskEntityTransformer implements ServiceTransformer<TaskEntity,
       return null;
     }
     return switch (source) {
+      case CREATING -> UserTaskState.CREATING;
       case CREATED -> UserTaskState.CREATED;
+      case ASSIGNING -> UserTaskState.ASSIGNING;
+      case UPDATING -> UserTaskState.UPDATING;
+      case COMPLETING -> UserTaskState.COMPLETING;
       case COMPLETED -> UserTaskState.COMPLETED;
+      case CANCELING -> UserTaskState.CANCELING;
       case FAILED -> UserTaskState.FAILED;
       default -> throw new IllegalArgumentException("Unexpected value: " + source);
     };

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UserTaskEntityTransformer.java
@@ -54,8 +54,8 @@ public class UserTaskEntityTransformer implements ServiceTransformer<TaskEntity,
       case COMPLETING -> UserTaskState.COMPLETING;
       case COMPLETED -> UserTaskState.COMPLETED;
       case CANCELING -> UserTaskState.CANCELING;
+      case CANCELED -> UserTaskState.CANCELED;
       case FAILED -> UserTaskState.FAILED;
-      default -> throw new IllegalArgumentException("Unexpected value: " + source);
     };
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -66,8 +66,13 @@ public record UserTaskEntity(
   }
 
   public enum UserTaskState {
+    CREATING,
     CREATED,
+    ASSIGNING,
+    UPDATING,
+    COMPLETING,
     COMPLETED,
+    CANCELING,
     CANCELED,
     FAILED
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/VariableSearchTermsQueryChunkIT.java
@@ -83,8 +83,8 @@ public class VariableSearchTermsQueryChunkIT extends TasklistZeebeIntegrationTes
     // Using the CamundaExporter and the shared Operate indices having the FNIs
     // present requires more time compared to the User Task created state check
     Awaitility.await()
-        .atMost(Duration.ofMinutes(1))
-        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(5))
         .untilAsserted(
             () -> {
               // User Task in Embedded Subprocess

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -12,6 +12,7 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.PartitionedEntity;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -372,6 +373,14 @@ public class TaskEntity
 
   public TaskEntity setChangedAttributes(final List<String> changedAttributes) {
     this.changedAttributes = changedAttributes;
+    return this;
+  }
+
+  public TaskEntity addChangedAttribute(final String changedAttribute) {
+    if (this.changedAttributes == null) {
+      this.changedAttributes = new ArrayList<>();
+    }
+    this.changedAttributes.add(changedAttribute);
     return this;
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskState.java
@@ -8,8 +8,13 @@
 package io.camunda.webapps.schema.entities.usertask;
 
 public enum TaskState {
+  CREATING,
   CREATED,
+  ASSIGNING,
+  UPDATING,
+  COMPLETING,
   COMPLETED,
+  CANCELING,
   CANCELED,
   FAILED
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -193,6 +193,10 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     if (entity.getBpmnProcessId() != null) {
       updateFields.put(TaskTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
     }
+    if (entity.getProcessDefinitionVersion() != null) {
+      updateFields.put(
+          TaskTemplate.PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
+    }
 
     return updateFields;
   }
@@ -330,6 +334,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
                     record.getValue().getElementId())
                 .orElse(null))
         .setBpmnProcessId(record.getValue().getBpmnProcessId())
-        .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()));
+        .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()))
+        .setProcessDefinitionVersion(record.getValue().getProcessDefinitionVersion());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -314,7 +314,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
                     record.getValue().getElementId())
                 .orElse(null))
         .setBpmnProcessId(record.getValue().getBpmnProcessId())
-        .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()))
-        .setState(TaskState.CREATED);
+        .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -314,6 +314,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         .setState(TaskState.CANCELED)
         .setCompletionTime(
             ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+    updateChangedAttributes(record, entity);
   }
 
   private void handleMigration(final Record<UserTaskRecordValue> record, final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -90,7 +90,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
   @Override
   public List<String> generateIds(final Record<UserTaskRecordValue> record) {
-    if (record.getIntent().equals(UserTaskIntent.CREATED)) {
+    if (record.getIntent().equals(UserTaskIntent.CREATING)) {
       exporterMetadata.setFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK, record.getKey());
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -113,10 +113,9 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
     switch ((UserTaskIntent) record.getIntent()) {
       case UserTaskIntent.CREATING -> createTaskEntity(entity, record);
-      case UserTaskIntent.CREATED -> handleCreated(record, entity);
-      case UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED -> {
-        updateChangedAttributes(record, entity);
+      case UserTaskIntent.CREATED, UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED -> {
         entity.setState(TaskState.CREATED);
+        updateChangedAttributes(record, entity);
       }
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
       case UserTaskIntent.CANCELED -> handleCancellation(record, entity);
@@ -299,19 +298,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         default -> LOGGER.warn(UNMAPPED_USER_TASK_ATTRIBUTE_WARNING, attribute);
       }
     }
-  }
-
-  private void handleCreated(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
-    entity
-        .setState(TaskState.CREATED)
-        .setAssignee(getAssigneeOrNull(record))
-        .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
-        .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
-        .setPriority(record.getValue().getPriority())
-        .setCandidateGroups(
-            ExporterUtil.toStringArrayOrNull(record.getValue().getCandidateGroupsList()))
-        .setCandidateUsers(
-            ExporterUtil.toStringArrayOrNull(record.getValue().getCandidateUsersList()));
   }
 
   private void handleCompletion(final Record<UserTaskRecordValue> record, final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -204,9 +204,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity
         .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
         .setState(TaskState.CREATING)
-        .setAssignee(getAssigneeOrNull(record))
-        .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
-        .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
         .setFlowNodeInstanceId(String.valueOf(record.getValue().getElementInstanceKey()))
         .setProcessInstanceId(String.valueOf(record.getValue().getProcessInstanceKey()))
         .setFlowNodeBpmnId(record.getValue().getElementId())
@@ -225,7 +222,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
                 ? null
                 : record.getValue().getExternalFormReference())
         .setCustomHeaders(record.getValue().getCustomHeaders())
-        .setPriority(record.getValue().getPriority())
         .setPartitionId(record.getPartitionId())
         .setTenantId(record.getValue().getTenantId())
         .setPosition(record.getPosition())
@@ -235,14 +231,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
                 : record.getValue().getAction())
         .setCreationTime(
             ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
-
-    if (!record.getValue().getCandidateGroupsList().isEmpty()) {
-      entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
-    }
-
-    if (!record.getValue().getCandidateUsersList().isEmpty()) {
-      entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
-    }
 
     if (!ExporterUtil.isEmpty(formKey)) {
       formCache
@@ -300,7 +288,20 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   }
 
   private void handleCreated(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
-    entity.setState(TaskState.CREATED);
+    entity
+        .setState(TaskState.CREATED)
+        .setAssignee(getAssigneeOrNull(record))
+        .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
+        .setPriority(record.getValue().getPriority());
+
+    if (!record.getValue().getCandidateGroupsList().isEmpty()) {
+      entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
+    }
+
+    if (!record.getValue().getCandidateUsersList().isEmpty()) {
+      entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
+    }
   }
 
   private void handleCompletion(final Record<UserTaskRecordValue> record, final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -49,7 +49,10 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           UserTaskIntent.ASSIGNING,
           UserTaskIntent.ASSIGNED,
           UserTaskIntent.UPDATING,
-          UserTaskIntent.UPDATED);
+          UserTaskIntent.UPDATED,
+          UserTaskIntent.ASSIGNMENT_DENIED,
+          UserTaskIntent.UPDATE_DENIED,
+          UserTaskIntent.COMPLETION_DENIED);
   private static final String UNMAPPED_USER_TASK_ATTRIBUTE_WARNING =
       "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}";
 
@@ -107,7 +110,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity.setAction(record.getValue().getAction());
     entity.setKey(record.getKey());
 
-    switch (record.getIntent()) {
+    switch ((UserTaskIntent) record.getIntent()) {
       case UserTaskIntent.CREATING -> createTaskEntity(entity, record);
       case UserTaskIntent.CREATED -> handleCreated(record, entity);
       case UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED ->
@@ -120,6 +123,8 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       case UserTaskIntent.UPDATING -> entity.setState(TaskState.UPDATING);
       case UserTaskIntent.COMPLETING -> entity.setState(TaskState.COMPLETING);
       case UserTaskIntent.CANCELING -> entity.setState(TaskState.CANCELING);
+      case UserTaskIntent.ASSIGNMENT_DENIED, UPDATE_DENIED, COMPLETION_DENIED ->
+          entity.setState(TaskState.CREATED);
       default -> {}
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -239,7 +239,18 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
                 ? null
                 : record.getValue().getAction())
         .setCreationTime(
-            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
+        .setPriority(record.getValue().getPriority());
+
+    if (!record.getValue().getCandidateGroupsList().isEmpty()) {
+      entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
+    }
+
+    if (!record.getValue().getCandidateUsersList().isEmpty()) {
+      entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
+    }
 
     if (!ExporterUtil.isEmpty(formKey)) {
       formCache
@@ -306,10 +317,14 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
     if (!record.getValue().getCandidateGroupsList().isEmpty()) {
       entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
+    } else {
+      entity.setCandidateGroups(null);
     }
 
     if (!record.getValue().getCandidateUsersList().isEmpty()) {
       entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
+    } else {
+      entity.setCandidateUsers(null);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -47,6 +47,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           UserTaskIntent.CANCELED,
           UserTaskIntent.MIGRATED,
           UserTaskIntent.ASSIGNING,
+          UserTaskIntent.CLAIMING,
           UserTaskIntent.ASSIGNED,
           UserTaskIntent.UPDATING,
           UserTaskIntent.UPDATED,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -240,15 +240,9 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
             ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
         .setDueDate(ExporterUtil.toOffsetDateTime(taskValue.getDueDate()))
         .setFollowUpDate(ExporterUtil.toOffsetDateTime(taskValue.getFollowUpDate()))
-        .setPriority(taskValue.getPriority());
-
-    if (!taskValue.getCandidateGroupsList().isEmpty()) {
-      entity.setCandidateGroups(taskValue.getCandidateGroupsList().toArray(new String[0]));
-    }
-
-    if (!taskValue.getCandidateUsersList().isEmpty()) {
-      entity.setCandidateUsers(taskValue.getCandidateUsersList().toArray(new String[0]));
-    }
+        .setPriority(taskValue.getPriority())
+        .setCandidateGroups(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateGroupsList()))
+        .setCandidateUsers(ExporterUtil.toStringArrayOrNull(taskValue.getCandidateUsersList()));
 
     if (!ExporterUtil.isEmpty(formKey)) {
       formCache
@@ -293,9 +287,11 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       switch (attribute) {
         case "assignee" -> entity.setAssignee(getAssigneeOrNull(record));
         case "candidateGroupsList" ->
-            entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
+            entity.setCandidateGroups(
+                ExporterUtil.toStringArrayOrNull(value.getCandidateGroupsList()));
         case "candidateUsersList" ->
-            entity.setCandidateUsers(value.getCandidateUsersList().toArray(new String[0]));
+            entity.setCandidateUsers(
+                ExporterUtil.toStringArrayOrNull(value.getCandidateUsersList()));
         case "dueDate" -> entity.setDueDate(ExporterUtil.toOffsetDateTime(value.getDueDate()));
         case "followUpDate" ->
             entity.setFollowUpDate(ExporterUtil.toOffsetDateTime(value.getFollowUpDate()));
@@ -311,19 +307,11 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         .setAssignee(getAssigneeOrNull(record))
         .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
         .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
-        .setPriority(record.getValue().getPriority());
-
-    if (!record.getValue().getCandidateGroupsList().isEmpty()) {
-      entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
-    } else {
-      entity.setCandidateGroups(null);
-    }
-
-    if (!record.getValue().getCandidateUsersList().isEmpty()) {
-      entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
-    } else {
-      entity.setCandidateUsers(null);
-    }
+        .setPriority(record.getValue().getPriority())
+        .setCandidateGroups(
+            ExporterUtil.toStringArrayOrNull(record.getValue().getCandidateGroupsList()))
+        .setCandidateUsers(
+            ExporterUtil.toStringArrayOrNull(record.getValue().getCandidateUsersList()));
   }
 
   private void handleCompletion(final Record<UserTaskRecordValue> record, final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -288,7 +288,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     final var value = record.getValue();
 
     for (final String attribute : value.getChangedAttributes()) {
-      entity.getChangedAttributes().add(attribute);
+      entity.addChangedAttribute(attribute);
 
       switch (attribute) {
         case "assignee" -> entity.setAssignee(getAssigneeOrNull(record));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -114,8 +114,10 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     switch ((UserTaskIntent) record.getIntent()) {
       case UserTaskIntent.CREATING -> createTaskEntity(entity, record);
       case UserTaskIntent.CREATED -> handleCreated(record, entity);
-      case UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED ->
-          updateChangedAttributes(record, entity);
+      case UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED -> {
+        updateChangedAttributes(record, entity);
+        entity.setState(TaskState.CREATED);
+      }
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
       case UserTaskIntent.CANCELED -> handleCancellation(record, entity);
       case UserTaskIntent.MIGRATED -> handleMigration(record, entity);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -40,10 +40,14 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =
       EnumSet.of(
           UserTaskIntent.CREATED,
+          UserTaskIntent.COMPLETING,
           UserTaskIntent.COMPLETED,
+          UserTaskIntent.CANCELING,
           UserTaskIntent.CANCELED,
           UserTaskIntent.MIGRATED,
+          UserTaskIntent.ASSIGNING,
           UserTaskIntent.ASSIGNED,
+          UserTaskIntent.UPDATING,
           UserTaskIntent.UPDATED);
   private static final String UNMAPPED_USER_TASK_ATTRIBUTE_WARNING =
       "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}";
@@ -109,6 +113,11 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
       case UserTaskIntent.CANCELED -> handleCancellation(record, entity);
       case UserTaskIntent.MIGRATED -> handleMigration(record, entity);
+      case UserTaskIntent.ASSIGNING, UserTaskIntent.CLAIMING ->
+          entity.setState(TaskState.ASSIGNING);
+      case UserTaskIntent.UPDATING -> entity.setState(TaskState.UPDATING);
+      case UserTaskIntent.COMPLETING -> entity.setState(TaskState.COMPLETING);
+      case UserTaskIntent.CANCELING -> entity.setState(TaskState.CANCELING);
       default -> {}
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -210,49 +210,44 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   }
 
   private void createTaskEntity(final TaskEntity entity, final Record<UserTaskRecordValue> record) {
-    final var formKey =
-        record.getValue().getFormKey() > 0 ? String.valueOf(record.getValue().getFormKey()) : null;
+    final var taskValue = record.getValue();
+    final var formKey = taskValue.getFormKey() > 0 ? String.valueOf(taskValue.getFormKey()) : null;
 
     entity
         .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
         .setState(TaskState.CREATING)
-        .setFlowNodeInstanceId(String.valueOf(record.getValue().getElementInstanceKey()))
-        .setProcessInstanceId(String.valueOf(record.getValue().getProcessInstanceKey()))
-        .setFlowNodeBpmnId(record.getValue().getElementId())
+        .setFlowNodeInstanceId(String.valueOf(taskValue.getElementInstanceKey()))
+        .setProcessInstanceId(String.valueOf(taskValue.getProcessInstanceKey()))
+        .setFlowNodeBpmnId(taskValue.getElementId())
         .setName(
             ProcessCacheUtil.getFlowNodeName(
-                    processCache,
-                    record.getValue().getProcessDefinitionKey(),
-                    record.getValue().getElementId())
+                    processCache, taskValue.getProcessDefinitionKey(), taskValue.getElementId())
                 .orElse(null))
-        .setBpmnProcessId(record.getValue().getBpmnProcessId())
-        .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()))
-        .setProcessDefinitionVersion(record.getValue().getProcessDefinitionVersion())
+        .setBpmnProcessId(taskValue.getBpmnProcessId())
+        .setProcessDefinitionId(String.valueOf(taskValue.getProcessDefinitionKey()))
+        .setProcessDefinitionVersion(taskValue.getProcessDefinitionVersion())
         .setFormKey(!ExporterUtil.isEmpty(formKey) ? formKey : null)
         .setExternalFormReference(
-            ExporterUtil.isEmpty(record.getValue().getExternalFormReference())
+            ExporterUtil.isEmpty(taskValue.getExternalFormReference())
                 ? null
-                : record.getValue().getExternalFormReference())
-        .setCustomHeaders(record.getValue().getCustomHeaders())
+                : taskValue.getExternalFormReference())
+        .setCustomHeaders(taskValue.getCustomHeaders())
         .setPartitionId(record.getPartitionId())
-        .setTenantId(record.getValue().getTenantId())
+        .setTenantId(taskValue.getTenantId())
         .setPosition(record.getPosition())
-        .setAction(
-            ExporterUtil.isEmpty(record.getValue().getAction())
-                ? null
-                : record.getValue().getAction())
+        .setAction(ExporterUtil.isEmpty(taskValue.getAction()) ? null : taskValue.getAction())
         .setCreationTime(
             ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
-        .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
-        .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
-        .setPriority(record.getValue().getPriority());
+        .setDueDate(ExporterUtil.toOffsetDateTime(taskValue.getDueDate()))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(taskValue.getFollowUpDate()))
+        .setPriority(taskValue.getPriority());
 
-    if (!record.getValue().getCandidateGroupsList().isEmpty()) {
-      entity.setCandidateGroups(record.getValue().getCandidateGroupsList().toArray(new String[0]));
+    if (!taskValue.getCandidateGroupsList().isEmpty()) {
+      entity.setCandidateGroups(taskValue.getCandidateGroupsList().toArray(new String[0]));
     }
 
-    if (!record.getValue().getCandidateUsersList().isEmpty()) {
-      entity.setCandidateUsers(record.getValue().getCandidateUsersList().toArray(new String[0]));
+    if (!taskValue.getCandidateUsersList().isEmpty()) {
+      entity.setCandidateUsers(taskValue.getCandidateUsersList().toArray(new String[0]));
     }
 
     if (!ExporterUtil.isEmpty(formKey)) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -15,6 +15,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,13 @@ public final class ExporterUtil {
 
   public static String toStringOrDefault(final Object object, final String defaultString) {
     return object == null ? defaultString : object.toString();
+  }
+
+  public static String[] toStringArrayOrNull(final List<String> inputList) {
+    if (inputList == null || inputList.isEmpty()) {
+      return null;
+    }
+    return inputList.toArray(new String[0]);
   }
 
   public static String trimWhitespace(final String str) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -65,7 +65,10 @@ public class UserTaskHandlerTest {
           UserTaskIntent.ASSIGNING,
           UserTaskIntent.ASSIGNED,
           UserTaskIntent.UPDATING,
-          UserTaskIntent.UPDATED);
+          UserTaskIntent.UPDATED,
+          UserTaskIntent.ASSIGNMENT_DENIED,
+          UserTaskIntent.UPDATE_DENIED,
+          UserTaskIntent.COMPLETION_DENIED);
 
   @Captor private ArgumentCaptor<Map<String, Object>> updateFieldsCaptor;
 
@@ -1015,21 +1018,14 @@ public class UserTaskHandlerTest {
   private TaskState mapIntentToExpectedState(final UserTaskIntent intent) {
     return switch (intent) {
       case CREATING -> TaskState.CREATING;
-      case CREATED -> TaskState.CREATED;
+      case CREATED, ASSIGNMENT_DENIED, COMPLETION_DENIED, UPDATE_DENIED -> TaskState.CREATED;
       case ASSIGNING, CLAIMING -> TaskState.ASSIGNING;
       case UPDATING -> TaskState.UPDATING;
       case COMPLETING -> TaskState.COMPLETING;
       case COMPLETED -> TaskState.COMPLETED;
       case CANCELING -> TaskState.CANCELING;
       case CANCELED -> TaskState.CANCELED;
-      case ASSIGNED,
-          CORRECTED,
-          MIGRATED,
-          UPDATED,
-          ASSIGNMENT_DENIED,
-          COMPLETION_DENIED,
-          UPDATE_DENIED ->
-          /* doesn't affect the state */ null;
+      case ASSIGNED, CORRECTED, MIGRATED, UPDATED -> /* doesn't affect the state */ null;
       default ->
           throw new IllegalArgumentException(
               """

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -96,7 +96,9 @@ public class UserTaskHandlerTest {
           final Record<UserTaskRecordValue> userTaskRecord =
               factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(intent));
           // when - then
-          assertThat(underTest.handlesRecord(userTaskRecord)).isTrue();
+          assertThat(underTest.handlesRecord(userTaskRecord))
+              .describedAs("Expect to handle intent %s", intent)
+              .isTrue();
         });
   }
 
@@ -110,7 +112,9 @@ public class UserTaskHandlerTest {
               final Record<UserTaskRecordValue> variableRecord =
                   factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(intent));
               // when - then
-              assertThat(underTest.handlesRecord(variableRecord)).isFalse();
+              assertThat(underTest.handlesRecord(variableRecord))
+                  .describedAs("Expect not to handle intent %s", intent)
+                  .isFalse();
             });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -63,6 +63,7 @@ public class UserTaskHandlerTest {
           UserTaskIntent.CANCELED,
           UserTaskIntent.MIGRATED,
           UserTaskIntent.ASSIGNING,
+          UserTaskIntent.CLAIMING,
           UserTaskIntent.ASSIGNED,
           UserTaskIntent.UPDATING,
           UserTaskIntent.UPDATED,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -55,11 +55,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class UserTaskHandlerTest {
   private static final Set<UserTaskIntent> SUPPORTED_INTENTS =
       EnumSet.of(
+          UserTaskIntent.CREATING,
           UserTaskIntent.CREATED,
+          UserTaskIntent.COMPLETING,
           UserTaskIntent.COMPLETED,
+          UserTaskIntent.CANCELING,
           UserTaskIntent.CANCELED,
           UserTaskIntent.MIGRATED,
+          UserTaskIntent.ASSIGNING,
           UserTaskIntent.ASSIGNED,
+          UserTaskIntent.UPDATING,
           UserTaskIntent.UPDATED);
 
   @Captor private ArgumentCaptor<Map<String, Object>> updateFieldsCaptor;
@@ -987,16 +992,15 @@ public class UserTaskHandlerTest {
    */
   private TaskState mapIntentToExpectedState(final UserTaskIntent intent) {
     return switch (intent) {
+      case CREATING -> TaskState.CREATING;
       case CREATED -> TaskState.CREATED;
+      case ASSIGNING, CLAIMING -> TaskState.ASSIGNING;
+      case UPDATING -> TaskState.UPDATING;
+      case COMPLETING -> TaskState.COMPLETING;
       case COMPLETED -> TaskState.COMPLETED;
+      case CANCELING -> TaskState.CANCELING;
       case CANCELED -> TaskState.CANCELED;
-      case CREATING,
-          CANCELING,
-          COMPLETING,
-          UPDATING,
-          ASSIGNING,
-          CLAIMING,
-          ASSIGNED,
+      case ASSIGNED,
           CORRECTED,
           MIGRATED,
           UPDATED,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -644,7 +644,13 @@ public class UserTaskHandlerTest {
     // given
     final long processInstanceKey = 123;
     final UserTaskRecordValue taskRecordValue =
-        ImmutableUserTaskRecordValue.builder().withProcessInstanceKey(processInstanceKey).build();
+        ImmutableUserTaskRecordValue.builder()
+            .withProcessInstanceKey(processInstanceKey)
+            .withProcessDefinitionKey(456L)
+            .withBpmnProcessId("ID")
+            .withProcessDefinitionVersion(2)
+            .withElementId("New_Element_ID")
+            .build();
 
     final Record<UserTaskRecordValue> taskRecord =
         factory.generateRecord(
@@ -659,7 +665,10 @@ public class UserTaskHandlerTest {
     underTest.updateEntity(taskRecord, taskEntity);
 
     // then
-    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+    assertThat(taskEntity.getProcessDefinitionId()).isEqualTo("456");
+    assertThat(taskEntity.getBpmnProcessId()).isEqualTo("ID");
+    assertThat(taskEntity.getProcessDefinitionVersion()).isEqualTo(2);
+    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo("New_Element_ID");
   }
 
   @Test
@@ -671,6 +680,7 @@ public class UserTaskHandlerTest {
             .withElementId("elementId")
             .withBpmnProcessId("bpmnProcessId")
             .withProcessInstanceKey(processInstanceKey)
+            .withProcessDefinitionVersion(2)
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
@@ -694,7 +704,8 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_ID, taskEntity.getProcessDefinitionId());
     expectedUpdates.put(TaskTemplate.BPMN_PROCESS_ID, taskEntity.getBpmnProcessId());
     expectedUpdates.put(TaskTemplate.FLOW_NODE_BPMN_ID, taskEntity.getFlowNodeBpmnId());
-    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+    expectedUpdates.put(
+        TaskTemplate.PROCESS_DEFINITION_VERSION, taskEntity.getProcessDefinitionVersion());
 
     // then
     assertThat(taskEntity.getProcessDefinitionId())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -750,6 +750,7 @@ public class UserTaskHandlerTest {
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(taskRecordValue.getAssignee());
@@ -792,6 +793,7 @@ public class UserTaskHandlerTest {
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.ASSIGNEE, null);
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     // then
     assertThat(taskEntity.getAssignee()).isEqualTo(null);
@@ -893,6 +895,7 @@ public class UserTaskHandlerTest {
         TaskTemplate.CHANGED_ATTRIBUTES,
         List.of(
             "priority", "dueDate", "followUpDate", "candidateUsersList", "candidateGroupsList"));
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -958,6 +961,7 @@ public class UserTaskHandlerTest {
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("priority", "assignee"));
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     // then
     assertThat(taskEntity.getPriority()).isEqualTo(taskRecordValue.getPriority());
@@ -1019,14 +1023,15 @@ public class UserTaskHandlerTest {
   private TaskState mapIntentToExpectedState(final UserTaskIntent intent) {
     return switch (intent) {
       case CREATING -> TaskState.CREATING;
-      case CREATED, ASSIGNMENT_DENIED, COMPLETION_DENIED, UPDATE_DENIED -> TaskState.CREATED;
+      case CREATED, ASSIGNED, ASSIGNMENT_DENIED, UPDATED, UPDATE_DENIED, COMPLETION_DENIED ->
+          TaskState.CREATED;
       case ASSIGNING, CLAIMING -> TaskState.ASSIGNING;
       case UPDATING -> TaskState.UPDATING;
       case COMPLETING -> TaskState.COMPLETING;
       case COMPLETED -> TaskState.COMPLETED;
       case CANCELING -> TaskState.CANCELING;
       case CANCELED -> TaskState.CANCELED;
-      case ASSIGNED, CORRECTED, MIGRATED, UPDATED -> /* doesn't affect the state */ null;
+      case CORRECTED, MIGRATED -> /* doesn't affect the state */ null;
       default ->
           throw new IllegalArgumentException(
               """

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5529,8 +5529,13 @@ components:
           type: string
           description: The state of the user task.
           enum:
+            - CREATING
             - CREATED
+            - ASSIGNING
+            - UPDATING
+            - COMPLETING
             - COMPLETED
+            - CANCELING
             - CANCELED
             - FAILED
         assignee:
@@ -5632,8 +5637,13 @@ components:
           type: string
           description: The state of the user task.
           enum:
+            - CREATING
             - CREATED
+            - ASSIGNING
+            - UPDATING
+            - COMPLETING
             - COMPLETED
+            - CANCELING
             - CANCELED
             - FAILED
         assignee:


### PR DESCRIPTION
## Description

### Summary
This PR enables full user task lifecycle state tracking in secondary storage (`Camunda-exporter), making all lifecycle states queryable via the REST APIs.

> [!NOTE]
> A follow-up PR will provide support for these intermediate states in the `rdbms-exporter` as well.

With this enhancement, the system now reflects in-progress transitions as first-class states, improving transparency for clients and enabling external systems to track and react to user task state changes in near real time**.

### Motivation
Previously, only `CREATED`, `COMPLETED`, and `CANCELED` user task states were persisted in secondary storage. However, a user task goes through multiple intermediate transitions such as `CREATING`, `ASSIGNING`, `UPDATING`, `COMPLETING`, and `CANCELING`. These states are useful for clients to understand what is happening to a task in real-time - not just what has happened.

To align with user expectations and provide visibility into in-progress task transitions, this PR expands the coverage to include all user task lifecycle states.

### What's changed

#### User Task Exporter (`camunda-exporter`)
- Handles intermediate `UserTaskIntent` values and maps them to corresponding task states
- Creates task entity on `CREATING`
- Ensures data from partial events (e.g., `ASSIGNING`, `UPDATING`) is not treated as committed - only final events (e.g., `ASSIGNED`, `UPDATED`) commit values

#### REST API Support

- Extended OpenAPI spec to support and expose the full lifecycle in [Get user task](https://docs.camunda.io/docs/8.8/apis-tools/orchestration-cluster-api-rest/specifications/get-user-task/) and [Search user tasks](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-user-tasks/) endpoints.

#### CamundaClient
- Updated to support all new user task states
- Ensured proper transformation of task state from API responses

#### Testing
- Added a test to verify all supported intents are mapped correctly
- Validated that only appropriate state transitions occur
- Added timeout and readiness improvements to stabilize test execution

#### Fixes and improvements

- **Corrections on canceled user tasks are now persisted**
  Previously, changes made during the `CANCELING` transition (e.g., assignee updates) were ignored. This is now fixed — the corrected attributes are applied to the entity on the `CANCELED` event.

- **Process version is updated on `MIGRATED` event**
  Migrated user tasks now correctly reflect their updated process version in secondary storage.

- **Rollback behavior clarified**
  On any `X_DENIED` event, the user task state rolls back to `CREATED`, to reflect the correct user task state.

- **Improved transitional state cleanup**
  Ensures `candidateUsers` and `candidateGroups` are set to `null` (not empty arrays) when removed during corrections - aligning with exporter expectations.

- **Generate ID on `CREATING`**
  Adjusted logic for determining the task key on `CREATING` events instead of `CREATED`, since `CREATING` is now appear first.

> [!NOTE]
> The `UserTaskIntent.CORRECTED` event is not handled, as it contains only uncommitted data and is always followed by either a confirming or denying intent (e.g., `ASSIGNED`, `ASSIGNMENT_DENIED`). Thus, no state update is required for it.

### Next steps
- A follow-up PR will bring equivalent support for intermediate states to the `rdbms-exporter`.
## Related issues

closes #32562 and #35471
