### PR TITLE
fix: use correct tag for zeebe broker deployment

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -297,6 +297,8 @@ jobs:
           --set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set camunda-platform.core.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.core.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
+          --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
+          --set camunda-platform.zeebe.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
           --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe


### PR DESCRIPTION
## Description

This PR fixes the 8.6 benchmark workflow which does not set the right tag on the Zeebe broker statefulset (it defaults to 8.6.13 instead).
