### PR TITLE
[Backport stable/8.7] fix: add legacy credentials-cache-path to mapped properties

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/zeebe-client-legacy-property-mappings.properties
@@ -35,4 +35,4 @@ camunda.client.auth.client-secret=zeebe.client.cloud.client-secret, zeebe.client
 camunda.client.auth.audience=camunda.client.zeebe.audience, zeebe.client.cloud.audience
 camunda.client.auth.scope=camunda.client.zeebe.scope, zeebe.client.cloud.scope, zeebe.token.scope
 camunda.client.auth.token-url=camunda.client.auth.issuer, zeebe.client.cloud.auth-url, zeebe.authorization.server.url
-camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path
+camunda.client.auth.credentials-cache-path=zeebe.client.cloud.credentials-cache-path, zeebe.client.config.path


### PR DESCRIPTION
# Description
Backport of #33121 to `stable/8.7`.

relates to #33120