### PR TITLE
ci: fix formatting of daily Slack message

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -87,7 +87,7 @@ jobs:
                 SUFFIX=" (<https://github.com/camunda/camunda/issues/$GH_ISSUE_ID|GH issue>)"
               fi
 
-              printf "• %sx \`%s.%s\`%s\n" "$NUMBER_OF_FLAKES" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
+              printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FLAKES" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
 
             done
             echo ""


### PR DESCRIPTION
## Description

In https://github.com/camunda/camunda/pull/32135 a shellcheck violation was fixed but that altered the Markdown output leading to visual difference in Slack. Users spotted [this visual regression](https://camunda.slack.com/archives/C071KP5BTHB/p1748586866834989?thread_ts=1748585425.674659&cid=C071KP5BTHB)

Culprit:

`echo "...\n"` leads to a double newline character being printed (desired), while `printf "...\n"` only has a single newline. This PR fixes that.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
