### PR TITLE
Minor: rename for consistency

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -45,10 +45,10 @@ public interface BatchOperationFilter extends SearchRequestFilter {
   /**
    * Filters batch operations by the specified type.
    *
-   * @param operationType the operationType
+   * @param batchOperationType the batchOperationType
    * @return the updated filter
    */
-  BatchOperationFilter operationType(final BatchOperationType operationType);
+  BatchOperationFilter operationType(final BatchOperationType batchOperationType);
 
   /**
    * Filter by operationType using {@link BatchOperationType} consumer


### PR DESCRIPTION
## Description
I noticed that commit [d5b4cbb](https://github.com/camunda/camunda/commit/d5b4cbb#diff-6b13af31803af7ea6e099ff50d4914652d9df5b4d9e6a22341e9fe1a54626004L56), renamed the parameter operationType to batchOperationType.

Here's a small patch to make that change consistent with the method overriden method `BatchOperationFilter.operationType`:


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
