### PR TITLE
test: fixed flaky authorization ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -334,6 +334,8 @@ class ProcessInstanceAuthorizationIT {
                           .join()
                           .items())
                   .hasSize(2); // PROCESS_ID_1 and PROCESS_ID_2
+              assertThat(camundaClient.newVariableSearchRequest().send().join().items())
+                  .hasSize(2); // One per process instance
               assertThat(camundaClient.newElementInstanceSearchRequest().send().join().items())
                   .hasSize(4); // Start event and service task for each process
             });

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
@@ -134,8 +134,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldNotReturnProcessDefinitionWithUnauthorizedUser(
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+  public void shouldNotReturnProcessDefinitionWithUnauthorizedUser() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -150,8 +149,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldBeAuthorizedToRetrieveProcessDefinition(
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+  public void shouldBeAuthorizedToRetrieveProcessDefinition() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -166,8 +164,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldReturnNoDefinitionsWithUnauthorizedUser(
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+  public void shouldReturnNoDefinitionsWithUnauthorizedUser() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -182,8 +179,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldBeAuthorizedToRetrieveDefinitionOne(
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+  public void shouldBeAuthorizedToRetrieveDefinitionOne() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -199,8 +195,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldBeAuthorizedToRetrieveDefinitions(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
+  public void shouldBeAuthorizedToRetrieveDefinitions() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -220,8 +215,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   @Test
-  public void shouldNotCreateInstanceWithUnauthorizedUser(
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+  public void shouldNotCreateInstanceWithUnauthorizedUser() {
     // given (non-admin) user without any authorizations
 
     // when
@@ -237,8 +231,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToCreateInstance(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (non-admin) user with authorizations
     final int currentCountOfPIs = countOfProcessInstances(adminClient, PROCESS_WITH_USER_TASK);
 
@@ -256,8 +249,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldCreateProcessInstanceWithoutAuthentication(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (non-admin) user without any authorizations
     final int currentCountOfPIs = countOfProcessInstances(adminClient, PROCESS_WITH_USER_TASK);
 
@@ -275,8 +267,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotAssignUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKey = createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
     final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey, false);
@@ -295,8 +286,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotCompleteUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     // create a process instance - with pre-assigned user task
     final var processInstanceKey =
@@ -318,8 +308,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToCompleteUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKey = createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
     final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey, false);
@@ -345,8 +334,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotUnassignUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     // create a process instance - with pre-assigned user task
     final var processInstanceKey =
@@ -368,8 +356,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToAssignUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
@@ -392,8 +379,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToUnassignUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithUserTask =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK_PRE_ASSIGNED);
@@ -415,8 +401,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotAssignJobBasedUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     // create a process instance with job based user task
     final long anotherProcessInstanceKeyWithJobBasedUserTask =
@@ -438,8 +423,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotCompleteJobBasedUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
@@ -461,8 +445,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToCompleteJobBasedUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK);
@@ -491,8 +474,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldNotUnassignJobBasedUserTaskWithUnauthorizedUser(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
@@ -514,8 +496,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToUnassignJobBasedUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
@@ -538,8 +519,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
 
   @Test
   public void shouldBeAuthorizedToAssignJobBasedUserTask(
-      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
-      @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
+      @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient) {
     // given (admin) to create instance
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/compatibility/NoCompatibilityModeTasklistUserTaskAuthorizationIT.java
@@ -28,6 +28,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
@@ -278,7 +279,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
       @Authenticated(TEST_USER_NAME_NO_PERMISSION) final CamundaClient noPermission) {
     // given (admin) to create instance
     final var processInstanceKey = createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
-    final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey);
+    final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey, false);
     // given (non-admin) user without any authorizations
 
     // when
@@ -300,7 +301,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     // create a process instance - with pre-assigned user task
     final var processInstanceKey =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK_PRE_ASSIGNED);
-    final var userTaskKeyPreAssigned = awaitUserTaskBeingAvailable(adminClient, processInstanceKey);
+    final var userTaskKeyPreAssigned =
+        awaitUserTaskBeingAvailable(adminClient, processInstanceKey, true);
     // given (non-admin) user without any authorizations
 
     // when
@@ -319,9 +321,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
       @Authenticated(ADMIN_USER_NAME) final CamundaClient adminClient,
       @Authenticated(TEST_USER_NAME_WITH_PERMISSION) final CamundaClient withPermission) {
     // given (admin) to create instance
-    // create a process instance - with pre-assigned user task
     final var processInstanceKey = createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
-    final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey);
+    final var userTaskKey = awaitUserTaskBeingAvailable(adminClient, processInstanceKey, false);
     // given (non-admin) user without any authorizations
     final var response =
         tasklistRestClient
@@ -350,7 +351,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     // create a process instance - with pre-assigned user task
     final var processInstanceKey =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK_PRE_ASSIGNED);
-    final var userTaskKeyPreAssigned = awaitUserTaskBeingAvailable(adminClient, processInstanceKey);
+    final var userTaskKeyPreAssigned =
+        awaitUserTaskBeingAvailable(adminClient, processInstanceKey, true);
     // given (non-admin) user without any authorizations
 
     // when
@@ -372,7 +374,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK);
     final var userTaskKeyWithJobBasedUserTask =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask);
