### PR TITLE
ci: increase renovate concurrency limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,8 +11,8 @@
     "main"
   ],
   "dependencyDashboard": true,
-  "prConcurrentLimit": 30,
-  "prHourlyLimit": 5,
+  "prConcurrentLimit": 50,
+  "prHourlyLimit": 10,
   "updateNotScheduled": false,
   "schedule": [
     "at any time"


### PR DESCRIPTION
## Description

As discussed in [this thread](https://camunda.slack.com/archives/C071KP5BTHB/p1748851703818149?thread_ts=1748840639.960299&cid=C071KP5BTHB) we're increasing the renovate concurrency limits once more to reduce the rate-limited PRs backlog.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
