### PR TITLE
fix: update flaky tests

### DIFF
--- a/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -120,9 +120,6 @@ class TaskDetailsPage {
 
   async clickCompleteTaskButton() {
     await this.completeTaskButton.click({timeout: 60000});
-    await expect(this.taskCompletedBanner).toBeVisible({
-      timeout: 200000,
-    });
   }
 
   async clickAddVariableButton() {

--- a/qa/core-application-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -78,9 +78,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskPanelPage.openTask('Job_Worker_Process');
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
       await navigateToApp(page, 'operate');
       await operateLoginPage.login('demo', 'demo');
@@ -151,9 +149,7 @@ test.describe('HTO User Flow Tests', () => {
         '"updatedValue"',
       );
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
     });
   });
 
@@ -183,9 +179,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.fillTextInput('Name*', 'Test User');
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
       await navigateToApp(page, 'operate');
       await operateLoginPage.login('demo', 'demo');
@@ -241,9 +235,7 @@ test.describe('HTO User Flow Tests', () => {
         taskDetailsPage.detailsPanel.getByText('critical'),
       ).toBeVisible();
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
       await taskPanelPage.openTask('priorityTest3');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(
@@ -251,9 +243,7 @@ test.describe('HTO User Flow Tests', () => {
       ).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
       await taskPanelPage.openTask('priorityTest2');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(
@@ -261,17 +251,13 @@ test.describe('HTO User Flow Tests', () => {
       ).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
       await taskPanelPage.openTask('priorityTest1');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(taskDetailsPage.detailsPanel.getByText('low')).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
       await taskPanelPage.filterBy('Completed');
       await taskPanelPage.assertCompletedHeadingVisible();
       await taskPanelPage.openTask('priorityTest4');
@@ -318,9 +304,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskPanelPage.openTask('Zeebe_User_Task_Process');
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
-        timeout: 200000,
-      });
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
       await navigateToApp(page, 'operate');
       await operateLoginPage.login('demo', 'demo');

--- a/qa/core-application-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/common-flows/hto-user-flows.spec.ts
@@ -78,7 +78,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskPanelPage.openTask('Job_Worker_Process');
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(page.getByText('Task completed')).toBeVisible({
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
         timeout: 200000,
       });
 
@@ -151,7 +151,7 @@ test.describe('HTO User Flow Tests', () => {
         '"updatedValue"',
       );
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(page.getByText('Task completed')).toBeVisible({
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
         timeout: 200000,
       });
     });
@@ -183,7 +183,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.fillTextInput('Name*', 'Test User');
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(page.getByText('Task completed')).toBeVisible({
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
         timeout: 200000,
       });
 
@@ -241,6 +241,9 @@ test.describe('HTO User Flow Tests', () => {
         taskDetailsPage.detailsPanel.getByText('critical'),
       ).toBeVisible();
       await taskDetailsPage.clickCompleteTaskButton();
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+        timeout: 200000,
+      });
       await taskPanelPage.openTask('priorityTest3');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(
@@ -248,6 +251,9 @@ test.describe('HTO User Flow Tests', () => {
       ).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+        timeout: 200000,
+      });
       await taskPanelPage.openTask('priorityTest2');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(
@@ -255,12 +261,17 @@ test.describe('HTO User Flow Tests', () => {
       ).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+        timeout: 200000,
+      });
       await taskPanelPage.openTask('priorityTest1');
       await taskDetailsPage.clickAssignToMeButton();
       await expect(taskDetailsPage.detailsPanel.getByText('low')).toBeVisible();
       await taskDetailsPage.taskCompletedBanner.waitFor({state: 'hidden'});
       await taskDetailsPage.clickCompleteTaskButton();
-
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+        timeout: 200000,
+      });
       await taskPanelPage.filterBy('Completed');
       await taskPanelPage.assertCompletedHeadingVisible();
       await taskPanelPage.openTask('priorityTest4');
@@ -307,7 +318,7 @@ test.describe('HTO User Flow Tests', () => {
       await taskPanelPage.openTask('Zeebe_User_Task_Process');
       await taskDetailsPage.clickAssignToMeButton();
       await taskDetailsPage.clickCompleteTaskButton();
-      await expect(page.getByText('Task completed')).toBeVisible({
+      await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
         timeout: 200000,
       });
 

--- a/qa/core-application-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -176,6 +176,7 @@ test.describe('task details page', () => {
     taskPanelPage,
     taskDetailsPage,
   }) => {
+    test.slow();
     await taskPanelPage.openTask('Zeebe_user_task');
     await taskDetailsPage.clickUnassignButton();
     await taskDetailsPage.clickAssignToMeButton();

--- a/qa/core-application-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -88,6 +88,7 @@ test.describe('task panel page', () => {
 
     await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
     await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
     await expect(async () => {
       await expect(taskPanelPage.availableTasks.getByText('user')).toHaveCount(


### PR DESCRIPTION
## Description

This PR aims to improve the reliability of the following test flows, which have been failing during [nightly runs](https://camunda.slack.com/archives/C08KSTFJ04X/p1748824402169979)

* Complete Zeebe and Job Worker Tasks
* Zeebe User Task User Flow

### Fixes Implemented:

* Moved the assertion on the completion banner out of the `clickCompleteTaskButton` function and made it explicit in the test call.
* Marked the **Complete Zeebe and Job Worker Tasks** test as `test.slow` to allow more time for execution.




🧪 The test run completed successfully — see the results [here](https://github.com/camunda/camunda/actions/runs/15387667528/job/43289738532)
❗ failing test is due to this [issue](https://github.com/camunda/camunda/issues/32439)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to #32309
