### PR TITLE
feat: add usage metric checker, processor, applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -339,7 +339,7 @@ public final class EngineProcessors {
         batchOperationMetrics);
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
-        typedRecordProcessors, config, clock, processingState);
+        typedRecordProcessors, config, clock, processingState, writers, keyGenerator);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.metrics.UsageMetricsProcessors;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
@@ -336,6 +337,9 @@ public final class EngineProcessors {
         partitionId,
         routingInfo,
         batchOperationMetrics);
+
+    UsageMetricsProcessors.addUsageMetricsProcessors(
+        typedRecordProcessors, config, clock, processingState);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsChecker.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import java.time.InstantSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UsageMetricsChecker implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsChecker.class);
+
+  private final Duration exportInterval;
+  private final InstantSource clock;
+  private ReadonlyStreamProcessorContext processingContext;
+  private boolean shouldReschedule = false;
+
+  public UsageMetricsChecker(final Duration exportInterval, final InstantSource clock) {
+    this.exportInterval = exportInterval;
+    this.clock = clock;
+  }
+
+  public void schedule(final boolean immediately) {
+    if (immediately) {
+      processingContext.getScheduleService().runAtAsync(0L, this);
+    } else {
+      LOG.trace("UsageMetricsChecker scheduled");
+      processingContext
+          .getScheduleService()
+          .runAt(clock.millis() + exportInterval.toMillis(), this);
+    }
+  }
+
+  @Override
+  public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    LOG.trace("UsageMetricsChecker running...");
+
+    taskResultBuilder.appendCommandRecord(
+        UsageMetricIntent.EXPORT,
+        new UsageMetricRecord().setIntervalType(IntervalType.ACTIVE).setEventType(EventType.NONE));
+
+    if (shouldReschedule) {
+      schedule(false);
+    }
+
+    return taskResultBuilder.build();
+  }
+
+  public void setProcessingContext(final ReadonlyStreamProcessorContext processingContext) {
+    this.processingContext = processingContext;
+  }
+
+  public void setShouldReschedule(final boolean shouldReschedule) {
+    this.shouldReschedule = shouldReschedule;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerScheduler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import java.time.InstantSource;
+
+public class UsageMetricsCheckerScheduler implements StreamProcessorLifecycleAware {
+
+  private final UsageMetricsChecker usageMetricsChecker;
+
+  public UsageMetricsCheckerScheduler(
+      final EngineConfiguration engineConfiguration, final InstantSource clock) {
+    final var exportInterval = engineConfiguration.getUsageMetricsExportInterval();
+    usageMetricsChecker = new UsageMetricsChecker(exportInterval, clock);
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
+    usageMetricsChecker.setProcessingContext(processingContext);
+    usageMetricsChecker.setShouldReschedule(true);
+    usageMetricsChecker.schedule(true);
+  }
+
+  @Override
+  public void onClose() {
+    usageMetricsChecker.setShouldReschedule(false);
+  }
+
+  @Override
+  public void onFailed() {
+    usageMetricsChecker.setShouldReschedule(false);
+  }
+
+  @Override
+  public void onPaused() {
+    usageMetricsChecker.setShouldReschedule(false);
+  }
+
+  @Override
+  public void onResumed() {
+    usageMetricsChecker.setShouldReschedule(true);
+    usageMetricsChecker.schedule(true);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExcludeAuthorizationCheck
+public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMetricRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsExportProcessor.class);
+
+  private final MutableUsageMetricState usageMetricState;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+
+  public UsageMetricsExportProcessor(
+      final MutableUsageMetricState usageMetricState,
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
+    this.usageMetricState = usageMetricState;
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
+  }
+
+  private UsageMetricRecord copyRecord(final UsageMetricRecord record) {
+    return new UsageMetricRecord()
+        .setEventType(record.getEventType())
+        .setIntervalType(record.getIntervalType())
+        .setResetTime(record.getResetTime())
+        .setStartTime(record.getStartTime())
+        .setEndTime(record.getEndTime());
+  }
+
+  private List<UsageMetricRecord> divideRecord(final UsageMetricRecord record) {
+    final var size = record.getValues().size();
+    final int halfCapacity = (int) Math.ceil(size / 2.0f);
+    final var values1 = new HashMap<String, Long>(halfCapacity);
+    final var values2 = new HashMap<String, Long>(halfCapacity);
+
+    record
+        .getValues()
+        .forEach(
+            (tenantId, value) -> {
+              if (values1.size() < halfCapacity) {
+                values1.put(tenantId, value);
+              } else {
+                values2.put(tenantId, value);
+              }
+            });
+
+    final var record1 =
+        copyRecord(record).setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values1)));
+    final var record2 =
+        copyRecord(record).setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values2)));
+
+    final var result = new ArrayList<>(checkRecordLength(record1));
+    result.addAll(checkRecordLength(record2));
+    return result;
+  }
+
+  private List<UsageMetricRecord> checkRecordLength(final UsageMetricRecord record) {
+    if (!stateWriter.canWriteEventOfLength(record.getLength())) {
+      return divideRecord(record);
+    }
+    return List.of(record);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<UsageMetricRecord> record) {
+
+    final UsageMetricRecord eventRecord =
+        new UsageMetricRecord()
+            .setIntervalType(IntervalType.ACTIVE)
+            .setEventType(EventType.NONE)
+            .setResetTime(record.getTimestamp());
+
+    final var bucket = usageMetricState.getActiveBucket();
+    if (bucket != null && !bucket.getTenantRPIMap().isEmpty()) {
+      eventRecord
+          .setEventType(EventType.RPI)
+          .setStartTime(bucket.getFromTime())
+          .setEndTime(bucket.getToTime())
+          .setValues(bucket.getTenantRPIMapValue());
+    }
+
+    checkRecordLength(eventRecord).forEach(this::appendFollowUpEvent);
+  }
+
+  private void appendFollowUpEvent(final UsageMetricRecord eventRecord) {
+    LOG.debug(
+        "Creating usage metric EXPORTED event for {} {}",
+        eventRecord.getStartTime(),
+        eventRecord.getEventType());
+    stateWriter.appendFollowUpEvent(
+        keyGenerator.nextKey(), UsageMetricIntent.EXPORTED, eventRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessor.java
@@ -44,15 +44,6 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
     this.keyGenerator = keyGenerator;
   }
 
-  private UsageMetricRecord copyRecord(final UsageMetricRecord record) {
-    return new UsageMetricRecord()
-        .setEventType(record.getEventType())
-        .setIntervalType(record.getIntervalType())
-        .setResetTime(record.getResetTime())
-        .setStartTime(record.getStartTime())
-        .setEndTime(record.getEndTime());
-  }
-
   private List<UsageMetricRecord> divideRecord(final UsageMetricRecord record) {
     final var size = record.getValues().size();
     final int halfCapacity = (int) Math.ceil(size / 2.0f);
@@ -71,9 +62,11 @@ public class UsageMetricsExportProcessor implements TypedRecordProcessor<UsageMe
             });
 
     final var record1 =
