### PR TITLE
Refactoring `newUnassignUserFromGroupCommand` to follow the agreed client command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1566,8 +1566,9 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    *
    * camundaClient
-   *  .newUnassignUserFromGroupCommand("groupId")
+   *  .newUnassignUserFromGroupCommand()
    *  .username("username")
+   *  .groupId("groupId")
    *  .send();
    * </pre>
    *
@@ -1575,7 +1576,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  UnassignUserFromGroupCommandStep1 newUnassignUserFromGroupCommand(String groupId);
+  UnassignUserFromGroupCommandStep1 newUnassignUserFromGroupCommand();
 
   /**
    * Command to create a user.

--- a/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UnassignUserFromGroupCommandStep1.java
@@ -17,15 +17,26 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UnassignUserFromGroupResponse;
 
-public interface UnassignUserFromGroupCommandStep1
-    extends FinalCommandStep<UnassignUserFromGroupResponse> {
+public interface UnassignUserFromGroupCommandStep1 {
 
   /**
    * Sets the username for the unassignment.
    *
    * @param username the username of the user
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  UnassignUserFromGroupCommandStep1 username(String username);
+  UnassignUserFromGroupCommandStep2 username(String username);
+
+  interface UnassignUserFromGroupCommandStep2
+      extends FinalCommandStep<UnassignUserFromGroupResponse> {
+
+    /**
+     * Sets the group ID for the unassignment.
+     *
+     * @param groupId the groupId of the group
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UnassignUserFromGroupCommandStep2 groupId(String groupId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -956,8 +956,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UnassignUserFromGroupCommandStep1 newUnassignUserFromGroupCommand(final String groupId) {
-    return new UnassignUserFromGroupCommandImpl(groupId, httpClient);
+  public UnassignUserFromGroupCommandStep1 newUnassignUserFromGroupCommand() {
+    return new UnassignUserFromGroupCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignUserFromGroupCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1;
+import io.camunda.client.api.command.UnassignUserFromGroupCommandStep1.UnassignUserFromGroupCommandStep2;
 import io.camunda.client.api.response.UnassignUserFromGroupResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class UnassignUserFromGroupCommandImpl implements UnassignUserFromGroupCommandStep1 {
+public class UnassignUserFromGroupCommandImpl
+    implements UnassignUserFromGroupCommandStep1, UnassignUserFromGroupCommandStep2 {
 
-  private final String groupId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private String username;
+  private String groupId;
 
-  public UnassignUserFromGroupCommandImpl(final String groupId, final HttpClient httpClient) {
-    this.groupId = groupId;
+  public UnassignUserFromGroupCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public UnassignUserFromGroupCommandStep1 username(final String username) {
+  public UnassignUserFromGroupCommandStep2 username(final String username) {
     this.username = username;
+    return this;
+  }
+
+  @Override
+  public UnassignUserFromGroupCommandStep2 groupId(final String groupId) {
+    this.groupId = groupId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
@@ -35,7 +35,7 @@ public class UnassignMemberGroupTest extends ClientRestTest {
   @Test
   void shouldUnassignUserFromGroup() {
     // when
-    client.newUnassignUserFromGroupCommand(GROUP_ID).username(USERNAME).send().join();
+    client.newUnassignUserFromGroupCommand().username(USERNAME).groupId(GROUP_ID).send().join();
 
     // then
     final LoggedRequest request = RestGatewayService.getLastRequest();
@@ -50,9 +50,75 @@ public class UnassignMemberGroupTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignUserFromGroupCommand(GROUP_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username(USERNAME)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullUsername() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username(null)
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyUsername() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username("")
+                    .groupId(GROUP_ID)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("username must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullGroupId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username(USERNAME)
+                    .groupId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyGroupId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username(USERNAME)
+                    .groupId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("groupId must not be empty");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/client/group/UnassignMemberGroupTest.java
@@ -260,34 +260,4 @@ public class UnassignMemberGroupTest extends ClientRestTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("mappingId must not be empty");
   }
-
-  @Test
-  void shouldRaiseExceptionOnNullGroupId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignMappingFromGroupCommand()
-                    .mappingId(MAPPING_ID)
-                    .groupId(null)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("groupId must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionOnEmptyGroupId() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignMappingFromGroupCommand()
-                    .mappingId(MAPPING_ID)
-                    .groupId("")
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("groupId must not be empty");
-  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
@@ -62,7 +62,7 @@ public class UnassignUserFromGroupTest {
   @Test
   void shouldUnassignUserFromGroup() {
     // when
-    client.newUnassignUserFromGroupCommand(groupId).username(username).send().join();
+    client.newUnassignUserFromGroupCommand().username(username).groupId(groupId).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityUnassignedFromGroup(
@@ -82,8 +82,9 @@ public class UnassignUserFromGroupTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignUserFromGroupCommand(nonExistentGroupId)
+                    .newUnassignUserFromGroupCommand()
                     .username(username)
+                    .groupId(nonExistentGroupId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -97,7 +98,13 @@ public class UnassignUserFromGroupTest {
   void shouldRejectIfMissingGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignUserFromGroupCommand(null).username("username").send().join())
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username("username")
+                    .groupId(null)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be null");
   }
@@ -106,7 +113,13 @@ public class UnassignUserFromGroupTest {
   void shouldRejectIfEmptyGroupId() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignUserFromGroupCommand("").username("username").send().join())
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username("username")
+                    .groupId("")
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("groupId must not be empty");
   }
@@ -115,7 +128,13 @@ public class UnassignUserFromGroupTest {
   void shouldRejectIfMissingUsername() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignUserFromGroupCommand("groupId").username(null).send().join())
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username(null)
+                    .groupId(groupId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("username must not be null");
   }
@@ -124,7 +143,13 @@ public class UnassignUserFromGroupTest {
   void shouldRejectIfEmptyUsername() {
     // when / then
     assertThatThrownBy(
-            () -> client.newUnassignUserFromGroupCommand("groupId").username("").send().join())
+            () ->
+                client
+                    .newUnassignUserFromGroupCommand()
+                    .username("")
+                    .groupId(groupId)
+                    .send()
+                    .join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("username must not be empty");
   }


### PR DESCRIPTION
## Description

Ensure `newUnassignUserFromGroupCommand` is following the agreed pattern: 
`assignXToY().x("").y("")` (same applies to unassign)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32504
