### PR TITLE
Refactoring `newUnassignUserFromTenantCommand` to follow the agreed command pattern

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2053,18 +2053,18 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newUnassignUserFromTenantCommand(tenantId)
+   *   .newUnassignUserFromTenantCommand()
    *   .username(username)
+   *   .tenantId(tenantId)
    *   .send();
    * </pre>
    *
    * <p>This command sends an HTTP DELETE request to remove the specified user from the given
    * tenant.
    *
-   * @param tenantId the unique identifier of the tenant
    * @return a builder for the remove user from tenant command
    */
-  RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand(String tenantId);
+  RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand();
 
   /**
    * Command to assign a group to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/RemoveUserFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/RemoveUserFromTenantCommandStep1.java
@@ -18,14 +18,25 @@ package io.camunda.client.api.command;
 import io.camunda.client.api.response.RemoveUserFromTenantResponse;
 
 /** Command to remove a user from a tenant. */
-public interface RemoveUserFromTenantCommandStep1
-    extends FinalCommandStep<RemoveUserFromTenantResponse> {
+public interface RemoveUserFromTenantCommandStep1 {
 
   /**
    * Sets the username for the removal of assignment.
    *
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
+   * @return the builder for this command.
    */
-  RemoveUserFromTenantCommandStep1 username(String username);
+  RemoveUserFromTenantCommandStep2 username(String username);
+
+  interface RemoveUserFromTenantCommandStep2
+      extends FinalCommandStep<RemoveUserFromTenantResponse> {
+
+    /**
+     * Sets the tenant ID.
+     *
+     * @param tenantId the tenantId of the tenant
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    RemoveUserFromTenantCommandStep2 tenantId(String tenantId);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -1099,8 +1099,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand(final String tenantId) {
-    return new RemoveUserFromTenantCommandImpl(httpClient, tenantId);
+  public RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand() {
+    return new RemoveUserFromTenantCommandImpl(httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/RemoveUserFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/RemoveUserFromTenantCommandImpl.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
+import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1.RemoveUserFromTenantCommandStep2;
 import io.camunda.client.api.response.RemoveUserFromTenantResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
@@ -25,22 +26,28 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public final class RemoveUserFromTenantCommandImpl implements RemoveUserFromTenantCommandStep1 {
+public final class RemoveUserFromTenantCommandImpl
+    implements RemoveUserFromTenantCommandStep1, RemoveUserFromTenantCommandStep2 {
 
-  private final String tenantId;
+  private String tenantId;
   private String username;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public RemoveUserFromTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
+  public RemoveUserFromTenantCommandImpl(final HttpClient httpClient) {
     this.httpClient = httpClient;
-    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 username(final String username) {
+  public RemoveUserFromTenantCommandStep2 username(final String username) {
     this.username = username;
+    return this;
+  }
+
+  @Override
+  public RemoveUserFromTenantCommandStep2 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
@@ -34,7 +34,7 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   @Test
   void shouldRemoveUserFromTenant() {
     // when
-    client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newUnassignUserFromTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -54,7 +54,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+                client
+                    .newUnassignUserFromTenantCommand()
+                    .username(USERNAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -69,7 +74,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+                client
+                    .newUnassignUserFromTenantCommand()
+                    .username(USERNAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -84,7 +94,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+                client
+                    .newUnassignUserFromTenantCommand()
+                    .username(USERNAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -99,7 +114,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+                client
+                    .newUnassignUserFromTenantCommand()
+                    .username(USERNAME)
+                    .tenantId(TENANT_ID)
+                    .send()
+                    .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -59,7 +59,7 @@ class RemoveUserFromTenantTest {
   @Test
   void shouldRemoveUserFromTenant() {
     // When
-    client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newUnassignUserFromTenantCommand().username(USERNAME).tenantId(TENANT_ID).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityRemovedFromTenant(
@@ -75,8 +75,9 @@ class RemoveUserFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignUserFromTenantCommand(invalidTenantId)
+                    .newUnassignUserFromTenantCommand()
                     .username(USERNAME)
+                    .tenantId(invalidTenantId)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -103,8 +104,9 @@ class RemoveUserFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignUserFromTenantCommand(TENANT_ID)
+                    .newUnassignUserFromTenantCommand()
                     .username(unassignedUsername)
+                    .tenantId(TENANT_ID)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)


### PR DESCRIPTION
## Description

Ensure `newUnassignUserFromTenantCommand` is following the agreed pattern: `assignXToY().x("").y("")` Same applies for unassign.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32514
