### PR TITLE
Fix some memory panels

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -121,6 +121,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -184,7 +185,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -293,7 +295,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -396,7 +399,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -472,7 +476,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -577,7 +582,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -685,7 +691,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -784,7 +791,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -856,7 +864,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -964,7 +973,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1037,7 +1047,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1116,7 +1127,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1195,7 +1207,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1300,7 +1313,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1394,7 +1408,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1480,7 +1495,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -1585,7 +1601,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1751,7 +1768,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   }
                 ]
               }
@@ -5517,6 +5535,7 @@
       "panels": [
         {
           "datasource": {
+            "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
           },
           "description": "Memory limits and requests are taken from the k8 pod metrics.",
@@ -5563,7 +5582,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5619,7 +5639,7 @@
             ]
           },
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 12,
             "x": 0,
             "y": 5
@@ -5627,10 +5647,15 @@
           "id": 261,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
               "mode": "multi",
@@ -5644,22 +5669,26 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*\", container=~\"zeebe.*\"}",
+              "editorMode": "code",
+              "expr": "container_memory_rss{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"}",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{pod}} RSS",
+              "range": true,
               "refId": "A"
             },
             {
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*\", container=~\"zeebe.*\"})",
+              "editorMode": "code",
+              "expr": "max(kube_pod_container_resource_limits_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"})",
               "hide": false,
               "interval": "",
               "legendFormat": "limit",
+              "range": true,
               "refId": "B"
             },
             {
@@ -5667,9 +5696,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*\", container=~\"zeebe.*\"})",
+              "editorMode": "code",
+              "expr": "min(kube_pod_container_resource_requests_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\".*zeebe.*|core.*\", container=~\"zeebe.*|core.*\"})",
               "interval": "",
               "legendFormat": "request",
+              "range": true,
               "refId": "C"
             }
           ],
@@ -5782,7 +5813,7 @@
             ]
           },
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 12,
             "x": 12,
             "y": 5
@@ -5790,10 +5821,15 @@
           "id": 659,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
               "mode": "multi",
@@ -5855,7 +5891,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 10,
+                "fillOpacity": 0,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -5885,7 +5921,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -5901,19 +5938,24 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 14
           },
           "id": 98,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
               "mode": "multi",
-              "sort": "none"
+              "sort": "desc"
             }
           },
           "pluginVersion": "10.4.0",
