### PR TITLE
deps: Revert Update alpine Docker tag to v3.19.7

### DIFF
--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="alpine:3.19.7"
-ARG BASE_DIGEST="sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377"
+ARG BASE_IMAGE="alpine:3.19.1"
+ARG BASE_DIGEST="sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b"
 
 # Prepare Operate Distribution
 FROM ${BASE_IMAGE}@${BASE_DIGEST} as prepare


### PR DESCRIPTION
Renovate alpine update had to be reverted because it blocked the release.

More context in the incident slack channel: https://camunda.slack.com/archives/C0900LW01GA

There is a follow up to look into this problem: https://github.com/camunda/camunda/issues/33187

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
