### PR TITLE
Add `read` authorization api to java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -80,6 +80,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AuthorizationGetRequest;
 import io.camunda.client.api.fetch.BatchOperationGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest;
@@ -2137,6 +2138,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder to configure and send the create authorization command
    */
   CreateAuthorizationCommandStep1 newCreateAuthorizationCommand();
+
+  /**
+   * Request to get an authorization by authorization key.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newAuthorizationGetRequest(authorizationKey)
+   *  .send();
+   * </pre>
+   *
+   * @param authorizationKey the authorizationKey of the authorization
+   * @return a builder for the request to get an authorization
+   */
+  AuthorizationGetRequest newAuthorizationGetRequest(long authorizationKey);
 
   /**
    * Command to delete an authorization

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/AuthorizationGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/AuthorizationGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.Authorization;
+
+public interface AuthorizationGetRequest extends FinalCommandStep<Authorization> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.protocol.rest.OwnerTypeEnum;
+import io.camunda.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.client.protocol.rest.ResourceTypeEnum;
+import java.util.List;
+
+public interface Authorization {
+
+  String getAuthorizationKey();
+
+  String getOwnerId();
+
+  OwnerTypeEnum getOwnerType();
+
+  ResourceTypeEnum getResourceType();
+
+  String getResourceId();
+
+  List<PermissionTypeEnum> getPermissionTypes();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Authorization.java
@@ -15,9 +15,9 @@
  */
 package io.camunda.client.api.search.response;
 
