### PR TITLE
Refactoring `newUnassignMappingFromGroupCommand` to follow the agreed commands pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2211,8 +2211,9 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    *
    * camundaClient
-   *  .newUnassignMappingFromGroupCommand(groupId)
+   *  .newUnassignMappingFromGroupCommand()
    *  .mappingId(mappingId)
+   *  .groupId(groupId)
    *  .send();
    * </pre>
    *
@@ -2220,7 +2221,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand(String groupId);
+  UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand();
 
   /**
    * Request to get a group by group ID.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingFromGroupStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignMappingFromGroupStep1.java
@@ -17,15 +17,25 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UnassignMappingFromGroupResponse;
 
-public interface UnassignMappingFromGroupStep1
-    extends FinalCommandStep<UnassignMappingFromGroupResponse> {
+public interface UnassignMappingFromGroupStep1 {
 
   /**
    * Sets the mapping ID for the unassignment.
    *
    * @param mappingId the ID of the mapping to unassign
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  UnassignMappingFromGroupStep1 mappingId(String mappingId);
+  UnassignMappingFromGroupStep2 mappingId(String mappingId);
+
+  interface UnassignMappingFromGroupStep2
+      extends FinalCommandStep<UnassignMappingFromGroupResponse> {
+    /**
+     * Sets the group ID.
+     *
+     * @param groupId the id of the group
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UnassignMappingFromGroupStep2 groupId(String groupId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1143,8 +1143,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand(final String groupId) {
-    return new UnassignMappingFromGroupCommandImpl(httpClient, groupId);
+  public UnassignMappingFromGroupStep1 newUnassignMappingFromGroupCommand() {
+    return new UnassignMappingFromGroupCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignMappingFromGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignMappingFromGroupStep1;
+import io.camunda.client.api.command.UnassignMappingFromGroupStep1.UnassignMappingFromGroupStep2;
 import io.camunda.client.api.response.UnassignMappingFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class UnassignMappingFromGroupCommandImpl implements UnassignMappingFromGroupStep1 {
+public class UnassignMappingFromGroupCommandImpl
+    implements UnassignMappingFromGroupStep1, UnassignMappingFromGroupStep2 {
 
-  private final String groupId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private String mappingId;
+  private String groupId;
 
-  public UnassignMappingFromGroupCommandImpl(final HttpClient httpClient, final String groupId) {
-    this.groupId = groupId;
+  public UnassignMappingFromGroupCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public UnassignMappingFromGroupStep1 mappingId(final String mappingId) {
+  public UnassignMappingFromGroupStep2 mappingId(final String mappingId) {
     this.mappingId = mappingId;
+    return this;
+  }
+
+  @Override
+  public UnassignMappingFromGroupStep2 groupId(final String groupId) {
+    this.groupId = groupId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
@@ -84,7 +84,12 @@ public class UnassignMemberGroupTest extends ClientRestTest {
   @Test
   void shouldUnassignMappingFromGroup() {
     // when
-    client.newUnassignMappingFromGroupCommand(GROUP_ID).mappingId(MAPPING_ID).send().join();
+    client
+        .newUnassignMappingFromGroupCommand()
+        .mappingId(MAPPING_ID)
+        .groupId(GROUP_ID)
+        .send()
+        .join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
@@ -101,8 +106,9 @@ public class UnassignMemberGroupTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignMappingFromGroupCommand(GROUP_ID)
+                    .newUnassignMappingFromGroupCommand()
                     .mappingId(MAPPING_ID)
+                    .groupId(GROUP_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -119,8 +125,9 @@ public class UnassignMemberGroupTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignMappingFromGroupCommand(GROUP_ID)
+                    .newUnassignMappingFromGroupCommand()
                     .mappingId(MAPPING_ID)
+                    .groupId(GROUP_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -137,11 +144,72 @@ public class UnassignMemberGroupTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignMappingFromGroupCommand(GROUP_ID)
+                    .newUnassignMappingFromGroupCommand()
                     .mappingId(MAPPING_ID)
+                    .groupId(GROUP_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullMappingId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(null)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyMappingId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId("")
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mappingId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullGroupId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(MAPPING_ID)
+                    .groupId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyGroupId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(MAPPING_ID)
+                    .groupId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be empty");
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignMappingFromGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignMappingFromGroupTest.java
@@ -63,7 +63,7 @@ public class UnassignMappingFromGroupTest {
   @Test
   void shouldUnassignMappingFromGroup() {
     // when
-    client.newUnassignMappingFromGroupCommand(groupId).mappingId(mappingId).send().join();
+    client.newUnassignMappingFromGroupCommand().mappingId(mappingId).groupId(groupId).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityUnassignedFromGroup(
@@ -83,8 +83,9 @@ public class UnassignMappingFromGroupTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignMappingFromGroupCommand(nonExistentGroupId)
+                    .newUnassignMappingFromGroupCommand()
                     .mappingId(mappingId)
+                    .groupId(nonExistentGroupId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -99,7 +100,12 @@ public class UnassignMappingFromGroupTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignMappingFromGroupCommand(null).mappingId(mappingId).send().join())
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(mappingId)
+                    .groupId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be null");
   }
@@ -108,7 +114,13 @@ public class UnassignMappingFromGroupTest {
   void shouldRejectIfEmptyGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignMappingFromGroupCommand("").mappingId(mappingId).send().join())
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(mappingId)
+                    .groupId("")
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be empty");
   }
@@ -118,7 +130,12 @@ public class UnassignMappingFromGroupTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignMappingFromGroupCommand("groupId").mappingId(null).send().join())
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId(null)
+                    .groupId(groupId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("mappingId must not be null");
   }
@@ -127,7 +144,13 @@ public class UnassignMappingFromGroupTest {
   void shouldRejectIfEmptyMappingId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignMappingFromGroupCommand("groupId").mappingId("").send().join())
+            () ->
+                client
+                    .newUnassignMappingFromGroupCommand()
+                    .mappingId("")
+                    .groupId(groupId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("mappingId must not be empty");
   }


### PR DESCRIPTION
## Description

Ensure `newUnassignMappingFromGroupCommand` is following the agreed pattern: 
`assignXToY().x("").y("")` (same applies to unassign)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32503
