### PR TITLE
ci: operate CI should push SNAPSHOT image to dockerhub

### DIFF
--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -1,7 +1,7 @@
 # description: Runs integration tests CI tests owned by Core Features
 # test location: operate/qa/integration-tests
 # owner: Core Features
-name: "[Legacy] Operate / [IT] Core Features"
+name: "[Legacy] Operate"
 on:
   workflow_dispatch:
   push:
@@ -40,9 +40,16 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  # builds image and pushes to Dockerhub if branch is `main`
+  run-operate-build:
+    name: "Build Operate and Image"
+    uses: ./.github/workflows/operate-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
   # over 10min run time
   run-core-features-integration-tests:
-    name: "Test"
+    name: "[IT] Core Features"
     uses: ./.github/workflows/operate-ci-test-reusable.yml
     secrets: inherit
     with:

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -2,7 +2,7 @@
 # test location: operate/client/src/App
 # owner: Core Features
 ---
-name: "[Legacy] Operate"
+name: "[Legacy] Operate [FE]"
 on:
   push:
     branches:
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   # Operate FE Unit tests do not meet the stability requirements to be in Unified CI.
   fe-unit-tests:
-    name: "[FE] Unit Tests"
+    name: "Unit Tests"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The CI for Operate should call `operate-ci-build-reuseable.yml` so that a Docker image will be pushed to dockerhub when run on the `main` branch

The call to that workflow was removed previously, this PR is adding it back in

See slack thread for when this was discovered: https://camunda.slack.com/archives/C06UWQNCU7M/p1748943111487119

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
