### PR TITLE
deps: update operate and zeebe dependencies for 8.5.15

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.5.14-SNAPSHOT",
+  "version": "8.5.15-SNAPSHOT",
   "private": true,
   "dependencies": {
     "@axe-core/playwright": "4.8.5",

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -92,7 +92,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -106,7 +106,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -123,7 +123,7 @@ services:
       - 9600:9600
     restart: always
   operate:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -110,7 +110,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -131,7 +131,7 @@ services:
       - "9600:9600"
     restart: always
   operate:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -37,7 +37,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -123,7 +123,7 @@ services:
       - "8000:8000"
     restart: always
   operate:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/docker-compose.opensearch.yml
+++ b/operate/docker-compose.opensearch.yml
@@ -26,7 +26,7 @@ services:
       - ./os-snapshots:/usr/local/os-snapshots
   zeebe-opensearch:
     container_name: zeebe-opensearch
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -41,7 +41,7 @@ services:
       - 8000:8000
     restart: always
   operate-opensearch:
-    image: camunda/operate:8.5.14
+    image: camunda/operate:8.5.15
     container_name: operate-opensearch
     environment:
       - SERVER_PORT=8080

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -47,7 +47,7 @@ services:
 
   zeebe-e2e:
     container_name: zeebe-e2e
-    image: camunda/zeebe:8.5.18
+    image: camunda/zeebe:8.5.19
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -67,7 +67,7 @@
     <commons-lang3.version>3.14.0</commons-lang3.version>
 
     <!-- Library versions not provided by spring boot -->
-    <version.zeebe>8.5.18</version.zeebe>
+    <version.zeebe>8.5.19</version.zeebe>
     <version.camunda>7.20.0</version.camunda>
     <version.identity>8.5.17</version.identity>
     <version.parsson>1.1.7</version.parsson>


### PR DESCRIPTION
Updates versions of dependencies (Zeebe and Identity) and Operate for release of version 8.5.15.

Correct versions can be found in the [release thread](https://camunda.slack.com/archives/C03NFMH4KC6/p1748844736068749).

Identity was already updated with https://github.com/camunda/camunda/pull/32774 and https://github.com/camunda/camunda/pull/32773

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
