### PR TITLE
Refactoring `newAssignUserToTenantCommand` to follow agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2034,17 +2034,17 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignUserToTenantCommand(tenantId)
+   *   .newAssignUserToTenantCommand()
    *   .username(username)
+   *   .tenantId(tenantId)
    *   .send();
    * </pre>
    *
    * <p>This command sends an HTTP PUT request to assign the specified user to the given tenant.
    *
-   * @param tenantId the unique identifier of the tenant
    * @return a builder for the assign user to tenant command
    */
-  AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(String tenantId);
+  AssignUserToTenantCommandStep1 newAssignUserToTenantCommand();
 
   /**
    * Command to remove a user from a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
@@ -18,15 +18,24 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.AssignUserToTenantResponse;
 
 /** Command to assign a user to a tenant. */
-public interface AssignUserToTenantCommandStep1
-    extends FinalCommandStep<AssignUserToTenantResponse> {
+public interface AssignUserToTenantCommandStep1 {
 
   /**
    * Sets the user key for the assignment.
    *
    * @param username the unique identifier for the user
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  AssignUserToTenantCommandStep1 username(String username);
+  AssignUserToTenantCommandStep2 username(String username);
+
+  interface AssignUserToTenantCommandStep2 extends FinalCommandStep<AssignUserToTenantResponse> {
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the id of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    AssignUserToTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1094,8 +1094,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(final String tenantId) {
-    return new AssignUserToTenantCommandImpl(httpClient, tenantId);
+  public AssignUserToTenantCommandStep1 newAssignUserToTenantCommand() {
+    return new AssignUserToTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
+import io.camunda.client.api.command.AssignUserToTenantCommandStep1.AssignUserToTenantCommandStep2;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.response.AssignUserToTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCommandStep1 {
+public final class AssignUserToTenantCommandImpl
+    implements AssignUserToTenantCommandStep1, AssignUserToTenantCommandStep2 {
 
-  private final String tenantId;
+  private String tenantId;
   private String username;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignUserToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public AssignUserToTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignUserToTenantCommandStep1 username(final String username) {
+  public AssignUserToTenantCommandStep2 username(final String username) {
     this.username = username;
+    return this;
+  }
+
+  @Override
+  public AssignUserToTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
@@ -35,7 +35,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
   @Test
   void shouldAssignUserToTenant() {
     // when
-    client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join();
+    client.newAssignUserToTenantCommand().username(USER_NAME).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -54,7 +54,13 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
+            () ->
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(USER_NAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -68,7 +74,13 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
+            () ->
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(USER_NAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -82,7 +94,13 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
+            () ->
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(USER_NAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -96,7 +114,13 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
+            () ->
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(USER_NAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
@@ -125,7 +125,7 @@ public class OperateMultiTenancyIT {
         .join()
         .getTenantKey();
     for (final var username : usernames) {
-      client.newAssignUserToTenantCommand(tenantId).username(username).send().join();
+      client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).send().join();
     }
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/tenants/TasklistV1MultiTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tasklist/v1/tenants/TasklistV1MultiTenancyIT.java
@@ -93,11 +93,16 @@ public class TasklistV1MultiTenancyIT {
 
     // User ONE <-> Tenant ONE
     adminClient.newCreateTenantCommand().tenantId(TENANT_ID_1).name(TENANT_ID_1).send().join();
-    adminClient.newAssignUserToTenantCommand(TENANT_ID_1).username("demo").send().join();
+    adminClient.newAssignUserToTenantCommand().username("demo").tenantId(TENANT_ID_1).send().join();
 
     // User TWO <-> Tenant TWO
     adminClient.newCreateTenantCommand().tenantId(TENANT_ID_2).name(TENANT_ID_2).send().join();
-    adminClient.newAssignUserToTenantCommand(TENANT_ID_2).username(USERNAME_2).send().join();
+    adminClient
+        .newAssignUserToTenantCommand()
+        .username(USERNAME_2)
+        .tenantId(TENANT_ID_2)
+        .send()
+        .join();
 
     // deploy
     final var processTenant1 =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -64,7 +64,7 @@ class AssignUserToTenantTest {
   @Test
   void shouldAssignUserToTenant() {
     // When
-    client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newAssignUserToTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 
     // Then
     assertThat(
@@ -86,8 +86,9 @@ class AssignUserToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignUserToTenantCommand(invalidTenantId)
+                    .newAssignUserToTenantCommand()
                     .username(USERNAME)
+                    .tenantId(invalidTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -100,11 +101,17 @@ class AssignUserToTenantTest {
   @Test
   void shouldRejectAssignIfTenantAlreadyAssignedToUser() {
     // Given
-    client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newAssignUserToTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 
     // When / Then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join())
+            () ->
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(USERNAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -53,7 +53,7 @@ class RemoveUserFromTenantTest {
         .join();
 
     // Assign User to Tenant
-    client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newAssignUserToTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
@@ -1631,6 +1631,11 @@ public class MultiTenancyIT {
     Arrays.stream(usernames)
         .forEach(
             username ->
-                client.newAssignUserToTenantCommand(tenantId).username(username).send().join());
+                client
+                    .newAssignUserToTenantCommand()
+                    .username(username)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -109,7 +109,7 @@ public class AuthorizationsUtil implements CloseableSilently {
         .join()
         .getTenantKey();
     for (final var username : usernames) {
-      client.newAssignUserToTenantCommand(tenantId).username(username).send().join();
+      client.newAssignUserToTenantCommand().username(username).tenantId(tenantId).send().join();
     }
     awaitTenantExistsInElasticsearch(tenantId);
   }


### PR DESCRIPTION
## Description

Ensure `newAssignUserToTenantCommand` is following the agreed pattern: `assignXToY().x("").y("")`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32513
