### PR TITLE
feat: enrich records appended by batch operation executions with `batchOperationKey` in record metadata

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -567,7 +567,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceRecordValue.builder()
                 .from((ImmutableProcessInstanceRecordValue) recordValueRecord.getValue())
@@ -590,7 +590,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceRecordValue.builder()
                 .from((ImmutableProcessInstanceRecordValue) recordValueRecord.getValue())
@@ -611,7 +611,7 @@ public class RecordFixtures {
         .withKey(incidentKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .build();
   }
 
@@ -626,7 +626,7 @@ public class RecordFixtures {
         .withKey(incidentKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .build();
   }
 
@@ -641,7 +641,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceMigrationRecordValue.builder()
                 .from((ImmutableProcessInstanceMigrationRecordValue) recordValueRecord.getValue())
@@ -662,7 +662,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceMigrationRecordValue.builder()
                 .from((ImmutableProcessInstanceMigrationRecordValue) recordValueRecord.getValue())
@@ -682,7 +682,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceModificationRecordValue.builder()
                 .from(
@@ -704,7 +704,7 @@ public class RecordFixtures {
         .withKey(processInstanceKey)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
-        .withOperationReference(batchOperationKey)
+        .withBatchOperationReference(batchOperationKey)
         .withValue(
             ImmutableProcessInstanceModificationRecordValue.builder()
                 .from(

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/RecordImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/RecordImpl.java
@@ -39,6 +39,7 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
 
   private Map<String, Object> authorizations;
   private long operationReference;
+  private long batchOperationReference;
 
   public RecordImpl() {}
 
@@ -179,6 +180,15 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return batchOperationReference;
+  }
+
+  public void setBatchOperationReference(final long batchOperationReference) {
+    this.batchOperationReference = batchOperationReference;
+  }
+
+  @Override
   public Record<T> clone() {
     throw new UnsupportedOperationException("Clone not implemented");
   }
@@ -216,6 +226,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
         + value
         + ", operationReference="
         + operationReference
+        + ", batchOperationReference="
+        + batchOperationReference
         + '}';
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -89,6 +89,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return -1;
+  }
+
+  @Override
   public long getKey() {
     return 0;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -131,6 +132,11 @@ public final class BatchOperationCancelProcessor
 
   private void cancelBatchOperationEvent(
       final Long cancelKey, final BatchOperationLifecycleManagementRecord recordValue) {
-    stateWriter.appendFollowUpEvent(cancelKey, BatchOperationIntent.CANCELED, recordValue);
+    stateWriter.appendFollowUpEvent(
+        cancelKey,
+        BatchOperationIntent.CANCELED,
+        recordValue,
+        FollowUpEventMetadata.of(
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -87,7 +88,11 @@ public final class BatchOperationCreateProcessor
     recordWithKey.setBatchOperationKey(key);
     recordWithKey.setPartitionIds(routingInfo.partitions());
 
-    stateWriter.appendFollowUpEvent(key, BatchOperationIntent.CREATED, recordWithKey);
+    stateWriter.appendFollowUpEvent(
+        key,
+        BatchOperationIntent.CREATED,
+        recordWithKey,
+        FollowUpEventMetadata.of(b -> b.batchOperationReference(key)));
     responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);
     commandDistributionBehavior
         .withKey(key)
@@ -101,7 +106,10 @@ public final class BatchOperationCreateProcessor
 
     LOGGER.debug("Processing distributed command with key '{}': {}", command.getKey(), recordValue);
     stateWriter.appendFollowUpEvent(
-        command.getKey(), BatchOperationIntent.CREATED, command.getValue());
+        command.getKey(),
+        BatchOperationIntent.CREATED,
+        command.getValue(),
+        FollowUpEventMetadata.of(b -> b.batchOperationReference(command.getKey())));
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.batchoperation.handlers.BatchOperationExecutor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -135,7 +136,9 @@ public final class BatchOperationExecuteProcessor
     stateWriter.appendFollowUpEvent(
         executionRecord.getBatchOperationKey(),
         BatchOperationExecutionIntent.EXECUTING,
-        batchExecute);
+        batchExecute,
+        FollowUpEventMetadata.of(
+            b -> b.batchOperationReference(executionRecord.getBatchOperationKey())));
   }
 
   private void appendBatchOperationExecutionExecutedEvent(
@@ -146,7 +149,9 @@ public final class BatchOperationExecuteProcessor
     stateWriter.appendFollowUpEvent(
         executionRecord.getBatchOperationKey(),
         BatchOperationExecutionIntent.EXECUTED,
-        batchExecute);
+        batchExecute,
+        FollowUpEventMetadata.of(
+            b -> b.batchOperationReference(executionRecord.getBatchOperationKey())));
   }
 
   private void appendBatchOperationExecutionCompletedEvent(
@@ -168,12 +173,16 @@ public final class BatchOperationExecuteProcessor
       commandWriter.appendFollowUpCommand(
           executionRecord.getBatchOperationKey(),
           BatchOperationIntent.COMPLETE_PARTITION,
-          batchInternalComplete);
+          batchInternalComplete,
+          FollowUpCommandMetadata.of(
+              b -> b.batchOperationReference(executionRecord.getBatchOperationKey())));
     } else {
       stateWriter.appendFollowUpEvent(
           executionRecord.getBatchOperationKey(),
           BatchOperationIntent.PARTITION_COMPLETED,
-          batchInternalComplete);
+          batchInternalComplete,
+          FollowUpEventMetadata.of(
+              b -> b.batchOperationReference(executionRecord.getBatchOperationKey())));
       commandDistributionBehavior
           .withKey(keyGenerator.nextKey())
           .inQueue(DistributionQueue.BATCH_OPERATION)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Collections;
@@ -111,7 +112,10 @@ public final class BatchOperationExecuteProcessor
     final var followupCommand = new BatchOperationExecutionRecord();
     followupCommand.setBatchOperationKey(batchKey);
     commandWriter.appendFollowUpCommand(
-        command.getKey(), BatchOperationExecutionIntent.EXECUTE, followupCommand, batchKey, null);
+        command.getKey(),
+        BatchOperationExecutionIntent.EXECUTE,
+        followupCommand,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
@@ -143,7 +144,11 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
     command.setBatchOperationKey(batchOperationKey);
     command.setBatchOperationType(batchOperation.getBatchOperationType());
     LOG.debug("Appending batch operation {} started event", batchOperationKey);
-    taskResultBuilder.appendCommandRecord(batchOperationKey, BatchOperationIntent.START, command);
+    taskResultBuilder.appendCommandRecord(
+        batchOperationKey,
+        BatchOperationIntent.START,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
   }
 
   private void appendFailedCommand(
@@ -153,7 +158,11 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
     command.setBatchOperationKey(batchOperationKey);
     command.setBatchOperationType(batchOperation.getBatchOperationType());
     LOG.debug("Appending batch operation {} failed event", batchOperationKey);
-    taskResultBuilder.appendCommandRecord(batchOperationKey, BatchOperationIntent.FAIL, command);
+    taskResultBuilder.appendCommandRecord(
+        batchOperationKey,
+        BatchOperationIntent.FAIL,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
   }
 
   private void appendChunk(
@@ -173,7 +182,10 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
     LOG.debug("Appending batch operation {} chunk with {} items.", batchOperationKey, items.size());
     taskResultBuilder.appendCommandRecord(
-        batchOperationKey, BatchOperationChunkIntent.CREATE, command);
+        batchOperationKey,
+        BatchOperationChunkIntent.CREATE,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
   }
 
   private void appendExecution(
@@ -183,7 +195,10 @@ public class BatchOperationExecutionScheduler implements StreamProcessorLifecycl
 
     LOG.debug("Appending batch operation execution {}", batchOperationKey);
     taskResultBuilder.appendCommandRecord(
-        batchOperationKey, BatchOperationExecutionIntent.EXECUTE, command, batchOperationKey);
+        batchOperationKey,
+        BatchOperationExecutionIntent.EXECUTE,
+        command,
+        FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperationKey)));
   }
 
   private Set<Item> queryAllKeys(final PersistedBatchOperation batchOperation) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationPartitionLifecycleRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.slf4j.Logger;
