### PR TITLE
Fix flakiness in `ExpireMessageTest`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
@@ -232,7 +232,7 @@ public final class ExpireMessageTest {
             // Speed up assertion. Otherwise, it waits 5 seconds for more EXPIRED records.
             .between(
                 r -> r.getIntent() == MessageBatchIntent.EXPIRE,
-                r -> r.getIntent() == SignalIntent.BROADCAST)
+                r -> r.getIntent() == SignalIntent.BROADCASTED)
             .withIntent(MessageIntent.EXPIRED)
             .withSourceRecordPosition(
                 expireBatchMessageCommand.getPosition()) // only filter by the batch


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

While working on the backport PR https://github.com/camunda/camunda/pull/32661, I realised `EXPIRED` events can be written after the `BROADCAST` command depending on the speed of processing which might cause flakiness in different test runs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
