### PR TITLE
Roles base page - integration

### DIFF
--- a/identity/client/e2e/tests/roles.spec.ts
+++ b/identity/client/e2e/tests/roles.spec.ts
@@ -13,8 +13,6 @@ import { relativizePath } from "../utils/relativizePaths";
 import { LOGIN_CREDENTIALS } from "../utils/constants";
 import { waitForItemInList } from "../utils/waitForItemInList";
 
-import { IS_ROLES_BASE_PAGE_INTEGRATED } from "../../src/feature-flags";
-
 const NEW_Role = {
   id: "testRoleID",
   name: "Test role",
@@ -26,43 +24,40 @@ test.beforeEach(async ({ page, loginPage }) => {
   await expect(page).toHaveURL(relativizePath(Paths.roles()));
 });
 
-test.describe[IS_ROLES_BASE_PAGE_INTEGRATED ? "serial" : "skip"](
-  "roles CRUD",
-  () => {
-    test("creates a role", async ({ page, rolesPage }) => {
-      await expect(
-        rolesPage.rolesList.getByRole("cell", { name: "Admin" }),
-      ).toBeVisible();
+test.describe.serial("roles CRUD", () => {
+  test("creates a role", async ({ page, rolesPage }) => {
+    await expect(
+      rolesPage.rolesList.getByRole("cell", { name: "Admin", exact: true }),
+    ).toBeVisible();
 
-      await rolesPage.createRoleButton.click();
-      await expect(rolesPage.createRoleModal).toBeVisible();
-      await rolesPage.createIdField.fill(NEW_Role.id);
-      await rolesPage.createNameField.fill(NEW_Role.name);
-      await rolesPage.createRoleModalCreateButton.click();
-      await expect(rolesPage.createRoleModal).not.toBeVisible();
+    await rolesPage.createRoleButton.click();
+    await expect(rolesPage.createRoleModal).toBeVisible();
+    await rolesPage.createIdField.fill(NEW_Role.id);
+    await rolesPage.createNameField.fill(NEW_Role.name);
+    await rolesPage.createRoleModalCreateButton.click();
+    await expect(rolesPage.createRoleModal).not.toBeVisible();
 
-      const item = rolesPage.rolesList.getByRole("cell", {
-        name: NEW_Role.name,
-      });
-
-      await waitForItemInList(page, item);
+    const item = rolesPage.rolesList.getByRole("cell", {
+      name: NEW_Role.name,
     });
 
-    test("deletes a role", async ({ page, rolesPage }) => {
-      await expect(
-        rolesPage.rolesList.getByRole("cell", { name: NEW_Role.name }),
-      ).toBeVisible();
+    await waitForItemInList(page, item);
+  });
 
-      await rolesPage.deleteRoleButton(NEW_Role.name).click();
-      await expect(rolesPage.deleteRoleModal).toBeVisible();
-      await rolesPage.deleteRoleModalDeleteButton.click();
-      await expect(rolesPage.deleteRoleModal).not.toBeVisible();
+  test("deletes a role", async ({ page, rolesPage }) => {
+    await expect(
+      rolesPage.rolesList.getByRole("cell", { name: NEW_Role.name }),
+    ).toBeVisible();
 
-      const item = rolesPage.rolesList.getByRole("cell", {
-        name: NEW_Role.name,
-      });
+    await rolesPage.deleteRoleButton(NEW_Role.name).click();
+    await expect(rolesPage.deleteRoleModal).toBeVisible();
+    await rolesPage.deleteRoleModalDeleteButton.click();
+    await expect(rolesPage.deleteRoleModal).not.toBeVisible();
 
-      await waitForItemInList(page, item, { shouldBeVisible: false });
+    const item = rolesPage.rolesList.getByRole("cell", {
+      name: NEW_Role.name,
     });
-  },
-);
+
+    await waitForItemInList(page, item, { shouldBeVisible: false });
+  });
+});

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -13,6 +13,3 @@ export const IS_TENANT_ROLES_SUPPORTED = false;
 // Roles details page - Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
 export const IS_ROLES_USERS_SUPPORTED = false;
 export const IS_ROLES_MAPPINGS_SUPPORTED = false;
-
-// Roles base page (and e2e tests) - Remove when Roles page is integrated https://github.com/camunda/camunda/issues/29768
-export const IS_ROLES_BASE_PAGE_INTEGRATED = false;


### PR DESCRIPTION
## Description

Integrating the Roles base page with the API endpoints that are now available. Most of this integration (migration from `roleKey` to `roleId`, as well as fixing the endpoints was done as part of the UI issue (pre-integration) and the Groups details page integration, where we needed to have this `rolesId` already available for the integration for the Roles tab on that page.

Work done as part of this PR:
- Remove the feature flag for roles base page integration;
- Unskip tests;
- Fix E2E tests where needed;
- Manual testing and running E2E tests to ensure integration works as intended

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29768
