### PR TITLE
feat: client token refresh logic

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -159,6 +159,11 @@
       <artifactId>spring-security-oauth2-jose</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/filters/OAuth2RefreshTokenFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OAuth2RefreshTokenFilter.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import io.camunda.authentication.config.WebSecurityConfig;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class OAuth2RefreshTokenFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OAuth2RefreshTokenFilter.class);
+
+  private final Duration clockSkew = Duration.ofSeconds(60L);
+  // Double clock skew is used to avoid falling into perpetual refresh loop
+  private final Duration doubleClockSkew = clockSkew.multipliedBy(2);
+  private final OAuth2AuthorizedClientRepository authorizedClientRepository;
+  private final OAuth2AuthorizedClientManager authorizedClientManager;
+  private final LogoutHandler logoutHandler;
+  private final Supplier<SecurityContext> securityContextSupplier;
+
+  public OAuth2RefreshTokenFilter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OAuth2AuthorizedClientManager authorizedClientManager) {
+    this(
+        authorizedClientRepository,
+        authorizedClientManager,
+        new CookieClearingLogoutHandler(WebSecurityConfig.SESSION_COOKIE),
+        SecurityContextHolder::getContext);
+  }
+
+  // This constructor is for testing
+  public OAuth2RefreshTokenFilter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OAuth2AuthorizedClientManager authorizedClientManager,
+      final LogoutHandler logoutHandler,
+      final Supplier<SecurityContext> securityContextSupplier) {
+    this.authorizedClientRepository = authorizedClientRepository;
+    this.authorizedClientManager = authorizedClientManager;
+    this.logoutHandler = logoutHandler;
+    this.securityContextSupplier = securityContextSupplier;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+
+    final var authenticationToken = getAuthenticationToken();
+
+    // Continue if it's not OAuth2 authentication
+    if (authenticationToken == null) {
+      LOG.debug("No OAuth2 authentication found in request");
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    final var authorizedClient = getAuthorizedClient(authenticationToken, request);
+    if (authorizedClient == null) {
+      logoutAndThrowAuthenticationException(
+          request,
+          response,
+          authenticationToken,
+          "unauthorized_client",
+          "No client could be authorized");
+    }
+
+    if (!hasTokenExpired(authorizedClient)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    if (!existsRefreshToken(authorizedClient)) {
+      logoutAndThrowAuthenticationException(
+          request,
+          response,
+          authenticationToken,
+          "access_token_expired",
+          "Access token expired, refresh token does not exist");
+    }
+
+    OAuth2AuthorizedClient refreshedAuthorizedClient = null;
+    try {
+      refreshedAuthorizedClient = refreshAccessToken(authenticationToken, authorizedClient);
+
+      if (refreshedAuthorizedClient == null) {
+        throw new OAuth2AuthenticationException("Failed to refresh access token");
+      }
+
+      // If the refreshed client is the same as the original one, it means
+      // re-authorization is not supported for the client OR is not required,
+      // e.g. a refresh token is not available OR the access token is not expired.
+      // @see OAuth2AuthorizedClientManager#authorize(OAuth2AuthorizeRequest)
+      if (refreshedAuthorizedClient == authorizedClient) {
+        throw new OAuth2AuthenticationException(
+            "Re-authorization is not supported or not required for the client");
+      }
+
+    } catch (final OAuth2AuthenticationException e) {
+      logoutAndThrowAuthenticationException(
+          request, response, authenticationToken, "refresh_token_failed", e);
+    }
+
+    if (refreshedAuthorizedClient == null || hasTokenExpired(refreshedAuthorizedClient)) {
+      logoutAndThrowAuthenticationException(
+          request, response, authenticationToken, "access_token_expired", "Access token expired");
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  protected OAuth2AuthenticationToken getAuthenticationToken() {
+    final var authentication = securityContextSupplier.get().getAuthentication();
+    return authentication instanceof final OAuth2AuthenticationToken oauth2AuthenticationToken
+        ? oauth2AuthenticationToken
+        : null;
+  }
+
+  protected OAuth2AuthorizedClient getAuthorizedClient(
+      final OAuth2AuthenticationToken authenticationToken, final HttpServletRequest request) {
+    final var clientRegistrationId = authenticationToken.getAuthorizedClientRegistrationId();
+    return authorizedClientRepository.loadAuthorizedClient(
+        clientRegistrationId, authenticationToken, request);
+  }
+
+  protected boolean hasTokenExpired(final OAuth2AuthorizedClient authorizedClient) {
+    final var tokenExpired =
+        Optional.of(authorizedClient)
+            .map(OAuth2AuthorizedClient::getAccessToken)
+            .map(this::isExpired)
+            .orElse(false);
+
+    if (tokenExpired) {
+      LOG.debug("Token expired for {}", authorizedClient.getPrincipalName());
+    }
+
+    return tokenExpired;
+  }
+
+  protected boolean isExpired(final OAuth2AccessToken token) {
+    if (token.getExpiresAt() == null) {
+      return false; // Token does not expire
+    }
+
+    if (applyClockSkewToExpirationCheck(token)) {
+      return Instant.now().plus(clockSkew).isAfter(token.getExpiresAt());
+    }
+
+    return Instant.now().isAfter(token.getExpiresAt());
+  }
+
+  private boolean applyClockSkewToExpirationCheck(final OAuth2AccessToken token) {
+    if (token.getIssuedAt() == null || token.getExpiresAt() == null) {
+      return false;
+    }
+
+    // If token issuance duration is too short, we do not apply clock skew
+    // to avoid falling into perpetual refresh loop
+    final var tokenDuration = Duration.between(token.getIssuedAt(), token.getExpiresAt()).abs();
+    return tokenDuration.minus(doubleClockSkew).isPositive();
+  }
+
+  protected boolean existsRefreshToken(final OAuth2AuthorizedClient authorizedClient) {
+    return authorizedClient.getRefreshToken() != null;
+  }
+
+  protected OAuth2AuthorizedClient refreshAccessToken(
+      final OAuth2AuthenticationToken authenticationToken,
+      final OAuth2AuthorizedClient authorizedClient) {
+    final var authorizeRequest =
+        OAuth2AuthorizeRequest.withAuthorizedClient(authorizedClient)
+            .principal(authenticationToken)
+            .build();
+    return authorizedClientManager.authorize(authorizeRequest);
+  }
+
+  private void logoutAndThrowAuthenticationException(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final OAuth2AuthenticationToken authenticationToken,
+      final String reasonCode,
+      final String reasonMessage) {
+    forceLogout(authenticationToken, request, response);
+    throw new OAuth2AuthenticationException(new OAuth2Error(reasonCode), reasonMessage);
+  }
+
+  private void logoutAndThrowAuthenticationException(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final OAuth2AuthenticationToken authenticationToken,
+      final String reasonCode,
+      final Throwable e) {
+    forceLogout(authenticationToken, request, response);
+    throw new OAuth2AuthenticationException(new OAuth2Error(reasonCode), e);
+  }
+
+  private void forceLogout(
+      final OAuth2AuthenticationToken authenticationToken,
+      final HttpServletRequest request,
+      final HttpServletResponse response) {
+    authenticationToken.setAuthenticated(false);
+    logoutHandler.logout(request, response, authenticationToken);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
@@ -11,14 +11,16 @@ import static com.google.common.net.HttpHeaders.CONTENT_SECURITY_POLICY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import io.camunda.authentication.config.controllers.OidcMockMvcTestHelper;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import io.camunda.security.configuration.headers.ContentSecurityPolicyConfig;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 /** See {@link OidcWebSecurityConfigTest} for scope and limitations of this test class. */
@@ -41,6 +43,8 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
     })
 public class OidcSaaSWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
 
+  @Autowired private OAuth2AuthorizedClientRepository authorizedClientRepository;
+
   @ParameterizedTest
   @MethodSource("getAllDummyEndpoints")
   public void shouldAddSecurityHeadersOnAllApiAndWebappRequests(final String endpoint) {
@@ -50,7 +54,7 @@ public class OidcSaaSWebSecurityConfigTest extends AbstractWebSecurityConfigTest
         mockMvcTester
             .get()
             .uri("https://localhost" + endpoint)
-            .with(SecurityMockMvcRequestPostProcessors.oidcLogin())
+            .with(OidcMockMvcTestHelper.oidcLogin(authorizedClientRepository))
             .exchange();
 
     // then

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -12,17 +12,20 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import io.camunda.authentication.CamundaJwtAuthenticationConverter;
+import io.camunda.authentication.config.controllers.OidcMockMvcTestHelper;
 import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
@@ -72,6 +75,8 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
     })
 public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
 
+  @Autowired private OAuth2AuthorizedClientRepository authorizedClientRepository;
+
   @ParameterizedTest
   @MethodSource("getAllDummyEndpoints")
   public void shouldAddSecurityHeadersOnAllApiAndWebappRequests(final String endpoint) {
@@ -81,7 +86,7 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
         mockMvcTester
             .get()
             .uri("https://localhost" + endpoint)
-            .with(SecurityMockMvcRequestPostProcessors.oidcLogin())
+            .with(OidcMockMvcTestHelper.oidcLogin(authorizedClientRepository))
             .exchange();
 
     // then

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcMockMvcTestHelper.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcMockMvcTestHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config.controllers;
+
+import java.util.Iterator;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+public class OidcMockMvcTestHelper {
+
+  /**
+   * Extends {@link SecurityMockMvcRequestPostProcessors#oidcLogin()} by consistently registering
+   * the generated {@link OAuth2AuthorizedClient} in the provided {@link
+   * OAuth2AuthorizedClientRepository}.
+   *
+   * <p>{@link SecurityMockMvcRequestPostProcessors#oidcLogin()} creates an {@link
+   * OAuth2AuthorizedClient} in {@link
+   * org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.OAuth2ClientRequestPostProcessor#postProcessRequest(MockHttpServletRequest)}.
+   * This client is registered in an instance of <code>
+   * org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.OAuth2ClientRequestPostProcessor.TestOAuth2AuthorizedClientRepository
+   * </code>, which is supposed to be a wrapper around the actual {@link
+   * OAuth2AuthorizedClientRepository} under test and which stores the authorized client in a
+   * request attribute of the mock http request. However, the wrapper is not properly registered in
+   * the application context, meaning that other beans that depend on {@link
+   * OAuth2AuthorizedClientRepository} do not get the wrapper injected and accordingly are not able
+   * to access the authorized client object. This class here extends this procedure by also
+   * registering this test object in a provided instance of {@link
+   * OAuth2AuthorizedClientRepository}.
+   *
+   * <p>Since {@link SecurityMockMvcRequestPostProcessors#oidcLogin()} doesn't expose the objects it
+   * creates, we have to access it in a fairly hacky way, see implementation.
+   */
+  public static RequestPostProcessor oidcLogin(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository) {
+    return (request) -> {
+      request = SecurityMockMvcRequestPostProcessors.oidcLogin().postProcessRequest(request);
+
+      final OAuth2AuthorizedClient client = findAuthorizedClientInRequestAttributes(request);
+      authorizedClientRepository.saveAuthorizedClient(
+          client, null, request, new MockHttpServletResponse());
+
+      return request;
+    };
+  }
+
+  private static OAuth2AuthorizedClient findAuthorizedClientInRequestAttributes(
+      final MockHttpServletRequest request) {
+    final Iterator<String> attributeIterator = request.getAttributeNames().asIterator();
+
+    OAuth2AuthorizedClient client = null;
+
+    while (attributeIterator.hasNext()) {
+      final String attributeName = attributeIterator.next();
+      final Object attribute = request.getAttribute(attributeName);
+
+      if (attribute instanceof OAuth2AuthorizedClient) {
+        if (client == null) {
+          client = (OAuth2AuthorizedClient) attribute;
+
+        } else {
+          throw new RuntimeException(
+              "Multiple OAuth2AuthorizedClient objects in request attributes found");
+        }
+      }
+    }
+
+    if (client == null) {
+      throw new RuntimeException("No OAuth2AuthorizedClient in request attributes found");
+    }
+    return client;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/filters/OAuth2RefreshTokenFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OAuth2RefreshTokenFilterTest.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2RefreshTokenFilterTest {
+  private static final String CLIENT_REGISTRATION_ID = "test-client";
+  private static final String PRINCIPAL_NAME = "test-user";
+  private static final String ACCESS_TOKEN_VALUE = "access-token-123";
+  private static final String REFRESH_TOKEN_VALUE = "refresh-token-456";
+
+  @Mock(strictness = Strictness.LENIENT)
+  private OAuth2AuthorizedClientRepository authorizedClientRepository;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private OAuth2AuthorizedClientManager authorizedClientManager;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private LogoutHandler logoutHandler;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private Supplier<SecurityContext> securityContextSupplier;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private SecurityContext securityContext;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private HttpServletRequest request;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private HttpServletResponse response;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private FilterChain filterChain;
+
+  private OAuth2RefreshTokenFilter filter;
+  private ClientRegistration clientRegistration;
+  private OAuth2User oauth2User;
+  private OAuth2AuthenticationToken authenticationToken;
+
+  @BeforeEach
+  void setUp() {
+    filter =
+        new OAuth2RefreshTokenFilter(
+            authorizedClientRepository,
+            authorizedClientManager,
+            logoutHandler,
+            securityContextSupplier);
+
+    clientRegistration =
+        ClientRegistration.withRegistrationId(CLIENT_REGISTRATION_ID)
+            .clientId("client-id")
+            .clientSecret("client-secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("http://localhost:8080/sso-callback")
+            .authorizationUri("http://localhost:18080/oauth/authorize")
+            .tokenUri("http://localhost:18080/oauth/token")
+            .build();
+
+    oauth2User =
+        new DefaultOAuth2User(
+            Set.of(() -> "USER"),
+            java.util.Map.of("sub", PRINCIPAL_NAME, "name", "Test User"),
+            "sub");
+
+    authenticationToken =
+        new OAuth2AuthenticationToken(oauth2User, Set.of(() -> "USER"), CLIENT_REGISTRATION_ID);
+
+    when(securityContextSupplier.get()).thenReturn(securityContext);
+  }
+
+  @Test
+  void shouldContinueFilterChainWhenNotOAuth2Authentication() throws ServletException, IOException {
+    // Given
+    when(securityContext.getAuthentication()).thenReturn(null);
+
+    // When
+    filter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(filterChain).doFilter(request, response);
+    verify(authorizedClientRepository, never()).loadAuthorizedClient(any(), any(), any());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenNoAuthorizedClientFound() {
+    // Given
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(null);
+
+    // When & Then
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("No client could be authorized");
+
+    assertThat(authenticationToken.isAuthenticated()).isFalse();
+    verify(logoutHandler).logout(request, response, authenticationToken);
+  }
+
+  @Test
+  void shouldContinueFilterChainWhenTokenNotExpired() throws ServletException, IOException {
+    // Given
+    final OAuth2AuthorizedClient authorizedClient = createValidAuthorizedClient();
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(authorizedClient);
+
+    // When
+    filter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(filterChain).doFilter(request, response);
+    verify(authorizedClientManager, never()).authorize(any());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenTokenExpiredAndNoRefreshToken() {
+    // Given
+    final OAuth2AuthorizedClient authorizedClient =
+        createExpiredAuthorizedClientWithoutRefreshToken();
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(authorizedClient);
+
+    // When & Then
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("Access token expired, refresh token does not exist");
+
+    assertThat(authenticationToken.isAuthenticated()).isFalse();
+    verify(logoutHandler).logout(request, response, authenticationToken);
+  }
+
+  @Test
+  void shouldRefreshTokenSuccessfullyWhenExpiredButRefreshTokenExists()
+      throws ServletException, IOException {
+    // Given
+    final OAuth2AuthorizedClient expiredClient = createExpiredAuthorizedClientWithRefreshToken();
+    final OAuth2AuthorizedClient refreshedClient = createValidAuthorizedClient();
+
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(expiredClient);
+    when(authorizedClientManager.authorize(any(OAuth2AuthorizeRequest.class)))
+        .thenReturn(refreshedClient);
+
+    // When
+    filter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    verify(filterChain).doFilter(request, response);
+    verify(authorizedClientManager).authorize(any(OAuth2AuthorizeRequest.class));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenRefreshReturnsSameClient() {
+    // Given
+    final OAuth2AuthorizedClient expiredClient = createExpiredAuthorizedClientWithRefreshToken();
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(expiredClient);
+    when(authorizedClientManager.authorize(any(OAuth2AuthorizeRequest.class)))
+        .thenReturn(expiredClient);
+
+    // When & Then
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(OAuth2AuthenticationException.class);
+
+    assertThat(authenticationToken.isAuthenticated()).isFalse();
+    verify(logoutHandler).logout(request, response, authenticationToken);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenRefreshFails() {
+    // Given
+    final OAuth2AuthorizedClient expiredClient = createExpiredAuthorizedClientWithRefreshToken();
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(expiredClient);
+    when(authorizedClientManager.authorize(any(OAuth2AuthorizeRequest.class)))
+        .thenThrow(new OAuth2AuthenticationException(new OAuth2Error("invalid_grant")));
+
+    // When & Then
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(OAuth2AuthenticationException.class);
+
+    assertThat(authenticationToken.isAuthenticated()).isFalse();
+    verify(logoutHandler).logout(request, response, authenticationToken);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenRefreshedTokenIsExpired() {
+    // Given
+    final OAuth2AuthorizedClient expiredClient = createExpiredAuthorizedClientWithRefreshToken();
+    final OAuth2AuthorizedClient stillExpiredClient =
+        createExpiredAuthorizedClientWithRefreshToken();
+
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(expiredClient);
+    when(authorizedClientManager.authorize(any(OAuth2AuthorizeRequest.class)))
+        .thenReturn(stillExpiredClient);
+
+    // When & Then
+    assertThatThrownBy(() -> filter.doFilterInternal(request, response, filterChain))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessageContaining("Access token expired");
+
+    assertThat(authenticationToken.isAuthenticated()).isFalse();
+    verify(logoutHandler).logout(request, response, authenticationToken);
+  }
+
+  @Test
+  void shouldReturnNullForNonOAuth2AuthenticationToken() throws ServletException, IOException {
+    // Given
+    final Authentication nonOAuth2Auth =
+        new Authentication() {
+          @Override
+          public Collection<? extends GrantedAuthority> getAuthorities() {
+            return List.of();
+          }
+
+          @Override
+          public Object getCredentials() {
+            return null;
+          }
+
+          @Override
+          public Object getDetails() {
+            return null;
+          }
+
+          @Override
+          public Object getPrincipal() {
+            return null;
+          }
+
+          @Override
+          public boolean isAuthenticated() {
+            return false;
+          }
+
+          @Override
+          public void setAuthenticated(final boolean isAuthenticated)
+              throws IllegalArgumentException {}
+
+          @Override
+          public String getName() {
+            return "";
+          }
+        };
+
+    when(securityContext.getAuthentication()).thenReturn(nonOAuth2Auth);
+
+    // When
+    filter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    assertThat(filter.getAuthenticationToken()).isNull();
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldDetectExpiredToken() {
+    // Given
+    final OAuth2AuthorizedClient expiredClient = createExpiredAuthorizedClientWithRefreshToken();
+    final OAuth2AuthorizedClient validClient = createValidAuthorizedClient();
+
+    // When & Then
+    assertThat(filter.hasTokenExpired(expiredClient)).isTrue();
+    assertThat(filter.hasTokenExpired(validClient)).isFalse();
+  }
+
+  @Test
+  void shouldDetectRefreshToken() {
+    // Given
+    final OAuth2AuthorizedClient clientWithRefreshToken =
+        createExpiredAuthorizedClientWithRefreshToken();
+    final OAuth2AuthorizedClient clientWithoutRefreshToken =
+        createExpiredAuthorizedClientWithoutRefreshToken();
+
+    // When & Then
+    assertThat(filter.existsRefreshToken(clientWithRefreshToken)).isTrue();
+    assertThat(filter.existsRefreshToken(clientWithoutRefreshToken)).isFalse();
+  }
+
+  @Test
+  void shouldCheckExpirationWithClockSkew() {
+    final var now = Instant.now();
+    // Given
+    final OAuth2AccessToken expiredAlready =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(5, ChronoUnit.MINUTES),
+            now.plus(30, ChronoUnit.SECONDS),
+            Set.of("read", "write"));
+
+    final OAuth2AccessToken notExpired =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(5, ChronoUnit.MINUTES),
+            now.plus(90, ChronoUnit.SECONDS),
+            Set.of("read", "write"));
+
+    // When & Then
+    assertThat(filter.isExpired(expiredAlready)).isTrue();
+    assertThat(filter.isExpired(notExpired)).isFalse();
+  }
+
+  @Test
+  void shouldCheckExpirationWithoutClockSkew() {
+    final var now = Instant.now();
+    // Given
+    final OAuth2AccessToken notExpired =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(5, ChronoUnit.SECONDS),
+            now.plus(30, ChronoUnit.SECONDS),
+            Set.of("read", "write"));
+
+    final OAuth2AccessToken expired =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(5, ChronoUnit.SECONDS),
+            now.minus(1, ChronoUnit.SECONDS),
+            Set.of("read", "write"));
+
+    // When & Then
+    assertThat(filter.isExpired(notExpired)).isFalse();
+    assertThat(filter.isExpired(expired)).isTrue();
+  }
+
+  @Test
+  void shouldHandleNullTokenExpiration() throws ServletException, IOException {
+    // Given
+    final OAuth2AccessToken tokenWithoutExpiration =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            Instant.now(),
+            null,
+            Set.of("read"));
+
+    final OAuth2AuthorizedClient clientWithNullExpiration =
+        new OAuth2AuthorizedClient(
+            clientRegistration, PRINCIPAL_NAME, tokenWithoutExpiration, null);
+
+    when(securityContext.getAuthentication()).thenReturn(authenticationToken);
+    when(authorizedClientRepository.loadAuthorizedClient(
+            eq(CLIENT_REGISTRATION_ID), eq(authenticationToken), any()))
+        .thenReturn(clientWithNullExpiration);
+
+    // When
+    filter.doFilterInternal(request, response, filterChain);
+
+    // Then
+    assertThat(filter.hasTokenExpired(clientWithNullExpiration)).isFalse();
+    verify(filterChain).doFilter(request, response);
+  }
+
+  private OAuth2AuthorizedClient createValidAuthorizedClient() {
+    final var now = Instant.now();
+    final OAuth2AccessToken accessToken =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now,
+            now.plus(1, ChronoUnit.HOURS),
+            Set.of("read", "write"));
+
+    final OAuth2RefreshToken refreshToken =
+        new OAuth2RefreshToken(REFRESH_TOKEN_VALUE, now, now.plus(30, ChronoUnit.DAYS));
+
+    return new OAuth2AuthorizedClient(
+        clientRegistration, PRINCIPAL_NAME, accessToken, refreshToken);
+  }
+
+  private OAuth2AuthorizedClient createExpiredAuthorizedClientWithRefreshToken() {
+    final var now = Instant.now();
+    final OAuth2AccessToken expiredAccessToken =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(2, ChronoUnit.HOURS),
+            now.minus(1, ChronoUnit.HOURS),
+            Set.of("read", "write"));
+
+    final OAuth2RefreshToken refreshToken =
+        new OAuth2RefreshToken(
+            REFRESH_TOKEN_VALUE, now.minus(2, ChronoUnit.HOURS), now.plus(30, ChronoUnit.DAYS));
+
+    return new OAuth2AuthorizedClient(
+        clientRegistration, PRINCIPAL_NAME, expiredAccessToken, refreshToken);
+  }
+
+  private OAuth2AuthorizedClient createExpiredAuthorizedClientWithoutRefreshToken() {
+    final var now = Instant.now();
+    final OAuth2AccessToken expiredAccessToken =
+        new OAuth2AccessToken(
+            OAuth2AccessToken.TokenType.BEARER,
+            ACCESS_TOKEN_VALUE,
+            now.minus(2, ChronoUnit.HOURS),
+            now.minus(1, ChronoUnit.HOURS),
+            Set.of("read", "write"));
+
+    return new OAuth2AuthorizedClient(clientRegistration, PRINCIPAL_NAME, expiredAccessToken, null);
+  }
+}


### PR DESCRIPTION
## Description

feat: session refresh logic

This PR covers 2 topics: 
- Access token refresh logic: attempt to re-authorize client if they have refresh token
- Persistent authorized client logic: if activated, persist authorized clients into DB (ES or OS), similar what we have for web session

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to: https://github.com/camunda/camunda/issues/26802
