### PR TITLE
Add read user request to java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -100,6 +100,7 @@ import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesByGroupSearchRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
+import io.camunda.client.api.fetch.UserGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.UsersByGroupSearchRequest;
@@ -1630,6 +1631,21 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   UpdateUserCommandStep1 newUpdateUserCommand(String username);
+
+  /**
+   * Request to get a user by username.
+   *
+   * <pre>
+   *
+   * camundaClient
+   *  .newUserGetRequest("username")
+   *  .send();
+   * </pre>
+   *
+   * @param username the username of the user
+   * @return a builder for the request to get a user
+   */
+  UserGetRequest newUserGetRequest(String username);
 
   /**
    * Command to create a mapping rule.

--- a/clients/java/src/main/java/io/camunda/client/api/fetch/UserGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/fetch/UserGetRequest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.fetch;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.response.User;
+
+public interface UserGetRequest extends FinalCommandStep<User> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -111,6 +111,7 @@ import io.camunda.client.api.fetch.ProcessInstanceGetRequest;
 import io.camunda.client.api.fetch.RoleGetRequest;
 import io.camunda.client.api.fetch.RolesByGroupSearchRequest;
 import io.camunda.client.api.fetch.RolesSearchRequest;
+import io.camunda.client.api.fetch.UserGetRequest;
 import io.camunda.client.api.fetch.UserTaskGetFormRequest;
 import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.UsersByGroupSearchRequest;
@@ -222,6 +223,7 @@ import io.camunda.client.impl.fetch.ProcessDefinitionGetXmlRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetCallHierarchyRequestImpl;
 import io.camunda.client.impl.fetch.ProcessInstanceGetRequestImpl;
 import io.camunda.client.impl.fetch.RoleGetRequestImpl;
+import io.camunda.client.impl.fetch.UserGetRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetFormRequestImpl;
 import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
@@ -973,6 +975,11 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public UpdateUserCommandStep1 newUpdateUserCommand(final String username) {
     return new UpdateUserCommandImpl(httpClient, username, jsonMapper);
+  }
+
+  @Override
+  public UserGetRequest newUserGetRequest(final String username) {
+    return new UserGetRequestImpl(httpClient, username);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/UserGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/UserGetRequestImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.fetch;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.fetch.UserGetRequest;
+import io.camunda.client.api.search.response.User;
+import io.camunda.client.impl.command.ArgumentUtil;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.UserResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class UserGetRequestImpl implements UserGetRequest {
+
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final String username;
+
+  public UserGetRequestImpl(final HttpClient httpClient, final String username) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.username = username;
+  }
+
+  @Override
+  public FinalCommandStep<User> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<User> send() {
+    ArgumentUtil.ensureNotNullNorEmpty("username", username);
+    final HttpCamundaFuture<User> result = new HttpCamundaFuture<>();
+    httpClient.get(
+        String.format("/users/%s", username),
+        httpRequestConfig.build(),
+        UserResult.class,
+        SearchResponseMapper::toUserResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/SearchUsersTest.java
@@ -16,6 +16,7 @@
 package io.camunda.client.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
@@ -40,5 +41,32 @@ public class SearchUsersTest extends ClientRestTest {
     final LoggedRequest request = gatewayService.getLastRequest();
     assertThat(request.getUrl()).isEqualTo("/v2/users/search");
     assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+  }
+
+  @Test
+  public void shouldSearchUserByUsername() {
+    // when
+    client.newUserGetRequest("username").send().join();
+
+    // then
+    final LoggedRequest request = gatewayService.getLastRequest();
+    assertThat(request.getUrl()).isEqualTo("/v2/users/" + "username");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullUsername() {
+    // when / then
+    assertThatThrownBy(() -> client.newUserGetRequest(null).send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyUsername() {
+    // when / then
+    assertThatThrownBy(() -> client.newUserGetRequest("").send().join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be empty");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -24,7 +23,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
-import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -60,6 +61,15 @@ public class UsersSearchIntegrationTest {
     assertThat(user.getUsername()).isEqualTo(USERNAME_1);
     assertThat(user.getEmail()).isEqualTo(EMAIL_1);
     assertThat(user.getName()).isEqualTo(NAME_1);
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenGettingUserThatDoesNotExist() {
+    // when / then
+    assertThatThrownBy(() -> camundaClient.newUserGetRequest("testUsername").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining("User with username testUsername not found");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -54,6 +54,15 @@ public class UsersSearchIntegrationTest {
   }
 
   @Test
+  void shouldGetUserByUsername() {
+    final User user = camundaClient.newUserGetRequest(USERNAME_1).send().join();
+
+    assertThat(user.getUsername()).isEqualTo(USERNAME_1);
+    assertThat(user.getEmail()).isEqualTo(EMAIL_1);
+    assertThat(user.getName()).isEqualTo(NAME_1);
+  }
+
+  @Test
   void searchShouldReturnUsersFilteredByUsername() {
     final SearchResponse<User> usersSearchResponse =
         camundaClient.newUsersSearchRequest().filter(fn -> fn.username(USERNAME_1)).send().join();


### PR DESCRIPTION
## Description

Add read user API to Java Client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32520
