### PR TITLE
schema-manager module unit and integration tests are not part of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [ root, modules, qa-integration, qa-update ]
         include:
           - group: root
             name: "Root Acceptance Tests"
@@ -714,6 +713,13 @@ jobs:
             runs-on: gcp-perf-core-16-longrunning
             docker-repository: localhost:5000/camunda/zeebe
             docker-file: Dockerfile
+          - group: schema-manager
+            name: "Schema Manager Integration Tests"
+            maven-modules: "schema-manager"
+            maven-build-threads: 1
+            maven-test-fork-count: 3
+            runs-on: gcp-perf-core-8-default
+            docker-file: ''
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
@@ -770,6 +776,7 @@ jobs:
         with:
           maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
+        if: ${{ matrix.docker-file != '' }}
         with:
           repository: ${{ matrix.docker-repository }}
           version: ${{ env.DOCKER_IMAGE_TAG }}

--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -172,44 +172,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <skipITs>${skipITs}</skipITs>
-          <includes>
-            <include>**/IT*.java</include>
-            <include>**/*IT.java</include>
-            <include>**/*ITCase.java</include>
-          </includes>
-          <excludes>
-            <exclude>${excludeITNames}</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>${excludeITNames}</exclude>
-          </excludes>
-          <skipTests>${skipITs}</skipTests>
-        </configuration>
       </plugin>
 
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>skipITs</id>
-      <activation>
-        <property>
-          <name>skipITs</name>
-        </property>
-      </activation>
-      <properties>
-        <excludeITNames>**/**/*IT.java</excludeITNames>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/ElasticsearchEngineClientIT.java
@@ -69,10 +69,13 @@ public class ElasticsearchEngineClientIT {
   void shouldPutMappingCorrectly() throws IOException {
     // given
     final var indexName = "test";
-    elsClient.indices().create(req -> req.index(indexName));
+    final var indexAlias = "test_alias";
+    elsClient
+        .indices()
+        .create(req -> req.index(indexName).aliases(indexAlias, a -> a.isWriteIndex(false)));
 
     final var descriptor = mock(IndexDescriptor.class);
-    doReturn(indexName).when(descriptor).getFullQualifiedName();
+    doReturn(indexAlias).when(descriptor).getAlias();
 
     final Set<IndexMappingProperty> newProperties = new HashSet<>();
     newProperties.add(new IndexMappingProperty("email", Map.of("type", "keyword")));

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerConcurrencyIT.java
@@ -72,7 +72,7 @@ public class SchemaManagerConcurrencyIT {
 
     index =
         SchemaTestUtil.mockIndex(
-            CONFIG_PREFIX + "-qualified_name", "alias", "index_name", "/mappings.json");
+            CONFIG_PREFIX + "-index-qualified_name", "alias", "index_name", "/mappings.json");
 
     when(indexTemplate.getFullQualifiedName()).thenReturn(CONFIG_PREFIX + "-qualified_name");
   }
@@ -163,9 +163,9 @@ public class SchemaManagerConcurrencyIT {
 
     // then
     assertThat(exceptions).isEmpty();
-    // assert that both schema managers detected a diff in the index mapping
-    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, Map.class)).hasSize(1);
-    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, Map.class)).hasSize(1);
+    // assert that both schema managers detected diffs in the index and index template mappings
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread1, Map.class)).hasSize(2);
+    assertThat(PostMethodPauseAdvice.getReturnedValueBeforePause(thread2, Map.class)).hasSize(2);
     // assert that the schema was correctly updated
     final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
     final var retrievedIndexTemplate =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As reported in this [Slack channel](https://camunda.slack.com/archives/C08MRKHJ0CD/p1749072776864559), 
The unit tests and integration tests of the schema-manager module are not part of any job in the common CI.

- I fixed the pom.xml so that unit tests are not skipped, now they should be part of ["[UT] General Unit Tests"](https://github.com/camunda/camunda/actions/runs/15464274889/job/43532653031?pr=33184) job
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.camunda.search.schema.IndexMappingTest
[INFO] Running io.camunda.search.schema.IndexSchemaValidatorTest
```

- In `ci.yml` I added a new group in the integration tests matrix to run integration tests that are part of  schema-manager module: [[IT] Schema Manager Integration Tests](https://github.com/camunda/camunda/actions/runs/15464274889/job/43532663230?pr=33184)

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.camunda.search.schema.OpensearchEngineClientIT
[INFO] Running io.camunda.search.schema.SchemaManagerConcurrencyIT
[INFO] Running io.camunda.search.schema.SchemaManagerIT
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[INFO] Running io.camunda.search.schema.OpensearchEngineClientIT$ImportersCompleted
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 79.38 s -- in io.camunda.search.schema.SchemaManagerConcurrencyIT
[INFO] Running io.camunda.search.schema.ElasticsearchEngineClientIT
[INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 106.7 s -- in io.camunda.search.schema.SchemaManagerIT
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.68 s -- in io.camunda.search.schema.OpensearchEngineClientIT$ImportersCompleted
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 108.7 s -- in io.camunda.search.schema.OpensearchEngineClientIT
[INFO] Running io.camunda.search.schema.ElasticsearchEngineClientIT$ImportersCompleted
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.548 s -- in io.camunda.search.schema.ElasticsearchEngineClientIT$ImportersCompleted
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.94 s -- in io.camunda.search.schema.ElasticsearchEngineClientIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 90, Failures: 0, Errors: 0, Skipped: 0
```

- I had to fix a couple of failing tests, luckily no code change was needed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
