### PR TITLE
[Backport main] ci: run operate importer tests on PR

### DIFF
--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   run-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -1,16 +1,22 @@
 # description: Workflow that runs Integration Tests that match **/*ZeebeImportIT.java or **/*ZeebeIT.java If the name of the Java class does not match either of those, then the test is not run
 # test location: operate/qa/integration-tests
 # owner: Data Layers
----
-name: Operate Run Test Importer
-
+name: "[Legacy] Operate / [IT] Import"
 on:
-  schedule:
-    - cron: "0 5 * * *"
-  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+    paths:
+      - '.github/workflows/operate-*'
+      - 'operate/**'
+  pull_request:
+    paths:
+      - '.github/workflows/operate-*'
+      - "operate/**"
 jobs:
   run-importer-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: ./mvnw -f operate verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -pl operate -am verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit


### PR DESCRIPTION
# Description
Backport of #32570 to `main`.

Migration tests were removed with https://github.com/camunda/camunda/pull/24620 so we only need the adjustment for the importer tests.

relates to camunda/camunda#24392