@@ -68,12 +70,16 @@ public final class BatchOperationFailProcessor
       commandWriter.appendFollowUpCommand(
           recordValue.getBatchOperationKey(),
           BatchOperationIntent.FAIL_PARTITION,
-          batchInternalFail);
+          batchInternalFail,
+          FollowUpCommandMetadata.of(
+              b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
     } else {
       stateWriter.appendFollowUpEvent(
           recordValue.getBatchOperationKey(),
           BatchOperationIntent.PARTITION_FAILED,
-          batchInternalFail);
+          batchInternalFail,
+          FollowUpEventMetadata.of(
+              b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
       commandDistributionBehavior
           .withKey(keyGenerator.nextKey())
           .inQueue(DistributionQueue.BATCH_OPERATION)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationPartitionCompleteProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -100,7 +101,11 @@ public final class BatchOperationPartitionCompleteProcessor
             command.getValue().getSourcePartitionId());
       } else {
         stateWriter.appendFollowUpEvent(
-            batchOperationKey, BatchOperationIntent.PARTITION_COMPLETED, command.getValue());
+            batchOperationKey,
+            BatchOperationIntent.PARTITION_COMPLETED,
+            command.getValue(),
+            FollowUpEventMetadata.of(
+                b -> b.batchOperationReference(command.getValue().getBatchOperationKey())));
 
         if (bo.getFinishedPartitions().size() == bo.getPartitions().size()) {
           LOGGER.debug(
@@ -109,7 +114,11 @@ public final class BatchOperationPartitionCompleteProcessor
           final var batchComplete = new BatchOperationLifecycleManagementRecord();
           batchComplete.setBatchOperationKey(batchOperationKey);
           stateWriter.appendFollowUpEvent(
-              batchOperationKey, BatchOperationIntent.COMPLETED, batchComplete);
+              batchOperationKey,
+              BatchOperationIntent.COMPLETED,
+              batchComplete,
+              FollowUpEventMetadata.of(
+                  b -> b.batchOperationReference(command.getValue().getBatchOperationKey())));
         }
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecord
 import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter.CommandMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -31,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -160,7 +160,7 @@ public final class BatchOperationResumeProcessor
           batchOperation.getKey(),
           BatchOperationExecutionIntent.EXECUTE,
           batchExecute,
