### PR TITLE
[Backport release-8.8.0-alpha5] fix: handle instance in new userReader where userId may be null when using M2M tokens

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -124,7 +124,7 @@ public class TaskController extends ApiErrorController {
         && !currentUser.getUserId().isEmpty()) {
       final List<String> listOfUserGroups = userGroupService.getUserGroups();
       if (!listOfUserGroups.contains(IdentityProperties.FULL_GROUP_ACCESS)) {
-        final String userName = userReader.getCurrentUserId();
+        final String userName = currentUser.getUserId();
         final TaskByCandidateUserOrGroup taskByCandidateUserOrGroup =
             new TaskByCandidateUserOrGroup();
         taskByCandidateUserOrGroup.setUserGroups(listOfUserGroups.toArray(String[]::new));

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -113,16 +113,18 @@ public class TaskController extends ApiErrorController {
     final var query =
         taskMapper.toTaskQuery(requireNonNullElse(searchRequest, new TaskSearchRequest()));
 
+    final var currentUser = userReader.getCurrentUser();
+
     if (tasklistProperties.getIdentity() != null
         && tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()
         // In the case of M2M tokens the userId is null, so we do not apply the user group
         // restrictions
         // this is backwards compatible with previous versions, but in the future this will change
-        && (userReader.getCurrentUser().getUserId() == null
-            || !userReader.getCurrentUser().getUserId().isEmpty())) {
+        && currentUser.getUserId() != null
+        && !currentUser.getUserId().isEmpty()) {
       final List<String> listOfUserGroups = userGroupService.getUserGroups();
       if (!listOfUserGroups.contains(IdentityProperties.FULL_GROUP_ACCESS)) {
-        final String userName = userReader.getCurrentUser().getUserId();
+        final String userName = userReader.getCurrentUserId();
         final TaskByCandidateUserOrGroup taskByCandidateUserOrGroup =
             new TaskByCandidateUserOrGroup();
         taskByCandidateUserOrGroup.setUserGroups(listOfUserGroups.toArray(String[]::new));
@@ -235,8 +237,8 @@ public class TaskController extends ApiErrorController {
   }
 
   private boolean hasAccessToTask(final LazySupplier<TaskDTO> taskSupplier) {
-    if (userReader.getCurrentUser().getUserId() == null
-        || userReader.getCurrentUser().getUserId().isEmpty()) {
+    final var currentUser = userReader.getCurrentUser();
+    if (currentUser.getUserId() == null || currentUser.getUserId().isEmpty()) {
       // In the case of M2M tokens the userId is null, so we do not apply the user group
       // restrictions
       // this is backwards compatible with previous versions, but in the future this will change

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -927,6 +927,7 @@ class TaskControllerTest {
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
       when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+      when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
       when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
@@ -968,6 +969,7 @@ class TaskControllerTest {
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
       when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+      when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
       when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
@@ -1001,6 +1003,7 @@ class TaskControllerTest {
       when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
       when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+      when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
       when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
       when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
       when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(false);
@@ -1053,6 +1056,7 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+        when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
         when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
@@ -1113,6 +1117,7 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+        when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
         when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
@@ -1177,6 +1182,7 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+        when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
         when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);
@@ -1217,6 +1223,7 @@ class TaskControllerTest {
         when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
         when(tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()).thenReturn(true);
         when(userReader.getCurrentUser()).thenReturn(mock(UserDTO.class));
+        when(userReader.getCurrentUser().getUserId()).thenReturn("demo");
         when(userReader.getCurrentUser().getDisplayName()).thenReturn("demo");
         when(userGroupService.getUserGroups()).thenReturn(List.of("Admins"));
         when(taskMapper.toTaskQuery(searchRequest)).thenReturn(searchQuery);


### PR DESCRIPTION
# Description
Backport of #33083 to `release-8.8.0-alpha5`.

relates to 