### PR TITLE
Identity migration app can migrate groups from old Identity to the orchestration cluster

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
@@ -39,8 +39,9 @@ public class AuthorizationMigrationHandler extends MigrationHandler<UserResource
     this.authorizationService = authorizationService.withAuthentication(authentication);
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<UserResourceAuthorization> fetchBatch() {
+  protected List<UserResourceAuthorization> fetchBatch(final int page) {
     return managementIdentityClient.fetchUserResourceAuthorizations(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -35,8 +35,8 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   }
 
   @Override
-  protected List<Group> fetchBatch() {
-    return managementIdentityClient.fetchGroups(SIZE);
+  protected List<Group> fetchBatch(final int page) {
+    return managementIdentityClient.fetchGroups(page);
   }
 
   @Override

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -8,9 +8,7 @@
 package io.camunda.migration.identity;
 
 import io.camunda.migration.identity.dto.Group;
-import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.GroupServices.GroupDTO;
@@ -47,8 +45,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
       groupServices.createGroup(groupDTO);
     } catch (final Exception e) {
       if (!isConflictError(e)) {
-        throw new RuntimeException(
-            "Failed to migrate group with ID: " + group.id(), e);
+        throw new RuntimeException("Failed to migrate group with ID: " + group.id(), e);
       }
     }
   }
@@ -57,7 +54,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   // For SaaS the group ID is derived from the group name, because in the old identity
   // management system the group ID was generated internally.
   private String normalizeGroupID(final Group group) {
-    if (group.id() == null || group.id().isEmpty()) {
+    if (group.name() == null || group.name().isEmpty()) {
       return group.id();
     }
     final String groupName = group.name();

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -46,7 +46,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
 
   private MigrationStatusUpdateRequest processTask(final Group group) {
     try {
-      final var groupDTO = new GroupDTO(normalizeGroupID(group.name()), group.name(), "");
+      final var groupDTO = new GroupDTO(normalizeGroupID(group), group.name(), "");
       groupServices.createGroup(groupDTO);
     } catch (final Exception e) {
       if (!isConflictError(e)) {
@@ -59,11 +59,18 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
   // Normalizes the group ID to ensure it meets the requirements for a valid group ID.
   // For SaaS the group ID is derived from the group name, because in the old identity
   // management system the group ID was generated internally.
-  private String normalizeGroupID(final String groupName) {
-    var normalizedId = groupName.toLowerCase();
+  private String normalizeGroupID(final Group group) {
+    if (group.id() == null || group.id().isEmpty()) {
+      return group.id();
+    }
+    final String groupName = group.name();
+
+    String normalizedId =
+        groupName.toLowerCase().replaceAll("[^a-z0-9_@.-]", "_"); // Replace disallowed characters
+
     if (normalizedId.length() > 256) {
       normalizedId = normalizedId.substring(0, 256);
     }
-    return normalizedId.replaceAll("[^a-zA-Z0-9_@.-]+", "_");
+    return normalizedId;
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -64,6 +64,6 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
     if (normalizedId.length() > 256) {
       normalizedId = normalizedId.substring(0, 256);
     }
-    return normalizedId.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+    return normalizedId.replaceAll("[^a-zA-Z0-9_@.-]+", "_");
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationHandler.java
@@ -31,14 +31,16 @@ public abstract class MigrationHandler<T> {
   public void migrate() {
     logger.info("Migrating started.");
     List<T> batch;
+    int page = 0;
     do {
-      batch = fetchBatch();
+      batch = fetchBatch(page);
       process(batch);
+      page++;
     } while (!batch.isEmpty());
     logger.info("Migrating finished.");
   }
 
-  protected abstract List<T> fetchBatch();
+  protected abstract List<T> fetchBatch(int page);
 
   protected abstract void process(List<T> batch);
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
@@ -39,8 +39,9 @@ public class RoleMigrationHandler extends MigrationHandler<Role> {
     this.managementIdentityTransformer = managementIdentityTransformer;
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<Role> fetchBatch() {
+  protected List<Role> fetchBatch(final int page) {
     return managementIdentityClient.fetchRoles(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
@@ -42,8 +42,9 @@ public class TenantMappingRuleMigrationHandler extends MigrationHandler<TenantMa
     this.mappingServices = mappingServices.withAuthentication(authentication);
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<TenantMappingRule> fetchBatch() {
+  protected List<TenantMappingRule> fetchBatch(final int page) {
     return managementIdentityClient.fetchTenantMappingRules(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -34,8 +34,9 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
     this.tenantServices = tenantServices.withAuthentication(authentication);
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<Tenant> fetchBatch() {
+  protected List<Tenant> fetchBatch(final int page) {
     return managementIdentityClient.fetchTenants(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
@@ -40,8 +40,9 @@ public class UserTenantsMigrationHandler extends MigrationHandler<UserTenants> {
     this.mappingServices = mappingServices;
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<UserTenants> fetchBatch() {
+  protected List<UserTenants> fetchBatch(final int page) {
     return managementIdentityClient.fetchUserTenants(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UsersGroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UsersGroupMigrationHandler.java
@@ -40,8 +40,9 @@ public class UsersGroupMigrationHandler extends MigrationHandler<UserGroups> {
     this.mappingServices = mappingServices;
   }
 
+  // TODO: this will be revisited
   @Override
-  protected List<UserGroups> fetchBatch() {
+  protected List<UserGroups> fetchBatch(final int page) {
     return managementIdentityClient.fetchUserGroups(SIZE);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -35,8 +35,7 @@ public class ManagementIdentityClient {
       "/api/migration/tenant/user?" + URL_PARAMS;
   private static final String MIGRATION_MAPPING_RULE_ENDPOINT =
       "/api/migration/mapping-rule?" + URL_PARAMS + "&type={1}";
-  private static final String MIGRATION_GROUPS_ENDPOINT =
-      "/api/group?page={0}&organizationId={1}";
+  private static final String MIGRATION_GROUPS_ENDPOINT = "/api/group?page={0}&organizationId={1}";
   private static final String MIGRATION_USER_GROUP_ENDPOINT =
       "/api/migration/group/user?" + URL_PARAMS;
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -36,7 +36,7 @@ public class ManagementIdentityClient {
   private static final String MIGRATION_MAPPING_RULE_ENDPOINT =
       "/api/migration/mapping-rule?" + URL_PARAMS + "&type={1}";
   private static final String MIGRATION_GROUPS_ENDPOINT =
-      "/api/migration/group?" + URL_PARAMS + "&organizationId={1}";
+      "/api/group?page={0}&organizationId={1}";
   private static final String MIGRATION_USER_GROUP_ENDPOINT =
       "/api/migration/group/user?" + URL_PARAMS;
 
@@ -80,11 +80,11 @@ public class ManagementIdentityClient {
         .toList();
   }
 
-  public List<Group> fetchGroups(final int pageSize) {
+  public List<Group> fetchGroups(final int page) {
     return Arrays.stream(
             Objects.requireNonNull(
                 restTemplate.getForObject(
-                    MIGRATION_GROUPS_ENDPOINT, Group[].class, pageSize, organizationId)))
+                    MIGRATION_GROUPS_ENDPOINT, Group[].class, page, organizationId)))
         .toList();
   }
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
@@ -23,6 +23,7 @@ import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
+import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -30,14 +31,12 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.NotImplementedException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@Disabled("https://github.com/camunda/camunda/issues/26973")
 @ExtendWith(MockitoExtension.class)
 public class GroupMigrationHandlerTest {
   private final ManagementIdentityClient managementIdentityClient;
@@ -83,7 +82,7 @@ public class GroupMigrationHandlerTest {
 
     // then
     verify(managementIdentityClient, times(2)).fetchGroups(anyInt());
-    verify(groupService, times(2)).createGroup(any());
+    verify(groupService, times(2)).createGroup(any(GroupDTO.class));
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
@@ -49,10 +49,7 @@ public class GroupMigrationHandlerTest {
     this.managementIdentityClient = managementIdentityClient;
     this.groupService = groupService;
     migrationHandler =
-        new GroupMigrationHandler(
-            Authentication.none(),
-            managementIdentityClient,
-            groupService);
+        new GroupMigrationHandler(Authentication.none(), managementIdentityClient, groupService);
   }
 
   @Test


### PR DESCRIPTION
## Description

Re-factor the already available handler to create new groups properly, following the ID validation present in the orchestration cluster.

## Related issues

closes #33045 
