### PR TITLE
fix: pass tenant as prop to diagram header

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -58,7 +58,9 @@ function setSearchParam(
 const DiagramPanel: React.FC = observer(() => {
   const navigate = useNavigate();
   const location = useLocation();
-  const {version, flowNodeId} = getProcessInstanceFilters(location.search);
+  const {version, flowNodeId, tenant} = getProcessInstanceFilters(
+    location.search,
+  );
 
   const isVersionSelected = version !== undefined && version !== 'all';
 
@@ -150,6 +152,7 @@ const DiagramPanel: React.FC = observer(() => {
         processDefinitionId={processId}
         isVersionSelected={isVersionSelected}
         panelHeaderRef={panelHeaderRef}
+        tenant={tenant}
       />
       <DiagramShell
         status={getStatus()}


### PR DESCRIPTION
## Description

Passes `tenant` variable as a prop to `DiagramHeader` component in order to provide the tenant ID that allows for further operations, such as checking for permissions, and in turn, allowing (in the proper scenarios) the deletion of a process definition.

This was tested and fixed for 8.8 (which is the target version for the fix per the client's request on the JIRA ticket) and along the way from 8.6 to 8.8 something had changed that fixed this for at least for some scenarios, so this change can be seen more as a "failsafe" so that we know for sure the tenant ID is getting to the component properly and in turn allowing operations to work as intended.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #25068
