### PR TITLE
[Backport stable/optimize-8.6] feat: optimize to only validate optimize indexes with OS

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -98,7 +98,6 @@ import org.springframework.stereotype.Component;
 public class OpenSearchSchemaManager
     extends DatabaseSchemaManager<OptimizeOpenSearchClient, IndexSettings.Builder> {
 
-  public static final String ALL_INDEXES = "_all";
   private final OpenSearchMetadataService metadataService;
 
   @Autowired
@@ -616,11 +615,12 @@ public class OpenSearchSchemaManager
   private void unblockIndices(final OptimizeOpenSearchClient osClient) {
     final List<String> indexesBlocked;
     try {
+      final String optimizeIndexes = indexNameService.getIndexPrefix() + "-*";
       final GetIndicesSettingsResponse settingsResponse =
           osClient
               .getOpenSearchClient()
               .indices()
-              .getSettings(new GetIndicesSettingsRequest.Builder().index(ALL_INDEXES).build());
+              .getSettings(new GetIndicesSettingsRequest.Builder().index(optimizeIndexes).build());
       indexesBlocked =
           settingsResponse.result().values().stream()
               .filter(


### PR DESCRIPTION
# Description
Backport of #32780 to `stable/optimize-8.6`.

relates to camunda/camunda#33064 camunda/camunda#33064