+        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask, false);
     // given (non-admin) user with permissions to assign task
 
     // when
@@ -395,7 +397,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     // given (admin) to create instance
     final var processInstanceKeyWithUserTask =
         createProcessInstance(adminClient, PROCESS_WITH_USER_TASK_PRE_ASSIGNED);
-    final var userTaskKey = awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithUserTask);
+    final var userTaskKey =
+        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithUserTask, true);
     // given (non-admin) user with permissions to unassign task
 
     // when
@@ -419,7 +422,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final long anotherProcessInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK);
     final var anotherUserTaskKeyWithJobBasedUserTask =
-        awaitJobBasedUserTaskBeingAvailable(anotherProcessInstanceKeyWithJobBasedUserTask);
+        awaitJobBasedUserTaskBeingAvailable(anotherProcessInstanceKeyWithJobBasedUserTask, false);
     // given (non-admin) user without any authorizations
 
     // when
@@ -441,7 +444,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
     final var userTaskKeyWithJobBasedUserTaskPreAssigned =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTaskPreAssigned);
+        awaitJobBasedUserTaskBeingAvailable(
+            processInstanceKeyWithJobBasedUserTaskPreAssigned, true);
     // given (non-admin) user without any authorizations
 
     // when
@@ -463,7 +467,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK);
     final var userTaskKeyWithJobBasedUserTask =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask);
+        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask, false);
     // given (non-admin) user with permissions to assign task
     final var response =
         tasklistRestClient
@@ -493,7 +497,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
     final var userTaskKeyWithJobBasedUserTaskPreAssigned =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTaskPreAssigned);
+        awaitJobBasedUserTaskBeingAvailable(
+            processInstanceKeyWithJobBasedUserTaskPreAssigned, true);
     // given (non-admin) user without any authorizations
 
     // when
@@ -515,7 +520,8 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTaskPreAssigned =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK_PRE_ASSIGNED);
     final var userTaskKeyWithJobBasedUserTaskPreAssigned =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTaskPreAssigned);
+        awaitJobBasedUserTaskBeingAvailable(
+            processInstanceKeyWithJobBasedUserTaskPreAssigned, true);
     // given (non-admin) user without any authorizations
 
     // when
@@ -538,7 +544,7 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
     final var processInstanceKeyWithJobBasedUserTask =
         createProcessInstance(adminClient, PROCESS_ID_WITH_JOB_BASED_USERTASK);
     final var userTaskKeyWithJobBasedUserTask =
-        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask);
+        awaitJobBasedUserTaskBeingAvailable(processInstanceKeyWithJobBasedUserTask, false);
     // given (non-admin) user with permissions to assign task
 
     // when
@@ -577,7 +583,9 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
   }
 
   public static long awaitUserTaskBeingAvailable(
-      final CamundaClient camundaClient, final long processInstanceKey) {
+      final CamundaClient camundaClient,
+      final long processInstanceKey,
+      final boolean shouldBePreAssigned) {
     final AtomicLong userTaskKey = new AtomicLong();
     Awaitility.await("should create an user task")
         .atMost(Duration.ofSeconds(60))
@@ -591,20 +599,32 @@ public class NoCompatibilityModeTasklistUserTaskAuthorizationIT {
                       .send()
                       .join();
               assertThat(result.items()).hasSize(1);
+              if (shouldBePreAssigned) {
+                assertThat(result.items().getFirst().getAssignee()).isNotNull();
+              }
               userTaskKey.set(result.items().getFirst().getUserTaskKey());
             });
     return userTaskKey.get();
   }
 
-  public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
+  public static long awaitJobBasedUserTaskBeingAvailable(
+      final long processInstanceKey, final boolean shouldBePreAssigned) {
     final var task =
         Awaitility.await("should create a job-based user task")
             .atMost(Duration.ofSeconds(60))
             .ignoreExceptions() // Ignore exceptions and continue retrying
             .until(
                 () -> findTasksForProcessInstance(processInstanceKey),
-                (result) -> result.length == 1);
+                existsAndAssigned(shouldBePreAssigned));
     return Long.parseLong(task[0].getId());
+  }
+
+  private static Predicate<TaskSearchResponse[]> existsAndAssigned(
+      final boolean shouldBePreAssigned) {
+    if (shouldBePreAssigned) {
+      return tsr -> tsr.length == 1 && tsr[0].getAssignee() != null;
+    }
+    return tsr -> tsr.length == 1;
   }
 
   public static void ensureUserTaskIsCompleted(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix flaky authorization ITs:

- Added assertions for tasks/variables having been exported before testing if they can be accessed
- Added assertions that user tasks have been automatically assigned in (where applicable) since this lead to user tasks falsely not having been assigned yet when the test starts, or causing `version_conflict_engine_exception` in elasticsearch in test cases with reassignment because the automatic assignment and deliberate re-assignment of the test may occur at the same time

Slack channel: https://camunda.slack.com/archives/C08V0ECCAM6

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
