### PR TITLE
docs: update c8run readme

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -1,58 +1,8 @@
-# C8 Run
+# Camunda 8 Run
 
-C8 Run is a packaged distribution of Camunda 8, which allows you to spin up Camunda 8 within seconds. It packages Camunda Core, ElasticSearch, and Connectors. The only prerequisite to run it, is to have a JDK 21+ installed locally.
+C8 Run is a packaged distribution of Camunda 8, which allows you to spin up Camunda 8 within seconds.
 
-C8 Run does not include Management Identity, Keycloak, or Optimize.
-
-Please see the [Camunda 8 Run Installation Guide](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/c8run/) for more details.
-
-## Installation
-
-To install C8 Run, go to the [Camunda Releases page](https://github.com/camunda/camunda/releases), and search for "c8run". Then download and extract the artifact for your distribution.
-
-![2024-09-24-144839_grim](https://github.com/user-attachments/assets/02f76946-fd43-4f92-8bad-6a3fa8f2e2f4)
-
-Once extracted, go to the extracted folder and run one of the following commands:
-
-## Linux / Mac Options
-
-```
-Usage: start.sh
-Options:
-  --detached   - Starts Camunda Run as a detached process
-```
-
-### Shutdown
-
-To stop c8run on Linux or Mac, run `./shutdown.sh`
-
-## Windows options
-
-```
-Usage: c8run.exe [start|stop] (options...)
-
-There are currently no options for windows, but we plan to add support for --config and --detached.
-```
-
-## Note about connectors
-
-Connectors is configured to run on port `8085`. Other camunda applications are expected to be accessible via `localhost:8080/<component>`.
-
-```
--------------------------------------------
-Access each component at the following urls:
-
-Operate:                     http://localhost:8080/operate
-Tasklist:                    http://localhost:8080/tasklist
-Zeebe Cluster Endpoint:      http://localhost:26500
-Inbound Connectors Endpoint: http://localhost:8085
-
-When using the Desktop Modeler, Authentication may be set to None.
-
-Refer to https://docs.camunda.io/docs/guides/getting-started-java-spring/ for help getting started with Camunda
-
--------------------------------------------
-```
+Please refer to the [local installation with Camunda 8 Run guide](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/c8run/) for further details.
 
 ## CI requirement for merging
 

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -2,7 +2,7 @@
 
 C8 Run is a packaged distribution of Camunda 8, which allows you to spin up Camunda 8 within seconds. It packages Camunda Core, ElasticSearch, and Connectors. The only prerequisite to run it, is to have a JDK 21+ installed locally.
 
-C8 Run does not include Identity, Keycloak, or Optimize.
+C8 Run does not include Management Identity, Keycloak, or Optimize.
 
 Please see the [Camunda 8 Run Installation Guide](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/c8run/) for more details.
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

* Updating the C8Run readme to highlight we refer to Management Identity.
* Remove other reference to have a single place of truth (the [public docs](https://docs.camunda.io/docs/next/self-managed/setup/deploy/local/c8run/))

Confusion was raised [by internal user](https://camunda.slack.com/archives/C03UR0V2R2M/p1749040604841469).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
