### PR TITLE
fix: delegate login for consolidate-auth

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-push-zeebe-docker
         name: Build & Push zeebe-io/zeebe
-        if: ${{ inputs.camunda-image-only == 'false' }}
+        if: ${{ !inputs.camunda-image-only }}
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/zeebe
           version: ${{ steps.image-tag.outputs.image-tag }}
@@ -103,7 +103,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-push-operate-docker
         name: Build & Push zeebe-io/operate
-        if: ${{ inputs.camunda-image-only == 'false' }}
+        if: ${{ !inputs.camunda-image-only }}
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/operate
           version: ${{ steps.image-tag.outputs.image-tag }}
@@ -114,7 +114,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-push-tasklist-docker
         name: Build & Push zeebe-io/tasklist
-        if: ${{ inputs.camunda-image-only == 'false' }}
+        if: ${{ !inputs.camunda-image-only }}
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/tasklist
           version: ${{ steps.image-tag.outputs.image-tag }}
@@ -125,7 +125,7 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-push-optimize-docker
         name: Build & Push zeebe-io/optimize
-        if: ${{ inputs.camunda-image-only == 'false' }}
+        if: ${{ !inputs.camunda-image-only }}
         with:
           repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/optimize
           version: ${{ steps.image-tag.outputs.image-tag }}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -88,7 +88,17 @@ public class WebSecurityConfig {
           "/tasklist/**",
           "/",
           "/sso-callback/**",
-          "/oauth2/authorization/**");
+          "/oauth2/authorization/**",
+          // old Tasklist and Operate webapps routes
+          "/processes",
+          "/processes/*",
+          "/{regex:[\\d]+}", // user task id
+          "/processes/*/start",
+          "/new/*",
+          "/decisions",
+          "/decisions/*",
+          "/instances",
+          "/instances/*");
   private static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           // endpoint for failure forwarding

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -62,10 +62,13 @@ public class WebappsConfigurationInitializer
 
   private boolean isLoginDelegated(final ConfigurableApplicationContext context) {
     final var activeProfiles = Arrays.asList(context.getEnvironment().getActiveProfiles());
-    final var consolidatedAuthVariation =
-        AuthenticationMethod.parse(String.valueOf(context.getEnvironment().getProperty(METHOD)));
-    return activeProfiles.stream().anyMatch(LOGIN_DELEGATED_PROFILES::contains)
-        || (consolidatedAuthVariation.isPresent()
-            && AuthenticationMethod.OIDC.equals(consolidatedAuthVariation.get()));
+    if (activeProfiles.stream().anyMatch(LOGIN_DELEGATED_PROFILES::contains)) {
+      return true;
+    }
+
+    final var authenticationMethodProperty = context.getEnvironment().getProperty(METHOD);
+    final var authenticationMethod = AuthenticationMethod.parse(authenticationMethodProperty);
+    return authenticationMethod.isPresent()
+        && AuthenticationMethod.OIDC.equals(authenticationMethod.get());
   }
 }

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -43,6 +43,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
     </dependency>
 

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -38,6 +38,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-authentication</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
     </dependency>
 

--- a/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
+++ b/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.operate;
 
+import static io.camunda.authentication.config.AuthenticationProperties.METHOD;
+
+import io.camunda.security.entity.AuthenticationMethod;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -45,6 +48,14 @@ public class OperateProfileService {
     return Arrays.asList(environment.getActiveProfiles()).contains(SSO_AUTH_PROFILE);
   }
 
+  public boolean isConsolidatedAuthOidc() {
+    final var consolidatedAuthVariation =
+        AuthenticationMethod.parse(String.valueOf(environment.getProperty(METHOD)));
+
+    return consolidatedAuthVariation.isPresent()
+        && AuthenticationMethod.OIDC.equals(consolidatedAuthVariation.get());
+  }
+
   public boolean isIdentityProfile() {
     return Arrays.asList(environment.getActiveProfiles()).contains(IDENTITY_AUTH_PROFILE);
   }
