### PR TITLE
deps: Update awssdk feign and minio for stable/8.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -123,10 +123,10 @@
     <version.jcip>1.0</version.jcip>
     <version.jnr-posix>3.1.20</version.jnr-posix>
     <version.zpt>8.5.18</version.zpt>
-    <version.feign>13.4</version.feign>
+    <version.feign>13.5</version.feign>
     <version.google-sdk>26.47.0</version.google-sdk>
     <version.azure-sdk>1.2.35</version.azure-sdk>
-    <version.awssdk>2.28.29</version.awssdk>
+    <version.awssdk>2.31.50</version.awssdk>
     <version.toxiproxy>2.1.7</version.toxiproxy>
     <version.validation-api>3.1.1</version.validation-api>
     <version.jackson-databind-nullable>0.2.6</version.jackson-databind-nullable>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
@@ -43,7 +43,7 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
    * this.
    */
   public MinioContainer() {
-    this("RELEASE.2023-11-20T22-40-07Z");
+    this("RELEASE.2025-04-22T22-12-26Z");
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`stable/8.7` has not gotten the version upgrade of `awssdk` like `main` has

Upgrade the version on `stable/8.7` to match `main`

Update `feign` and `minio` in support of the `awssdk` upgrade. Backup ITs were failing without them

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/32778