-          CommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
+          FollowUpCommandMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -138,7 +139,12 @@ public final class BatchOperationSuspendProcessor
 
   private void suspendBatchOperation(
       final Long suspendKey, final BatchOperationLifecycleManagementRecord recordValue) {
-    stateWriter.appendFollowUpEvent(suspendKey, BatchOperationIntent.SUSPENDED, recordValue);
+    stateWriter.appendFollowUpEvent(
+        suspendKey,
+        BatchOperationIntent.SUSPENDED,
+        recordValue,
+        FollowUpEventMetadata.of(
+            b -> b.batchOperationReference(recordValue.getBatchOperationKey())));
   }
 
   private void rejectInvalidState(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/CancelProcessInstanceBatchOperationExecutor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWr
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,9 @@ public class CancelProcessInstanceBatchOperationExecutor implements BatchOperati
         itemKey,
         ProcessInstanceIntent.CANCEL,
         command,
-        batchOperation.getKey(),
-        batchOperation.getAuthentication().claims());
+        FollowUpCommandMetadata.of(
+            b ->
+                b.batchOperationReference(batchOperation.getKey())
+                    .claims(batchOperation.getAuthentication().claims())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/MigrateProcessInstanceBatchOperationExecutor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,9 @@ public class MigrateProcessInstanceBatchOperationExecutor implements BatchOperat
         processInstanceKey,
         ProcessInstanceMigrationIntent.MIGRATE,
         command,
-        batchOperation.getKey(),
-        batchOperation.getAuthentication().claims());
+        FollowUpCommandMetadata.of(
+            b ->
+                b.batchOperationReference(batchOperation.getKey())
+                    .claims(batchOperation.getAuthentication().claims())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ModifyProcessInstanceBatchOperationExecutor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue.ProcessInstanceModificationMoveInstructionValue;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import java.util.ArrayDeque;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -73,7 +74,9 @@ public class ModifyProcessInstanceBatchOperationExecutor implements BatchOperati
         processInstanceKey,
         ProcessInstanceModificationIntent.MODIFY,
         command,
-        batchOperation.getKey(),
-        batchOperation.getAuthentication().claims());
+        FollowUpCommandMetadata.of(
+            b ->
+                b.batchOperationReference(batchOperation.getKey())
+                    .claims(batchOperation.getAuthentication().claims())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/handlers/ResolveIncidentBatchOperationExecutor.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,9 @@ public class ResolveIncidentBatchOperationExecutor implements BatchOperationExec
         itemKey,
         IncidentIntent.RESOLVE,
         command,
-        batchOperation.getKey(),
-        batchOperation.getAuthentication().claims());
+        FollowUpCommandMetadata.of(
+            b ->
+                b.batchOperationReference(batchOperation.getKey())
+                    .claims(batchOperation.getAuthentication().claims())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 
 import io.camunda.security.auth.MappingRuleMatcher;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -82,8 +82,11 @@ public final class AuthorizationCheckBehavior {
     }
 
     if (!request.getCommand().hasRequestMetadata()
-        && request.getCommand().getOperationReference() == operationReferenceNullValue()) {
-      // The command is written by Zeebe internally. Internal Zeebe commands are always authorized
+        // Internal commands for batchOperations still need authChecks
+        && request.getCommand().getBatchOperationReference()
+            == batchOperationReferenceNullValue()) {
+      // The command is written by Zeebe internally and not part of a batch operation.
+      // These commands are always authorized
       return Either.right(null);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/RetryTypedRecord.java
@@ -112,6 +112,11 @@ public final class RetryTypedRecord<T extends UnifiedRecordValue> implements Typ
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return 0;
+  }
+
+  @Override
   public Record<T> copyOf() {
     return this;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
 import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
+import java.util.function.Consumer;
 
 /**
  * Metadata for customizing the writing of follow-up event.
@@ -17,20 +18,27 @@ import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
  * recordVersion} (to specify a version of the event record to use when writing and applying the
  * event).
  */
-public final class FollowUpEventMetadata {
+public record FollowUpEventMetadata(
+    long operationReference, long batchOperationReference, int recordVersion) {
 
   public static final int VERSION_NOT_SET = -1;
 
-  private final long operationReference;
-  private final int recordVersion;
+  public static FollowUpEventMetadata of(final Consumer<Builder> consumer) {
+    final Builder builder = new Builder();
+    consumer.accept(builder);
+    return builder.build();
+  }
 
-  private FollowUpEventMetadata(Builder builder) {
-    this.operationReference = builder.operationReference;
-    this.recordVersion = builder.recordVersion;
+  public static FollowUpEventMetadata empty() {
+    return new Builder().build();
   }
 
   public long getOperationReference() {
     return operationReference;
+  }
+
+  public long getBatchOperationReference() {
+    return batchOperationReference;
   }
 
   public int getRecordVersion() {
@@ -44,10 +52,16 @@ public final class FollowUpEventMetadata {
   public static final class Builder {
 
     private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
+    private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
     private int recordVersion = VERSION_NOT_SET;
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;
+      return this;
+    }
+
+    public Builder batchOperationReference(final long batchOperationReference) {
+      this.batchOperationReference = batchOperationReference;
       return this;
     }
 
@@ -57,7 +71,7 @@ public final class FollowUpEventMetadata {
     }
 
     public FollowUpEventMetadata build() {
-      return new FollowUpEventMetadata(this);
+      return new FollowUpEventMetadata(operationReference, batchOperationReference, recordVersion);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -67,7 +67,8 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
-            .operationReference(metadata.getOperationReference());
+            .operationReference(metadata.getOperationReference())
+            .batchOperationReference(metadata.getBatchOperationReference());
 
     resultBuilder().appendRecord(key, value, recordMetadata);
     eventApplier.applyState(key, intent, value, recordVersion);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
-import java.util.Map;
 
 /** This interface is supposed to replace TypedCommandWriter */
 public interface TypedCommandWriter {
@@ -40,17 +40,12 @@ public interface TypedCommandWriter {
    *
    * @param intent the intent of the command
    * @param value the record of the command
-   * @param operationReference the operation reference of the command
-   * @param claims the authorization claims
+   * @param metadata the optional metadata for the command
    * @throws ExceededBatchRecordSizeException if the appended command doesn't fit into the
    *     RecordBatch
    */
   void appendFollowUpCommand(
-      long key,
-      Intent intent,
-      RecordValue value,
-      long operationReference,
-      Map<String, Object> claims);
+      long key, Intent intent, RecordValue value, FollowUpCommandMetadata metadata);
 
   /**
    * @param commandLength the length of the command that will be written

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -27,8 +27,8 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
@@ -111,15 +111,24 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationState).foreachPendingBatchOperation(any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.START),
+            any(BatchOperationCreationRecord.class),
+            any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.FAIL), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.FAIL),
+            any(BatchOperationCreationRecord.class),
+            any());
 
     // and should NOT append an execute command
     verify(taskResultBuilder, times(0))
         .appendCommandRecord(
-            anyLong(), any(Intent.class), any(UnifiedRecordValue.class), anyLong());
+            anyLong(),
+            eq(BatchOperationExecutionIntent.EXECUTE),
+            any(UnifiedRecordValue.class),
+            any());
   }
 
   @Test
@@ -135,10 +144,13 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationState).foreachPendingBatchOperation(any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.START),
+            any(BatchOperationCreationRecord.class),
+            any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture(), any());
     final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
     assertThat(batchOperationChunkRecord.getItems().size()).isEqualTo(3);
   }
@@ -234,10 +246,13 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationState).foreachPendingBatchOperation(any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.START),
+            any(BatchOperationCreationRecord.class),
+            any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture(), any());
     final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
     assertThat(batchOperationChunkRecord.getItems().size()).isEqualTo(3);
   }
@@ -259,10 +274,13 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationState).foreachPendingBatchOperation(any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.START),
+            any(BatchOperationCreationRecord.class),
+            any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture(), any());
     final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
     assertThat(batchOperationChunkRecord.getItems().size()).isEqualTo(3);
   }
@@ -284,10 +302,13 @@ public class BatchOperationExecutionSchedulerTest {
     verify(batchOperationState).foreachPendingBatchOperation(any());
     verify(taskResultBuilder)
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationIntent.START), any(BatchOperationCreationRecord.class));
+            anyLong(),
+            eq(BatchOperationIntent.START),
+            any(BatchOperationCreationRecord.class),
+            any());
     verify(taskResultBuilder, times(2))
         .appendCommandRecord(
-            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture(), any());
     var batchOperationChunkRecord = chunkRecordCaptor.getAllValues().getFirst();
     assertThat(batchOperationChunkRecord.getItems().size()).isEqualTo(CHUNK_SIZE);
     assertThat(extractRecordItemKeys(batchOperationChunkRecord.getItems()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessorTest.java
@@ -9,9 +9,9 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static org.mockito.Mockito.*;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter.EventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
@@ -70,7 +70,7 @@ class BatchOperationResumeProcessorTest {
             resumeKey,
             BatchOperationIntent.RESUMED,
             recordValue,
-            EventMetadata.of(m -> m.batchOperationReference(batchOperationKey)));
+            FollowUpEventMetadata.of(m -> m.batchOperationReference(batchOperationKey)));
     verify(commandWriter, never()).appendFollowUpCommand(anyLong(), any(), any(), any());
   }
 
@@ -96,7 +96,7 @@ class BatchOperationResumeProcessorTest {
             resumeKey,
             BatchOperationIntent.RESUMED,
             recordValue,
-            EventMetadata.of(m -> m.batchOperationReference(batchOperationKey)));
+            FollowUpEventMetadata.of(m -> m.batchOperationReference(batchOperationKey)));
 
     final ArgumentCaptor<BatchOperationExecutionRecord> captor =
         ArgumentCaptor.forClass(BatchOperationExecutionRecord.class);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/MigrateProcessesBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/MigrateProcessesBatchExecutorTest.java
@@ -95,6 +95,7 @@ public final class MigrateProcessesBatchExecutorTest extends AbstractBatchOperat
             .getFirst();
     assertThat(migrationCommand.getIntent()).isEqualTo(ProcessInstanceMigrationIntent.MIGRATE);
     assertThat(migrationCommand.getAuthorizations()).isEqualTo(claims);
+    assertThat(migrationCommand.getBatchOperationReference()).isEqualTo(batchOperationKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ModifyProcessInstanceBatchExecutorTest.java
@@ -74,6 +74,7 @@ public final class ModifyProcessInstanceBatchExecutorTest extends AbstractBatchO
             .getFirst();
     assertThat(modificationCommand.getIntent()).isEqualTo(ProcessInstanceModificationIntent.MODIFY);
     assertThat(modificationCommand.getAuthorizations()).isEqualTo(claims);
+    assertThat(modificationCommand.getBatchOperationReference()).isEqualTo(batchOperationKey);
   }
 
   @Test
@@ -134,8 +135,8 @@ public final class ModifyProcessInstanceBatchExecutorTest extends AbstractBatchO
                 .withRecordKey(processInstanceKey)
                 .onlyCommandRejections()
                 .limit(r -> r.getIntent() == ProcessInstanceModificationIntent.MODIFY))
-        .extracting(Record::getIntent)
-        .containsSequence(ProcessInstanceModificationIntent.MODIFY);
+        .hasSize(1)
+        .allSatisfy(r -> assertThat(r.getBatchOperationReference()).isEqualTo(batchOperationKey));
   }
 
   @Test
@@ -165,13 +166,13 @@ public final class ModifyProcessInstanceBatchExecutorTest extends AbstractBatchO
         .extracting(Record::getIntent)
         .containsSequence(BatchOperationExecutionIntent.EXECUTE);
 
-    // and we have a modified event
+    // and we have a rejected command
     assertThat(
             RecordingExporter.processInstanceModificationRecords()
                 .withRecordKey(42L)
                 .onlyCommandRejections()
                 .limit(r -> r.getIntent() == ProcessInstanceModificationIntent.MODIFY))
-        .extracting(Record::getIntent)
-        .containsSequence(ProcessInstanceModificationIntent.MODIFY);
+        .hasSize(1)
+        .allSatisfy(r -> assertThat(r.getBatchOperationReference()).isEqualTo(batchOperationKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ResolveIncidentBatchExecutorTest.java
@@ -110,6 +110,7 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
             .getFirst();
     assertThat(incidentCommand.getIntent()).isEqualTo(IncidentIntent.RESOLVE);
     assertThat(incidentCommand.getAuthorizations()).isEqualTo(claims);
+    assertThat(incidentCommand.getBatchOperationReference()).isEqualTo(batchOperationKey);
   }
 
   @Test
@@ -164,13 +165,14 @@ public final class ResolveIncidentBatchExecutorTest extends AbstractBatchOperati
         .extracting(Record::getIntent)
         .containsSequence(BatchOperationExecutionIntent.EXECUTE);
 
-    // and we have a resolve incident command
+    // and we have a resolved the incident
     assertThat(RecordingExporter.jobRecords().withProcessInstanceKey(processInstanceKey)).isEmpty();
     assertThat(
             RecordingExporter.incidentRecords()
                 .withRecordKey(incidentKey)
-                .limit(r -> r.getIntent() == IncidentIntent.RESOLVE))
-        .extracting(Record::getIntent)
-        .containsSequence(IncidentIntent.RESOLVE);
+                .withIntents(IncidentIntent.RESOLVE, IncidentIntent.RESOLVED)
+                .limit(r -> r.getIntent() == IncidentIntent.RESOLVED))
+        .isNotEmpty()
+        .allSatisfy(r -> assertThat(r.getBatchOperationReference()).isEqualTo(batchOperationKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -135,6 +135,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return metadata.getBatchOperationReference();
+  }
+
+  @Override
   public Record<T> copyOf() {
     throw new UnsupportedOperationException("not yet implemented");
   }

--- a/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
+++ b/zeebe/exporter-api/src/test/java/io/camunda/zeebe/exporter/api/ExporterTest.java
@@ -254,5 +254,10 @@ public final class ExporterTest {
     public long getOperationReference() {
       return 0;
     }
+
+    @Override
+    public long getBatchOperationReference() {
+      return 0;
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
@@ -45,13 +45,13 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
 
   @Override
   public boolean handlesRecord(final Record<R> record) {
-    return record.getOperationReference() != operationReferenceNullValue()
+    return record.getBatchOperationReference() != batchOperationReferenceNullValue()
         && (isCompleted(record) || isFailed(record));
   }
 
   @Override
   public List<String> generateIds(final Record<R> record) {
-    return List.of(generateId(record.getOperationReference(), getItemKey(record)));
+    return List.of(generateId(record.getBatchOperationReference(), getItemKey(record)));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -39,7 +39,7 @@ class BatchOperationStatusHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-index";
-  private final long operationalReference = 42L;
+  private final long batchOperationKey = 42L;
 
   abstract class AbstractOperationStatusHandlerTest<T extends RecordValue> {
 
@@ -57,11 +57,11 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Test
-    void shouldNotHandleSuccessRecordWithoutOperationReference() {
+    void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
       final var record =
           ImmutableRecord.<T>builder()
               .from(createSuccessRecord())
-              .withOperationReference(operationReferenceNullValue())
+              .withBatchOperationReference(batchOperationReferenceNullValue())
               .build();
 
       assertThat(handler.handlesRecord(record)).isFalse();
@@ -75,11 +75,11 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Test
-    void shouldNotHandleFailureRecordWithoutOperationReference() {
+    void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
       final var record =
           ImmutableRecord.<T>builder()
               .from(createFailureRecord())
-              .withOperationReference(operationReferenceNullValue())
+              .withBatchOperationReference(batchOperationReferenceNullValue())
               .build();
 
       assertThat(handler.handlesRecord(record)).isFalse();
@@ -145,7 +145,7 @@ class BatchOperationStatusHandlerTest {
       final var generatedIds = handler.generateIds(record);
 
       assertThat(generatedIds)
-          .containsExactly(operationalReference + "_" + handler.getItemKey(record));
+          .containsExactly(batchOperationKey + "_" + handler.getItemKey(record));
     }
 
     @Test
@@ -178,7 +178,7 @@ class BatchOperationStatusHandlerTest {
           ValueType.PROCESS_INSTANCE_MODIFICATION,
           b ->
               b.withIntent(ProcessInstanceModificationIntent.MODIFIED)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
 
     @Override
@@ -188,7 +188,7 @@ class BatchOperationStatusHandlerTest {
           b ->
               b.withRejectionType(RejectionType.NOT_FOUND)
                   .withIntent(ProcessInstanceModificationIntent.MODIFY)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
   }
 
@@ -214,7 +214,7 @@ class BatchOperationStatusHandlerTest {
           ValueType.PROCESS_INSTANCE_MIGRATION,
           b ->
               b.withIntent(ProcessInstanceMigrationIntent.MIGRATED)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
 
     @Override
@@ -224,7 +224,7 @@ class BatchOperationStatusHandlerTest {
           b ->
               b.withRejectionType(RejectionType.NOT_FOUND)
                   .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
   }
 
@@ -255,7 +255,7 @@ class BatchOperationStatusHandlerTest {
                           .from(factory.generateObject(ProcessInstanceRecordValue.class))
                           .withBpmnElementType(BpmnElementType.PROCESS)
                           .build())
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
 
     @Override
@@ -270,7 +270,7 @@ class BatchOperationStatusHandlerTest {
                           .withBpmnElementType(BpmnElementType.PROCESS)
                           .build())
                   .withIntent(ProcessInstanceIntent.CANCEL)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
   }
 
@@ -294,7 +294,8 @@ class BatchOperationStatusHandlerTest {
     Record<IncidentRecordValue> createSuccessRecord() {
       return factory.generateRecord(
           ValueType.INCIDENT,
-          b -> b.withIntent(IncidentIntent.RESOLVED).withOperationReference(operationalReference));
+          b ->
+              b.withIntent(IncidentIntent.RESOLVED).withBatchOperationReference(batchOperationKey));
     }
 
     @Override
@@ -304,7 +305,7 @@ class BatchOperationStatusHandlerTest {
           b ->
               b.withRejectionType(RejectionType.NOT_FOUND)
                   .withIntent(IncidentIntent.RESOLVE)
-                  .withOperationReference(operationalReference));
+                  .withBatchOperationReference(batchOperationKey));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/protocol/TestRecord.java
@@ -92,6 +92,11 @@ public record TestRecord(long position, ValueType valueType) implements Record<T
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return 0;
+  }
+
+  @Override
   public Record<TestValue> copyOf() {
     return this;
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -53,6 +53,9 @@
         },
         "operationReference": {
           "type": "long"
+        },
+        "batchOperationReference": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -53,6 +53,9 @@
         },
         "operationReference": {
           "type": "long"
+        },
+        "batchOperationReference": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
-import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
@@ -28,7 +28,7 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
 
   @Override
   public boolean canExport(final Record<T> record) {
-    return record.getOperationReference() != operationReferenceNullValue()
+    return record.getBatchOperationReference() != batchOperationReferenceNullValue()
         && (isCompleted(record) || isFailed(record));
   }
 
@@ -36,14 +36,14 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
   public void export(final Record<T> record) {
     if (isCompleted(record)) {
       batchOperationWriter.updateItem(
-          String.valueOf(record.getOperationReference()),
+          String.valueOf(record.getBatchOperationReference()),
           getItemKey(record),
           BatchOperationItemState.COMPLETED,
           DateUtil.toOffsetDateTime(record.getTimestamp()),
           null);
     } else if (isFailed(record)) {
       batchOperationWriter.updateItem(
-          String.valueOf(record.getOperationReference()),
+          String.valueOf(record.getBatchOperationReference()),
           getItemKey(record),
           BatchOperationItemState.FAILED,
           DateUtil.toOffsetDateTime(record.getTimestamp()),

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -35,6 +35,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final AuthInfo authorization;
   private final int recordVersion;
   private final long operationReference;
+  private final long batchOperationReference;
 
   public CopiedRecord(
       final T recordValue,
@@ -60,6 +61,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     authorization = metadata.getAuthorization();
     recordVersion = metadata.getRecordVersion();
     operationReference = metadata.getOperationReference();
+    batchOperationReference = metadata.getBatchOperationReference();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -95,6 +97,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     authorization = copiedRecord.authorization;
     recordVersion = copiedRecord.recordVersion;
     operationReference = copiedRecord.operationReference;
+    batchOperationReference = copiedRecord.batchOperationReference;
   }
 
   @Override
@@ -170,6 +173,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public long getOperationReference() {
     return operationReference;
+  }
+
+  @Override
+  public long getBatchOperationReference() {
+    return batchOperationReference;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -56,6 +56,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private VersionInfo brokerVersion = CURRENT_BROKER_VERSION;
   private int recordVersion = DEFAULT_RECORD_VERSION;
   private long operationReference;
+  private long batchOperationReference;
 
   public RecordMetadata() {
     reset();
@@ -80,6 +81,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = Intent.fromProtocolValue(valueType, decoder.intent());
     rejectionType = decoder.rejectionType();
     operationReference = decoder.operationReference();
+    batchOperationReference = decoder.batchOperationReference();
 
     brokerVersion =
         Optional.ofNullable(decoder.brokerVersion())
@@ -149,7 +151,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .intent(intentValue)
         .rejectionType(rejectionType)
         .recordVersion(recordVersion)
-        .operationReference(operationReference);
+        .operationReference(operationReference)
+        .batchOperationReference(batchOperationReference);
 
     encoder
         .brokerVersion()
@@ -282,6 +285,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return operationReference;
   }
 
+  public RecordMetadata batchOperationReference(final long batchOperationReference) {
+    this.batchOperationReference = batchOperationReference;
+    return this;
+  }
+
+  public long getBatchOperationReference() {
+    return batchOperationReference;
+  }
+
   public RecordMetadata reset() {
     recordType = RecordType.NULL_VAL;
     requestId = RecordMetadataEncoder.requestIdNullValue();
@@ -296,6 +308,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
     operationReference = RecordMetadataEncoder.operationReferenceNullValue();
+    batchOperationReference = RecordMetadataEncoder.batchOperationReferenceNullValue();
     return this;
   }
 
@@ -313,7 +326,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         protocolVersion,
         brokerVersion,
         recordVersion,
-        operationReference);
+        operationReference,
+        batchOperationReference);
   }
 
   @Override
@@ -336,7 +350,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && authorization.equals(that.authorization)
         && brokerVersion.equals(that.brokerVersion)
         && recordVersion == that.recordVersion
-        && operationReference == that.operationReference;
+        && operationReference == that.operationReference
+        && batchOperationReference == that.batchOperationReference;
   }
 
   @Override
@@ -366,6 +381,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     }
     if (operationReference != RecordMetadataEncoder.operationReferenceNullValue()) {
       builder.append(", operationReference=").append(operationReference);
+    }
+    if (batchOperationReference != RecordMetadataEncoder.batchOperationReferenceNullValue()) {
+      builder.append(", batchOperationReference=").append(batchOperationReference);
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -175,7 +175,8 @@ final class JsonSerializableToJsonTest {
                   .requestId(requestId)
                   .requestStreamId(requestStreamId)
                   .authorization(authInfo)
-                  .operationReference(1234);
+                  .operationReference(1234)
+                  .batchOperationReference(5678);
 
               final String resourceName = "resource";
               final DirectBuffer resource = wrapString("contents");
@@ -225,6 +226,7 @@ final class JsonSerializableToJsonTest {
           },
           "recordVersion": 10,
           "operationReference": 1234,
+          "batchOperationReference": 5678,
           "sourceRecordPosition": 231,
           "value": {
             "processesMetadata": [
@@ -289,6 +291,7 @@ final class JsonSerializableToJsonTest {
           "authorizations": {},
           "recordVersion": 1,
           "operationReference": -1,
+          "batchOperationReference": -1,
           "value": {
               "resources": [],
               "decisionRequirementsMetadata": [],

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <protocol.version>5</protocol.version>
+    <protocol.version>6</protocol.version>
   </properties>
 
   <dependencies>

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -140,6 +140,16 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   long getOperationReference();
 
   /**
+   * The batchOperationKey indicates the batch operation this record was produced by.
+   *
+   * @return the batch operation key
+   */
+  @Value.Default
+  default long getBatchOperationReference() {
+    return RecordMetadataDecoder.batchOperationReferenceNullValue();
+  }
+
+  /**
    * Creates a deep copy of the current record. Can be used to collect records.
    *
    * @return a deep copy of this record

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -175,6 +175,8 @@
     <field name="rejectionType" id="7" type="RejectionType"/>
     <!-- populated when the client passes an operation reference to the gateway-->
     <field name="operationReference" id="12" type="uint64" presence="optional" sinceVersion="5"/>
+    <!-- populated when the record was created as part of a batch operation -->
+    <field name="batchOperationReference" id="13" type="uint64" presence="optional" sinceVersion="6"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/FollowUpCommandMetadata.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.api;
+
+import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public record FollowUpCommandMetadata(
+    long operationReference, long batchOperationReference, Map<String, Object> claims) {
+
+  public static FollowUpCommandMetadata empty() {
+    return of(builder -> {});
+  }
+
+  public static FollowUpCommandMetadata of(final Consumer<Builder> consumer) {
+    final Builder builder = new Builder();
+    consumer.accept(builder);
+    return builder.build();
+  }
+
+  public static class Builder {
+    private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
+    private long batchOperationReference = RecordMetadataDecoder.batchOperationReferenceNullValue();
+    private Map<String, Object> claims = null;
+
+    public Builder operationReference(final long operationReference) {
+      this.operationReference = operationReference;
+      return this;
+    }
+
+    public Builder batchOperationReference(final long batchOperationReference) {
+      this.batchOperationReference = batchOperationReference;
+      return this;
+    }
+
+    public Builder claims(final Map<String, Object> claims) {
+      this.claims = claims;
+      return this;
+    }
+
+    public Builder claim(final String key, final Object value) {
+      if (claims == null) {
+        claims = new HashMap<>();
+      }
+
+      claims.put(key, value);
+      return this;
+    }
+
+    public FollowUpCommandMetadata build() {
+      return new FollowUpCommandMetadata(operationReference, batchOperationReference, claims);
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/TaskResultBuilder.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api.scheduling;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.FollowUpCommandMetadata;
 
 /** Here the interface is just a suggestion. Can be whatever PDT team thinks is best to work with */
 public interface TaskResultBuilder {
@@ -16,11 +17,23 @@ public interface TaskResultBuilder {
   long NULL_KEY = -1;
 
   /**
+   * Appends a record to the result without a key
+   *
+   * @return returns true if the record still fits into the result, false otherwise
+   */
+  default boolean appendCommandRecord(final Intent intent, final UnifiedRecordValue value) {
+    return appendCommandRecord(NULL_KEY, intent, value);
+  }
+
+  /**
    * Appends a record to the result
    *
    * @return returns true if the record still fits into the result, false otherwise
    */
-  boolean appendCommandRecord(final long key, final Intent intent, final UnifiedRecordValue value);
+  default boolean appendCommandRecord(
+      final long key, final Intent intent, final UnifiedRecordValue value) {
+    return appendCommandRecord(key, intent, value, FollowUpCommandMetadata.empty());
+  }
 
   /**
    * Appends a record to the result
@@ -31,16 +44,7 @@ public interface TaskResultBuilder {
       final long key,
       final Intent intent,
       final UnifiedRecordValue value,
-      final long operationReference);
-
-  /**
-   * Appends a record to the result without a key
-   *
-   * @return returns true if the record still fits into the result, false otherwise
-   */
-  default boolean appendCommandRecord(final Intent intent, final UnifiedRecordValue value) {
-    return appendCommandRecord(NULL_KEY, intent, value);
-  }
+      final FollowUpCommandMetadata metadata);
 
   TaskResult build();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -337,7 +337,9 @@ public final class ProcessingStateMachine {
     // be appended to the followup events
     final var processingResultBuilder =
         new BufferedProcessingResultBuilder(
-            logStreamWriter::canWriteEvents, initialCommand.getOperationReference());
+            logStreamWriter::canWriteEvents,
+            initialCommand.getOperationReference(),
+            initialCommand.getBatchOperationReference());
     var lastProcessingResultSize = 0;
 
     // It might be that we reached the batch size limit during processing a command.
@@ -522,7 +524,9 @@ public final class ProcessingStateMachine {
     final var rejectionReason = errorMessage != null ? errorMessage : "";
     final ProcessingResultBuilder processingResultBuilder =
         new BufferedProcessingResultBuilder(
-            logStreamWriter::canWriteEvents, typedCommand.getOperationReference());
+            logStreamWriter::canWriteEvents,
+            typedCommand.getOperationReference(),
+            typedCommand.getBatchOperationReference());
     final var errorRecord = new ErrorRecord();
     errorRecord.initErrorRecord(
         new CommandRejectionException(rejectionReason), currentRecord.getPosition());
@@ -535,7 +539,8 @@ public final class ProcessingStateMachine {
             .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("")
-            .operationReference(typedCommand.getOperationReference());
+            .operationReference(typedCommand.getOperationReference())
+            .batchOperationReference(typedCommand.getBatchOperationReference());
     processingResultBuilder.appendRecord(currentRecord.getKey(), errorRecord, recordMetadata);
     processingResultBuilder.withResponse(
         RecordType.COMMAND_REJECTION,
@@ -563,7 +568,9 @@ public final class ProcessingStateMachine {
         () -> {
           final ProcessingResultBuilder processingResultBuilder =
               new BufferedProcessingResultBuilder(
-                  logStreamWriter::canWriteEvents, typedCommand.getOperationReference());
+                  logStreamWriter::canWriteEvents,
+                  typedCommand.getOperationReference(),
+                  typedCommand.getBatchOperationReference());
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -109,6 +109,11 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return metadata.getBatchOperationReference();
+  }
+
+  @Override
   public Record copyOf() {
     return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -99,6 +99,11 @@ public class UnwrittenRecord implements TypedRecord {
   }
 
   @Override
+  public long getBatchOperationReference() {
+    return metadata.getBatchOperationReference();
+  }
+
+  @Override
   public long getKey() {
     return key;
   }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 408]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 416]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 409);
+    final var recordBatch = new RecordBatch((count, size) -> size < 417);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -417,8 +417,9 @@ public final class StreamProcessorTest {
 
     // when
     final long operationReference = 1234L;
+    final long batchOperationKey = 5678L;
     streamPlatform.writeBatch(
-        RecordToWrite.command(operationReference)
+        RecordToWrite.command(operationReference, batchOperationKey)
             .processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
     // then
@@ -446,6 +447,9 @@ public final class StreamProcessorTest {
     assertThat(firstRecordMetadata.getOperationReference())
         .as("Record metadata should contain the operation reference")
         .isEqualTo(operationReference);
+    assertThat(firstRecordMetadata.getBatchOperationReference())
+        .as("Record metadata should contain the batch operation reference")
+        .isEqualTo(batchOperationKey);
 
     await("should write follow up events")
         .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,12 +55,13 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
-  public static RecordToWrite command(final long operationReference, final long batchOperationKey) {
+  public static RecordToWrite command(
+      final long operationReference, final long batchOperationReference) {
     final var recordMetadata =
         new RecordMetadata()
             .recordType(RecordType.COMMAND)
             .operationReference(operationReference)
-            .batchOperationKey(batchOperationKey);
+            .batchOperationReference(batchOperationReference);
     return new RecordToWrite(recordMetadata);
   }
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,9 +55,12 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
-  public static RecordToWrite command(final long operationReference) {
+  public static RecordToWrite command(final long operationReference, final long batchOperationKey) {
     final var recordMetadata =
-        new RecordMetadata().recordType(RecordType.COMMAND).operationReference(operationReference);
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .operationReference(operationReference)
+            .batchOperationKey(batchOperationKey);
     return new RecordToWrite(recordMetadata);
   }
 

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -131,6 +131,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public long getBatchOperationReference() {
+      return 0;
+    }
+
+    @Override
     public Record<TestValue> copyOf() {
       return this;
     }


### PR DESCRIPTION
## Description

This PR adds a new record metadata property `batchOperationKey`. This property - if not set to the default value from `RecordMetadataEncoder.batchOperationKeyNullValue()` - indicates, that this record was produced during a batch operation.

That metadata value is used in the exporters to correlate commands and events to a running batch operation and with this to track the progress/result of the batch operation.

## Related issues

closes #30289 