-        copyRecord(record).setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values1)));
+        UsageMetricRecord.copyWithoutValues(record)
+            .setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values1)));
     final var record2 =
-        copyRecord(record).setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values2)));
+        UsageMetricRecord.copyWithoutValues(record)
+            .setValues(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(values2)));
 
     final var result = new ArrayList<>(checkRecordLength(record1));
     result.addAll(checkRecordLength(record2));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsProcessors.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import java.time.InstantSource;
+
+public class UsageMetricsProcessors {
+
+  public static void addUsageMetricsProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final EngineConfiguration config,
+      final InstantSource clock) {
+    typedRecordProcessors.withListener(new UsageMetricsCheckerScheduler(config, clock));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -184,8 +184,7 @@ public class ProcessingDbState implements MutableProcessingState {
     batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
     membershipState = new DbMembershipState(zeebeDb, transactionContext);
     usageMetricState =
-        new DbUsageMetricState(
-            zeebeDb, transactionContext, clock, config.getUsageMetricsExportInterval());
+        new DbUsageMetricState(zeebeDb, transactionContext, config.getUsageMetricsExportInterval());
     asyncRequestState = new DbAsyncRequestState(zeebeDb, transactionContext);
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -269,7 +269,12 @@ public final class EventAppliers implements EventApplier {
 
     register(
         ProcessInstanceCreationIntent.CREATED,
-        new ProcessInstanceCreationCreatedApplier(
+        1,
+        new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
+    register(
+        ProcessInstanceCreationIntent.CREATED,
+        2,
+        new ProcessInstanceCreationCreatedV2Applier(
             processState, elementInstanceState, usageMetricState));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -62,6 +62,7 @@ import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -259,10 +260,12 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {
     final var processState = state.getProcessState();
     final var elementInstanceState = state.getElementInstanceState();
+    final var usageMetricState = state.getUsageMetricState();
 
     register(
         ProcessInstanceCreationIntent.CREATED,
-        new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
+        new ProcessInstanceCreationCreatedApplier(
+            processState, elementInstanceState, usageMetricState));
   }
 
   private void registerProcessInstanceModificationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -270,7 +270,7 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceCreationIntent.CREATED,
         1,
-        new ProcessInstanceCreationCreatedApplier(processState, elementInstanceState));
+        new ProcessInstanceCreationCreatedV1Applier(processState, elementInstanceState));
     register(
         ProcessInstanceCreationIntent.CREATED,
         2,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -142,8 +142,13 @@ public final class EventAppliers implements EventApplier {
     registerBatchOperationAppliers(state);
     registerIdentitySetupAppliers();
     registerAsyncRequestAppliers(state);
+    registerUsageMetricsAppliers(state);
 
     return this;
+  }
+
+  private void registerUsageMetricsAppliers(final MutableProcessingState state) {
+    register(UsageMetricIntent.EXPORTED, new UsageMetricsExportedApplier(state));
   }
 
   private void registerProcessAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
@@ -59,10 +59,10 @@ final class ProcessInstanceCreationCreatedApplier
               });
     }
 
-    createUsageMetric(value);
+    incrementUsageMetric(value);
   }
 
