### PR TITLE
deps: prepare for next development iteration

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../operate/pom.xml</relativePath>
   </parent>
 

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-archiver</artifactId>

--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-common</artifactId>

--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-data-generator</artifactId>

--- a/operate/importer-8_4/pom.xml
+++ b/operate/importer-8_4/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_4</artifactId>

--- a/operate/importer-8_5/pom.xml
+++ b/operate/importer-8_5/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-8_5</artifactId>

--- a/operate/importer-common/pom.xml
+++ b/operate/importer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer-common</artifactId>

--- a/operate/importer/pom.xml
+++ b/operate/importer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-importer</artifactId>

--- a/operate/mvc-auth-commons/pom.xml
+++ b/operate/mvc-auth-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-mvc-auth-commons</artifactId>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -5,7 +5,7 @@
   <name>Operate Parent</name>
   <groupId>io.camunda</groupId>
   <artifactId>operate-parent</artifactId>
-  <version>8.5.14-SNAPSHOT</version>
+  <version>8.5.16-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>

--- a/operate/qa/backup-restore-tests/pom.xml
+++ b/operate/qa/backup-restore-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-backup-restore-tests</artifactId>
 

--- a/operate/qa/batch-operation-performance-tests/pom.xml
+++ b/operate/qa/batch-operation-performance-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-batch-operation-performance-tests</artifactId>
 

--- a/operate/qa/data-generator/pom.xml
+++ b/operate/qa/data-generator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-data-generator</artifactId>
 

--- a/operate/qa/import-performance-tests/pom.xml
+++ b/operate/qa/import-performance-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-import-performance-tests</artifactId>
 

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-it-tests</artifactId>
 

--- a/operate/qa/migration-performance-test/pom.xml
+++ b/operate/qa/migration-performance-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-performance-test</artifactId>
 

--- a/operate/qa/migration-tests/migration-test/pom.xml
+++ b/operate/qa/migration-tests/migration-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests</artifactId>
 

--- a/operate/qa/migration-tests/pom.xml
+++ b/operate/qa/migration-tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.camunda</groupId>
 		<artifactId>operate-qa</artifactId>
-		<version>8.5.14-SNAPSHOT</version>
+		<version>8.5.16-SNAPSHOT</version>
 	</parent>
 
 	<name>Operate QA Migration Tests Parent</name>

--- a/operate/qa/migration-tests/test-fixture-110/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-110/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-110</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-120/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-120/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-120</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-130/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-130/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-130</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-800/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-800/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-800</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-810/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-810/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-810</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-820/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-820/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-820</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-830/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-830/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-830</artifactId>
 

--- a/operate/qa/migration-tests/test-fixture-840/pom.xml
+++ b/operate/qa/migration-tests/test-fixture-840/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa-migration-tests-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-migration-tests-test-fixture-840</artifactId>
 

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-qa</artifactId>

--- a/operate/qa/query-performance-tests/pom.xml
+++ b/operate/qa/query-performance-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-query-performance-tests</artifactId>
 

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-qa</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
   </parent>
   <artifactId>operate-qa-util</artifactId>
 

--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-schema</artifactId>

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>operate-parent</artifactId>
-    <version>8.5.14-SNAPSHOT</version>
+    <version>8.5.16-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>operate-webapp</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
It seems like the release process for 8.5 is missing automation to set the new SNAPSHOT version.
This was already not done after the last release. I manually fixed this and put it in the [list of things that need to be fixed](https://docs.google.com/document/d/1PYOMGEW5vcIhgDBY_BIe62s4sE26C2EbDqjgSM30URE/) for the releases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
