### PR TITLE
fix: use correct userId when applying groups

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -124,7 +124,7 @@ public class TaskController extends ApiErrorController {
         && !currentUser.getUserId().isEmpty()) {
       final List<String> listOfUserGroups = userGroupService.getUserGroups();
       if (!listOfUserGroups.contains(IdentityProperties.FULL_GROUP_ACCESS)) {
-        final String userName = userReader.getCurrentUserId();
+        final String userName = currentUser.getUserId();
         final TaskByCandidateUserOrGroup taskByCandidateUserOrGroup =
             new TaskByCandidateUserOrGroup();
         taskByCandidateUserOrGroup.setUserGroups(listOfUserGroups.toArray(String[]::new));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

`userReader.getCurrentUserId()` does not return the same/expected value here, the previous code used `final String userName = userReader.getCurrentUser().getUserId();` so the correct change here is to use `currentUser.getUserId()`