-import io.camunda.client.protocol.rest.OwnerTypeEnum;
-import io.camunda.client.protocol.rest.PermissionTypeEnum;
-import io.camunda.client.protocol.rest.ResourceTypeEnum;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import java.util.List;
 
 public interface Authorization {
@@ -26,11 +26,11 @@ public interface Authorization {
 
   String getOwnerId();
 
-  OwnerTypeEnum getOwnerType();
+  OwnerType getOwnerType();
 
-  ResourceTypeEnum getResourceType();
+  ResourceType getResourceType();
 
   String getResourceId();
 
-  List<PermissionTypeEnum> getPermissionTypes();
+  List<PermissionType> getPermissionTypes();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -91,6 +91,7 @@ import io.camunda.client.api.command.UpdateTenantCommandStep1;
 import io.camunda.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.client.api.command.UpdateUserCommandStep1;
 import io.camunda.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.client.api.fetch.AuthorizationGetRequest;
 import io.camunda.client.api.fetch.BatchOperationGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetRequest;
 import io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest;
@@ -208,6 +209,7 @@ import io.camunda.client.impl.command.UpdateRoleCommandImpl;
 import io.camunda.client.impl.command.UpdateTenantCommandImpl;
 import io.camunda.client.impl.command.UpdateUserCommandImpl;
 import io.camunda.client.impl.command.UpdateUserTaskCommandImpl;
+import io.camunda.client.impl.fetch.AuthorizationGetRequestImpl;
 import io.camunda.client.impl.fetch.BatchOperationGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetRequestImpl;
 import io.camunda.client.impl.fetch.DecisionDefinitionGetXmlRequestImpl;
@@ -1127,6 +1129,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public CreateAuthorizationCommandStep1 newCreateAuthorizationCommand() {
     return new CreateAuthorizationCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AuthorizationGetRequest newAuthorizationGetRequest(final long authorizationKey) {
+    return new AuthorizationGetRequestImpl(httpClient, authorizationKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/AuthorizationGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/AuthorizationGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.AuthorizationGetRequest;
+import io.camunda.client.api.search.response.Authorization;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.AuthorizationResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AuthorizationGetRequestImpl implements AuthorizationGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long authorizationKey;
+
+  public AuthorizationGetRequestImpl(final HttpClient httpClient, final long authorizationKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.authorizationKey = authorizationKey;
+  }
+
+  @Override
+  public FinalCommandStep<Authorization> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Authorization> send() {
+    ArgumentUtil.ensureNotNegative("authorizationKey", authorizationKey);
+    final HttpCamundaFuture<Authorization> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/authorizations/%d", authorizationKey),
+        httpRequestConfig.build(),
+        AuthorizationResult.class,
+        SearchResponseMapper::toAuthorizationResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/AuthorizationGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/AuthorizationGetRequestImpl.java
@@ -48,7 +48,7 @@ public class AuthorizationGetRequestImpl implements AuthorizationGetRequest {
 
   @Override
   public CamundaFuture<Authorization> send() {
-    ArgumentUtil.ensureNotNegative("authorizationKey", authorizationKey);
+    ArgumentUtil.ensureGreaterThan("authorizationKey", authorizationKey, 0);
     final HttpCamundaFuture<Authorization> result = new HttpCamundaFuture<>();
     httpClient.get(
         String.format("/authorizations/%d", authorizationKey),

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
@@ -15,10 +15,10 @@
  */
 package io.camunda.client.impl.search.response;
 
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Authorization;
-import io.camunda.client.protocol.rest.OwnerTypeEnum;
-import io.camunda.client.protocol.rest.PermissionTypeEnum;
-import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import java.util.List;
 
 public class AuthorizationImpl implements Authorization {
@@ -26,17 +26,17 @@ public class AuthorizationImpl implements Authorization {
   private final String authorizationKey;
   private final String ownerId;
   private final String resourceId;
-  private final OwnerTypeEnum ownerType;
-  private final ResourceTypeEnum resourceType;
-  private final List<PermissionTypeEnum> permissionTypes;
+  private final OwnerType ownerType;
+  private final ResourceType resourceType;
+  private final List<PermissionType> permissionTypes;
 
   public AuthorizationImpl(
       final String authorizationKey,
       final String ownerId,
       final String resourceId,
-      final OwnerTypeEnum ownerType,
-      final ResourceTypeEnum resourceType,
-      final List<PermissionTypeEnum> permissionTypes) {
+      final OwnerType ownerType,
+      final ResourceType resourceType,
+      final List<PermissionType> permissionTypes) {
     this.authorizationKey = authorizationKey;
     this.ownerId = ownerId;
     this.resourceId = resourceId;
@@ -56,12 +56,12 @@ public class AuthorizationImpl implements Authorization {
   }
 
   @Override
-  public OwnerTypeEnum getOwnerType() {
+  public OwnerType getOwnerType() {
     return ownerType;
   }
 
   @Override
-  public ResourceTypeEnum getResourceType() {
+  public ResourceType getResourceType() {
     return resourceType;
   }
 
@@ -71,7 +71,7 @@ public class AuthorizationImpl implements Authorization {
   }
 
   @Override
-  public List<PermissionTypeEnum> getPermissionTypes() {
+  public List<PermissionType> getPermissionTypes() {
     return permissionTypes;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AuthorizationImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.Authorization;
+import io.camunda.client.protocol.rest.OwnerTypeEnum;
+import io.camunda.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.client.protocol.rest.ResourceTypeEnum;
+import java.util.List;
+
+public class AuthorizationImpl implements Authorization {
+
+  private final String authorizationKey;
+  private final String ownerId;
+  private final String resourceId;
+  private final OwnerTypeEnum ownerType;
+  private final ResourceTypeEnum resourceType;
+  private final List<PermissionTypeEnum> permissionTypes;
+
+  public AuthorizationImpl(
+      final String authorizationKey,
+      final String ownerId,
+      final String resourceId,
+      final OwnerTypeEnum ownerType,
+      final ResourceTypeEnum resourceType,
+      final List<PermissionTypeEnum> permissionTypes) {
+    this.authorizationKey = authorizationKey;
+    this.ownerId = ownerId;
+    this.resourceId = resourceId;
+    this.ownerType = ownerType;
+    this.resourceType = resourceType;
+    this.permissionTypes = permissionTypes;
+  }
+
+  @Override
+  public String getAuthorizationKey() {
+    return authorizationKey;
+  }
+
+  @Override
+  public String getOwnerId() {
+    return ownerId;
+  }
+
+  @Override
+  public OwnerTypeEnum getOwnerType() {
+    return ownerType;
+  }
+
+  @Override
+  public ResourceTypeEnum getResourceType() {
+    return resourceType;
+  }
+
+  @Override
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  @Override
+  public List<PermissionTypeEnum> getPermissionTypes() {
+    return permissionTypes;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationItems;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
@@ -201,6 +202,16 @@ public final class SearchResponseMapper {
 
   private static RoleUser toRoleUser(final RoleUserResult response) {
     return new RoleUserImpl(response.getUsername());
+  }
+
+  public static Authorization toAuthorizationResponse(final AuthorizationResult response) {
+    return new AuthorizationImpl(
+        response.getAuthorizationKey(),
+        response.getOwnerId(),
+        response.getResourceId(),
+        response.getOwnerType(),
+        response.getResourceType(),
+        response.getPermissionTypes());
   }
 
   public static Group toGroupResponse(final GroupResult response) {

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -16,6 +16,9 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.api.search.response.BatchOperation;
 import io.camunda.client.api.search.response.BatchOperationItems;
@@ -41,8 +44,10 @@ import io.camunda.client.api.search.response.User;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.search.response.BatchOperationItemsImpl.BatchOperationItemImpl;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.*;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -205,13 +210,20 @@ public final class SearchResponseMapper {
   }
 
   public static Authorization toAuthorizationResponse(final AuthorizationResult response) {
+    final List<PermissionTypeEnum> permissionTypes = response.getPermissionTypes();
+    final List<PermissionType> convertedPermissionTypes = new ArrayList<>();
+    for (final PermissionTypeEnum permissionType : permissionTypes) {
+      final PermissionType converted = EnumUtil.convert(permissionType, PermissionType.class);
+      convertedPermissionTypes.add(converted);
+    }
+
     return new AuthorizationImpl(
         response.getAuthorizationKey(),
         response.getOwnerId(),
         response.getResourceId(),
-        response.getOwnerType(),
-        response.getResourceType(),
-        response.getPermissionTypes());
+        EnumUtil.convert(response.getOwnerType(), OwnerType.class),
+        EnumUtil.convert(response.getResourceType(), ResourceType.class),
+        convertedPermissionTypes);
   }
 
   public static Group toGroupResponse(final GroupResult response) {

--- a/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class SearchAuthorizationTest extends ClientRestTest {
+
+  public static final long AUTHORIZATION_KEY = 100L;
+
+  @Test
+  public void shouldSearchAuthorizationByAuthorizationKey() {
+    // when
+    client.newAuthorizationGetRequest(AUTHORIZATION_KEY).send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/authorizations/" + AUTHORIZATION_KEY);
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNegativeAuthorizationKey() {
+    // when / then
+    assertThatThrownBy(() -> client.newAuthorizationGetRequest(-1).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("authorizationKey must be not negative");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/SearchAuthorizationTest.java
@@ -43,6 +43,6 @@ public class SearchAuthorizationTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(() -> client.newAuthorizationGetRequest(-1).send().join())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("authorizationKey must be not negative");
+        .hasMessageContaining("authorizationKey must be greater than 0");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -67,5 +68,19 @@ public class AuthorizationIntegrationTest {
               assertThat(retrievedAuthorization.getPermissionTypes())
                   .isEqualTo(List.of(PermissionTypeEnum.CREATE));
             });
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenGettingNonExistentAuthorization() {
+    // when / then
+    final var nonExistingAuthorizationKey = 100L;
+    assertThatThrownBy(
+            () ->
+                camundaClient.newAuthorizationGetRequest(nonExistingAuthorizationKey).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Authorization with authorization key %d not found"
+                .formatted(nonExistingAuthorizationKey));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -9,40 +9,26 @@ package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.CreateAuthorizationResponse;
 import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
-import io.camunda.client.protocol.rest.AuthorizationResult;
+import io.camunda.client.api.search.response.Authorization;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.List;
-import java.util.Objects;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
 public class AuthorizationIntegrationTest {
 
   private static CamundaClient camundaClient;
-
-  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-
-  private static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @Test
   void shouldCreateAndGetAuthorizationByAuthorizationKey() {
@@ -66,38 +52,20 @@ public class AuthorizationIntegrationTest {
 
     // then
     Awaitility.await()
+        .ignoreExceptionsInstanceOf(ProblemException.class)
         .untilAsserted(
-            () ->
-                assertThat(
-                        getAuthorization(
-                            camundaClient.getConfiguration().getRestAddress().toString(),
-                            authorizationKey))
-                    .matches(
-                        r ->
-                            Objects.equals(
-                                r.getAuthorizationKey(), String.valueOf(authorizationKey)))
-                    .matches(r -> Objects.equals(r.getOwnerId(), ownerId))
-                    .matches(r -> Objects.equals(r.getOwnerType(), OwnerTypeEnum.USER))
-                    .matches(r -> Objects.equals(r.getResourceId(), resourceId))
-                    .matches(r -> Objects.equals(r.getResourceType(), ResourceTypeEnum.RESOURCE))
-                    .matches(
-                        r ->
-                            Objects.equals(
-                                r.getPermissionTypes(), List.of(PermissionTypeEnum.CREATE))));
-  }
-
-  // TODO search authorizations command is unimplemented, remove the code below after implementation
-  private static AuthorizationResult getAuthorization(
-      final String restAddress, final long authorizationKey)
-      throws URISyntaxException, IOException, InterruptedException {
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(new URI("%s%s%d".formatted(restAddress, "v2/authorizations/", authorizationKey)))
-            .GET()
-            .build();
-
-    final HttpResponse<String> response =
-        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-    return OBJECT_MAPPER.readValue(response.body(), AuthorizationResult.class);
+            () -> {
+              final Authorization retrievedAuthorization =
+                  camundaClient.newAuthorizationGetRequest(authorizationKey).send().join();
+              assertThat(retrievedAuthorization.getAuthorizationKey())
+                  .isEqualTo(String.valueOf(authorizationKey));
+              assertThat(retrievedAuthorization.getResourceId()).isEqualTo(resourceId);
+              assertThat(retrievedAuthorization.getResourceType())
+                  .isEqualTo(ResourceTypeEnum.RESOURCE);
+              assertThat(retrievedAuthorization.getOwnerId()).isEqualTo(ownerId);
+              assertThat(retrievedAuthorization.getOwnerType()).isEqualTo(OwnerTypeEnum.USER);
+              assertThat(retrievedAuthorization.getPermissionTypes())
+                  .isEqualTo(List.of(PermissionTypeEnum.CREATE));
+            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AuthorizationIntegrationTest.java
@@ -17,9 +17,6 @@ import io.camunda.client.api.search.enums.OwnerType;
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
 import io.camunda.client.api.search.response.Authorization;
-import io.camunda.client.protocol.rest.OwnerTypeEnum;
-import io.camunda.client.protocol.rest.PermissionTypeEnum;
-import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.test.util.Strings;
 import java.util.List;
@@ -36,16 +33,19 @@ public class AuthorizationIntegrationTest {
     // given
     final var ownerId = Strings.newRandomValidIdentityId();
     final var resourceId = Strings.newRandomValidIdentityId();
+    final OwnerType ownerType = OwnerType.USER;
+    final ResourceType resourceType = ResourceType.RESOURCE;
+    final PermissionType permissionType = PermissionType.CREATE;
 
     // when
     final CreateAuthorizationResponse authorization =
         camundaClient
             .newCreateAuthorizationCommand()
             .ownerId(ownerId)
-            .ownerType(OwnerType.USER)
+            .ownerType(ownerType)
             .resourceId(resourceId)
-            .resourceType(ResourceType.RESOURCE)
-            .permissionTypes(PermissionType.CREATE)
+            .resourceType(resourceType)
+            .permissionTypes(permissionType)
             .send()
             .join();
     final long authorizationKey = authorization.getAuthorizationKey();
@@ -61,12 +61,11 @@ public class AuthorizationIntegrationTest {
               assertThat(retrievedAuthorization.getAuthorizationKey())
                   .isEqualTo(String.valueOf(authorizationKey));
               assertThat(retrievedAuthorization.getResourceId()).isEqualTo(resourceId);
-              assertThat(retrievedAuthorization.getResourceType())
-                  .isEqualTo(ResourceTypeEnum.RESOURCE);
+              assertThat(retrievedAuthorization.getResourceType()).isEqualTo(resourceType);
               assertThat(retrievedAuthorization.getOwnerId()).isEqualTo(ownerId);
-              assertThat(retrievedAuthorization.getOwnerType()).isEqualTo(OwnerTypeEnum.USER);
+              assertThat(retrievedAuthorization.getOwnerType()).isEqualTo(ownerType);
               assertThat(retrievedAuthorization.getPermissionTypes())
-                  .isEqualTo(List.of(PermissionTypeEnum.CREATE));
+                  .isEqualTo(List.of(permissionType));
             });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -76,7 +76,7 @@ public class UsersUpdateIntegrationTest {
             () ->
                 camundaClient
                     .newUpdateUserCommand(nonExistingUserName)
-                    .name("Role Name")
+                    .name("User Name")
                     .email("new_email@email.com")
                     .send()
                     .join())


### PR DESCRIPTION
## Description

Add read authorization API to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32518
