### PR TITLE
fix: show 'user' owner type in OIDC mode for authorization creation

### DIFF
--- a/identity/client/src/pages/authorizations/modals/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/AddModal.tsx
@@ -71,9 +71,7 @@ const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
   const [apiCall, { loading, error }] = useApiCall(createAuthorization, {
     suppressErrorNotification: true,
   });
-  const [ownerType, setOwnerType] = useState<OwnerType>(
-    isOIDC ? OwnerType.MAPPING : OwnerType.USER,
-  );
+  const [ownerType, setOwnerType] = useState<OwnerType>(OwnerType.USER);
   const [ownerId, setOwnerId] = useState("");
   const [resourceId, setResourceId] = useState("");
   const [resourceType, setResourceType] =
@@ -132,7 +130,7 @@ const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
           titleText={t("ownerType")}
           items={ownerTypeItems.filter((ownerType) => {
             const excludedType = isOIDC
-              ? [OwnerType.USER]
+              ? []
               : [OwnerType.MAPPING, OwnerType.CLIENT];
 
             return !excludedType.includes(ownerType);

--- a/identity/client/src/pages/authorizations/modals/OwnerSelection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/OwnerSelection/index.tsx
@@ -15,6 +15,7 @@ import { searchRoles } from "src/utility/api/roles";
 import useTranslate from "src/utility/localization";
 import OwnerSelection from "./OwnerSelection";
 import TextField from "src/components/form/TextField";
+import { isOIDC } from "src/configuration";
 
 type SelectionProps = {
   type: OwnerType;
@@ -27,6 +28,17 @@ const Selection: FC<SelectionProps> = ({ type, ownerId, onChange }) => {
 
   switch (type) {
     case OwnerType.USER:
+      if (isOIDC) {
+        return (
+          <TextField
+            value={ownerId}
+            label={t("username")}
+            onChange={onChange}
+            placeholder={t("enterUsername")}
+            type="text"
+          />
+        );
+      }
       return (
         <OwnerSelection
           id="userSelection"
@@ -66,7 +78,6 @@ const Selection: FC<SelectionProps> = ({ type, ownerId, onChange }) => {
           itemToString={(role) => role.name || role.roleId}
         />
       );
-
     case OwnerType.CLIENT:
       return (
         <TextField

--- a/identity/client/src/utility/localization/en/authorizations.json
+++ b/identity/client/src/utility/localization/en/authorizations.json
@@ -61,5 +61,6 @@
   "deleteConfirmation": "Are you sure you want to delete the following authorization:",
   "permission": "Permission",
   "irreversibleAction": "This action cannot be undone.",
-  "selectPermission": "Select at least one permission. Visit <2>authorizations</2> for a full overview."
+  "selectPermission": "Select at least one permission. Visit <2>authorizations</2> for a full overview.",
+  "enterUsername": "Enter username"
 }


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
I readded the user option in OIDC mode as a text field to provide the username
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33211
