### PR TITLE
Log and exit application on fatal class circularity error

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -11,9 +11,10 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import org.slf4j.Logger;
 
 /**
- * Handles all Throwables and exits for {@link VirtualMachineError}. It can also be used as a {@link
- * UncaughtExceptionHandler uncaught exception handler}, for example as the {@link
- * Thread#setDefaultUncaughtExceptionHandler default uncaught exception handler}
+ * Handles all Throwables and exits for {@link VirtualMachineError} and other virtual machine errors
+ * like {@link ClassCircularityError}. It can also be used as a {@link UncaughtExceptionHandler
+ * uncaught exception handler}, for example as the {@link Thread#setDefaultUncaughtExceptionHandler
+ * default uncaught exception handler}
  */
 public final class VirtualMachineErrorHandler
     implements FatalErrorHandler, UncaughtExceptionHandler {
@@ -38,7 +39,7 @@ public final class VirtualMachineErrorHandler
    */
   @Override
   public void handleError(final Throwable e) {
-    if (e instanceof VirtualMachineError) {
+    if (e instanceof VirtualMachineError || e instanceof ClassCircularityError) {
       tryLogging(e);
       System.exit(EXIT_CODE);
     }


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->

The ClassCircularityError is "Thrown when the Java Virtual Machine detects a circularity in the superclass hierarchy of a class being loaded". When this occurs, our applications cannot recover from it, and a shutdown is the only reasonable solution.

We've started seeing this error occur in our virtual threads usage for request handling in the gRPC gateway.

By expanding the VirtualMachineErrorHandler (which is used by the UncaughtExceptionHandler for the virtual thread factory of the grpc gateway as a FatalErrorHandler), we ensure that the gateway shutsdown as soon as this fatal error occurs. Managed clusters like those using k8s can then automatically recover by restarting the gateway.

Of course, the underlying bug that causes this in the gRPC gateway must also be resolved, but we can at least support an quick shutdown when we encounter this error.

## Related issues

closes #32572 