### PR TITLE
feat: support advanced filter for batch operations

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -17,7 +17,9 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
 public interface BatchOperationFilter extends SearchRequestFilter {
 
@@ -28,6 +30,14 @@ public interface BatchOperationFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   BatchOperationFilter batchOperationId(final String batchOperationId);
+
+  /**
+   * Filter by batchOperationId using {@link StringProperty} consumer
+   *
+   * @param fn the consumer to apply to the StringProperty
+   * @return the updated filter
+   */
+  BatchOperationFilter batchOperationId(final Consumer<StringProperty> fn);
 
   /**
    * Filters batch operations by the specified type.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
@@ -39,7 +40,7 @@ public interface BatchOperationFilter extends SearchRequestFilter {
    * @param fn the consumer to apply to the StringProperty
    * @return the updated filter
    */
-  BatchOperationFilter batchOperationId(final Consumer<StringProperty> fn);
+  BatchOperationFilter batchOperationId(final Consumer<BasicStringProperty> fn);
 
   /**
    * Filters batch operations by the specified type.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -17,6 +17,8 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -48,10 +50,26 @@ public interface BatchOperationFilter extends SearchRequestFilter {
   BatchOperationFilter operationType(final BatchOperationType operationType);
 
   /**
+   * Filter by operationType using {@link BatchOperationType} consumer
+   *
+   * @param fn the consumer to apply to the BatchOperationType
+   * @return the updated filter
+   */
+  BatchOperationFilter operationType(Consumer<BatchOperationTypeProperty> fn);
+
+  /**
    * Filters batch operations by the specified state.
    *
    * @param state the state
    * @return the updated filter
    */
   BatchOperationFilter state(final BatchOperationState state);
+
+  /**
+   * Filter by state using {@link BatchOperationStateProperty} consumer
+   *
+   * @param fn the consumer to apply to the BatchOperationStateProperty
+   * @return the updated filter
+   */
+  BatchOperationFilter state(Consumer<BatchOperationStateProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
@@ -38,7 +39,7 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
    * @param fn the consumer to apply to the StringProperty
    * @return the updated filter
    */
-  BatchOperationItemFilter batchOperationId(final Consumer<StringProperty> fn);
+  BatchOperationItemFilter batchOperationId(final Consumer<BasicStringProperty> fn);
 
   /**
    * Filters batch operation items by the specified itemKey.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -16,6 +16,8 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -47,12 +49,12 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
   BatchOperationItemFilter itemKey(final long itemKey);
 
   /**
-   * Filter by itemKey using {@link StringProperty} consumer
+   * Filter by itemKey using {@link BasicLongProperty} consumer
    *
-   * @param fn the consumer to apply to the StringProperty
+   * @param fn the consumer to apply to the BasicLongProperty
    * @return the updated filter
    */
-  BatchOperationItemFilter itemKey(final Consumer<StringProperty> fn);
+  BatchOperationItemFilter itemKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters batch operation items by the specified processInstanceKey.
@@ -63,12 +65,12 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
   BatchOperationItemFilter processInstanceKey(final long processInstanceKey);
 
   /**
-   * Filter by processInstanceKey using {@link StringProperty} consumer
+   * Filter by processInstanceKey using {@link BasicLongProperty} consumer
    *
-   * @param fn the consumer to apply to the StringProperty
+   * @param fn the consumer to apply to the BasicLongProperty
    * @return the updated filter
    */
-  BatchOperationItemFilter processInstanceKey(final Consumer<StringProperty> fn);
+  BatchOperationItemFilter processInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters batch operations by the specified state.
@@ -77,4 +79,12 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   BatchOperationItemFilter state(final BatchOperationItemState state);
+
+  /**
+   * Filter by state using {@link BatchOperationItemState} consumer
+   *
+   * @param fn the consumer to apply to the BatchOperationItemState
+   * @return the updated filter
+   */
+  BatchOperationItemFilter state(final Consumer<BatchOperationItemStateProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -16,7 +16,9 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
 public interface BatchOperationItemFilter extends SearchRequestFilter {
 
@@ -29,6 +31,14 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
   BatchOperationItemFilter batchOperationId(final String batchOperationId);
 
   /**
+   * Filter by batchOperationId using {@link StringProperty} consumer
+   *
+   * @param fn the consumer to apply to the StringProperty
+   * @return the updated filter
+   */
+  BatchOperationItemFilter batchOperationId(final Consumer<StringProperty> fn);
+
+  /**
    * Filters batch operation items by the specified itemKey.
    *
    * @param itemKey the itemKey
@@ -37,12 +47,28 @@ public interface BatchOperationItemFilter extends SearchRequestFilter {
   BatchOperationItemFilter itemKey(final long itemKey);
 
   /**
+   * Filter by itemKey using {@link StringProperty} consumer
+   *
+   * @param fn the consumer to apply to the StringProperty
+   * @return the updated filter
+   */
+  BatchOperationItemFilter itemKey(final Consumer<StringProperty> fn);
+
+  /**
    * Filters batch operation items by the specified processInstanceKey.
    *
    * @param processInstanceKey the processInstanceKey
    * @return the updated filter
    */
   BatchOperationItemFilter processInstanceKey(final long processInstanceKey);
+
+  /**
+   * Filter by processInstanceKey using {@link StringProperty} consumer
+   *
+   * @param fn the consumer to apply to the StringProperty
+   * @return the updated filter
+   */
+  BatchOperationItemFilter processInstanceKey(final Consumer<StringProperty> fn);
 
   /**
    * Filters batch operations by the specified state.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicStringProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicStringProperty.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import java.util.List;
+
+public interface BasicStringProperty extends PropertyBase<String, BasicStringProperty> {
+
+  BasicStringProperty notIn(final List<String> values);
+
+  BasicStringProperty notIn(final String... values);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationItemStateProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationItemStateProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+
+public interface BatchOperationItemStateProperty
+    extends LikeProperty<BatchOperationItemState, String, BatchOperationItemStateProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationStateProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationStateProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+
+public interface BatchOperationStateProperty
+    extends LikeProperty<BatchOperationState, String, BatchOperationStateProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationTypeProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BatchOperationTypeProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationType;
+
+public interface BatchOperationTypeProperty
+    extends LikeProperty<BatchOperationType, String, BatchOperationTypeProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -17,10 +17,13 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationFilter;
 import io.camunda.client.protocol.rest.BatchOperationFilter.StateEnum;
 import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import java.util.function.Consumer;
 
 public class BatchOperationFilterImpl
     extends TypedSearchRequestPropertyProvider<BatchOperationFilter>
@@ -35,7 +38,16 @@ public class BatchOperationFilterImpl
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter batchOperationId(
       final String batchOperationId) {
-    filter.setBatchOperationId(batchOperationId);
+    batchOperationId(b -> b.eq(batchOperationId));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter batchOperationId(
+      final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBatchOperationId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -17,12 +17,12 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
-import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationTypePropertyImpl;
-import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationFilter;
 import java.util.function.Consumer;
@@ -46,8 +46,8 @@ public class BatchOperationFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter batchOperationId(
-      final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
+      final Consumer<BasicStringProperty> fn) {
+    final BasicStringProperty property = new BasicStringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationId(provideSearchRequestProperty(property));
     return this;
@@ -66,7 +66,7 @@ public class BatchOperationFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter operationType(
-      Consumer<BatchOperationTypeProperty> fn) {
+      final Consumer<BatchOperationTypeProperty> fn) {
     final BatchOperationTypeProperty property = new BatchOperationTypePropertyImpl();
     fn.accept(property);
     filter.operationType(provideSearchRequestProperty(property));
@@ -86,7 +86,7 @@ public class BatchOperationFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter state(
-      Consumer<BatchOperationStateProperty> fn) {
+      final Consumer<BatchOperationStateProperty> fn) {
     final BatchOperationStateProperty property = new BatchOperationStatePropertyImpl();
     fn.accept(property);
     filter.setState(provideSearchRequestProperty(property));

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationFilterImpl.java
@@ -17,12 +17,14 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.BatchOperationStatePropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BatchOperationTypePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationFilter;
-import io.camunda.client.protocol.rest.BatchOperationFilter.StateEnum;
-import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
 import java.util.function.Consumer;
 
 public class BatchOperationFilterImpl
@@ -53,13 +55,21 @@ public class BatchOperationFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationFilter operationType(
-      final BatchOperationType operationType) {
-    if (operationType == null) {
+      final BatchOperationType batchOperationType) {
+    if (batchOperationType == null) {
       filter.setOperationType(null);
       return this;
     }
 
-    filter.setOperationType(BatchOperationTypeEnum.valueOf(operationType.name()));
+    return operationType(b -> b.eq(batchOperationType));
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter operationType(
+      Consumer<BatchOperationTypeProperty> fn) {
+    final BatchOperationTypeProperty property = new BatchOperationTypePropertyImpl();
+    fn.accept(property);
+    filter.operationType(provideSearchRequestProperty(property));
     return this;
   }
 
@@ -71,7 +81,15 @@ public class BatchOperationFilterImpl
       return this;
     }
 
-    filter.setState(StateEnum.valueOf(state.name()));
+    return state(b -> b.eq(state));
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationFilter state(
+      Consumer<BatchOperationStateProperty> fn) {
+    final BatchOperationStateProperty property = new BatchOperationStatePropertyImpl();
+    fn.accept(property);
+    filter.setState(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
@@ -17,11 +17,11 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
-import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.BatchOperationItemStatePropertyImpl;
-import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationItemFilter;
 import java.util.function.Consumer;
@@ -45,8 +45,8 @@ public class BatchOperationItemFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter batchOperationId(
-      final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
+      final Consumer<BasicStringProperty> fn) {
+    final BasicStringProperty property = new BasicStringPropertyImpl();
     fn.accept(property);
     filter.setBatchOperationId(provideSearchRequestProperty(property));
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
@@ -16,9 +16,12 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationItemFilter;
 import io.camunda.client.protocol.rest.BatchOperationItemFilter.StateEnum;
+import java.util.function.Consumer;
 
 public class BatchOperationItemFilterImpl
     extends TypedSearchRequestPropertyProvider<BatchOperationItemFilter>
@@ -33,20 +36,47 @@ public class BatchOperationItemFilterImpl
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter batchOperationId(
       final String batchOperationId) {
-    filter.setBatchOperationId(batchOperationId);
+    batchOperationId(b -> b.eq(batchOperationId));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter batchOperationId(
+      final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setBatchOperationId(provideSearchRequestProperty(property));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter itemKey(final long itemKey) {
-    filter.itemKey(Long.toString(itemKey));
+    itemKey(b -> b.eq(Long.toString(itemKey)));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter itemKey(
+      final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setItemKey(provideSearchRequestProperty(property));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter processInstanceKey(
       final long processInstanceKey) {
-    filter.processInstanceKey(Long.toString(processInstanceKey));
+    processInstanceKey(b -> b.eq(Long.toString(processInstanceKey)));
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter processInstanceKey(
+      final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessInstanceKey(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/BatchOperationItemFilterImpl.java
@@ -16,11 +16,14 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BatchOperationItemStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.BatchOperationItemFilter;
-import io.camunda.client.protocol.rest.BatchOperationItemFilter.StateEnum;
 import java.util.function.Consumer;
 
 public class BatchOperationItemFilterImpl
@@ -51,14 +54,14 @@ public class BatchOperationItemFilterImpl
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter itemKey(final long itemKey) {
-    itemKey(b -> b.eq(Long.toString(itemKey)));
+    itemKey(b -> b.eq(itemKey));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter itemKey(
-      final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
+      final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setItemKey(provideSearchRequestProperty(property));
     return this;
@@ -67,14 +70,14 @@ public class BatchOperationItemFilterImpl
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter processInstanceKey(
       final long processInstanceKey) {
-    processInstanceKey(b -> b.eq(Long.toString(processInstanceKey)));
+    processInstanceKey(b -> b.eq(processInstanceKey));
     return this;
   }
 
   @Override
   public io.camunda.client.api.search.filter.BatchOperationItemFilter processInstanceKey(
-      final Consumer<StringProperty> fn) {
-    final StringProperty property = new StringPropertyImpl();
+      final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setProcessInstanceKey(provideSearchRequestProperty(property));
     return this;
@@ -88,7 +91,15 @@ public class BatchOperationItemFilterImpl
       return this;
     }
 
-    filter.setState(StateEnum.valueOf(state.name()));
+    return state(b -> b.eq(state));
+  }
+
+  @Override
+  public io.camunda.client.api.search.filter.BatchOperationItemFilter state(
+      final Consumer<BatchOperationItemStateProperty> fn) {
+    final BatchOperationItemStateProperty property = new BatchOperationItemStatePropertyImpl();
+    fn.accept(property);
+    filter.setState(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicStringPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicStringPropertyImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.client.impl.search.filter.builder;
 
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicStringPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicStringPropertyImpl.java
@@ -1,0 +1,63 @@
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
+import java.util.List;
+
+public class BasicStringPropertyImpl
+    extends TypedSearchRequestPropertyProvider<BasicStringFilterProperty>
+    implements BasicStringProperty {
+
+  private final BasicStringFilterProperty filterProperty = new BasicStringFilterProperty();
+
+  @Override
+  public BasicStringProperty eq(final String value) {
+    filterProperty.set$Eq(value);
+    return this;
+  }
+
+  @Override
+  public BasicStringProperty neq(final String value) {
+    filterProperty.set$Neq(value);
+    return this;
+  }
+
+  @Override
+  public BasicStringProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public BasicStringProperty in(final List<String> values) {
+    filterProperty.set$In(values);
+    return this;
+  }
+
+  @Override
+  public BasicStringProperty in(final String... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  public BasicStringProperty notIn(final List<String> values) {
+    filterProperty.set$NotIn(values);
+    return this;
+  }
+
+  @Override
+  public BasicStringProperty notIn(final String... values) {
+    return notIn(CollectionUtil.toList(values));
+  }
+
+  public BasicStringFilterProperty build() {
+    return filterProperty;
+  }
+
+  @Override
+  protected BasicStringFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationItemStatePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationItemStatePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.BatchOperationItemStateEnum;
+import io.camunda.client.protocol.rest.BatchOperationItemStateFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BatchOperationItemStatePropertyImpl
+    extends TypedSearchRequestPropertyProvider<BatchOperationItemStateFilterProperty>
+    implements BatchOperationItemStateProperty {
+
+  private final BatchOperationItemStateFilterProperty filterProperty =
+      new BatchOperationItemStateFilterProperty();
+
+  @Override
+  public BatchOperationItemStateProperty eq(final BatchOperationItemState value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, BatchOperationItemStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemStateProperty neq(final BatchOperationItemState value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, BatchOperationItemStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemStateProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemStateProperty in(final List<BatchOperationItemState> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> EnumUtil.convert(source, BatchOperationItemStateEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public BatchOperationItemStateProperty in(final BatchOperationItemState... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected BatchOperationItemStateFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public BatchOperationItemStateProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationStatePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationStatePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.BatchOperationStateEnum;
+import io.camunda.client.protocol.rest.BatchOperationStateFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BatchOperationStatePropertyImpl
+    extends TypedSearchRequestPropertyProvider<BatchOperationStateFilterProperty>
+    implements BatchOperationStateProperty {
+
+  private final BatchOperationStateFilterProperty filterProperty =
+      new BatchOperationStateFilterProperty();
+
+  @Override
+  public BatchOperationStateProperty eq(final BatchOperationState value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, BatchOperationStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationStateProperty neq(final BatchOperationState value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, BatchOperationStateEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationStateProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public BatchOperationStateProperty in(final List<BatchOperationState> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> EnumUtil.convert(source, BatchOperationStateEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public BatchOperationStateProperty in(final BatchOperationState... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected BatchOperationStateFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public BatchOperationStateProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationTypePropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BatchOperationTypePropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.client.protocol.rest.BatchOperationTypeFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BatchOperationTypePropertyImpl
+    extends TypedSearchRequestPropertyProvider<BatchOperationTypeFilterProperty>
+    implements BatchOperationTypeProperty {
+
+  private final BatchOperationTypeFilterProperty filterProperty =
+      new BatchOperationTypeFilterProperty();
+
+  @Override
+  public BatchOperationTypeProperty eq(final BatchOperationType value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, BatchOperationTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationTypeProperty neq(final BatchOperationType value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, BatchOperationTypeEnum.class));
+    return this;
+  }
+
+  @Override
+  public BatchOperationTypeProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public BatchOperationTypeProperty in(final List<BatchOperationType> values) {
+    filterProperty.set$In(
+        values.stream()
+            .map(source -> EnumUtil.convert(source, BatchOperationTypeEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public BatchOperationTypeProperty in(final BatchOperationType... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected BatchOperationTypeFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public BatchOperationTypeProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationItemsTest.java
@@ -21,7 +21,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.protocol.rest.*;
-import io.camunda.client.protocol.rest.BatchOperationItemFilter.StateEnum;
 import io.camunda.client.protocol.rest.BatchOperationItemSearchQuerySortRequest.FieldEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
@@ -45,7 +44,7 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
     assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operation-items/search");
     assertThat(restRequest.getBodyAsString())
         .isEqualTo(
-            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":\"123\"}}");
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":{\"$eq\":\"123\",\"$in\":[],\"$notIn\":[]}}}");
   }
 
   @Test
@@ -76,10 +75,11 @@ class SearchBatchOperationItemsTest extends ClientRestTest {
     // then
     final BatchOperationItemSearchQuery request =
         gatewayService.getLastRequest(BatchOperationItemSearchQuery.class);
-    assertThat(request.getFilter().getBatchOperationId()).isEqualTo("123");
-    assertThat(request.getFilter().getState()).isEqualTo(StateEnum.ACTIVE);
-    assertThat(request.getFilter().getProcessInstanceKey()).isEqualTo("123");
-    assertThat(request.getFilter().getItemKey()).isEqualTo("456");
+    assertThat(request.getFilter().getBatchOperationId().get$Eq()).isEqualTo("123");
+    assertThat(request.getFilter().getState().get$Eq())
+        .isEqualTo(BatchOperationItemStateEnum.ACTIVE);
+    assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("123");
+    assertThat(request.getFilter().getItemKey().get$Eq()).isEqualTo("456");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SearchBatchOperationsTest.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.client.api.search.enums.BatchOperationType;
 import io.camunda.client.protocol.rest.*;
-import io.camunda.client.protocol.rest.BatchOperationFilter.StateEnum;
 import io.camunda.client.protocol.rest.BatchOperationSearchQuerySortRequest.FieldEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
@@ -46,7 +45,7 @@ class SearchBatchOperationsTest extends ClientRestTest {
     assertThat(restRequest.getUrl()).isEqualTo("/v2/batch-operations/search");
     assertThat(restRequest.getBodyAsString())
         .isEqualTo(
-            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":\"123\"}}");
+            "{\"sort\":[{\"field\":\"state\",\"order\":\"ASC\"}],\"filter\":{\"batchOperationId\":{\"$eq\":\"123\",\"$in\":[],\"$notIn\":[]}}}");
   }
 
   @Test
@@ -76,9 +75,9 @@ class SearchBatchOperationsTest extends ClientRestTest {
     // then
     final BatchOperationSearchQuery request =
         gatewayService.getLastRequest(BatchOperationSearchQuery.class);
-    assertThat(request.getFilter().getBatchOperationId()).isEqualTo("123");
-    assertThat(request.getFilter().getState()).isEqualTo(StateEnum.ACTIVE);
-    assertThat(request.getFilter().getOperationType())
+    assertThat(request.getFilter().getBatchOperationId().get$Eq()).isEqualTo("123");
+    assertThat(request.getFilter().getState().get$Eq()).isEqualTo(BatchOperationStateEnum.ACTIVE);
+    assertThat(request.getFilter().getOperationType().get$Eq())
         .isEqualTo(BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE);
   }
 

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -208,7 +208,7 @@
     </if>
     <if test="filter.itemKeyOperations != null and !filter.itemKeyOperations.isEmpty()">
       <foreach collection="filter.itemKeyOperations" item="operation">
-        AND ITEM_KEYS
+        AND ITEM_KEY
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -159,15 +159,18 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.operationTypes != null and !filter.operationTypes.isEmpty()">
-      AND OPERATION_TYPE IN
-      <foreach collection="filter.operationTypes" item="value" open="(" separator=", " close=")">
-        #{value}
+    <if
+      test="filter.operationTypeOperations != null and !filter.operationTypeOperations.isEmpty()">
+      <foreach collection="filter.operationTypeOperations" item="operation">
+        AND OPERATION_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.state != null and !filter.state.isEmpty()">
-      AND STATE IN
-      <foreach collection="filter.state" item="value" open="(" separator=", " close=")">#{value}
+    <if
+      test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+      <foreach collection="filter.stateOperations" item="operation">
+        AND STATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
   </sql>
@@ -216,9 +219,11 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.state != null and !filter.state.isEmpty()">
-      AND STATE IN
-      <foreach collection="filter.state" item="value" open="(" separator=", " close=")">#{value}
+    <if
+      test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+      <foreach collection="filter.stateOperations" item="operation">
+        AND STATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
   </sql>

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -152,10 +152,11 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <!-- basic filters -->
-    <if test="filter.batchOperationIds != null and !filter.batchOperationIds.isEmpty()">
-      AND BATCH_OPERATION_ID IN
-      <foreach collection="filter.batchOperationIds" item="value" open="(" separator=", "
-        close=")">#{value}
+    <if
+      test="filter.batchOperationIdOperations != null and !filter.batchOperationIdOperations.isEmpty()">
+      <foreach collection="filter.batchOperationIdOperations" item="operation">
+        AND BATCH_OPERATION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
     <if test="filter.operationTypes != null and !filter.operationTypes.isEmpty()">
@@ -195,21 +196,24 @@
   <sql id="itemSearchFilter">
     WHERE 1 = 1
     <!-- basic filters -->
-    <if test="filter.batchOperationIds != null and !filter.batchOperationIds.isEmpty()">
-      AND BATCH_OPERATION_ID IN
-      <foreach collection="filter.batchOperationIds" item="value" open="(" separator=", "
-        close=")">#{value}
+    <if
+      test="filter.batchOperationIdOperations != null and !filter.batchOperationIdOperations.isEmpty()">
+      <foreach collection="filter.batchOperationIdOperations" item="operation">
+        AND BATCH_OPERATION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.itemKeys != null and !filter.itemKeys.isEmpty()">
-      AND ITEM_KEYS IN
-      <foreach collection="filter.itemKeys" item="value" open="(" separator=", " close=")">
-        #{value}
+    <if test="filter.itemKeyOperations != null and !filter.itemKeyOperations.isEmpty()">
+      <foreach collection="filter.itemKeyOperations" item="operation">
+        AND ITEM_KEYS
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.processInstanceKeys != null and !filter.processInstanceKeys.isEmpty()">
-      AND PROCESS_INSTANCE_KEY IN
-      <foreach collection="filter.processInstanceKeys" item="value" open="(" separator=", " close=")">#{value}
+    <if
+      test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.processInstanceKeyOperations" item="operation">
+        AND PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
     <if test="filter.state != null and !filter.state.isEmpty()">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.getScopedVariables;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
+import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForScopedActiveProcessInstances;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.search.enums.BatchOperationItemState;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.client.api.search.enums.BatchOperationType;
+import io.camunda.client.api.search.response.BatchOperation;
+import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchOperationSearchTest {
+
+  private static CamundaClient camundaClient;
+
+  private static String testScopeId;
+
+  private static String batchOperationId1;
+  private static String batchOperationId2;
+
+  private static final List<Long> ACTIVE_PROCESS_INSTANCES_1 = new ArrayList<>();
+  private static final List<Long> ACTIVE_PROCESS_INSTANCES_2 = new ArrayList<>();
+
+  @BeforeAll
+  public static void beforeAll(final TestInfo testInfo) {
+    Objects.requireNonNull(camundaClient);
+    testScopeId =
+        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
+
+    deployProcessAndWaitForIt(camundaClient, "process/service_tasks_v1.bpmn")
+        .getProcessDefinitionKey();
+    final long sourceProcessDefinitionKey =
+        deployProcessAndWaitForIt(camundaClient, "process/migration-process_v1.bpmn")
+            .getProcessDefinitionKey();
+    final var targetProcessDefinitionKey =
+        deployProcessAndWaitForIt(camundaClient, "process/migration-process_v2.bpmn")
+            .getProcessDefinitionKey();
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+
+    // Batch 1 - Cancel Processes
+    IntStream.range(0, 10)
+        .forEach(
+            i ->
+                ACTIVE_PROCESS_INSTANCES_1.add(
+                    startScopedProcessInstance(
+                            camundaClient, "service_tasks_v1", testScopeId, emptyMap())
+                        .getProcessInstanceKey()));
+
+    waitForScopedActiveProcessInstances(
+        camundaClient, testScopeId, ACTIVE_PROCESS_INSTANCES_1.size());
+
+    batchOperationId1 = startBatchOperationCancelProcesses(testScopeId);
+
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchOperationId1, ACTIVE_PROCESS_INSTANCES_1.size());
+
+    waitForBatchOperationCompleted(
+        camundaClient, batchOperationId1, ACTIVE_PROCESS_INSTANCES_1.size(), 0);
+
+    for (final Long key : ACTIVE_PROCESS_INSTANCES_1) {
+      waitForProcessInstanceToBeTerminated(camundaClient, key);
+    }
+
+    // Batch 2 - Migrate Processes
+    IntStream.range(0, 5)
+        .forEach(
+            i ->
+                ACTIVE_PROCESS_INSTANCES_2.add(
+                    startScopedProcessInstance(
+                            camundaClient,
+                            sourceProcessDefinitionKey,
+                            testScopeId,
+                            Map.of("foo", "bar"))
+                        .getProcessInstanceKey()));
+
+    waitForScopedActiveProcessInstances(
+        camundaClient, testScopeId, ACTIVE_PROCESS_INSTANCES_2.size());
+
+    batchOperationId2 =
+        startBatchOperationMigrateProcesses(
+            testScopeId, sourceProcessDefinitionKey, targetProcessDefinitionKey);
+
+    waitForBatchOperationWithCorrectTotalCount(
+        camundaClient, batchOperationId2, ACTIVE_PROCESS_INSTANCES_2.size());
+
+    waitForBatchOperationCompleted(
+        camundaClient, batchOperationId2, ACTIVE_PROCESS_INSTANCES_2.size(), 0);
+  }
+
+  @Test
+  void shouldGetBatchOperation() {
+    // when
+    final var batch = camundaClient.newBatchOperationGetRequest(batchOperationId1).send().join();
+    final var batch2 = camundaClient.newBatchOperationGetRequest(batchOperationId2).send().join();
+
+    // then
+    assertCancelBatchOperation(batch);
+    assertMigrateBatchOperation(batch2);
+
+    // and when we query items
+    final var items1 =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationId(batchOperationId1))
+            .send()
+            .join();
+    final var items2 =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(f -> f.batchOperationId(batchOperationId2))
+            .send()
+            .join();
+
+    // then
+    assertItems(items1, ACTIVE_PROCESS_INSTANCES_1);
+    assertItems(items2, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  @Test
+  void shouldSearchBatchOperationWithIn() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationSearchRequest()
+            .filter(
+                f ->
+                    f.batchOperationId(batchOperationId2)
+                        .operationType(
+                            p ->
+                                p.in(
+                                    BatchOperationType.CANCEL_PROCESS_INSTANCE,
+                                    BatchOperationType.MIGRATE_PROCESS_INSTANCE))
+                        .state(p -> p.in(BatchOperationState.COMPLETED)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.page().totalItems()).isEqualTo(1);
+    final var items = page.items();
+    assertThat(items.size()).isEqualTo(1);
+    assertMigrateBatchOperation(items.getFirst());
+  }
+
+  @Test
+  void shouldSearchBatchOperationItemsWithIn() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(
+                f ->
+                    f.batchOperationId(p -> p.in(batchOperationId1))
+                        .processInstanceKey(p -> p.in(ACTIVE_PROCESS_INSTANCES_1))
+                        .itemKey(p -> p.in(ACTIVE_PROCESS_INSTANCES_1))
+                        .state(p -> p.in(BatchOperationItemState.COMPLETED)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertItems(page, ACTIVE_PROCESS_INSTANCES_1);
+  }
+
+  @Test
+  void shouldSearchCompletedBatchOperation() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.state(BatchOperationState.COMPLETED))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.page().totalItems()).isEqualTo(2);
+    final var items = page.items();
+    assertThat(items.size()).isEqualTo(2);
+    final var batch1 =
+        items.stream().filter(b -> b.getBatchOperationId().equals(batchOperationId1)).findFirst();
+    assertThat(batch1).isPresent();
+    assertCancelBatchOperation(batch1.get());
+    final var batch2 =
+        items.stream().filter(b -> b.getBatchOperationId().equals(batchOperationId2)).findFirst();
+    assertThat(batch2).isPresent();
+    assertMigrateBatchOperation(batch2.get());
+  }
+
+  @Test
+  void shouldSearchNotCompletedBatchOperation() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.state(p -> p.neq(BatchOperationState.COMPLETED)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.page().totalItems()).isEqualTo(0);
+    final var items = page.items();
+    assertThat(items.size()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldSearchCancelProcessesBatchOperation() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.operationType(BatchOperationType.CANCEL_PROCESS_INSTANCE))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.page().totalItems()).isEqualTo(1);
+    final var items = page.items();
+    assertThat(items.size()).isEqualTo(1);
+    assertCancelBatchOperation(items.getFirst());
+  }
+
+  @Test
+  void shouldSearchMigrateProcessesBatchOperationWithNeq() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationSearchRequest()
+            .filter(f -> f.operationType(p -> p.neq(BatchOperationType.CANCEL_PROCESS_INSTANCE)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertThat(page.page().totalItems()).isEqualTo(1);
+    final var items = page.items();
+    assertThat(items.size()).isEqualTo(1);
+    assertMigrateBatchOperation(items.getFirst());
+  }
+
+  @Test
+  void shouldSearchBatchOperationItemsWithNeq() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(
+                f ->
+                    f.batchOperationId(p -> p.neq(batchOperationId1))
+                        .state(p -> p.neq(BatchOperationItemState.ACTIVE)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertItems(page, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  @Test
+  void shouldSearchBatchOperationItemsWithNotIn() {
+    // when
+    final var page =
+        camundaClient
+            .newBatchOperationItemsSearchRequest()
+            .filter(
+                f ->
+                    f.batchOperationId(p -> p.notIn(batchOperationId1))
+                        .processInstanceKey(p -> p.notIn(ACTIVE_PROCESS_INSTANCES_1))
+                        .itemKey(p -> p.notIn(ACTIVE_PROCESS_INSTANCES_1)))
+            .send()
+            .join();
+
+    // then
+    assertThat(page).isNotNull();
+    assertItems(page, ACTIVE_PROCESS_INSTANCES_2);
+  }
+
+  private static void assertCancelBatchOperation(final BatchOperation batch) {
+    assertThat(batch).isNotNull();
+    assertThat(batch.getBatchOperationId()).isEqualTo(batchOperationId1);
+    assertThat(batch.getType()).isEqualTo(BatchOperationType.CANCEL_PROCESS_INSTANCE);
+    assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+    assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
+    assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_1.size());
+    assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+  }
+
+  private static void assertMigrateBatchOperation(final BatchOperation batch) {
+    assertThat(batch).isNotNull();
+    assertThat(batch.getBatchOperationId()).isEqualTo(batchOperationId2);
+    assertThat(batch.getType()).isEqualTo(BatchOperationType.MIGRATE_PROCESS_INSTANCE);
+    assertThat(batch.getStatus()).isEqualTo(BatchOperationState.COMPLETED);
+    assertThat(batch.getOperationsTotalCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
+    assertThat(batch.getOperationsCompletedCount()).isEqualTo(ACTIVE_PROCESS_INSTANCES_2.size());
+    assertThat(batch.getOperationsFailedCount()).isEqualTo(0);
+  }
+
+  private static void assertItems(
+      final SearchResponse<BatchOperationItem> searchResponse,
+      final List<Long> expectedProcessInstanceKeys) {
+    assertThat(searchResponse).isNotNull();
+    assertThat(searchResponse.page().totalItems()).isEqualTo(expectedProcessInstanceKeys.size());
+    final var items = searchResponse.items();
+    assertThat(items).isNotNull();
+    assertThat(items.size()).isEqualTo(expectedProcessInstanceKeys.size());
+    for (final Long key : expectedProcessInstanceKeys) {
+      final var item = items.stream().filter(i -> Objects.equals(i.getItemKey(), key)).findFirst();
+      assertThat(item).isPresent();
+      assertThat(item.get().getProcessInstanceKey()).isEqualTo(key);
+      assertThat(item.get().getStatus()).isEqualTo(BatchOperationItemState.COMPLETED);
+    }
+  }
+
+  private static String startBatchOperationCancelProcesses(final String testScopeId) {
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+
+    assertThat(result).isNotNull();
+
+    return result.getBatchOperationId();
+  }
+
+  private static String startBatchOperationMigrateProcesses(
+      final String testScopeId,
+      final long sourceProcessDefinitionKey,
+      final long targetProcessDefinitionKey) {
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .migrateProcessInstance()
+            .migrationPlan(
+                MigrationPlan.newBuilder()
+                    .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction("taskA", "taskA2")
+                    .addMappingInstruction("taskB", "taskB2")
+                    .addMappingInstruction("taskC", "taskC2")
+                    .build())
+            .filter(
+                new ProcessInstanceFilterImpl()
+                    .processDefinitionKey(sourceProcessDefinitionKey)
+                    .variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+
+    assertThat(result).isNotNull();
+
+    return result.getBatchOperationId();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationSearchTest.java
@@ -13,7 +13,6 @@ import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
-import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitForScopedActiveProcessInstances;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,8 +67,6 @@ public class BatchOperationSearchTest {
     final var targetProcessDefinitionKey =
         deployProcessAndWaitForIt(camundaClient, "process/migration-process_v2.bpmn")
             .getProcessDefinitionKey();
-
-    waitForProcessesToBeDeployed(camundaClient, 3);
 
     // Batch 1 - Cancel Processes
     IntStream.range(0, 10)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -10,15 +10,18 @@ package io.camunda.it.rdbms.db.batchoperation;
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveBatchOperation;
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveRandomBatchOperationItems;
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveRandomBatchOperations;
+import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createSaveReturnRandomBatchOperationItems;
 import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.insertBatchOperationsItems;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringKey;
+import static io.camunda.util.FilterUtil.mapDefaultToOperation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -428,6 +431,37 @@ public class BatchOperationIT {
   }
 
   @TestTemplate
+  public void shouldFindBatchOperationWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    createAndSaveRandomBatchOperations(
+        rdbmsService.createWriter(0), b -> b.state(BatchOperationState.COMPLETED));
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            rdbmsService.createWriter(0), b -> b.state(BatchOperationState.ACTIVE));
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationReader()
+            .search(
+                new BatchOperationQuery(
+                    new BatchOperationFilter.Builder()
+                        .batchOperationIds(batchOperation.batchOperationId())
+                        .operationTypes(batchOperation.operationType())
+                        .states(batchOperation.state().name())
+                        .build(),
+                    BatchOperationSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.items()).isNotEmpty();
+    assertThat(searchResult.items())
+        .allSatisfy(i -> assertThat(i.state()).isEqualTo(BatchOperationState.ACTIVE));
+    assertThat(searchResult.items()).anySatisfy(i -> assertBatchOperationEntity(i, batchOperation));
+  }
+
+  @TestTemplate
   public void shouldFindAllBatchOperationsPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
 
@@ -446,6 +480,72 @@ public class BatchOperationIT {
 
     assertThat(searchResult).isNotNull();
     assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAllBatchOperationItemsPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+
+    final var batchOperation = createAndSaveBatchOperation(writer, b -> b);
+
+    final var items =
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 10);
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationItemReader()
+            .search(
+                new BatchOperationItemQuery(
+                    new BatchOperationItemFilter.Builder()
+                        .batchOperationIds(batchOperation.batchOperationId())
+                        .build(),
+                    BatchOperationItemSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(10);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindBatchOperationItemsWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+
+    final var batchOperation =
+        createAndSaveBatchOperation(writer, b -> b.state(BatchOperationState.ACTIVE).endDate(null));
+
+    final var items =
+        createSaveReturnRandomBatchOperationItems(writer, batchOperation.batchOperationId(), 10);
+
+    final var itemKeys =
+        items.stream().map(BatchOperationItemDbModel::itemKey).collect(Collectors.toList());
+
+    final var processInstanceKeys =
+        items.stream()
+            .map(BatchOperationItemDbModel::processInstanceKey)
+            .collect(Collectors.toList());
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationItemReader()
+            .search(
+                new BatchOperationItemQuery(
+                    new BatchOperationItemFilter.Builder()
+                        .batchOperationIds(batchOperation.batchOperationId())
+                        .itemKeyOperations(mapDefaultToOperation(itemKeys))
+                        .processInstanceKeyOperations(mapDefaultToOperation(processInstanceKeys))
+                        .states(BatchOperationState.ACTIVE.name())
+                        .build(),
+                    BatchOperationItemSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(10);
     assertThat(searchResult.items()).hasSize(5);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -415,7 +415,7 @@ public class BatchOperationIT {
             .search(
                 new BatchOperationQuery(
                     new BatchOperationFilter.Builder()
-                        .state(BatchOperationState.ACTIVE.name())
+                        .states(BatchOperationState.ACTIVE.name())
                         .build(),
                     BatchOperationSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -229,7 +229,7 @@ public final class TestHelper {
    */
   public static void waitForScopedProcessInstancesToStart(
       final CamundaClient camundaClient, final String scopeId, final int expectedProcessInstances) {
-    Awaitility.await("should start process instances and import in Operate")
+    Awaitility.await("should wait until process instances are available")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
@@ -253,7 +253,7 @@ public final class TestHelper {
    */
   public static void waitForScopedActiveProcessInstances(
       final CamundaClient camundaClient, final String scopeId, final int expectedProcessInstances) {
-    Awaitility.await("should start process instances and import in Operate")
+    Awaitility.await("should wait until process instances are available and active")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -245,6 +245,33 @@ public final class TestHelper {
   }
 
   /**
+   * Waits for active process instances which are having a process variable {@link
+   * #VAR_TEST_SCOPE_ID}.
+   *
+   * @param camundaClient ... CamundaClient
+   * @param scopeId ... some unique id for the test case
+   */
+  public static void waitForScopedActiveProcessInstances(
+      final CamundaClient camundaClient, final String scopeId, final int expectedProcessInstances) {
+    Awaitility.await("should start process instances and import in Operate")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newProcessInstanceSearchRequest()
+                      .filter(
+                          f ->
+                              f.state(ProcessInstanceState.ACTIVE)
+                                  .variables(getScopedVariables(scopeId)))
+                      .send()
+                      .join();
+              assertThat(result.page().totalItems()).isEqualTo(expectedProcessInstances);
+            });
+  }
+
+  /**
    * Waits for process instances to start which are having a process variable {@link *
    * #VAR_TEST_SCOPE_ID}.
    *

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -9,12 +9,12 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.*;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.*;
+import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.ArrayList;
-import java.util.Optional;
 
 public final class BatchOperationFilterTransformer
     extends IndexFilterTransformer<BatchOperationFilter> {
@@ -27,9 +27,10 @@ public final class BatchOperationFilterTransformer
   public SearchQuery toSearchQuery(final BatchOperationFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
 
-    Optional.ofNullable(stringTerms(ID, filter.batchOperationIds())).ifPresent(queries::add);
-    Optional.ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
-    Optional.ofNullable(stringTerms(TYPE, filter.operationTypes())).ifPresent(queries::add);
+    ofNullable(stringOperations(ID, filter.batchOperationIdOperations()))
+        .ifPresent(queries::addAll);
+    ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
+    ofNullable(stringTerms(TYPE, filter.operationTypes())).ifPresent(queries::add);
 
     return and(queries);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -29,8 +29,8 @@ public final class BatchOperationFilterTransformer
 
     ofNullable(stringOperations(ID, filter.batchOperationIdOperations()))
         .ifPresent(queries::addAll);
-    ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
-    ofNullable(stringTerms(TYPE, filter.operationTypes())).ifPresent(queries::add);
+    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
+    ofNullable(stringOperations(TYPE, filter.operationTypeOperations())).ifPresent(queries::addAll);
 
     return and(queries);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -27,12 +27,13 @@ public final class BatchOperationItemFilterTransformer
   public SearchQuery toSearchQuery(final BatchOperationItemFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
 
-    Optional.ofNullable(stringTerms(BATCH_OPERATION_ID, filter.batchOperationIds()))
-        .ifPresent(queries::add);
+    Optional.ofNullable(stringOperations(BATCH_OPERATION_ID, filter.batchOperationIdOperations()))
+        .ifPresent(queries::addAll);
     Optional.ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
-    Optional.ofNullable(longTerms(ITEM_KEY, filter.itemKeys())).ifPresent(queries::add);
-    Optional.ofNullable(longTerms(PROCESS_INSTANCE_KEY, filter.processInstanceKeys()))
-        .ifPresent(queries::add);
+    Optional.ofNullable(longOperations(ITEM_KEY, filter.itemKeyOperations()))
+        .ifPresent(queries::addAll);
+    Optional.ofNullable(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))
+        .ifPresent(queries::addAll);
 
     return and(queries);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -29,7 +29,8 @@ public final class BatchOperationItemFilterTransformer
 
     Optional.ofNullable(stringOperations(BATCH_OPERATION_ID, filter.batchOperationIdOperations()))
         .ifPresent(queries::addAll);
-    Optional.ofNullable(stringTerms(STATE, filter.state())).ifPresent(queries::add);
+    Optional.ofNullable(stringOperations(STATE, filter.stateOperations()))
+        .ifPresent(queries::addAll);
     Optional.ofNullable(longOperations(ITEM_KEY, filter.itemKeyOperations()))
         .ifPresent(queries::addAll);
     Optional.ofNullable(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformerTest.java
@@ -59,7 +59,7 @@ class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
   @Test
   void shouldQueryByState() {
     // given
-    final var filter = FilterBuilders.batchOperation(f -> f.state("ACTIVE"));
+    final var filter = FilterBuilders.batchOperation(f -> f.states("ACTIVE"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -99,7 +99,7 @@ class BatchOperationFilterTransformerTest extends AbstractTransformerTest {
     // given
     final var filter =
         FilterBuilders.batchOperation(
-            f -> f.batchOperationIds("123").state("ACTIVE").operationTypes("CREATE"));
+            f -> f.batchOperationIds("123").states("ACTIVE").operationTypes("CREATE"));
 
     // when
     final var searchRequest = transformQuery(filter);

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformerTest.java
@@ -97,7 +97,7 @@ class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
   @Test
   void shouldQueryByState() {
     // given
-    final var filter = FilterBuilders.batchOperationItem(f -> f.state("ACTIVE"));
+    final var filter = FilterBuilders.batchOperationItem(f -> f.states("ACTIVE"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -120,7 +120,7 @@ class BatchOperationItemFilterTransformerTest extends AbstractTransformerTest {
         FilterBuilders.batchOperationItem(
             f ->
                 f.batchOperationIds("123")
-                    .state("ACTIVE")
+                    .states("ACTIVE")
                     .itemKeys(123L)
                     .processInstanceKeys(456L));
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -19,15 +19,15 @@ import java.util.Objects;
 
 public record BatchOperationFilter(
     List<Operation<String>> batchOperationIdOperations,
-    List<String> operationTypes,
-    List<String> state)
+    List<Operation<String>> operationTypeOperations,
+    List<Operation<String>> stateOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
 
     private List<Operation<String>> batchOperationIdOperations;
-    private List<String> operationTypes;
-    private List<String> state;
+    private List<Operation<String>> operationTypeOperations;
+    private List<Operation<String>> stateOperations;
 
     public Builder batchOperationIdOperations(final List<Operation<String>> operations) {
       batchOperationIdOperations = addValuesToList(batchOperationIdOperations, operations);
@@ -49,30 +49,52 @@ public record BatchOperationFilter(
       return batchOperationIdOperations(collectValues(operation, operations));
     }
 
+    public Builder operationTypeOperations(final List<Operation<String>> operations) {
+      operationTypeOperations = addValuesToList(operationTypeOperations, operations);
+      return this;
+    }
+
     public Builder operationTypes(final String value, final String... values) {
-      return operationTypes(collectValues(value, values));
+      return operationTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder operationTypes(final List<String> values) {
-      operationTypes = addValuesToList(operationTypes, values);
+    public Builder replaceOperationTypeOperations(final List<Operation<String>> operations) {
+      operationTypeOperations = new ArrayList<>(operations);
       return this;
     }
 
-    public Builder state(final String value, final String... values) {
-      return state(collectValues(value, values));
+    @SafeVarargs
+    public final Builder operationTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return operationTypeOperations(collectValues(operation, operations));
     }
 
-    public Builder state(final List<String> values) {
-      state = addValuesToList(state, values);
+    public Builder stateOperations(final List<Operation<String>> operations) {
+      stateOperations = addValuesToList(stateOperations, operations);
       return this;
+    }
+
+    public Builder states(final String value, final String... values) {
+      return stateOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceStateOperations(final List<Operation<String>> operations) {
+      stateOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder stateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return stateOperations(collectValues(operation, operations));
     }
 
     @Override
     public BatchOperationFilter build() {
       return new BatchOperationFilter(
           Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(operationTypes, Collections.emptyList()),
-          Objects.requireNonNullElse(state, Collections.emptyList()));
+          Objects.requireNonNullElse(operationTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -10,28 +10,43 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
+import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public record BatchOperationFilter(
-    List<String> batchOperationIds, List<String> operationTypes, List<String> state)
+    List<Operation<String>> batchOperationIdOperations,
+    List<String> operationTypes,
+    List<String> state)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
 
-    private List<String> batchOperationIds;
+    private List<Operation<String>> batchOperationIdOperations;
     private List<String> operationTypes;
     private List<String> state;
 
-    public Builder batchOperationIds(final String value, final String... values) {
-      return batchOperationIds(collectValues(value, values));
+    public Builder batchOperationIdOperations(final List<Operation<String>> operations) {
+      batchOperationIdOperations = addValuesToList(batchOperationIdOperations, operations);
+      return this;
     }
 
-    public Builder batchOperationIds(final List<String> values) {
-      batchOperationIds = addValuesToList(batchOperationIds, values);
+    public Builder batchOperationIds(final String value, final String... values) {
+      return batchOperationIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceBatchOperationIdOperations(final List<Operation<String>> operations) {
+      batchOperationIdOperations = new ArrayList<>(operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder batchOperationIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return batchOperationIdOperations(collectValues(operation, operations));
     }
 
     public Builder operationTypes(final String value, final String... values) {
@@ -55,7 +70,7 @@ public record BatchOperationFilter(
     @Override
     public BatchOperationFilter build() {
       return new BatchOperationFilter(
-          Objects.requireNonNullElse(batchOperationIds, Collections.emptyList()),
+          Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(operationTypes, Collections.emptyList()),
           Objects.requireNonNullElse(state, Collections.emptyList()));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
@@ -10,50 +10,85 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
+import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public record BatchOperationItemFilter(
-    List<String> batchOperationIds,
-    List<Long> itemKeys,
-    List<Long> processInstanceKeys,
+    List<Operation<String>> batchOperationIdOperations,
+    List<Operation<Long>> itemKeyOperations,
+    List<Operation<Long>> processInstanceKeyOperations,
     List<String> state)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationItemFilter> {
 
-    private List<String> batchOperationIds;
-    private List<Long> itemKeys;
-    private List<Long> processInstanceKeys;
+    private List<Operation<String>> batchOperationIdOperations;
+    private List<Operation<Long>> itemKeyOperations;
+    private List<Operation<Long>> processInstanceKeyOperations;
     private List<String> state;
 
-    public Builder batchOperationIds(final String value, final String... values) {
-      return batchOperationIds(collectValues(value, values));
+    public Builder batchOperationIdOperations(final List<Operation<String>> operations) {
+      batchOperationIdOperations = addValuesToList(batchOperationIdOperations, operations);
+      return this;
     }
 
-    public Builder batchOperationIds(final List<String> values) {
-      batchOperationIds = addValuesToList(batchOperationIds, values);
+    public Builder batchOperationIds(final String value, final String... values) {
+      return batchOperationIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceBatchOperationIdOperations(final List<Operation<String>> operations) {
+      batchOperationIdOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder batchOperationIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return batchOperationIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder itemKeyOperations(final List<Operation<Long>> operations) {
+      itemKeyOperations = addValuesToList(itemKeyOperations, operations);
       return this;
     }
 
     public Builder itemKeys(final Long value, final Long... values) {
-      return itemKeys(collectValues(value, values));
+      return itemKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder itemKeys(final List<Long> values) {
-      itemKeys = addValuesToList(itemKeys, values);
+    public Builder replaceItemKeyOperations(final List<Operation<Long>> operations) {
+      itemKeyOperations = new ArrayList<>(operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder itemKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return itemKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
       return this;
     }
 
     public Builder processInstanceKeys(final Long value, final Long... values) {
-      return processInstanceKeys(collectValues(value, values));
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder processInstanceKeys(final List<Long> values) {
-      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+    public Builder replaceProcessInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = new ArrayList<>(operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
     }
 
     public Builder state(final String value, final String... values) {
@@ -68,9 +103,9 @@ public record BatchOperationItemFilter(
     @Override
     public BatchOperationItemFilter build() {
       return new BatchOperationItemFilter(
-          Objects.requireNonNullElse(batchOperationIds, Collections.emptyList()),
-          Objects.requireNonNullElse(itemKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(itemKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(state, Collections.emptyList()));
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationItemFilter.java
@@ -21,7 +21,7 @@ public record BatchOperationItemFilter(
     List<Operation<String>> batchOperationIdOperations,
     List<Operation<Long>> itemKeyOperations,
     List<Operation<Long>> processInstanceKeyOperations,
-    List<String> state)
+    List<Operation<String>> stateOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationItemFilter> {
@@ -29,7 +29,7 @@ public record BatchOperationItemFilter(
     private List<Operation<String>> batchOperationIdOperations;
     private List<Operation<Long>> itemKeyOperations;
     private List<Operation<Long>> processInstanceKeyOperations;
-    private List<String> state;
+    private List<Operation<String>> stateOperations;
 
     public Builder batchOperationIdOperations(final List<Operation<String>> operations) {
       batchOperationIdOperations = addValuesToList(batchOperationIdOperations, operations);
@@ -91,13 +91,24 @@ public record BatchOperationItemFilter(
       return processInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder state(final String value, final String... values) {
-      return state(collectValues(value, values));
+    public Builder stateOperations(final List<Operation<String>> operations) {
+      stateOperations = addValuesToList(stateOperations, operations);
+      return this;
     }
 
-    public Builder state(final List<String> values) {
-      state = addValuesToList(state, values);
+    public Builder states(final String value, final String... values) {
+      return stateOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder replaceStateOperationsOperations(final List<Operation<String>> operations) {
+      stateOperations = new ArrayList<>(operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder stateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return stateOperations(collectValues(operation, operations));
     }
 
     @Override
@@ -106,7 +117,7 @@ public record BatchOperationItemFilter(
           Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(itemKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(state, Collections.emptyList()));
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9553,11 +9553,11 @@ components:
       properties:
         batchOperationId:
           description: The key (or operate legacy ID) of the batch operation.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         operationType:
           $ref: "#/components/schemas/BatchOperationTypeEnum"
         state:
-          type: string
           description: The state of the batch operation.
           enum:
             - CREATED
@@ -9603,13 +9603,16 @@ components:
       properties:
         batchOperationId:
           description: The key (or operate legacy ID) of the batch operation.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         itemKey:
           description: The key of the item, e.g. a process instance key.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
         processInstanceKey:
           description: The process instance key of the processed item.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
         state:
           type: string
           description: The state of the batch operation.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9554,7 +9554,7 @@ components:
         batchOperationId:
           description: The key (or operate legacy ID) of the batch operation.
           allOf:
-            - $ref: "#/components/schemas/StringFilterProperty"
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
         operationType:
           description: The type of the batch operation.
           allOf:
@@ -9694,7 +9694,7 @@ components:
         batchOperationId:
           description: The key (or operate legacy ID) of the batch operation.
           allOf:
-            - $ref: "#/components/schemas/StringFilterProperty"
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
         itemKey:
           description: The key of the item, e.g. a process instance key.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9556,17 +9556,107 @@ components:
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
         operationType:
-          $ref: "#/components/schemas/BatchOperationTypeEnum"
+          description: The type of the batch operation.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationTypeFilterProperty"
         state:
           description: The state of the batch operation.
-          enum:
-            - CREATED
-            - ACTIVE
-            - SUSPENDED
-            - COMPLETED
-            - COMPLETED_WITH_ERRORS
-            - CANCELED
-            - INCOMPLETED
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationStateFilterProperty"
+    BatchOperationTypeFilterProperty:
+      description: BatchOperationTypeEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationTypeEnum"
+        - $ref: "#/components/schemas/AdvancedBatchOperationTypeFilter"
+    AdvancedBatchOperationTypeFilter:
+      title: Advanced filter
+      description: Advanced BatchOperationTypeEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationTypeEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationTypeEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchOperationTypeEnum"
+        $like:
+          description: |
+            Checks if the property matches the provided like value.
+
+            Supported wildcard characters are:
+
+            * `*`: matches zero, one, or multiple characters.
+            * `?`: matches one, single character.
+
+            Wildcard characters can be escaped with backslash, for instance: `\*`.
+          type: string
+    BatchOperationStateFilterProperty:
+      description: BatchOperationStateEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationStateEnum"
+        - $ref: "#/components/schemas/AdvancedBatchOperationStateFilter"
+    AdvancedBatchOperationStateFilter:
+      title: Advanced filter
+      description: Advanced BatchOperationStateEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationStateEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationStateEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchOperationStateEnum"
+        $like:
+          description: |
+            Checks if the property matches the provided like value.
+
+            Supported wildcard characters are:
+
+            * `*`: matches zero, one, or multiple characters.
+            * `?`: matches one, single character.
+
+            Wildcard characters can be escaped with backslash, for instance: `\*`.
+          type: string
+    BatchOperationStateEnum:
+      description: The state, one of ACTIVE, COMPLETED, TERMINATED.
+      enum:
+        - CREATED
+        - ACTIVE
+        - SUSPENDED
+        - COMPLETED
+        - COMPLETED_WITH_ERRORS
+        - CANCELED
+        - INCOMPLETED
     BatchOperationItemSearchQuerySortRequest:
       type: object
       properties:
@@ -9616,11 +9706,57 @@ components:
         state:
           type: string
           description: The state of the batch operation.
-          enum:
-            - ACTIVE
-            - COMPLETED
-            - CANCELED
-            - FAILED
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationItemStateFilterProperty"
+    BatchOperationItemStateFilterProperty:
+      description: BatchOperationItemStateEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationItemStateEnum"
+        - $ref: "#/components/schemas/AdvancedBatchOperationItemStateFilter"
+    AdvancedBatchOperationItemStateFilter:
+      title: Advanced filter
+      description: Advanced BatchOperationItemStateEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationItemStateEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/BatchOperationItemStateEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchOperationItemStateEnum"
+        $like:
+          description: |
+            Checks if the property matches the provided like value.
+
+            Supported wildcard characters are:
+
+            * `*`: matches zero, one, or multiple characters.
+            * `?`: matches one, single character.
+
+            Wildcard characters can be escaped with backslash, for instance: `\*`.
+          type: string
+    BatchOperationItemStateEnum:
+      description: The state, one of ACTIVE, COMPLETED, TERMINATED.
+      enum:
+        - ACTIVE
+        - COMPLETED
+        - CANCELED
+        - FAILED
     BatchOperationSearchQueryResult:
       type: object
       allOf:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -75,8 +75,6 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.gateway.protocol.rest.*;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter.StateEnum;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemFilter;
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.gateway.rest.util.ProcessInstanceStateConverter;
 import io.camunda.zeebe.gateway.rest.validator.RequestValidator;
@@ -687,10 +685,12 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getBatchOperationId())
           .map(mapToOperations(String.class))
           .ifPresent(builder::batchOperationIdOperations);
-      ofNullable(filter.getState()).map(StateEnum::toString).ifPresent(builder::state);
+      ofNullable(filter.getState())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::stateOperations);
       ofNullable(filter.getOperationType())
-          .map(BatchOperationTypeEnum::toString)
-          .ifPresent(builder::operationTypes);
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::operationTypeOperations);
     }
 
     return builder.build();
@@ -739,8 +739,8 @@ public final class SearchQueryRequestMapper {
           .map(mapToOperations(String.class))
           .ifPresent(builder::batchOperationIdOperations);
       ofNullable(filter.getState())
-          .map(BatchOperationItemFilter.StateEnum::toString)
-          .ifPresent(builder::state);
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::stateOperations);
       ofNullable(filter.getItemKey())
           .map(mapToOperations(Long.class))
           .ifPresent(builder::itemKeyOperations);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -684,7 +684,9 @@ public final class SearchQueryRequestMapper {
     final var builder = FilterBuilders.batchOperation();
 
     if (filter != null) {
-      ofNullable(filter.getBatchOperationId()).ifPresent(builder::batchOperationIds);
+      ofNullable(filter.getBatchOperationId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::batchOperationIdOperations);
       ofNullable(filter.getState()).map(StateEnum::toString).ifPresent(builder::state);
       ofNullable(filter.getOperationType())
           .map(BatchOperationTypeEnum::toString)
@@ -733,10 +735,18 @@ public final class SearchQueryRequestMapper {
     final var builder = FilterBuilders.batchOperationItem();
 
     if (filter != null) {
-      ofNullable(filter.getBatchOperationId()).ifPresent(builder::batchOperationIds);
+      ofNullable(filter.getBatchOperationId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::batchOperationIdOperations);
       ofNullable(filter.getState())
           .map(BatchOperationItemFilter.StateEnum::toString)
           .ifPresent(builder::state);
+      ofNullable(filter.getItemKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::itemKeyOperations);
+      ofNullable(filter.getProcessInstanceKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::processInstanceKeyOperations);
     }
 
     return builder.build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -10,12 +10,18 @@ package io.camunda.zeebe.gateway.rest.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.zeebe.gateway.protocol.rest.BasicStringFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.DateTimeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.IntegerFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.BatchOperatioItemStateFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationStateFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DateTimeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ElementInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.IntegerFilterPropertyDeserializer;
@@ -43,6 +49,14 @@ public class JacksonConfig {
     module.addDeserializer(
         ElementInstanceStateFilterProperty.class,
         new ElementInstanceStateFilterPropertyDeserializer());
+    module.addDeserializer(
+        BatchOperationStateFilterProperty.class,
+        new BatchOperationStateFilterPropertyDeserializer());
+    module.addDeserializer(
+        BatchOperationTypeFilterProperty.class, new BatchOperationTypeFilterPropertyDeserializer());
+    module.addDeserializer(
+        BatchOperationItemStateFilterProperty.class,
+        new BatchOperatioItemStateFilterPropertyDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperatioItemStateFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperatioItemStateFilterPropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedBatchOperationItemStateFilter;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateEnum;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationItemStateFilterProperty;
+
+public class BatchOperatioItemStateFilterPropertyDeserializer
+    extends FilterDeserializer<BatchOperationItemStateFilterProperty, BatchOperationItemStateEnum> {
+
+  @Override
+  protected Class<? extends BatchOperationItemStateFilterProperty> getFinalType() {
+    return AdvancedBatchOperationItemStateFilter.class;
+  }
+
+  @Override
+  protected Class<BatchOperationItemStateEnum> getImplicitValueType() {
+    return BatchOperationItemStateEnum.class;
+  }
+
+  @Override
+  protected BatchOperationItemStateFilterProperty createFromImplicitValue(
+      final BatchOperationItemStateEnum value) {
+    final var filter = new AdvancedBatchOperationItemStateFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperationStateFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperationStateFilterPropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedBatchOperationStateFilter;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateEnum;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateFilterProperty;
+
+public class BatchOperationStateFilterPropertyDeserializer
+    extends FilterDeserializer<BatchOperationStateFilterProperty, BatchOperationStateEnum> {
+
+  @Override
+  protected Class<? extends BatchOperationStateFilterProperty> getFinalType() {
+    return AdvancedBatchOperationStateFilter.class;
+  }
+
+  @Override
+  protected Class<BatchOperationStateEnum> getImplicitValueType() {
+    return BatchOperationStateEnum.class;
+  }
+
+  @Override
+  protected BatchOperationStateFilterProperty createFromImplicitValue(
+      final BatchOperationStateEnum value) {
+    final var filter = new AdvancedBatchOperationStateFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperationTypeFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/BatchOperationTypeFilterPropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedBatchOperationTypeFilter;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeFilterProperty;
+
+public class BatchOperationTypeFilterPropertyDeserializer
+    extends FilterDeserializer<BatchOperationTypeFilterProperty, BatchOperationTypeEnum> {
+
+  @Override
+  protected Class<? extends BatchOperationTypeFilterProperty> getFinalType() {
+    return AdvancedBatchOperationTypeFilter.class;
+  }
+
+  @Override
+  protected Class<BatchOperationTypeEnum> getImplicitValueType() {
+    return BatchOperationTypeEnum.class;
+  }
+
+  @Override
+  protected BatchOperationTypeFilterProperty createFromImplicitValue(
+      final BatchOperationTypeEnum value) {
+    final var filter = new AdvancedBatchOperationTypeFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -125,6 +125,15 @@ public abstract class RestControllerTest {
         .forEach(streamBuilder::add);
   }
 
+  public static void basicStringOperationTestCases(
+      final Stream.Builder<Arguments> streamBuilder,
+      final String filterKey,
+      final Function<List<Operation<String>>, Object> builderMethod) {
+    BASIC_STRING_OPERATIONS.stream()
+        .map(ops -> generateParameterizedArguments(filterKey, builderMethod, ops, true))
+        .forEach(streamBuilder::add);
+  }
+
   public static void stringOperationTestCases(
       final Stream.Builder<Arguments> streamBuilder,
       final String filterKey,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -8,23 +8,28 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.BatchOperationServices;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationFilter;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationSearchQuery;
-import io.camunda.zeebe.gateway.protocol.rest.BatchOperationSearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationStateEnum;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -69,22 +74,74 @@ class BatchOperationControllerTest extends RestControllerTest {
           }""");
   }
 
-  @Test
-  void shouldSearchBatchOperations() {
-    final var searchQueryResult = new BatchOperationSearchQueryResult();
+  private static Stream<Arguments> provideAdvancedSearchParameters() {
+    final var streamBuilder = Stream.<Arguments>builder();
+
+    stringOperationTestCases(
+        streamBuilder,
+        "batchOperationId",
+        ops ->
+            new io.camunda.search.filter.BatchOperationFilter.Builder()
+                .batchOperationIdOperations(ops)
+                .build());
+    customOperationTestCases(
+        streamBuilder,
+        "operationType",
+        ops ->
+            new io.camunda.search.filter.BatchOperationFilter.Builder()
+                .operationTypeOperations(ops)
+                .build(),
+        List.of(
+            List.of(Operation.eq(String.valueOf(BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE))),
+            List.of(Operation.neq(String.valueOf(BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE))),
+            List.of(
+                Operation.in(
+                    String.valueOf(BatchOperationTypeEnum.MIGRATE_PROCESS_INSTANCE),
+                    String.valueOf(BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE)),
+                Operation.like("act"))),
+        true);
+    customOperationTestCases(
+        streamBuilder,
+        "state",
+        ops ->
+            new io.camunda.search.filter.BatchOperationFilter.Builder()
+                .stateOperations(ops)
+                .build(),
+        List.of(
+            List.of(Operation.eq(String.valueOf(BatchOperationStateEnum.ACTIVE))),
+            List.of(Operation.neq(String.valueOf(BatchOperationStateEnum.COMPLETED))),
+            List.of(
+                Operation.in(
+                    String.valueOf(BatchOperationStateEnum.COMPLETED),
+                    String.valueOf(BatchOperationStateEnum.ACTIVE)),
+                Operation.like("act"))),
+        true);
+
+    return streamBuilder.build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAdvancedSearchParameters")
+  void shouldSearchBatchOperationsWithAdvancedFilter(
+      final String filterString, final io.camunda.search.filter.BatchOperationFilter filter) {
+    // given
     final var entity = getBatchOperationEntity("1");
+    final var request =
+        """
+            {
+                "filter": %s
+            }"""
+            .formatted(filterString);
+
+    // when / then
     when(batchOperationServices.search(any(BatchOperationQuery.class)))
         .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
-
-    final var searchQuery =
-        new BatchOperationSearchQuery()
-            .filter(new BatchOperationFilter().state(BatchOperationFilter.StateEnum.ACTIVE));
 
     webClient
         .post()
         .uri("/v2/batch-operations/search")
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(searchQuery)
+        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isOk()
@@ -104,6 +161,8 @@ class BatchOperationControllerTest extends RestControllerTest {
             }],
             "page":{"totalItems":1,"firstSortValues":[],"lastSortValues":[]}
            }""");
+
+    verify(batchOperationServices).search(new BatchOperationQuery.Builder().filter(filter).build());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -77,7 +77,7 @@ class BatchOperationControllerTest extends RestControllerTest {
   private static Stream<Arguments> provideAdvancedSearchParameters() {
     final var streamBuilder = Stream.<Arguments>builder();
 
-    stringOperationTestCases(
+    basicStringOperationTestCases(
         streamBuilder,
         "batchOperationId",
         ops ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -60,7 +60,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
             new io.camunda.search.filter.BatchOperationItemFilter.Builder()
                 .processInstanceKeyOperations(ops)
                 .build());
-    stringOperationTestCases(
+    basicStringOperationTestCases(
         streamBuilder,
         "batchOperationId",
         ops ->


### PR DESCRIPTION
## Description

Use advanced operations for all batch operation (item) filter fields. Especially to use advanced operations on enums is a little bit tricky and requires some more code. 

## Related issues

closes #32575 
