### PR TITLE
ci: publish GH releases with complete changelog automatically

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -252,6 +252,7 @@ jobs:
 
           # Default changelog value
           changelog="Release ${{ inputs.releaseVersion }}"
+          isDraftRelease="true"
 
           # Right now we only support patch releases for generating the changelog
           # as it is the easiest to automate and the most repetitive work to do on a release
@@ -284,6 +285,7 @@ jobs:
             --token=${{ secrets.GITHUB_TOKEN }} \
             --label="version:$ZCL_TARGET_REV" \
             --org camunda --repo zeebe)
+            isDraftRelease="false"
           fi
 
           # With multiline strings the output needs to be set differently.
@@ -295,6 +297,7 @@ jobs:
             echo "$changelog"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
+          echo "isDraftRelease=$isDraftRelease" >> "$GITHUB_OUTPUT"
 
           # To show the changelog also as step summary
           echo "$changelog" >> "$GITHUB_STEP_SUMMARY"
@@ -333,7 +336,7 @@ jobs:
           name: ${{ inputs.releaseVersion }}
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
-          draft: true
+          draft: ${{ steps.gen-changelog.outputs.isDraftRelease }}
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}


### PR DESCRIPTION
## Description

This PR is a quickfix improvement until https://github.com/camunda/camunda/issues/32376 is implemented fully: we discovered that historically, GH releases have been set to published only after the whole C8 release train is done since more artifacts needed to be added to the release.

This is not the case anymore so we can publish releases with complete changelogs automatically.

See https://github.com/camunda/zeebe-engineering-processes/pull/582 for releases with manual changelog generation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None