### PR TITLE
include bootstrapped partition into the set of active partitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -385,7 +385,7 @@ public final class PartitionManagerImpl
               (ignored, error) -> {
                 if (error != null) {
                   // bootstrap has failed, let's stop and return the error.
-                  return stopPartition(partitionId, true)
+                  return stopPartition(partitionId)
                       .andThen(
                           none -> CompletableActorFuture.completedExceptionally(error),
                           concurrencyControl);
@@ -569,7 +569,7 @@ public final class PartitionManagerImpl
     return scalingExecutor.notifyPartitionBootstrapped(partitionId);
   }
 
-  private ActorFuture<Void> stopPartition(final int partitionId, final boolean purgeData) {
+  private ActorFuture<Void> stopPartition(final int partitionId) {
     final var partition = partitions.get(partitionId);
     if (partition != null) {
       return partition
@@ -577,9 +577,6 @@ public final class PartitionManagerImpl
           .andThen(
               ignored -> {
                 partitions.remove(partitionId);
-                if (purgeData) {
-                  partition.raftPartition().delete();
-                }
                 return null;
               },
               concurrencyControl);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -382,29 +382,28 @@ public final class PartitionManagerImpl
         () ->
             bootstrapPartition(partitionMetadata, partitionConfig, initializeFromSnapshot)
                 .onComplete(future));
-    if (initializeFromSnapshot) {
-      return future
-          .andThen(ignored -> notifyPartitionBootstrapped(partitionId), concurrencyControl)
-          .andThen(
-              (ignored, error) -> {
-                if (error != null) {
-                  if (error instanceof PartitionAlreadyExistsException) {
-                    return CompletableActorFuture.completedExceptionally(error);
-                  } else {
-                    // bootstrap has failed, let's stop and return the error.
-                    return stopPartition(partitionId)
-                        .andThen(
-                            none -> CompletableActorFuture.completedExceptionally(error),
-                            concurrencyControl);
-                  }
-                } else {
-                  return CompletableActorFuture.completed();
-                }
-              },
-              concurrencyControl);
-    } else {
+    if (!initializeFromSnapshot) {
       return future;
     }
+    return future
+        .andThen(ignored -> notifyPartitionBootstrapped(partitionId), concurrencyControl)
+        .andThen(
+            (ignored, error) -> {
+              if (error != null) {
+                if (error instanceof PartitionAlreadyExistsException) {
+                  return CompletableActorFuture.completedExceptionally(error);
+                } else {
+                  // bootstrap has failed, let's stop and return the error.
+                  return stopPartition(partitionId)
+                      .andThen(
+                          none -> CompletableActorFuture.completedExceptionally(error),
+                          concurrencyControl);
+                }
+              } else {
+                return CompletableActorFuture.completed();
+              }
+            },
+            concurrencyControl);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
@@ -28,10 +28,12 @@ public interface PartitionScalingChangeExecutor {
   ActorFuture<Void> awaitRedistributionCompletion(
       int desiredPartitionCount, Set<Integer> redistributedPartitions, Duration timeout);
 
+  ActorFuture<Void> notifyPartitionBootstrapped(int partitionId);
+
   final class NoopPartitionScalingChangeExecutor implements PartitionScalingChangeExecutor {
     @Override
     public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
 
     @Override
@@ -39,7 +41,12 @@ public interface PartitionScalingChangeExecutor {
         final int desiredPartitionCount,
         final Set<Integer> redistributedPartitions,
         final Duration timeout) {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
+    }
+
+    @Override
+    public ActorFuture<Void> notifyPartitionBootstrapped(final int partitionId) {
+      return CompletableActorFuture.completed();
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/MarkPartitionsBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/MarkPartitionsBootstrappedProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class MarkPartitionsBootstrappedProcessor implements TypedRecordProcessor<ScaleRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final RoutingState routingState;
+
+  public MarkPartitionsBootstrappedProcessor(
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final ProcessingState processingState) {
+    this.keyGenerator = keyGenerator;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    stateWriter = writers.state();
+    routingState = processingState.getRoutingState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ScaleRecord> command) {
+    final var scaleUp = command.getValue();
+    if (!(routingState.desiredPartitions().size() == scaleUp.getDesiredPartitionCount())) {
+      final var reason =
+          String.format(
+              "The redistributed partitions do not match the desired partitions. "
+                  + "The redistributed partitions are %s, the desired partitions are %s.",
+              scaleUp.getRedistributedPartitions(), routingState.desiredPartitions());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
+    }
+    final var scalingKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITIONS_BOOTSTRAPPED, scaleUp);
+    // TODO remove when relocation is needed
+    responseWriter.writeEventOnCommand(
+        scalingKey, ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED, scaleUp, command);
+    stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, scaleUp);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -61,7 +61,6 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
     scaleUp.setBootstrappedAt(command.getKey());
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
     responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
-    stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, scaleUp);
   }
 
   private Optional<Rejection> validateCommand(final TypedRecord<ScaleRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -33,7 +33,7 @@ public final class ScalingProcessors {
         new ScaleUpStatusProcessor(keyGenerator, writers, processingState.getRoutingState()));
     typedRecordProcessors.onCommand(
         ValueType.SCALE,
-        ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
-        new MarkPartitionsBootstrappedProcessor(keyGenerator, writers, processingState));
+        ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
+        new MarkPartitionBootstrappedProcessor(keyGenerator, writers, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -31,5 +31,9 @@ public final class ScalingProcessors {
         ValueType.SCALE,
         ScaleIntent.STATUS,
         new ScaleUpStatusProcessor(keyGenerator, writers, processingState.getRoutingState()));
+    typedRecordProcessors.onCommand(
+        ValueType.SCALE,
+        ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+        new MarkPartitionsBootstrappedProcessor(keyGenerator, writers, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.util.PartitionUtil;
+import java.util.TreeSet;
 
 public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
   final MutableRoutingState routingState;
@@ -25,6 +26,6 @@ public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRec
     final var partitionCount = value.getDesiredPartitionCount();
     final var partitions = PartitionUtil.allPartitions(partitionCount);
 
-    routingState.setDesiredPartitions(partitions, key);
+    routingState.setDesiredPartitions(new TreeSet<>(partitions), key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -570,7 +570,7 @@ public final class EventAppliers implements EventApplier {
     register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
     register(ScaleIntent.SCALED_UP, new ScaledUpApplier(state.getRoutingState()));
     register(ScaleIntent.STATUS_RESPONSE, new ScaleUpStatusResponseApplier());
-    register(ScaleIntent.PARTITIONS_BOOTSTRAPPED, new PartitionsBootstrappedApplier(state));
+    register(ScaleIntent.PARTITION_BOOTSTRAPPED, new PartitionBootstrappedApplier(state));
   }
 
   private void registerTenantAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -570,6 +570,7 @@ public final class EventAppliers implements EventApplier {
     register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
     register(ScaleIntent.SCALED_UP, new ScaledUpApplier(state.getRoutingState()));
     register(ScaleIntent.STATUS_RESPONSE, new ScaleUpStatusResponseApplier());
+    register(ScaleIntent.PARTITIONS_BOOTSTRAPPED, new PartitionsBootstrappedApplier(state));
   }
 
   private void registerTenantAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionBootstrappedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionBootstrappedApplier.java
@@ -12,17 +12,32 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class PartitionsBootstrappedApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+public class PartitionBootstrappedApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionBootstrappedApplier.class);
   private final MutableRoutingState routingState;
 
-  public PartitionsBootstrappedApplier(final MutableProcessingState state) {
+  public PartitionBootstrappedApplier(final MutableProcessingState state) {
     routingState = state.getRoutingState();
   }
 
   @Override
   public void applyState(final long key, final ScaleRecord value) {
-    routingState.arriveAtDesiredState();
+    if (value.getRedistributedPartitions().size() == 1) {
+      final var partitionId = value.getRedistributedPartitions().getFirst();
+      final var allActivated = routingState.activatePartition(partitionId);
+      if (allActivated) {
+        LOG.debug(
+            "All partitions for scale operation to {} have been activated.",
+            value.getDesiredPartitionCount());
+      }
+    } else {
+      LOG.warn(
+          "Received a scale event with more than one partition to redistribute. Ignoring it. Record is {}",
+          value);
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionsBootstrappedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionsBootstrappedApplier.java
@@ -5,22 +5,24 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.scaling;
+package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 
-public class ScaledUpApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+public class PartitionsBootstrappedApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+
   private final MutableRoutingState routingState;
 
-  public ScaledUpApplier(final MutableRoutingState routingState) {
-    this.routingState = routingState;
+  public PartitionsBootstrappedApplier(final MutableProcessingState state) {
+    routingState = state.getRoutingState();
   }
 
   @Override
   public void applyState(final long key, final ScaleRecord value) {
-    // TODO: when relocation is done, apply the changes to the routing state
+    routingState.arriveAtDesiredState();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
@@ -30,8 +30,12 @@ public interface MutableRoutingState extends RoutingState {
   void setDesiredPartitions(Set<Integer> partitions, long key);
 
   /**
-   * Copies the desired state to the current state. The desired state must be set via {@link
-   * #setDesiredPartitions(Set, long)} before calling this method.
+   * Move {@param partitionId} from the desired set of partition to the current partitions. The
+   * partitions must be activated in order as the partitions must be contiguous.
+   *
+   * @param partitionId the partition to move
+   * @return true if the partition was the last remaining partition in order to arrive at desired
+   *     state, false otherwise
    */
-  void arriveAtDesiredState();
+  boolean activatePartition(int partitionId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import java.util.Collections;
-import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -38,7 +38,7 @@ final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
         .declareProperty(hashModPartitionCount);
   }
 
-  public Set<Integer> getPartitions() {
+  public SortedSet<Integer> getPartitions() {
     return partitions.stream()
         .map(IntegerValue::getValue)
         .collect(
@@ -46,7 +46,7 @@ final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
                 Collectors.toCollection(TreeSet::new), Collections::unmodifiableSortedSet));
   }
 
-  public void setPartitions(final Set<Integer> partitions) {
+  public void setPartitions(final SortedSet<Integer> partitions) {
     this.partitions.reset();
     for (final var partition : partitions) {
       this.partitions.add().setValue(partition);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributorTest.java
@@ -171,7 +171,7 @@ public class CommandRedistributorTest {
 
       // then
       // Partition 3 is now scaled up, so it should be redistributed to
-      routingState.arriveAtDesiredState();
+      routingState.activatePartition(3);
 
       // run cycle twice, since first one always does not try distributing the records
       commandRedistributor.runRetryCycle();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -66,9 +66,7 @@ public class ScaleUpTest {
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
-                new ScaleRecord()
-                    .setDesiredPartitionCount(3)
-                    .setRedistributedPartitions(List.of(3)));
+                new ScaleRecord().setRedistributedPartitions(List.of(3)));
     // when
     engine.writeRecords(command, bootstrapPartitions);
 
@@ -280,9 +278,7 @@ public class ScaleUpTest {
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
-                new ScaleRecord()
-                    .setDesiredPartitionCount(3)
-                    .setRedistributedPartitions(List.of(3)));
+                new ScaleRecord().setRedistributedPartitions(List.of(3)));
     // when
     engine.writeRecords(scaleTo3, bootstrapPartitionsTo3);
 
@@ -313,9 +309,7 @@ public class ScaleUpTest {
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
-                new ScaleRecord()
-                    .setDesiredPartitionCount(4)
-                    .setRedistributedPartitions(List.of(4)));
+                new ScaleRecord().setRedistributedPartitions(List.of(4)));
     engine.writeRecords(scaleTo4, bootstrapPartitionsTo4);
 
     // then
@@ -346,9 +340,7 @@ public class ScaleUpTest {
         RecordToWrite.command()
             .scale(
                 ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
-                new ScaleRecord()
-                    .setDesiredPartitionCount(3)
-                    .setRedistributedPartitions(List.of(3)));
+                new ScaleRecord().setRedistributedPartitions(List.of(3)));
     // when
     engine.writeRecords(scaleTo3, bootstrapPartitionsTo3);
     assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -62,15 +62,25 @@ public class ScaleUpTest {
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
 
+    final var bootstrapPartitions =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+                new ScaleRecord().setDesiredPartitionCount(3));
     // when
-    engine.writeRecords(command);
+    engine.writeRecords(command, bootstrapPartitions);
 
     // then
     assertThat(
             RecordingExporter.scaleRecords()
                 .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
                 .map(Record::getIntent))
-        .containsExactly(ScaleIntent.SCALE_UP, ScaleIntent.SCALING_UP, ScaleIntent.SCALED_UP);
+        .containsExactly(
+            ScaleIntent.SCALE_UP,
+            ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALING_UP,
+            ScaleIntent.PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALED_UP);
   }
 
   @Test
@@ -217,56 +227,90 @@ public class ScaleUpTest {
                 ScaleIntent.STATUS,
                 new ScaleRecord()
                     .setDesiredPartitionCount(4)
-                    .setRedistributedPartitions(List.of(4)));
+                    .setRedistributedPartitions(List.of(3, 4)));
     // when
     final var key = engine.writeRecords(scaleUpCommand, getStatusCommand);
 
     // then
-
     final var record =
         RecordingExporter.scaleRecords()
             .limit(r -> r.getIntent() == ScaleIntent.STATUS_RESPONSE)
             .getLast();
-    assertThat(record.getValue().getRedistributedPartitions())
-        // NOTE: currently scaling up is immediate as it's implemented as noop.
-        // In the future, the expected number of partitions should be (1,2,3)
-        // until redistribution is completed
-        .containsExactlyInAnyOrder(1, 2, 3, 4);
+    assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
+    assertThat(record.getValue().getRedistributedPartitions()).isEqualTo(List.of(1, 2));
     assertThat(record.getValue().getBootstrappedAt()).isGreaterThanOrEqualTo(key);
+
+    // when the partitions are marked as bootstrapped
+    final var bootstrapPartitions =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+                new ScaleRecord().setDesiredPartitionCount(4));
+    engine.writeRecords(bootstrapPartitions, getStatusCommand);
+
+    // then
+    final var finalResponse =
+        RecordingExporter.scaleRecords()
+            .skipUntil(r -> r.getIntent() == ScaleIntent.PARTITIONS_BOOTSTRAPPED)
+            .limit(r -> r.getIntent() == ScaleIntent.STATUS_RESPONSE)
+            .getLast();
+    assertThat(finalResponse.getValue().getDesiredPartitionCount()).isEqualTo(4);
+    assertThat(finalResponse.getValue().getRedistributedPartitions())
+        .isEqualTo(List.of(1, 2, 3, 4));
   }
 
   @Test
   public void shouldScaleUpContinuously() {
     // given
-    final var command =
+    final var scaleTo3 =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
 
+    final var bootstrapPartitionsTo3 =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+                new ScaleRecord().setDesiredPartitionCount(3));
     // when
-    engine.writeRecords(command);
+    engine.writeRecords(scaleTo3, bootstrapPartitionsTo3);
 
     // then
     assertThat(
             RecordingExporter.scaleRecords()
                 .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
                 .map(Record::getIntent))
-        .hasSize(3)
-        .containsSequence(ScaleIntent.SCALE_UP, ScaleIntent.SCALING_UP, ScaleIntent.SCALED_UP);
+        .hasSize(5)
+        .containsSequence(
+            ScaleIntent.SCALE_UP,
+            ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALING_UP,
+            ScaleIntent.PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALED_UP);
 
     RecordingExporter.reset();
 
     // when scaling up again
-    final var command2 =
+    final var scaleTo4 =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(4));
-    engine.writeRecords(command2);
+    final var bootstrapPartitionsTo4 =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+                new ScaleRecord().setDesiredPartitionCount(4));
+    engine.writeRecords(scaleTo4, bootstrapPartitionsTo4);
 
     // then
     assertThat(
             RecordingExporter.scaleRecords()
                 .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
                 .map(Record::getIntent))
-        .hasSize(3)
-        .containsSequence(ScaleIntent.SCALE_UP, ScaleIntent.SCALING_UP, ScaleIntent.SCALED_UP);
+        .hasSize(5)
+        .containsSequence(
+            ScaleIntent.SCALE_UP,
+            ScaleIntent.MARK_PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALING_UP,
+            ScaleIntent.PARTITIONS_BOOTSTRAPPED,
+            ScaleIntent.SCALED_UP);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributorTest.java
@@ -141,7 +141,7 @@ public class DeploymentRedistributorTest {
 
     // then
     // Partition 3 is now scaled up, so it should be redistributed
-    routingState.arriveAtDesiredState();
+    routingState.activatePartition(3);
 
     // run the scheduled task twice, since first one always does not try distributing the records
     scheduledTask.run();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
@@ -77,7 +77,8 @@ final class DbRoutingStateTest {
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(1));
 
     // when
-    routingState.arriveAtDesiredState();
+    routingState.activatePartition(2);
+    routingState.activatePartition(3);
 
     // then
     assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionBootstrappedRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionBootstrappedRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public class BrokerPartitionBootstrappedRequest extends BrokerExecuteCommand<ScaleRecord> {
+
+  private final ScaleRecord requestDto = new ScaleRecord();
+
+  public BrokerPartitionBootstrappedRequest(final int bootstrappedPartition) {
+    super(ValueType.SCALE, ScaleIntent.MARK_PARTITION_BOOTSTRAPPED);
+    requestDto.setRedistributedPartitions(List.of(bootstrappedPartition));
+
+    // set the target partition for this request
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ScaleRecord toResponseDto(final DirectBuffer buffer) {
+    final var responseDto = new ScaleRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -14,6 +14,9 @@ import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue {
   private final IntegerProperty desiredPartitionCountProp =
@@ -49,8 +52,10 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   }
 
   @Override
-  public Collection<Integer> getRedistributedPartitions() {
-    return redistributedPartitions.stream().map(IntegerValue::getValue).toList();
+  public SortedSet<Integer> getRedistributedPartitions() {
+    return redistributedPartitions.stream()
+        .map(IntegerValue::getValue)
+        .collect(Collectors.toCollection(TreeSet::new));
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
@@ -22,7 +22,9 @@ public enum ScaleIntent implements Intent {
   SCALING_UP((short) 2, true),
   SCALED_UP((short) 3, true),
   STATUS((short) 4, false),
-  STATUS_RESPONSE((short) 5, true);
+  STATUS_RESPONSE((short) 5, true),
+  MARK_PARTITIONS_BOOTSTRAPPED((short) 6, false),
+  PARTITIONS_BOOTSTRAPPED((short) 7, true);
 
   // A static field is needed as values() would allocate at every call
   private static final ScaleIntent[] INTENTS = values();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
@@ -23,8 +23,8 @@ public enum ScaleIntent implements Intent {
   SCALED_UP((short) 3, true),
   STATUS((short) 4, false),
   STATUS_RESPONSE((short) 5, true),
-  MARK_PARTITIONS_BOOTSTRAPPED((short) 6, false),
-  PARTITIONS_BOOTSTRAPPED((short) 7, true);
+  MARK_PARTITION_BOOTSTRAPPED((short) 6, false),
+  PARTITION_BOOTSTRAPPED((short) 7, true);
 
   // A static field is needed as values() would allocate at every call
   private static final ScaleIntent[] INTENTS = values();


### PR DESCRIPTION
## Description
When a partition has complete the bootstrap, it will inform partition 1 that it's ready to be included in the set of active partition.

A new command intent has been created for it (`MARK_PARTITION_BOOTSTRAPPED`) and the corresponding event (`PARTITION_BOOTSTRAPPED`).
Each partition is moved to the set of active partition individually, not in bulk as it was before (with `moveToDesiredState`).

Currently, when the last partition has bootstrapped, the SCALED_UP event is sent. When relocation will be activated as well, SCALED_UP will be sent when relocation is done.
> [!NOTE]
> Command distribution for these events is implemented in  PR #33164 (based on this).

## Related issues
relates #31092
