### PR TITLE
Preventing schema initialization from blocking broker startup

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -16,8 +16,10 @@ import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -37,7 +39,10 @@ public class SearchEngineDatabaseConfiguration {
   @Bean
   public SearchEngineSchemaInitializer searchEngineSchemaInitializer(
       final SearchEngineConfiguration searchEngineConfiguration,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      @Autowired(required = false)
+          final Broker broker // if present, then it will ensure that the broker is started first
+      ) {
     return new SearchEngineSchemaInitializer(searchEngineConfiguration, meterRegistry);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.spring;
 
+import io.camunda.application.Profile;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
@@ -23,7 +24,12 @@ final class CamundaApplicationSpringDependenciesTest extends AbstractSpringDepen
   private static final TestCamundaApplication CAMUNDA_APPLICATION =
       new TestCamundaApplication()
           .withProperty("management.endpoint.beans.access", "unrestricted")
-          .withCreateSchema(false);
+          .withAdditionalProfiles(
+              Profile.CONSOLIDATED_AUTH,
+              Profile.BROKER,
+              Profile.OPERATE,
+              Profile.TASKLIST,
+              Profile.IDENTITY);
 
   @BeforeEach
   void setUp() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -252,6 +252,15 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
   }
 
   /**
+   * Configures additional active Spring profiles.
+   *
+   * @return itself for chaining
+   */
+  default T withAdditionalProfiles(final Profile... profiles) {
+    return withAdditionalProfiles(List.of(profiles));
+  }
+
+  /**
    * @see #withAdditionalProfile(String)
    */
   default T withAdditionalProfile(final Profile profile) {


### PR DESCRIPTION
### Description

Spring initializes beans sequentially, but the order is not guaranteed (except for dependent beans). 

Although, there is no spring dependency from [`broker`](https://github.com/camunda/camunda/blob/84483b7ea53e33c3f1eb1b8c859c341025379809/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java#L109-L136) bean to `SearchEngineSchemaInitializer`, as proven by [CamundaApplicationSpringDependenciesTest](https://github.com/camunda/camunda/blob/hb-dep-sm-broker/qa/acceptance-tests/src/test/java/io/camunda/it/spring/CamundaApplicationSpringDependenciesTest.java) test, Spring may initialize the latter first, which can unnecessarily block the broker initialization and the engine processing for a "long" period.

To enforce the desired order, the broker is injected as an optional "fake" dependency into `SearchEngineSchemaInitializer`, ensuring the broker bean is created first if present. The use of `required = false` allows this to safely ignore it when the `broker` spring profile is not enabled. 

This pattern is already used in other places like [OperateModuleConfiguration](https://github.com/camunda/camunda/blob/hb-dep-sm-broker/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java#L41).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/28896