### PR TITLE
Verify inherited authorizations using basic auth and OIDC

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -494,6 +494,11 @@
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -327,13 +327,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.dasniko</groupId>
-      <artifactId>testcontainers-keycloak</artifactId>
-      <version>3.7.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-api</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedAuthorizationIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.Membership;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class InheritedAuthorizationIT {
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_AUTHORIZED_GROUP =
+      new TestUser(Strings.newRandomValidUsername(), "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_UNAUTHORIZED_GROUP =
+      new TestUser(Strings.newRandomValidIdentityId(), "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_AUTHORIZED_ROLE =
+      new TestUser(Strings.newRandomValidUsername(), "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_UNAUTHORIZED_ROLE =
+      new TestUser(Strings.newRandomValidIdentityId(), "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE =
+      new TestUser(Strings.newRandomValidUsername(), "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      new TestUser(Strings.newRandomValidUsername(), "password", List.of());
+
+  @GroupDefinition
+  private static final TestGroup UNAUTHORIZED_GROUP =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroup",
+          "unauthorized",
+          List.of(new Membership(USER_THROUGH_UNAUTHORIZED_GROUP.username(), EntityType.USER)));
+
+  @GroupDefinition
+  private static final TestGroup AUTHORIZED_GROUP =
+      new TestGroup(
+          "authorizedGroup",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(new Membership(USER_THROUGH_AUTHORIZED_GROUP.username(), EntityType.USER)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_AUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "authorizedGroupThroughRole",
+          "authorized",
+          List.of(
+              new Membership(
+                  USER_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE.username(), EntityType.USER)));
+
+  @RoleDefinition
+  private static final TestRole AUTHORIZED_ROLE =
+      new TestRole(
+          "authorizedRole",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(
+              new Membership(USER_THROUGH_AUTHORIZED_ROLE.username(), EntityType.USER),
+              new Membership(GROUP_THROUGH_AUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroupThroughRole",
+          "unauthorized",
+          List.of(
+              new Membership(
+                  USER_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE.username(), EntityType.USER)));
+
+  @RoleDefinition
+  private static final TestRole UNAUTHORIZED_ROLE =
+      TestRole.withoutPermissions(
+          "unauthorizedRole",
+          "unauthorized",
+          List.of(
+              new Membership(USER_THROUGH_UNAUTHORIZED_ROLE.username(), EntityType.USER),
+              new Membership(GROUP_THROUGH_UNAUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedUsers")
+  void shouldBeAuthorizedToDeploy(final TestUser user) {
+    // given
+    try (final CamundaClient client = createClient(user)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedUsers")
+  void shouldBeUnauthorizedToDeploy(final TestUser user) {
+    // given
+    try (final CamundaClient client = createClient(user)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("403: 'Forbidden'");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedUsers")
+  void shouldBeAuthorizedToRead(final TestUser user) {
+    // given
+    try (final CamundaClient client = createClient(user)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedUsers")
+  void shouldBeUnauthorizedToRead(final TestUser user) {
+    // given
+    try (final CamundaClient client = createClient(user)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("404: 'Not Found'");
+    }
+  }
+
+  private static CamundaClient createClient(final TestUser user) {
+    return BROKER
+        .newClientBuilder()
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .username(user.username())
+                .password(user.password())
+                .build())
+        .build();
+  }
+
+  private static Stream<Named<TestUser>> provideAuthorizedUsers() {
+    return Stream.of(
+        Named.of("#userThroughGroup", USER_THROUGH_AUTHORIZED_GROUP),
+        Named.of("#userThroughRole", USER_THROUGH_AUTHORIZED_ROLE),
+        Named.of("#userThroughGroupThroughRole", USER_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE));
+  }
+
+  private static Stream<Named<TestUser>> provideUnauthorizedUsers() {
+    return Stream.of(
+        Named.of("#userThroughGroup", USER_THROUGH_UNAUTHORIZED_GROUP),
+        Named.of("#userThroughRole", USER_THROUGH_UNAUTHORIZED_ROLE),
+        Named.of("#userThroughGroupThroughRole", USER_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedBasicAuthAuthorizationIT.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
-public class InheritedAuthorizationIT {
+public class InheritedBasicAuthAuthorizationIT {
   @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_NAME;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.MappingDefinition;
+import io.camunda.qa.util.auth.Membership;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TestGroup;
+import io.camunda.qa.util.auth.TestMapping;
+import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@MultiDbTest(setupKeycloak = true)
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class InheritedOIDCAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withAuthorizationsEnabled()
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
+
+  // Injected by the MultiDbTest extension
+  private static KeycloakContainer keycloak;
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_GROUP =
+      new TestMapping("mappingId", DEFAULT_MAPPING_CLAIM_NAME, "claimValue", List.of());
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_GROUP =
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_ROLE =
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_ROLE =
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE =
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
+
+  @MappingDefinition
+  private static final TestMapping MAPPING_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
+
+  @GroupDefinition
+  private static final TestGroup UNAUTHORIZED_GROUP =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroup",
+          "unauthorized",
+          List.of(new Membership(MAPPING_THROUGH_UNAUTHORIZED_GROUP.id(), EntityType.MAPPING)));
+
+  @GroupDefinition
+  private static final TestGroup AUTHORIZED_GROUP =
+      new TestGroup(
+          "authorizedGroup",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(new Membership(MAPPING_THROUGH_AUTHORIZED_GROUP.id(), EntityType.MAPPING)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_AUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "authorizedGroupThroughRole",
+          "authorized",
+          List.of(
+              new Membership(
+                  MAPPING_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE.id(), EntityType.MAPPING)));
+
+  @RoleDefinition
+  private static final TestRole AUTHORIZED_ROLE =
+      new TestRole(
+          "authorizedRole",
+          "authorized",
+          List.of(
+              new Permissions(ResourceType.RESOURCE, PermissionType.CREATE, List.of("*")),
+              new Permissions(
+                  ResourceType.GROUP, PermissionType.READ, List.of(UNAUTHORIZED_GROUP.id()))),
+          List.of(
+              new Membership(MAPPING_THROUGH_AUTHORIZED_ROLE.id(), EntityType.MAPPING),
+              new Membership(GROUP_THROUGH_AUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP_THROUGH_UNAUTHORIZED_ROLE =
+      TestGroup.withoutPermissions(
+          "unauthorizedGroupThroughRole",
+          "unauthorized",
+          List.of(
+              new Membership(
+                  MAPPING_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE.id(), EntityType.MAPPING)));
+
+  @RoleDefinition
+  private static final TestRole UNAUTHORIZED_ROLE =
+      TestRole.withoutPermissions(
+          "unauthorizedRole",
+          "unauthorized",
+          List.of(
+              new Membership(MAPPING_THROUGH_UNAUTHORIZED_ROLE.id(), EntityType.MAPPING),
+              new Membership(GROUP_THROUGH_UNAUTHORIZED_ROLE.id(), EntityType.GROUP)));
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedMappings")
+  void shouldBeAuthorizedToDeploy(final TestMapping mapping, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(mapping, tempDir)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedMappings")
+  void shouldBeUnauthorizedToDeploy(final TestMapping mapping, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(mapping, tempDir)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(
+                          Bpmn.createExecutableProcess().startEvent().endEvent().done(),
+                          "process.bpmn")
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("403: 'Forbidden'");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAuthorizedMappings")
+  void shouldBeAuthorizedToRead(final TestMapping mapping, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(mapping, tempDir)) {
+
+      // then
+      Assertions.assertThatNoException()
+          .isThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                      .send()
+                      .join());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideUnauthorizedMappings")
+  void shouldBeUnauthorizedToRead(final TestMapping mapping, @TempDir final Path tempDir) {
+    // given
+    try (final CamundaClient client = createClient(mapping, tempDir)) {
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  client
+                      .newGroupGetRequest(
+                          UNAUTHORIZED_GROUP.id()) // Attempt to read a random group we've created
+                      .send()
+                      .join())
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("404: 'Not Found'");
+    }
+  }
+
+  private CamundaClient createClient(final TestMapping mapping, final Path tempDir) {
+    return BROKER
+        .newClientBuilder()
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(mapping.claimValue())
+                .clientSecret(mapping.claimValue())
+                .audience("zeebe")
+                .authorizationServerUrl(
+                    keycloak.getAuthServerUrl() + "/realms/camunda/protocol/openid-connect/token")
+                .credentialsCachePath(tempDir.resolve("default").toString())
+                .build())
+        .build();
+  }
+
+  private static Stream<Named<TestMapping>> provideAuthorizedMappings() {
+    return Stream.of(
+        Named.of("#userThroughGroup", MAPPING_THROUGH_AUTHORIZED_GROUP),
+        Named.of("#userThroughRole", MAPPING_THROUGH_AUTHORIZED_ROLE),
+        Named.of("#userThroughGroupThroughRole", MAPPING_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE));
+  }
+
+  private static Stream<Named<TestMapping>> provideUnauthorizedMappings() {
+    return Stream.of(
+        Named.of("#userThroughGroup", MAPPING_THROUGH_UNAUTHORIZED_GROUP),
+        Named.of("#userThroughRole", MAPPING_THROUGH_UNAUTHORIZED_ROLE),
+        Named.of("#userThroughGroupThroughRole", MAPPING_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -39,9 +39,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @MultiDbTest(setupKeycloak = true)
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
@@ -59,7 +57,11 @@ public class InheritedOIDCAuthorizationIT {
 
   @MappingDefinition
   private static final TestMapping MAPPING_THROUGH_AUTHORIZED_GROUP =
-      new TestMapping("mappingId", DEFAULT_MAPPING_CLAIM_NAME, "claimValue", List.of());
+      new TestMapping(
+          Strings.newRandomValidIdentityId(),
+          DEFAULT_MAPPING_CLAIM_NAME,
+          Strings.newRandomValidIdentityId(),
+          List.of());
 
   @MappingDefinition
   private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_GROUP =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/InheritedOIDCAuthorizationIT.java
@@ -56,52 +56,24 @@ public class InheritedOIDCAuthorizationIT {
   private static KeycloakContainer keycloak;
 
   @MappingDefinition
-  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_GROUP =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_GROUP = createTestMapping();
 
   @MappingDefinition
-  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_GROUP =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_GROUP = createTestMapping();
 
   @MappingDefinition
-  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_ROLE =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+  private static final TestMapping MAPPING_THROUGH_AUTHORIZED_ROLE = createTestMapping();
 
   @MappingDefinition
-  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_ROLE =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+  private static final TestMapping MAPPING_THROUGH_UNAUTHORIZED_ROLE = createTestMapping();
 
   @MappingDefinition
   private static final TestMapping MAPPING_THROUGH_GROUP_THROUGH_AUTHORIZED_ROLE =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+      createTestMapping();
 
   @MappingDefinition
   private static final TestMapping MAPPING_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE =
-      new TestMapping(
-          Strings.newRandomValidIdentityId(),
-          DEFAULT_MAPPING_CLAIM_NAME,
-          Strings.newRandomValidIdentityId(),
-          List.of());
+      createTestMapping();
 
   @GroupDefinition
   private static final TestGroup UNAUTHORIZED_GROUP =
@@ -267,5 +239,13 @@ public class InheritedOIDCAuthorizationIT {
         Named.of("#userThroughGroup", MAPPING_THROUGH_UNAUTHORIZED_GROUP),
         Named.of("#userThroughRole", MAPPING_THROUGH_UNAUTHORIZED_ROLE),
         Named.of("#userThroughGroupThroughRole", MAPPING_THROUGH_GROUP_THROUGH_UNAUTHORIZED_ROLE));
+  }
+
+  private static TestMapping createTestMapping() {
+    return new TestMapping(
+        Strings.newRandomValidIdentityId(),
+        DEFAULT_MAPPING_CLAIM_NAME,
+        Strings.newRandomValidIdentityId(),
+        List.of());
   }
 }

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -197,6 +197,25 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.dasniko</groupId>
+      <artifactId>testcontainers-keycloak</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-admin-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>apache-client</artifactId>
       <scope>compile</scope>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -200,15 +200,13 @@
       <groupId>com.github.dasniko</groupId>
       <artifactId>testcontainers-keycloak</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-core</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-admin-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-client-common-synced</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/MappingDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/MappingDefinition.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for a role definition, that is picked up by the {@link
+ * CamundaMultiDBExtension}. This is to clearly communicate that this mapping definition,
+ * will be consumed and created (related permissions and memberships) by the {@link CamundaMultiDBExtension}.
+ *
+ *  <pre>{@code
+ *  @Tag("multi-db-test")
+ *  final class MyAuthMultiDbTest {
+ *
+ *    static final TestStandaloneBroker BROKER =
+ *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *    @RegisterExtension
+ *    static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+ *
+ *    @MappingDefinition
+ *    private static final TestMapping MAPPING =
+ *      new TestMapping("mappingId",
+ *                   "claimName",
+ *                   "claimValue",
+ *                   List.of(new Permissions(AUTHORIZATION, PermissionTypeEnum.READ, List.of("*"))));
+ *
+ *    @Test
+ *    void shouldHaveCreatedMapping(@Authenticated(ADMIN) final CamundaClient adminClient) {
+ *      // The mapping and permissions are created before this test runs
+ *    }
+ *  }</pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MappingDefinition {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/MappingDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/MappingDefinition.java
@@ -15,7 +15,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marker annotation for a role definition, that is picked up by the {@link
+ * Marker annotation for a mapping definition, that is picked up by the {@link
  * CamundaMultiDBExtension}. This is to clearly communicate that this mapping definition,
  * will be consumed and created (related permissions and memberships) by the {@link CamundaMultiDBExtension}.
  *

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestMapping.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestMapping.java
@@ -10,4 +10,9 @@ package io.camunda.qa.util.auth;
 import java.util.List;
 
 public record TestMapping(
-    String id, String claimName, String claimValue, List<Permissions> permissions) {}
+    String id, String claimName, String claimValue, List<Permissions> permissions) {
+
+  public TestMapping(final String id, final String claimName, final String claimValue) {
+    this(id, claimName, claimValue, List.of());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestMapping.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestMapping.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.util.List;
+
+public record TestMapping(
+    String id, String claimName, String claimValue, List<Permissions> permissions) {}

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -244,6 +244,11 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   }
 
   @Override
+  public CamundaSecurityProperties securityConfig() {
+    return securityConfig;
+  }
+
+  @Override
   public Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return apiAuthenticationMethod();
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
@@ -59,7 +59,6 @@ public final class BasicAuthCamundaClientTestFactory implements CamundaClientTes
     return cachedClients.get(username);
   }
 
-  @Override
   public void createClientForUser(final TestGateway<?> gateway, final TestUser user) {
     final var client = createAuthenticatedClient(gateway, user.username(), user.password());
     cachedClients.put(user.username(), client);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.ApplicationUnderTest;
+import io.camunda.security.configuration.InitializationConfiguration;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BasicAuthCamundaClientTestFactory implements CamundaClientTestFactory {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BasicAuthCamundaClientTestFactory.class);
+
+  private final Map<String, CamundaClient> cachedClients = new ConcurrentHashMap<>();
+
+  public BasicAuthCamundaClientTestFactory(final ApplicationUnderTest application) {
+    cachedClients.put(
+        InitializationConfiguration.DEFAULT_USER_USERNAME, createDefaultUserClient(application));
+  }
+
+  @Override
+  public CamundaClient getDefaultUserCamundaClient() {
+    return getCamundaClient(InitializationConfiguration.DEFAULT_USER_USERNAME);
+  }
+
+  @Override
+  public CamundaClient getCamundaClient(final String username) {
+    return cachedClients.get(username);
+  }
+
+  @Override
+  public CamundaClient getCamundaClient(
+      final TestGateway<?> gateway, final Authenticated authenticated) {
+    if (authenticated == null) {
+      LOGGER.info(
+          "Creating unauthorized Camunda client for broker address '{}", gateway.restAddress());
+      return gateway.newClientBuilder().preferRestOverGrpc(true).build();
+    }
+
+    LOGGER.info(
+        "Retrieving Camunda client for user '{}' and broker address '{}",
+        authenticated.value(),
+        gateway.restAddress());
+    final var username = authenticated.value();
+    return cachedClients.get(username);
+  }
+
+  @Override
+  public void createClientForUser(final TestGateway<?> gateway, final TestUser user) {
+    final var client = createAuthenticatedClient(gateway, user.username(), user.password());
+    cachedClients.put(user.username(), client);
+  }
+
+  private CamundaClient createDefaultUserClient(final ApplicationUnderTest application) {
+    final CamundaClient defaultClient =
+        createAuthenticatedClient(
+            application.application(),
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD);
+    // Block until the default user is created. If the application is not managed by the extension
+    // there is no point waiting for the topology to be healthy, as the application might not be
+    // started yet.
+    if (application.shouldBeManaged()) {
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(20))
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(defaultClient.newTopologyRequest().send().join())
+                      .isHealthy());
+    }
+    return defaultClient;
+  }
+
+  private CamundaClient createAuthenticatedClient(
+      final TestGateway<?> gateway, final String username, final String password) {
+    return gateway
+        .newClientBuilder()
+        .preferRestOverGrpc(true)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder().username(username).password(password).build())
+        .build();
+  }
+
+  @Override
+  public void close() {
+    CloseHelper.quietCloseAll(cachedClients.values());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/BasicAuthCamundaClientTestFactory.java
@@ -36,7 +36,7 @@ public final class BasicAuthCamundaClientTestFactory implements CamundaClientTes
   }
 
   @Override
-  public CamundaClient getDefaultUserCamundaClient() {
+  public CamundaClient getAdminCamundaClient() {
     return getCamundaClient(InitializationConfiguration.DEFAULT_USER_USERNAME);
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
@@ -9,6 +9,7 @@ package io.camunda.qa.util.multidb;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestMapping;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
 
@@ -18,7 +19,7 @@ public interface CamundaClientTestFactory extends AutoCloseable {
    * Returns a client for the default user. The default user can be setup using the security
    * configuration.
    */
-  CamundaClient getDefaultUserCamundaClient();
+  CamundaClient getAdminCamundaClient();
 
   /** Returns a client for the given username */
   CamundaClient getCamundaClient(final String username);
@@ -27,5 +28,9 @@ public interface CamundaClientTestFactory extends AutoCloseable {
   CamundaClient getCamundaClient(final TestGateway<?> gateway, final Authenticated authenticated);
 
   /** Creates a Camunda client for the given user. Only implemented for basic auth! */
-  void createClientForUser(final TestGateway<?> gateway, final TestUser user);
+  default void createClientForUser(final TestGateway<?> gateway, final TestUser user) {}
+
+  /** Creates a Camunda client for the given mapping. Only implemented for OIDC! */
+  default void createClientForMapping(
+      final TestGateway<?> gateway, final TestMapping mappingName) {}
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
@@ -9,8 +9,6 @@ package io.camunda.qa.util.multidb;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.auth.Authenticated;
-import io.camunda.qa.util.auth.TestMapping;
-import io.camunda.qa.util.auth.TestUser;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
 
 public interface CamundaClientTestFactory extends AutoCloseable {
@@ -26,11 +24,4 @@ public interface CamundaClientTestFactory extends AutoCloseable {
 
   /** Returns a Camunda client for the given gateway and authenticated user */
   CamundaClient getCamundaClient(final TestGateway<?> gateway, final Authenticated authenticated);
-
-  /** Creates a Camunda client for the given user. Only implemented for basic auth! */
-  default void createClientForUser(final TestGateway<?> gateway, final TestUser user) {}
-
-  /** Creates a Camunda client for the given mapping. Only implemented for OIDC! */
-  default void createClientForMapping(
-      final TestGateway<?> gateway, final TestMapping mappingName) {}
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaClientTestFactory.java
@@ -19,8 +19,8 @@ public interface CamundaClientTestFactory extends AutoCloseable {
    */
   CamundaClient getAdminCamundaClient();
 
-  /** Returns a client for the given username */
-  CamundaClient getCamundaClient(final String username);
+  /** Returns a client for the given id */
+  CamundaClient getCamundaClient(final String id);
 
   /** Returns a Camunda client for the given gateway and authenticated user */
   CamundaClient getCamundaClient(final TestGateway<?> gateway, final Authenticated authenticated);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -305,7 +305,7 @@ public class CamundaMultiDBExtension
       manageApplicationUnderTest();
     }
 
-    authenticatedClientFactory = new CamundaClientTestFactory(applicationUnderTest);
+    authenticatedClientFactory = new BasicAuthCamundaClientTestFactory(applicationUnderTest);
     entityManager = new EntityManager(authenticatedClientFactory.getDefaultUserCamundaClient());
     createEntities(testClass);
     // we support only static fields for now - to make sure test setups are build in a way
@@ -440,7 +440,7 @@ public class CamundaMultiDBExtension
   }
 
   @Override
-  public void afterAll(final ExtensionContext context) {
+  public void afterAll(final ExtensionContext context) throws Exception {
     CloseHelper.quietCloseAll(closeables);
     authenticatedClientFactory.close();
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -77,4 +77,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @ExtendWith(CamundaMultiDBExtension.class)
 @Inherited
-public @interface MultiDbTest {}
+public @interface MultiDbTest {
+
+  /**
+   * @return if true, then a Keycoak container will be started. This is useful for tests that
+   *     require OIDC authentication.
+   */
+  boolean setupKeycloak() default false;
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -79,7 +79,6 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
     return cachedClients.get(mappingId);
   }
 
-  @Override
   public void createClientForMapping(final TestGateway<?> gateway, final TestMapping mapping) {
     final var client = createAuthenticatedClient(gateway, mapping.id(), mapping.claimValue());
     cachedClients.put(mapping.id(), client);
@@ -109,7 +108,7 @@ public final class OidcCamundaClientTestFactory implements CamundaClientTestFact
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     deleteTempDirectory();
     CloseHelper.quietCloseAll(cachedClients.values());
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/OidcCamundaClientTestFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestMapping;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.ApplicationUnderTest;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.agrona.CloseHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class OidcCamundaClientTestFactory implements CamundaClientTestFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OidcCamundaClientTestFactory.class);
+
+  private final Map<String, CamundaClient> cachedClients = new ConcurrentHashMap<>();
+  private final Path tempDirectory;
+  private final String authorizationServerUrl;
+  private final CamundaClient adminCamundaClient;
+
+  public OidcCamundaClientTestFactory(
+      final ApplicationUnderTest application,
+      final String testPrefix,
+      final String authorizationServerUrl)
+      throws IOException {
+    tempDirectory = Files.createTempDirectory(testPrefix);
+    this.authorizationServerUrl = authorizationServerUrl;
+    adminCamundaClient =
+        createAuthenticatedClient(
+            application.application(),
+            TestStandaloneBroker.DEFAULT_MAPPING_ID,
+            TestStandaloneBroker.DEFAULT_MAPPING_CLAIM_VALUE);
+  }
+
+  @Override
+  public CamundaClient getAdminCamundaClient() {
+    if (adminCamundaClient == null) {
+      throw new IllegalStateException(
+          "No admin Camunda client has been created. Ensure that the OIDC mappings are configured correctly.");
+    }
+    return adminCamundaClient;
+  }
+
+  @Override
+  public CamundaClient getCamundaClient(final String mappingId) {
+    return cachedClients.get(mappingId);
+  }
+
+  @Override
+  public CamundaClient getCamundaClient(
+      final TestGateway<?> gateway, final Authenticated authenticated) {
+    if (authenticated == null) {
+      LOGGER.info(
+          "Creating unauthorized Camunda client for broker address '{}", gateway.restAddress());
+      return gateway.newClientBuilder().preferRestOverGrpc(true).build();
+    }
+
+    final var mappingId = authenticated.value();
+    LOGGER.info(
+        "Retrieving Camunda client for mapping id '{}' and broker address '{}",
+        mappingId,
+        gateway.restAddress());
+    return cachedClients.get(mappingId);
+  }
+
+  @Override
+  public void createClientForMapping(final TestGateway<?> gateway, final TestMapping mapping) {
+    final var client = createAuthenticatedClient(gateway, mapping.id(), mapping.claimValue());
+    cachedClients.put(mapping.id(), client);
+  }
+
+  private CamundaClient createAuthenticatedClient(
+      final TestGateway<?> gateway, final String mappingId, final String claimValue) {
+    final var client =
+        gateway
+            .newClientBuilder()
+            .preferRestOverGrpc(true)
+            .restAddress(gateway.restAddress())
+            .grpcAddress(gateway.grpcAddress())
+            .usePlaintext()
+            .defaultRequestTimeout(Duration.ofSeconds(15))
+            .credentialsProvider(
+                new OAuthCredentialsProviderBuilder()
+                    .clientId(claimValue)
+                    .clientSecret(claimValue)
+                    .audience("zeebe")
+                    .authorizationServerUrl(authorizationServerUrl)
+                    .credentialsCachePath(tempDirectory.resolve("default").toString())
+                    .build())
+            .build();
+    cachedClients.put(mappingId, client);
+    return client;
+  }
+
+  @Override
+  public void close() throws Exception {
+    deleteTempDirectory();
+    CloseHelper.quietCloseAll(cachedClients.values());
+  }
+
+  private void deleteTempDirectory() {
+    try (final var paths = Files.walk(tempDirectory)) {
+      paths
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (final IOException e) {
+                  LOGGER.error("Failed to delete temporary file: {}", p, e);
+                }
+              });
+    } catch (final IOException e) {
+      LOGGER.error("Failed to delete temporary directory: {}", tempDirectory, e);
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/auth/MappingRuleMatcher.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/MappingRuleMatcher.java
@@ -37,6 +37,9 @@ public final class MappingRuleMatcher {
 
   public static <T extends MappingRule> Stream<T> matchingRules(
       final Stream<T> mappingRules, final Map<String, Object> claims) {
+    if (claims == null) {
+      return Stream.empty();
+    }
     final EvaluationCache evaluationCache = new EvaluationCache(claims);
     return mappingRules.filter(mappingRule -> matchRule(evaluationCache, mappingRule));
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -43,9 +43,13 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
    */
   T withBrokerConfig(final Consumer<BrokerBasedProperties> modifier);
 
-  BrokerBasedProperties brokerConfig();
+  /**
+   * Modifies the security configuration. Will still mutate the configuration if the broker is
+   * started, but likely has no effect until it's restarted.
+   */
+  T withSecurityConfig(final Consumer<CamundaSecurityProperties> modifier);
 
-  CamundaSecurityProperties securityConfig();
+  BrokerBasedProperties brokerConfig();
 
   default Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return Optional.empty();
@@ -69,8 +73,6 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
                         .username(DEFAULT_USER_USERNAME)
                         .password(DEFAULT_USER_PASSWORD)
                         .build());
-              } else {
-                throw new IllegalStateException("Unsupported authentication method: " + method);
               }
             });
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -11,6 +11,7 @@ import static io.camunda.security.configuration.InitializationConfiguration.DEFA
 import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
 
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
+import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.security.entity.AuthenticationMethod;
@@ -43,6 +44,8 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
   T withBrokerConfig(final Consumer<BrokerBasedProperties> modifier);
 
   BrokerBasedProperties brokerConfig();
+
+  CamundaSecurityProperties securityConfig();
 
   default Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return Optional.empty();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -244,6 +244,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   @Override
+  public CamundaSecurityProperties securityConfig() {
+    return securityConfig;
+  }
+
+  @Override
   public Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return apiAuthenticationMethod();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds 2 ITs. They are responsible for verifying authorizations that are inherited through roles, groups and groups with roles.

The big challenge of this PR was setting up OIDC in an easy and reuseable way. I've extends the `@MultiDbTest` annotation with a `setupKeycloak` flag. When enabled the extension will manage a keycloak instance for your test. This means it will start a testcontainer instance of keycloak and ensure any defined mappings are created. It also manages the camunda clients for you.
To make this possible I've also added a `@MappingDefinition` which you can use to define your mapping. It'll get created in the engine similar to when you use a `@UserDefinition`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31999
