### PR TITLE
Automate changelog generation

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -240,7 +240,13 @@ jobs:
           gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
           tar -xzvf zeebe-changelog_*
           chmod +x zcl
-      - name: Generate Changelog for patch release
+      - name: Identify previous release version
+        id: prev_version
+        uses: camunda/infra-global-github-actions/previous-version@main
+        with:
+          version: "${{ inputs.releaseVersion }}"
+          verbose: 'false'
+      - name: Generate Changelog
         id: gen-changelog
         run: |
           # We set some bash properties to better fail/debug this script
@@ -252,41 +258,28 @@ jobs:
 
           # Default changelog value
           changelog="Release ${{ inputs.releaseVersion }}"
-          isDraftRelease="true"
 
-          # Right now we only support patch releases for generating the changelog
-          # as it is the easiest to automate and the most repetitive work to do on a release
-          if [[ "${{ inputs.releaseVersion }}" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
-          then
-            # Next, add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
-            #
-            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
-            # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
-            #
-            # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.
+          # Add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
+          #
+          # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
+          # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type
+          ZCL_FROM_REV="${{ steps.prev_version.outputs.previous_version }}"
+          ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
 
-            # To find the previous patch version we extract the patch version and subtract by one
-            patchVersion=$(echo "${{ inputs.releaseVersion }}" | sed 's/8\.[1-9][0-9]*\.//')
-            majorMinor=$(echo "${{ inputs.releaseVersion }}" | sed 's/\.[1-9][0-9]*$//')
-            ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
-            ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
+          # The following command will add labels to the issues on GitHub.
+          # You can verify this step by looking at closed issues. They should now be tagged with the release.
+          ./zcl add-labels \
+          --token=${{ secrets.GITHUB_TOKEN }} \
+          --from="$ZCL_FROM_REV" \
+          --target="$ZCL_TARGET_REV" \
+          --label="version:$ZCL_TARGET_REV" \
+          --org camunda --repo camunda
 
-            # The following command will add labels to the issues on GitHub.
-            # You can verify this step by looking at closed issues. They should now be tagged with the release.
-            ./zcl add-labels \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --from="$ZCL_FROM_REV" \
-            --target="$ZCL_TARGET_REV" \
-            --label="version:$ZCL_TARGET_REV" \
-            --org camunda --repo zeebe
-
-            # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
-            changelog=$(./zcl generate \
-            --token=${{ secrets.GITHUB_TOKEN }} \
-            --label="version:$ZCL_TARGET_REV" \
-            --org camunda --repo zeebe)
-            isDraftRelease="false"
-          fi
+          # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
+          changelog=$(./zcl generate \
+          --token=${{ secrets.GITHUB_TOKEN }} \
+          --label="version:$ZCL_TARGET_REV" \
+          --org camunda --repo camunda)
 
           # With multiline strings the output needs to be set differently.
           #
@@ -297,7 +290,6 @@ jobs:
             echo "$changelog"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
-          echo "isDraftRelease=$isDraftRelease" >> "$GITHUB_OUTPUT"
 
           # To show the changelog also as step summary
           echo "$changelog" >> "$GITHUB_STEP_SUMMARY"
@@ -336,7 +328,7 @@ jobs:
           name: ${{ inputs.releaseVersion }}
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
-          draft: ${{ steps.gen-changelog.outputs.isDraftRelease }}
+          draft: false
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}


### PR DESCRIPTION
## Description

Enable automated changelog generation for all release versions. 
Besides, Github release is now created as non-draft for all versions.

[prev_tag.sh](https://github.com/camunda/camunda/compare/32376-automate-changelog-generation?expand=1#diff-a2fdc1853eebc73d915f38b1c9cafd95c4cbdd4ca9e3d4457e4cf6fcfc9aae82) is introduced for previous release version identification.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32376