-  private void createUsageMetric(final ProcessInstanceCreationRecord value) {
+  private void incrementUsageMetric(final ProcessInstanceCreationRecord value) {
     usageMetricState.recordRPIMetric(value.getTenantId());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedApplier.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -24,12 +25,15 @@ final class ProcessInstanceCreationCreatedApplier
 
   private final ProcessState processState;
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableUsageMetricState usageMetricState;
 
   public ProcessInstanceCreationCreatedApplier(
       final MutableProcessState processState,
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState,
+      final MutableUsageMetricState usageMetricState) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
+    this.usageMetricState = usageMetricState;
   }
 
   @Override
@@ -54,6 +58,12 @@ final class ProcessInstanceCreationCreatedApplier
                 incrementNumberOfTakenSequenceFlows(element, flowScope);
               });
     }
+
+    createUsageMetric(value);
+  }
+
+  private void createUsageMetric(final ProcessInstanceCreationRecord value) {
+    usageMetricState.recordRPIMetric(value.getTenantId());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedV1Applier.java
@@ -19,13 +19,13 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
-final class ProcessInstanceCreationCreatedApplier
+final class ProcessInstanceCreationCreatedV1Applier
     implements TypedEventApplier<ProcessInstanceCreationIntent, ProcessInstanceCreationRecord> {
 
   private final ProcessState processState;
   private final MutableElementInstanceState elementInstanceState;
 
-  public ProcessInstanceCreationCreatedApplier(
+  public ProcessInstanceCreationCreatedV1Applier(
       final MutableProcessState processState,
       final MutableElementInstanceState elementInstanceState) {
     this.processState = processState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceCreationCreatedV2Applier.java
@@ -13,23 +13,27 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
-final class ProcessInstanceCreationCreatedApplier
+final class ProcessInstanceCreationCreatedV2Applier
     implements TypedEventApplier<ProcessInstanceCreationIntent, ProcessInstanceCreationRecord> {
 
   private final ProcessState processState;
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableUsageMetricState usageMetricState;
 
-  public ProcessInstanceCreationCreatedApplier(
+  public ProcessInstanceCreationCreatedV2Applier(
       final MutableProcessState processState,
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState,
+      final MutableUsageMetricState usageMetricState) {
     this.processState = processState;
     this.elementInstanceState = elementInstanceState;
+    this.usageMetricState = usageMetricState;
   }
 
   @Override
@@ -54,6 +58,12 @@ final class ProcessInstanceCreationCreatedApplier
                 incrementNumberOfTakenSequenceFlows(element, flowScope);
               });
     }
+
+    incrementUsageMetric(value);
+  }
+
+  private void incrementUsageMetric(final ProcessInstanceCreationRecord value) {
+    usageMetricState.recordRPIMetric(value.getTenantId());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UsageMetricsExportedApplier
+    implements TypedEventApplier<UsageMetricIntent, UsageMetricRecord> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UsageMetricsExportedApplier.class);
+
+  private final MutableUsageMetricState usageMetricState;
+
+  public UsageMetricsExportedApplier(final MutableProcessingState processingState) {
+    usageMetricState = processingState.getUsageMetricState();
+  }
+
+  @Override
+  public void applyState(final long key, final UsageMetricRecord record) {
+    final var activeBucket = usageMetricState.getActiveBucket();
+    if (activeBucket == null || activeBucket.getFromTime() != record.getResetTime()) {
+      LOG.debug("Reset active bucket {}", record.getResetTime());
+      usageMetricState.resetActiveBucket(record.getResetTime());
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUsageMetricState.java
@@ -13,5 +13,5 @@ public interface MutableUsageMetricState extends UsageMetricState {
 
   void recordRPIMetric(final String tenantId);
 
-  void deleteActiveBucket();
+  void resetActiveBucket(final long fromTime);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
@@ -293,6 +294,7 @@ public class MultiResourceDeploymentTest {
           RecordingExporter.records()
               .onlyEvents()
               .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
+              .filter(r -> r.getIntent() != UsageMetricIntent.EXPORTED)
               .limit(record -> record.getPosition() >= firstDeploymentRecord.getPosition())
               .count();
       assertThat(recordsCountBefore)
@@ -352,6 +354,7 @@ public class MultiResourceDeploymentTest {
           RecordingExporter.records()
               .onlyEvents()
               .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
+              .filter(r -> r.getIntent() != UsageMetricIntent.EXPORTED)
               .limit(record -> record.getPosition() >= secondDeploymentRecord.getPosition())
               .count();
       assertThat(recordsCountAfter - recordsCountBefore)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsCheckerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import java.time.InstantSource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class UsageMetricsCheckerTest {
+
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+  private UsageMetricsChecker checker;
+  private InstantSource mockClock;
+  private TaskResultBuilder mockTaskResultBuilder;
+  private ReadonlyStreamProcessorContext mockProcessingContext;
+  private ProcessingScheduleService mockProcessingScheduleService;
+  private ArgumentCaptor<UnifiedRecordValue> recordCaptor;
+
+  @Before
+  public void setUp() {
+    mockClock = mock(InstantSource.class);
+    mockTaskResultBuilder = mock(TaskResultBuilder.class);
+    mockProcessingContext = mock(ReadonlyStreamProcessorContext.class);
+    mockProcessingScheduleService = mock(ProcessingScheduleService.class);
+    when(mockProcessingContext.getScheduleService()).thenReturn(mockProcessingScheduleService);
+    recordCaptor = ArgumentCaptor.forClass(UnifiedRecordValue.class);
+
+    checker = new UsageMetricsChecker(Duration.ofMillis(1), mockClock);
+    checker.setProcessingContext(mockProcessingContext);
+  }
+
+  @Test
+  public void shouldScheduleImmediately() {
+    // when
+    checker.schedule(true);
+
+    // then
+    verify(mockProcessingContext).getScheduleService();
+    verify(mockProcessingScheduleService).runAtAsync(0L, checker);
+  }
+
+  @Test
+  public void shouldScheduleToExportedInterval() {
+    // given
+    when(mockClock.millis()).thenReturn(1L);
+
+    // when
+    checker.schedule(false);
+
+    // then
+    verify(mockProcessingContext).getScheduleService();
+    verify(mockProcessingScheduleService).runAt(2L, checker);
+  }
+
+  @Test
+  public void shouldCreateMetricsRecordAndNotReschedule() {
+    // given
+    when(mockClock.millis()).thenReturn(1L);
+
+    // when
+    checker.execute(mockTaskResultBuilder);
+
+    // then
+    verify(mockTaskResultBuilder)
+        .appendCommandRecord(eq(UsageMetricIntent.EXPORT), recordCaptor.capture());
+    verify(mockProcessingContext, never()).getScheduleService();
+    verify(mockProcessingScheduleService, never()).runAt(anyLong(), same(checker));
+    assertThat(recordCaptor.getValue())
+        .isEqualTo(new UsageMetricRecord().setIntervalType(IntervalType.ACTIVE));
+  }
+
+  @Test
+  public void shouldCreateMetricsRecordAndReschedule() {
+    // given
+    when(mockClock.millis()).thenReturn(1L);
+
+    // when
+    checker.setShouldReschedule(true);
+    checker.execute(mockTaskResultBuilder);
+
+    // then
+    verify(mockTaskResultBuilder)
+        .appendCommandRecord(eq(UsageMetricIntent.EXPORT), recordCaptor.capture());
+    verify(mockProcessingContext).getScheduleService();
+    verify(mockProcessingScheduleService).runAt(2, checker);
+    assertThat(recordCaptor.getValue())
+        .isEqualTo(new UsageMetricRecord().setIntervalType(IntervalType.ACTIVE));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricsExportProcessorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UsageMetricsExportProcessorTest {
+
+  private MutableUsageMetricState state;
+  private StateWriter stateWriter;
+  private UsageMetricsExportProcessor processor;
+  private TypedRecord<UsageMetricRecord> record;
+  private ArgumentCaptor<UsageMetricRecord> recordArgumentCaptor;
+
+  @BeforeEach
+  void setUp() {
+    stateWriter = mock(StateWriter.class);
+    state = mock(MutableUsageMetricState.class);
+    record = mock(TypedRecord.class);
+    final UsageMetricRecord recordValue = new UsageMetricRecord();
+    final var keyGenerator = mock(KeyGenerator.class);
+    final var writers = mock(Writers.class);
+
+    when(writers.state()).thenReturn(stateWriter);
+    when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true);
+    when(keyGenerator.nextKey()).thenReturn(1L);
+    when(record.getTimestamp()).thenReturn(2L);
+    when(record.getValue()).thenReturn(recordValue);
+
+    recordArgumentCaptor = ArgumentCaptor.forClass(UsageMetricRecord.class);
+
+    processor = new UsageMetricsExportProcessor(state, writers, keyGenerator);
+  }
+
+  @Test
+  void shouldAppendExportedNoneEventWhenBucketNull() {
+    // given
+    when(state.getActiveBucket()).thenReturn(null);
+
+    // when
+    processor.processRecord(record);
+
+    // then
+    verify(state).getActiveBucket();
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(1L), eq(UsageMetricIntent.EXPORTED), recordArgumentCaptor.capture());
+    final var actual = recordArgumentCaptor.getValue();
+    assertThat(actual.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
+    assertThat(actual.getEventType()).isEqualTo(EventType.NONE);
+    assertThat(actual.getResetTime()).isEqualTo(2);
+    assertThat(actual.getStartTime()).isEqualTo(-1);
+    assertThat(actual.getEndTime()).isEqualTo(-1);
+    assertThat(actual.getValues()).isEmpty();
+  }
+
+  @Test
+  void shouldAppendExportedEvent() {
+    // given
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics()
+                .setFromTime(1)
+                .setToTime(10)
+                .setTenantRPIMap(Map.of("tenant1", 10L)));
+
+    // when
+    processor.processRecord(record);
+
+    // then
+    verify(state).getActiveBucket();
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(1L), eq(UsageMetricIntent.EXPORTED), recordArgumentCaptor.capture());
+    final var actual = recordArgumentCaptor.getValue();
+    assertThat(actual.getIntervalType()).isEqualTo(IntervalType.ACTIVE);
+    assertThat(actual.getEventType()).isEqualTo(EventType.RPI);
+    assertThat(actual.getResetTime()).isEqualTo(2);
+    assertThat(actual.getStartTime()).isEqualTo(1);
+    assertThat(actual.getEndTime()).isEqualTo(10);
+    assertThat(actual.getValues()).isEqualTo(Map.of("tenant1", 10L));
+  }
+
+  @Test
+  void shouldAppendMultipleExportedEventsWhenRecordTooLong() {
+    // given
+    when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true);
+    doAnswer(i -> i.getArgument(0, Integer.class) <= 100)
+        .when(stateWriter)
+        .canWriteEventOfLength(anyInt());
+    final var tenantRPIMap = new HashMap<String, Long>();
+    for (int i = 0; i < 5; i++) {
+      tenantRPIMap.put("tenant" + i, (long) i);
+    }
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(1).setToTime(10).setTenantRPIMap(tenantRPIMap));
+
+    // when
+    processor.processRecord(record);
+
+    // then
+    verify(state).getActiveBucket();
+    verify(stateWriter, times(3))
+        .appendFollowUpEvent(
+            eq(1L), eq(UsageMetricIntent.EXPORTED), recordArgumentCaptor.capture());
+    final List<UsageMetricRecord> actual = recordArgumentCaptor.getAllValues();
+    assertThat(actual).hasSize(3);
+    assertThat(actual)
+        .extracting(UsageMetricRecord::getIntervalType)
+        .containsOnly(IntervalType.ACTIVE);
+    assertThat(actual).extracting(UsageMetricRecord::getEventType).containsOnly(EventType.RPI);
+    assertThat(actual).extracting(UsageMetricRecord::getResetTime).containsOnly(2L);
+    assertThat(actual).extracting(UsageMetricRecord::getStartTime).containsOnly(1L);
+    assertThat(actual).extracting(UsageMetricRecord::getEndTime).containsOnly(10L);
+    assertThat(actual)
+        .extracting(UsageMetricRecord::getValues)
+        .containsOnly(
+            Map.of("tenant0", 0L, "tenant1", 1L),
+            Map.of("tenant2", 2L, "tenant3", 3L),
+            Map.of("tenant4", 4L));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -214,6 +215,7 @@ public class ResourceDeletionTest {
             RecordingExporter.records()
                 .onlyEvents()
                 .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
+                .filter(r -> r.getIntent() != UsageMetricIntent.EXPORTED)
                 .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED)))
         .describedAs("Should write events in correct order")
         .extracting(Record::getIntent)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -219,8 +219,8 @@ public class ScaleUpTest {
             .getLast();
     assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(record.getValue().getRedistributedPartitions()).containsExactly(1, 2);
-    // SCALE_UP command is the first command
-    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(1);
+    // SCALE_UP command is the first command after usage metrics export
+    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(3);
 
     // when the partitions are marked as bootstrapped
     final var bootstrapPartition3 =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -56,7 +56,8 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.AUTHORIZATIONS,
           ZbColumnFamilies.AUTHORIZATION_KEYS_BY_OWNER,
           ZbColumnFamilies.ROUTING,
-          ZbColumnFamilies.BOOTSTRAPPED_AT);
+          ZbColumnFamilies.BOOTSTRAPPED_AT,
+          ZbColumnFamilies.USAGE_METRICS);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
-import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
@@ -167,8 +166,6 @@ public class EventAppliersTest {
         Intent.INTENT_CLASSES.stream()
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
-            // TODO will be removed by https://github.com/camunda/camunda/issues/31070
-            .filter(intent -> !(intent instanceof UsageMetricIntent))
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UsageMetricsExportedApplierTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+class UsageMetricsExportedApplierTest {
+
+  private MutableProcessingState processingState;
+  private MutableUsageMetricState usageMetricState;
+  private UsageMetricsExportedApplier usageMetricsExportedApplier;
+
+  @BeforeEach
+  public void setup() {
+    usageMetricState = processingState.getUsageMetricState();
+    usageMetricsExportedApplier = new UsageMetricsExportedApplier(processingState);
+  }
+
+  @Test
+  void shouldResetActiveBucket() {
+    // given
+    usageMetricState.resetActiveBucket(1L);
+    usageMetricState.recordRPIMetric("tenant1");
+    usageMetricState.recordRPIMetric("tenant1");
+    final var bucket = usageMetricState.getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsExactlyInAnyOrderEntriesOf(Map.of("tenant1", 2L));
+
+    // when
+    usageMetricsExportedApplier.applyState(1L, new UsageMetricRecord().setResetTime(2L));
+
+    // then
+    assertThat(usageMetricState.getActiveBucket().getFromTime()).isEqualTo(2L);
+    assertThat(usageMetricState.getActiveBucket().getToTime()).isEqualTo(300002L);
+    assertThat(usageMetricState.getActiveBucket().getTenantRPIMap()).isEmpty();
+  }
+
+  @Test
+  void shouldNotResetActiveBucketWhenResetTimeIsFromTime() {
+    // given
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockUsageMetricsState = mock(MutableUsageMetricState.class);
+    when(mockProcessingState.getUsageMetricState()).thenReturn(mockUsageMetricsState);
+    when(mockUsageMetricsState.getActiveBucket())
+        .thenReturn(new PersistedUsageMetrics().setFromTime(3L));
+
+    // when
+    new UsageMetricsExportedApplier(mockProcessingState)
+        .applyState(1L, new UsageMetricRecord().setResetTime(3L));
+
+    // then
+    verify(mockUsageMetricsState, never()).resetActiveBucket(1L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/metrics/DbUsageMetricStateTest.java
@@ -25,16 +25,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
 public class DbUsageMetricStateTest {
+
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
   private TransactionContext transactionContext;
-
   private InstantSource mockClock;
   private MutableUsageMetricState state;
 
   @BeforeEach
   void beforeEach() {
     mockClock = mock(InstantSource.class);
-    state = new DbUsageMetricState(zeebeDb, transactionContext, mockClock, Duration.ofSeconds(1));
+    state = new DbUsageMetricState(zeebeDb, transactionContext, Duration.ofSeconds(1));
   }
 
   @Test
@@ -78,7 +78,7 @@ public class DbUsageMetricStateTest {
   }
 
   @Test
-  public void shouldDeleteActiveBucket() {
+  public void shouldResetActiveBucket() {
     // given
     final var eventTime = InstantSource.system().millis();
     when(mockClock.millis()).thenReturn(eventTime);
@@ -88,7 +88,7 @@ public class DbUsageMetricStateTest {
         .containsExactlyInAnyOrderEntriesOf(Map.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L));
 
     // when
-    state.deleteActiveBucket();
+    state.resetActiveBucket(1L);
 
     // then
     final var actual = state.getActiveBucket();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -23,13 +23,15 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
       new EnumProperty<>("intervalType", IntervalType.class, IntervalType.ACTIVE);
   private final EnumProperty<EventType> eventTypeProp =
       new EnumProperty<>("eventType", EventType.class, EventType.NONE);
+  private final LongProperty resetTimeProp = new LongProperty("resetTime", -1);
   private final LongProperty startTimeProp = new LongProperty("startTime", -1);
   private final LongProperty endTimeProp = new LongProperty("endTime", -1);
   private final DocumentProperty valuesProp = new DocumentProperty("values");
 
   public UsageMetricRecord() {
-    super(5);
+    super(6);
     declareProperty(intervalTypeProp)
+        .declareProperty(resetTimeProp)
         .declareProperty(startTimeProp)
         .declareProperty(endTimeProp)
         .declareProperty(eventTypeProp)
@@ -83,6 +85,15 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
 
   public UsageMetricRecord setValues(final DirectBuffer value) {
     valuesProp.setValue(value);
+    return this;
+  }
+
+  public long getResetTime() {
+    return resetTimeProp.getValue();
+  }
+
+  public UsageMetricRecord setResetTime(final Long resetTime) {
+    resetTimeProp.setValue(resetTime);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -38,6 +38,15 @@ public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetric
         .declareProperty(valuesProp);
   }
 
+  public static UsageMetricRecord copyWithoutValues(final UsageMetricRecord record) {
+    return new UsageMetricRecord()
+        .setEventType(record.getEventType())
+        .setIntervalType(record.getIntervalType())
+        .setResetTime(record.getResetTime())
+        .setStartTime(record.getStartTime())
+        .setEndTime(record.getEndTime());
+  }
+
   @Override
   public IntervalType getIntervalType() {
     return intervalTypeProp.getValue();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3441,6 +3441,7 @@ final class JsonSerializableToJsonTest {
       {
         "intervalType": "ACTIVE",
         "eventType": "RPI",
+        "resetTime": -1,
         "startTime": 123,
         "endTime": 124,
         "values": {"tenant1":5}
@@ -3457,6 +3458,7 @@ final class JsonSerializableToJsonTest {
       {
         "intervalType": "ACTIVE",
         "eventType": "NONE",
+        "resetTime": -1,
         "startTime": -1,
         "endTime": -1,
         "values": {}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -40,7 +40,7 @@ public class BrokerAdminServiceEndpointTest {
       {
         "1": {
           "role": "LEADER",
-          "processedPosition": 1,
+          "processedPosition": 2,
           "snapshotId": null,
           "processedPositionInSnapshot": null,
           "streamProcessorPhase": "PROCESSING",
@@ -97,7 +97,7 @@ public class BrokerAdminServiceEndpointTest {
       """
       {
         "role": "LEADER",
-        "processedPosition": 1,
+        "processedPosition": 2,
         "snapshotId": null,
         "processedPositionInSnapshot": null,
         "streamProcessorPhase": "PROCESSING",


### PR DESCRIPTION
## Description

- Write rPI metric with tenant
- Implement usage metric checker & scheduler
- Implement usage metric EXPORT processor
- Implement usage metric EXPORTED applier
- Add tests

## Related issues

closes https://github.com/camunda/camunda/issues/31070
