### PR TITLE
[Backport stable/8.6] deps: Update awssdk feign and minio for stable/8.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -123,10 +123,10 @@
     <version.jcip>1.0</version.jcip>
     <version.jnr-posix>3.1.20</version.jnr-posix>
     <version.zpt>8.5.18</version.zpt>
-    <version.feign>13.4</version.feign>
+    <version.feign>13.5</version.feign>
     <version.google-sdk>26.47.0</version.google-sdk>
     <version.azure-sdk>1.2.35</version.azure-sdk>
-    <version.awssdk>2.28.29</version.awssdk>
+    <version.awssdk>2.31.50</version.awssdk>
     <version.toxiproxy>2.1.7</version.toxiproxy>
     <version.validation-api>3.1.1</version.validation-api>
     <version.jackson-databind-nullable>0.2.6</version.jackson-databind-nullable>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/testcontainers/MinioContainer.java
@@ -43,7 +43,7 @@ public final class MinioContainer extends GenericContainer<MinioContainer> {
    * this.
    */
   public MinioContainer() {
-    this("RELEASE.2023-11-20T22-40-07Z");
+    this("RELEASE.2025-04-22T22-12-26Z");
   }
 
   /**


### PR DESCRIPTION
# Description
Backport of #32777 to `stable/8.6`.

relates to camunda/camunda#32778