### PR TITLE
fix: add legacy credentials-cache-path to mapped properties

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/camunda-client-legacy-property-mappings.properties
@@ -44,4 +44,4 @@ camunda.client.auth.client-secret=zeebe.client.cloud.client-secret, zeebe.client
 camunda.client.auth.audience=camunda.client.zeebe.audience, zeebe.client.cloud.audience
 camunda.client.auth.scope=camunda.client.zeebe.scope, zeebe.client.cloud.scope, zeebe.token.scope
 camunda.client.auth.token-url=camunda.client.auth.issuer, zeebe.client.cloud.auth-url, zeebe.authorization.server.url
-camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path
+camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path, zeebe.client.config.path


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the legacy property for the `camunda.client.auth.credentials-cache-path` to the mapped properties

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33120 
