### PR TITLE
Refactoring `newAssignMappingToTenantCommand` to follow the agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2014,18 +2014,18 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignMappingToTenantCommand(tenantId)
-   *   .mappingId(mappingId)
+   *   .newAssignMappingToTenantCommand()
+   *   .mappingId("mappingId")
+   *   .tenantId("tenantId")
    *   .send();
    * </pre>
    *
    * <p>This command sends an HTTP PUT request to assign the specified mapping rule to the given
    * tenant.
    *
-   * @param tenantId the unique identifier of the tenant
    * @return a builder for the assign mapping rule to tenant command
    */
-  AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(String tenantId);
+  AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand();
 
   /**
    * Command to assign a user to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignMappingToTenantCommandStep1.java
@@ -18,15 +18,26 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.AssignMappingToTenantResponse;
 
 /** Command to assign a mapping to a tenant. */
-public interface AssignMappingToTenantCommandStep1
-    extends FinalCommandStep<AssignMappingToTenantResponse> {
+public interface AssignMappingToTenantCommandStep1 {
 
   /**
-   * Sets the mapping id for the assignment. Sets the mapping ID for the assignment.
+   * Sets the mapping id for the assignment.
    *
    * @param mappingId the id of the mapping
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  AssignMappingToTenantCommandStep1 mappingId(String mappingId);
+  AssignMappingToTenantCommandStep2 mappingId(String mappingId);
+
+  interface AssignMappingToTenantCommandStep2
+      extends FinalCommandStep<AssignMappingToTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the tenantId of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignMappingToTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1089,8 +1089,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(final String tenantId) {
-    return new AssignMappingToTenantCommandImpl(httpClient, tenantId);
+  public AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand() {
+    return new AssignMappingToTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignMappingToTenantCommandStep1;
+import io.camunda.client.api.command.AssignMappingToTenantCommandStep1.AssignMappingToTenantCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignMappingToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class AssignMappingToTenantCommandImpl implements AssignMappingToTenantCommandStep1 {
+public final class AssignMappingToTenantCommandImpl
+    implements AssignMappingToTenantCommandStep1, AssignMappingToTenantCommandStep2 {
 
-  private final String tenantId;
+  private String tenantId;
   private String mappingId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignMappingToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public AssignMappingToTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignMappingToTenantCommandStep1 mappingId(final String mappingId) {
+  public AssignMappingToTenantCommandStep2 mappingId(final String mappingId) {
     this.mappingId = mappingId;
+    return this;
+  }
+
+  @Override
+  public AssignMappingToTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
@@ -33,7 +33,12 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   @Test
   void shouldAssignMappingToTenant() {
     // when
-    client.newAssignMappingToTenantCommand(TENANT_ID).mappingId(MAPPING_ID).send().join();
+    client
+        .newAssignMappingToTenantCommand()
+        .mappingId(MAPPING_ID)
+        .tenantId(TENANT_ID)
+        .send()
+        .join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -52,8 +57,9 @@ public class AssignMappingToTenantTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_ID)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(MAPPING_ID)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -71,8 +77,9 @@ public class AssignMappingToTenantTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_ID)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(MAPPING_ID)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -90,8 +97,9 @@ public class AssignMappingToTenantTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_ID)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(MAPPING_ID)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -109,8 +117,9 @@ public class AssignMappingToTenantTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_ID)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(MAPPING_ID)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -62,7 +62,7 @@ class AssignMappingToTenantTest {
   @Test
   void shouldAssignMappingToTenant() {
     // When
-    client.newAssignMappingToTenantCommand(TENANT_ID).mappingId(ID).send().join();
+    client.newAssignMappingToTenantCommand().mappingId(ID).tenantId(TENANT_ID).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
@@ -83,8 +83,9 @@ class AssignMappingToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(invalidTenantId)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(mappingId)
+                    .tenantId(invalidTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -103,8 +104,9 @@ class AssignMappingToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_ID)
+                    .newAssignMappingToTenantCommand()
                     .mappingId(invalidMappingId)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -117,11 +119,17 @@ class AssignMappingToTenantTest {
   @Test
   void shouldRejectAssignIfTenantAlreadyAssignedToMapping() {
     // given
-    client.newAssignMappingToTenantCommand(TENANT_ID).mappingId(ID).send().join();
+    client.newAssignMappingToTenantCommand().mappingId(ID).tenantId(TENANT_ID).send().join();
 
     // When / Then
     assertThatThrownBy(
-            () -> client.newAssignMappingToTenantCommand(TENANT_ID).mappingId(ID).send().join())
+            () ->
+                client
+                    .newAssignMappingToTenantCommand()
+                    .mappingId(ID)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining(


### PR DESCRIPTION
## Description

Ensure `newAssignMappingToTenantCommand` is following the agreed pattern: `assignXToY().x("").y("")`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32506