@@ -55,6 +66,6 @@ public class OperateProfileService {
   }
 
   public boolean isLoginDelegated() {
-    return isIdentityProfile() || isSSOProfile();
+    return isIdentityProfile() || isSSOProfile() || isConsolidatedAuthOidc();
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
+++ b/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
@@ -50,7 +50,7 @@ public class OperateProfileService {
 
   public boolean isConsolidatedAuthOidc() {
     final var consolidatedAuthVariation =
-        AuthenticationMethod.parse(String.valueOf(environment.getProperty(METHOD)));
+        AuthenticationMethod.parse(environment.getProperty(METHOD));
 
     return consolidatedAuthVariation.isPresent()
         && AuthenticationMethod.OIDC.equals(consolidatedAuthVariation.get());

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerConsolidatedAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerConsolidatedAuthIT.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.controllers;
+
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"tasklist", "standalone", "test", "consolidated-auth"})
+public class OldRoutesRedirectionControllerConsolidatedAuthIT
+    extends OldRoutesRedirectionControllerIT {}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -45,7 +45,7 @@ public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
   }
 
   static Stream<String> notFoundTestDataProvider() {
-    return Stream.of("/v1/user-tasks", "/decisions", "/a12345", "/new");
+    return Stream.of("/v1/user-tasks", "/decisions", "/new");
   }
 
   @ParameterizedTest

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.tasklist.webapp.security;
 
+import static io.camunda.authentication.config.AuthenticationProperties.METHOD;
+
+import io.camunda.security.entity.AuthenticationMethod;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -37,7 +40,7 @@ public class TasklistProfileServiceImpl implements TasklistProfileService {
 
   @Override
   public boolean isLoginDelegated() {
-    return isIdentityProfile() || isSSOProfile();
+    return isIdentityProfile() || isSSOProfile() || isConsolidatedAuthOidc();
   }
 
   private boolean isDevelopmentProfileActive() {
@@ -50,5 +53,13 @@ public class TasklistProfileServiceImpl implements TasklistProfileService {
 
   private boolean isIdentityProfile() {
     return Arrays.asList(environment.getActiveProfiles()).contains(IDENTITY_AUTH_PROFILE);
+  }
+
+  public boolean isConsolidatedAuthOidc() {
+    final var consolidatedAuthVariation =
+        AuthenticationMethod.parse(String.valueOf(environment.getProperty(METHOD)));
+
+    return consolidatedAuthVariation.isPresent()
+        && AuthenticationMethod.OIDC.equals(consolidatedAuthVariation.get());
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
@@ -57,7 +57,7 @@ public class TasklistProfileServiceImpl implements TasklistProfileService {
 
   public boolean isConsolidatedAuthOidc() {
     final var consolidatedAuthVariation =
-        AuthenticationMethod.parse(String.valueOf(environment.getProperty(METHOD)));
+        AuthenticationMethod.parse(environment.getProperty(METHOD));
 
     return consolidatedAuthVariation.isPresent()
         && AuthenticationMethod.OIDC.equals(consolidatedAuthVariation.get());


### PR DESCRIPTION
## Description

 * Since 8.6, we agreed to have a redirection in Tasklist and Operate backends to /tasklist and /operate subpaths, checkout this PR
   * We do this for sso-auth and the identity profile, but not yet for the consolidate-auth
 * This causes issues on SaaS for example with Webmodeler, where it is not correctly redirecting to the correct endpoint


### This PR contains 

This PR was a team effort between (@Ben-Sheppard @houssain-barouni and myself):

 * We first added the consolidate-auth to be considered in the redirect
 * Later, we made the condition more strict to be only in the case of OIDC
 * Furthermore, we made sure that old routes are part of the Web-app paths, as the new profile always requires authenticated paths
 * Additionally, we improve the workflow to deploy Docker image to the SaaS environment, so we can test it 

### Testing

 * We were able to test this in the DEV environment with the branch image

https://github.com/user-attachments/assets/fdac12d7-194d-46db-b5e7-bae4661f0390


  * We extended a little the existing test, but [realized](https://camunda.slack.com/archives/C06UYJMMETZ/p1748875533700419?thread_ts=1748853210.358229&cid=C06UYJMMETZ) we need better test support for OIDC (\cc @Ben-Sheppard )


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
