### PR TITLE
fix: fix flow node filter selection

### DIFF
--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -108,31 +108,6 @@ class BpmnJS {
       hasOuterBorderOnSelection,
     } = options;
 
-    const selectedFlowNodeIds = unfilteredSelectedFlowNodeIds?.filter(
-      (flowNodeId) => {
-        const element = this.#navigatedViewer
-          ?.get('elementRegistry')
-          .get(flowNodeId);
-        return element !== undefined;
-      },
-    );
-    const highlightedFlowNodeIds = unfilteredHighlightedFlowNodeIds?.filter(
-      (flowNodeId) => {
-        const element = this.#navigatedViewer
-          ?.get('elementRegistry')
-          .get(flowNodeId);
-        return element !== undefined;
-      },
-    );
-    const selectableFlowNodes = unfilteredSelectableFlowNodes?.filter(
-      (flowNodeId) => {
-        const element = this.#navigatedViewer
-          ?.get('elementRegistry')
-          .get(flowNodeId);
-        return element !== undefined;
-      },
-    );
-
     if (this.#navigatedViewer === null) {
       this.#createViewer(container);
     }
@@ -141,6 +116,19 @@ class BpmnJS {
       this.#xml = xml;
       await this.import(xml);
     }
+
+    const doesElementExist = (flowNodeId: string) => {
+      return (
+        this.#navigatedViewer?.get('elementRegistry')?.get(flowNodeId) !==
+        undefined
+      );
+    };
+    const selectedFlowNodeIds =
+      unfilteredSelectedFlowNodeIds?.filter(doesElementExist);
+    const highlightedFlowNodeIds =
+      unfilteredHighlightedFlowNodeIds?.filter(doesElementExist);
+    const selectableFlowNodes =
+      unfilteredSelectableFlowNodes?.filter(doesElementExist);
 
     // if render is called a second time before importing has finished,
     // exit early because there is no root element yet.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This is a bug introduced by me on [this PR](https://github.com/camunda/camunda/pull/32159). In some cases in the processes tab in Operate the diagram wouldn't be rendered so the selectable flow nodes were not calculated properly.

Steps to reproduce this:
1. Go to the processes tab in Operate
2. Select the processes `complexProcess`
3. Select a node
4. Reload the page with ctrl + R (cmd + R)
5. No flow node is selected and you can select any other flow nodes

The expected behavior should be that we're able to select flow nodes

