### PR TITLE
fix: zeebe: make project.version interpreted properly

### DIFF
--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -129,7 +129,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args="${project.version}" --non-recursive exec:exec 2>/dev/null)
+            VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec 2>/dev/null)
           fi
           export VERSION
           if [[ "${VERSION}" == *-SNAPSHOT ]]; then

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -129,6 +129,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
+            # shellcheck disable=SC2016
             VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec 2>/dev/null)
           fi
           export VERSION


### PR DESCRIPTION
## Description

Zeebe Snyk scan workflow is failing since the introduction of `schellchek` in `actionlint`. This fix restores the original behavior by not letting the shell trying to interpret an internal Maven variable.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

- https://camunda.slack.com/archives/C071KP5BTHB/p1748863428345519
- https://github.com/camunda/camunda/pull/32135/files#diff-679587664df4f89a3f08abb26fac902dfd0acee17efb2278c0143c8da389dc7d