@@ -6023,7 +6065,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6039,7 +6082,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 14
           },
           "id": 35,
           "options": {
@@ -6132,7 +6175,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -6144,7 +6188,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 22
           },
           "id": 579,
           "options": {
@@ -6223,7 +6267,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -6235,7 +6280,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 22
           },
           "id": 580,
           "options": {
@@ -6314,7 +6359,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6330,7 +6376,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 30
           },
           "id": 285,
           "options": {
@@ -6423,7 +6469,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6439,7 +6486,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 30
           },
           "id": 286,
           "options": {
@@ -6517,7 +6564,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6548,7 +6594,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6564,7 +6611,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 6
           },
           "id": 614,
           "options": {
@@ -6619,7 +6666,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6651,7 +6697,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent"
+                    "color": "transparent",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6667,7 +6714,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 15
           },
           "id": 64,
           "options": {
@@ -6723,7 +6770,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6755,7 +6801,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -6771,7 +6818,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 15
           },
           "id": 294,
           "options": {
@@ -8765,7 +8812,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9156,7 +9204,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -9187,7 +9234,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9332,7 +9380,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -9417,7 +9465,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -9646,7 +9694,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -9774,7 +9823,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12712,7 +12762,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12728,7 +12779,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 13
+            "y": 44
           },
           "id": 180,
           "options": {
@@ -12808,7 +12859,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12824,7 +12876,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 52
           },
           "id": 368,
           "options": {
@@ -12905,7 +12957,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -12921,7 +12974,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 52
           },
           "id": 411,
           "options": {
@@ -12971,7 +13024,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13002,7 +13054,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -13018,7 +13071,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 59
           },
           "id": 300,
           "options": {
@@ -13089,7 +13142,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 59
           },
           "id": 89,
           "options": {
@@ -13130,7 +13183,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13173,7 +13226,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 66
           },
           "id": 401,
           "options": {
@@ -13214,7 +13267,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13250,7 +13303,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13281,7 +13333,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -13297,7 +13350,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 66
           },
           "id": 416,
           "options": {
@@ -13390,7 +13443,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 73
           },
           "id": 386,
           "options": {
@@ -13431,7 +13484,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13473,7 +13526,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 73
           },
           "id": 81,
           "options": {
@@ -13515,7 +13568,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13558,7 +13611,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 79
           },
           "id": 426,
           "options": {
@@ -13599,7 +13652,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13634,7 +13687,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13665,7 +13717,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -13681,7 +13734,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 79
           },
           "id": 427,
           "options": {
@@ -13747,7 +13800,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 86
           },
           "id": 78,
           "options": {
@@ -13788,7 +13841,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13829,7 +13882,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 86
           },
           "id": 391,
           "options": {
@@ -13870,7 +13923,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13913,7 +13966,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 92
           },
           "id": 559,
           "options": {
@@ -13954,7 +14007,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -13990,7 +14043,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14021,7 +14073,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -14033,7 +14086,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 92
           },
           "id": 560,
           "options": {
@@ -14098,7 +14151,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -14131,7 +14183,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -14143,7 +14196,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 509
+            "y": 45
           },
           "id": 356,
           "options": {
@@ -14203,7 +14256,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 542
+            "y": 51
           },
           "id": 357,
           "options": {
@@ -14243,7 +14296,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -14287,7 +14340,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 542
+            "y": 51
           },
           "id": 358,
           "options": {
@@ -14328,7 +14381,7 @@
               "unit": "kbytes"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -14365,7 +14418,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14398,7 +14450,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -14410,7 +14463,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 550
+            "y": 59
           },
           "id": 586,
           "options": {
@@ -14462,7 +14515,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14495,7 +14547,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -14507,7 +14560,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 550
+            "y": 59
           },
           "id": 589,
           "options": {
@@ -14559,7 +14612,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14592,7 +14644,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -14604,7 +14657,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 550
+            "y": 59
           },
           "id": 590,
           "options": {
@@ -14655,7 +14708,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14686,7 +14738,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -14701,7 +14754,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 559
+            "y": 68
           },
           "id": 606,
           "options": {
@@ -14755,7 +14808,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14786,7 +14838,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -14801,7 +14854,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 559
+            "y": 68
           },
           "id": 607,
           "options": {
@@ -14869,7 +14922,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14900,7 +14952,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -14911,7 +14964,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 567
+            "y": 76
           },
           "id": 608,
           "options": {
@@ -14962,7 +15015,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14993,7 +15045,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -15004,7 +15057,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 567
+            "y": 76
           },
           "id": 609,
           "options": {
@@ -15055,7 +15108,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15086,7 +15138,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15101,7 +15154,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 575
+            "y": 84
           },
           "id": 610,
           "options": {
@@ -15166,7 +15219,6 @@
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15197,7 +15249,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15212,7 +15265,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 575
+            "y": 84
           },
           "id": 611,
           "options": {
@@ -15274,7 +15327,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 583
+            "y": 92
           },
           "id": 588,
           "options": {
@@ -15344,7 +15397,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 583
+            "y": 92
           },
           "id": 591,
           "options": {
@@ -15415,7 +15468,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 583
+            "y": 92
           },
           "id": 592,
           "options": {
@@ -15472,7 +15525,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -15492,7 +15546,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 583
+            "y": 92
           },
           "id": 613,
           "options": {
@@ -15510,7 +15564,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -15562,7 +15616,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 10,
+                "fillOpacity": 2,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -15580,7 +15634,7 @@
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "normal"
+                  "mode": "none"
                 },
                 "thresholdsStyle": {
                   "mode": "off"
@@ -15593,7 +15647,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15609,7 +15664,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 1276
+            "y": 48
           },
           "id": 154,
           "options": {
@@ -15690,7 +15745,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15706,7 +15762,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1276
+            "y": 48
           },
           "id": 144,
           "options": {
@@ -15786,7 +15842,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15802,7 +15859,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1282
+            "y": 54
           },
           "id": 142,
           "options": {
@@ -15883,7 +15940,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15899,7 +15957,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 1288
+            "y": 60
           },
           "id": 151,
           "options": {
@@ -15980,7 +16038,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -15996,7 +16055,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1288
+            "y": 60
           },
           "id": 152,
           "options": {
@@ -16077,7 +16136,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16093,7 +16153,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1294
+            "y": 66
           },
           "id": 150,
           "options": {
@@ -16174,7 +16234,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16190,7 +16251,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 1300
+            "y": 72
           },
           "id": 147,
           "options": {
@@ -16271,7 +16332,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16287,7 +16349,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1300
+            "y": 72
           },
           "id": 149,
           "options": {
@@ -16367,7 +16429,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16383,7 +16446,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1307
+            "y": 79
           },
           "id": 148,
           "options": {
@@ -16463,7 +16526,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16479,7 +16543,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1313
+            "y": 85
           },
           "id": 155,
           "options": {
@@ -16559,7 +16623,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16575,7 +16640,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1313
+            "y": 85
           },
           "id": 156,
           "options": {
@@ -16654,7 +16719,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16669,7 +16735,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 1321
+            "y": 93
           },
           "id": 158,
           "options": {
@@ -16750,7 +16816,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16766,7 +16833,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 1321
+            "y": 93
           },
           "id": 157,
           "options": {
@@ -16846,7 +16913,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16862,7 +16930,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1321
+            "y": 93
           },
           "id": 146,
           "options": {
@@ -16942,7 +17010,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -16958,7 +17027,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 1327
+            "y": 99
           },
           "id": 159,
           "options": {
@@ -17038,7 +17107,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -17054,7 +17124,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 1327
+            "y": 99
           },
           "id": 160,
           "options": {
@@ -17135,7 +17205,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -17151,7 +17222,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1327
+            "y": 99
           },
           "id": 153,
           "options": {
@@ -17234,7 +17305,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -17250,7 +17322,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 1334
+            "y": 106
           },
           "id": 603,
           "options": {
@@ -17324,7 +17396,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 227
           },
           "id": 20,
           "options": {
@@ -17431,7 +17503,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -17447,7 +17520,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 227
           },
           "id": 255,
           "options": {
@@ -17502,7 +17575,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 237
           },
           "id": 21,
           "options": {
@@ -17624,7 +17697,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 237
           },
           "id": 185,
           "options": {
@@ -17725,7 +17798,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 70
+            "y": 247
           },
           "id": 52,
           "options": {
@@ -20483,7 +20556,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 690
+            "y": 232
           },
           "id": 538,
           "options": {
@@ -20524,7 +20597,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -20568,7 +20641,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 690
+            "y": 232
           },
           "id": 540,
           "options": {
@@ -20609,7 +20682,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "11.4.0",
+          "pluginVersion": "10.4.0",
           "targets": [
             {
               "datasource": {
@@ -20646,7 +20719,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20678,7 +20750,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -20694,7 +20767,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 714
+            "y": 240
           },
           "id": 444,
           "options": {
@@ -20758,7 +20831,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20789,7 +20861,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -20805,7 +20878,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 714
+            "y": 240
           },
           "id": 446,
           "options": {
@@ -20869,7 +20942,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20900,7 +20972,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -20915,7 +20988,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 722
+            "y": 248
           },
           "id": 440,
           "options": {
@@ -20965,7 +21038,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20996,7 +21068,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21011,7 +21084,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 722
+            "y": 248
           },
           "id": 442,
           "options": {
@@ -21082,7 +21155,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1281
+            "y": 233
           },
           "id": 547,
           "options": {
@@ -21190,7 +21263,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21205,7 +21279,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1281
+            "y": 233
           },
           "id": 549,
           "options": {
@@ -21301,7 +21375,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21317,7 +21392,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 1282
+            "y": 234
           },
           "id": 562,
           "options": {
@@ -21400,7 +21475,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21416,7 +21492,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 1282
+            "y": 234
           },
           "id": 563,
           "options": {
@@ -21499,7 +21575,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21515,7 +21592,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 1282
+            "y": 234
           },
           "id": 564,
           "options": {
@@ -21589,7 +21666,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21621,7 +21697,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21637,7 +21714,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 675
+            "y": 235
           },
           "id": 566,
           "options": {
@@ -21688,7 +21765,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21720,7 +21796,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21736,7 +21813,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 675
+            "y": 235
           },
           "id": 567,
           "options": {
@@ -21787,7 +21864,6 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
-                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21819,7 +21895,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21835,7 +21912,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 675
+            "y": 235
           },
           "id": 568,
           "options": {
@@ -21930,7 +22007,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -21965,7 +22043,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1284
+            "y": 236
           },
           "id": 573,
           "options": {
@@ -22056,7 +22134,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -22091,7 +22170,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1284
+            "y": 236
           },
           "id": 574,
           "options": {
@@ -22189,7 +22268,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -22205,7 +22285,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1292
+            "y": 244
           },
           "id": 600,
           "options": {
@@ -22292,7 +22372,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -22308,7 +22389,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1292
+            "y": 244
           },
           "id": 601,
           "options": {
@@ -22388,7 +22469,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -22404,7 +22486,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1300
+            "y": 252
           },
           "id": 575,
           "options": {
@@ -23203,7 +23285,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -23214,7 +23297,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1311
+            "y": 239
           },
           "id": 596,
           "options": {
@@ -23283,7 +23366,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -23311,7 +23395,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1311
+            "y": 239
           },
           "id": 597,
           "options": {
@@ -23373,7 +23457,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1319
+            "y": 247
           },
           "id": 598,
           "options": {
@@ -23454,7 +23538,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -23498,7 +23583,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1319
+            "y": 247
           },
           "id": 599,
           "options": {
@@ -23551,7 +23636,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 28
       },
       "id": 662,
       "panels": [
@@ -23624,7 +23709,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 240
           },
           "id": 664,
           "maxPerRow": 6,
@@ -23838,7 +23923,6 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "zeebe-dashboard",
-  "version": 31,
-  "weekStart": "",
-  "id": null
+  "version": 34,
+  "weekStart": ""
 }


### PR DESCRIPTION


## Description

 * Some panels were not correctly showing data or even weirdly
 * This commit improves and fixes the memory related panels
 * Add legends as tables to sort the values
 * Adjust tooltip to be ordered desc, etc.


Before:

The Process memory panel didn't worked anymore with the new deployments. Furthermore, the legend was not that useful.

![before-2](https://github.com/user-attachments/assets/b1dc55fb-a825-404f-b256-7368f6f3f89b)

The RocksDB memory always confused me with the stacked approach, I normally want to see how much memory is used by partition. 

![before](https://github.com/user-attachments/assets/fca2be0b-4c10-4fb8-9d1a-b03c1a84a4b2)


After:

The panels are fixed and I can have a better overview of the values by the legends, etc. I found it useful to make screenshots, and do investigations.

![2025-06-05_13-53](https://github.com/user-attachments/assets/d3a56b4e-722f-4044-b12b-6b9a05995a24)

Now I can clearly see how much memory is assigned to RocksDB
![2025-06-05_13-54](https://github.com/user-attachments/assets/56587cdf-aaca-425b-924c-4d27789e23c8)

<!-- Describe the goal and purpose of this PR. -->

## Related issues

Used in recent chaos day https://camunda.github.io/zeebe-chaos/2025/06/05/Lower-memory-consumption-of-Camunda-deployment
