### PR TITLE
fix: Write `VariableDocument` terminal events with `operationReference`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
-import java.util.OptionalInt;
-import java.util.OptionalLong;
+import io.camunda.zeebe.protocol.record.RecordMetadataDecoder;
 
 /**
  * Metadata for customizing the writing of follow-up event.
@@ -20,7 +19,7 @@ import java.util.OptionalLong;
  */
 public final class FollowUpEventMetadata {
 
-  private static final int NOT_SET = -1;
+  public static final int VERSION_NOT_SET = -1;
 
   private final long operationReference;
   private final int recordVersion;
@@ -30,14 +29,12 @@ public final class FollowUpEventMetadata {
     this.recordVersion = builder.recordVersion;
   }
 
-  public OptionalLong getOperationReference() {
-    return operationReference == NOT_SET
-        ? OptionalLong.empty()
-        : OptionalLong.of(operationReference);
+  public long getOperationReference() {
+    return operationReference;
   }
 
-  public OptionalInt getRecordVersion() {
-    return recordVersion == NOT_SET ? OptionalInt.empty() : OptionalInt.of(recordVersion);
+  public int getRecordVersion() {
+    return recordVersion;
   }
 
   public static Builder builder() {
@@ -46,8 +43,8 @@ public final class FollowUpEventMetadata {
 
   public static final class Builder {
 
-    private long operationReference = NOT_SET;
-    private int recordVersion = NOT_SET;
+    private long operationReference = RecordMetadataDecoder.operationReferenceNullValue();
+    private int recordVersion = VERSION_NOT_SET;
 
     public Builder operationReference(final long operationReference) {
       this.operationReference = operationReference;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/FollowUpEventMetadata.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.streamprocessor;
+
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+/**
+ * Metadata for customizing the writing of follow-up event.
+ *
+ * <p>This metadata allows enriching follow-up events with additional information such as {@code
+ * operationReference} (to correlate follow-up records with prior client operations) and {@code
+ * recordVersion} (to specify a version of the event record to use when writing and applying the
+ * event).
+ */
+public final class FollowUpEventMetadata {
+
+  private static final int NOT_SET = -1;
+
+  private final long operationReference;
+  private final int recordVersion;
+
+  private FollowUpEventMetadata(Builder builder) {
+    this.operationReference = builder.operationReference;
+    this.recordVersion = builder.recordVersion;
+  }
+
+  public OptionalLong getOperationReference() {
+    return operationReference == NOT_SET
+        ? OptionalLong.empty()
+        : OptionalLong.of(operationReference);
+  }
+
+  public OptionalInt getRecordVersion() {
+    return recordVersion == NOT_SET ? OptionalInt.empty() : OptionalInt.of(recordVersion);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private long operationReference = NOT_SET;
+    private int recordVersion = NOT_SET;
+
+    public Builder operationReference(final long operationReference) {
+      this.operationReference = operationReference;
+      return this;
+    }
+
+    public Builder recordVersion(final int recordVersion) {
+      this.recordVersion = recordVersion;
+      return this;
+    }
+
+    public FollowUpEventMetadata build() {
+      return new FollowUpEventMetadata(this);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -56,7 +56,9 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
       final RecordValue value,
       final FollowUpEventMetadata metadata) {
     final int recordVersion =
-        metadata.getRecordVersion().orElseGet(() -> eventApplier.getLatestVersion(intent));
+        metadata.getRecordVersion() == FollowUpEventMetadata.VERSION_NOT_SET
+            ? eventApplier.getLatestVersion(intent)
+            : metadata.getRecordVersion();
 
     final var recordMetadata =
         new RecordMetadata()
@@ -64,8 +66,8 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
             .intent(intent)
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason("");
-    metadata.getOperationReference().ifPresent(recordMetadata::operationReference);
+            .rejectionReason("")
+            .operationReference(metadata.getOperationReference());
 
     resultBuilder().appendRecord(key, value, recordMetadata);
     eventApplier.applyState(key, intent, value, recordVersion);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -46,8 +46,7 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
-    appendFollowUpEvent(
-        key, intent, value, FollowUpEventMetadata.builder().recordVersion(recordVersion).build());
+    appendFollowUpEvent(key, intent, value, m -> m.recordVersion(recordVersion));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedEventApplyingStateWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -45,14 +46,29 @@ final class ResultBuilderBackedEventApplyingStateWriter extends AbstractResultBu
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
-    final var metadata =
+    appendFollowUpEvent(
+        key, intent, value, FollowUpEventMetadata.builder().recordVersion(recordVersion).build());
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final FollowUpEventMetadata metadata) {
+    final int recordVersion =
+        metadata.getRecordVersion().orElseGet(() -> eventApplier.getLatestVersion(intent));
+
+    final var recordMetadata =
         new RecordMetadata()
             .recordType(RecordType.EVENT)
             .intent(intent)
             .recordVersion(recordVersion)
             .rejectionType(RejectionType.NULL_VAL)
             .rejectionReason("");
-    resultBuilder().appendRecord(key, value, metadata);
+    metadata.getOperationReference().ifPresent(recordMetadata::operationReference);
+
+    resultBuilder().appendRecord(key, value, recordMetadata);
     eventApplier.applyState(key, intent, value, recordVersion);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
@@ -14,7 +15,7 @@ import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 public interface TypedEventWriter {
 
   /**
-   * Append a follow up event to the result builder.
+   * Append a follow-up event to the result builder.
    *
    * <p>Different versions of event records may be applied by different {@link
    * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
@@ -23,8 +24,11 @@ public interface TypedEventWriter {
    * of Zeebe.
    *
    * <p>This method always uses the latest available {@link
-   * io.camunda.zeebe.engine.state.EventApplier EventApplier}. If a specific needs to be used,
-   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, int)} instead.
+   * io.camunda.zeebe.engine.state.EventApplier}. If a specific version needs to be used, consider
+   * using {@link #appendFollowUpEvent(long, Intent, RecordValue, int)} instead.
+   *
+   * <p>For advanced use cases requiring enriched metadata such as {@code operationReference},
+   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, FollowUpEventMetadata)}.
    *
    * @param key the key of the event
    * @param intent the intent of the event
@@ -34,13 +38,15 @@ public interface TypedEventWriter {
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
 
   /**
-   * Append a specific version of a follow up event to the result builder.
+   * Append a specific version of a follow-up event to the result builder.
    *
    * <p>Different versions of event records may be applied by different {@link
-   * io.camunda.zeebe.engine.state.EventApplier EventApplier}s, leading to differing state changes.
-   * This allows fixing bugs in event appliers because every event applier must produce the same
-   * state changes for an event both when writing it and when replaying it, even on newer versions
-   * of Zeebe.
+   * io.camunda.zeebe.engine.state.EventApplier}s, leading to differing state changes. This allows
+   * fixing bugs in event appliers because every event applier must produce the same state changes
+   * for an event both when writing it and when replaying it, even on newer versions of Zeebe.
+   *
+   * <p>For advanced use cases requiring additional metadata such as {@code operationReference},
+   * consider using {@link #appendFollowUpEvent(long, Intent, RecordValue, FollowUpEventMetadata)}.
    *
    * @param key the key of the event
    * @param intent the intent of the event
@@ -49,6 +55,29 @@ public interface TypedEventWriter {
    * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
    */
   void appendFollowUpEvent(long key, Intent intent, RecordValue value, int recordVersion);
+
+  /**
+   * Append a follow-up event with additional metadata (like operation reference and/or record
+   * version).
+   *
+   * <p>This variant allows writing enriched events with a specific {@code operationReference} that
+   * will be used to correlate event with the client operations.
+   *
+   * <p>If the record version isn't explicitly set in metadata, the latest version from the {@link
+   * io.camunda.zeebe.engine.state.EventApplier} will be used.
+   *
+   * <p>This method is intended for advanced use cases requiring enriched metadata for correlation
+   * or tracking purposes. For typical usage, consider using {@link #appendFollowUpEvent(long,
+   * Intent, RecordValue)}.
+   *
+   * @param key the key of the event
+   * @param intent the intent of the event
+   * @param value the value of the record
+   * @param metadata metadata for the follow-up event
+   * @throws ExceededBatchRecordSizeException if the appended event doesn't fit into the RecordBatch
+   */
+  void appendFollowUpEvent(
+      long key, Intent intent, RecordValue value, FollowUpEventMetadata metadata);
 
   /**
    * Use this to know whether you can write an event of this length.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUse
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -275,7 +276,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
                               stateWriter.appendFollowUpEvent(
                                   variableDocumentKey,
                                   VariableDocumentIntent.UPDATE_DENIED,
-                                  variableDocumentRecord);
+                                  variableDocumentRecord,
+                                  FollowUpEventMetadata.builder()
+                                      .operationReference(request.operationReference())
+                                      .build());
 
                               final var deniedReason =
                                   USER_TASK_VARIABLE_UPDATE_REJECTION.formatted(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUse
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.incident.RetryTypedRecord;
-import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -277,9 +276,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
                                   variableDocumentKey,
                                   VariableDocumentIntent.UPDATE_DENIED,
                                   variableDocumentRecord,
-                                  FollowUpEventMetadata.builder()
-                                      .operationReference(request.operationReference())
-                                      .build());
+                                  m -> m.operationReference(request.operationReference()));
 
                               final var deniedReason =
                                   USER_TASK_VARIABLE_UPDATE_REJECTION.formatted(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -145,7 +146,12 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
         stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
         final long variableDocumentKey = variableDocumentState.getKey();
         stateWriter.appendFollowUpEvent(
-            variableDocumentKey, VariableDocumentIntent.UPDATED, variableDocumentRecord);
+            variableDocumentKey,
+            VariableDocumentIntent.UPDATED,
+            variableDocumentRecord,
+            FollowUpEventMetadata.builder()
+                .operationReference(request.operationReference())
+                .build());
 
         responseWriter.writeResponse(
             variableDocumentKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.usertask.processors;
 import io.camunda.zeebe.engine.processing.AsyncRequestBehavior;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -149,9 +148,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
             variableDocumentKey,
             VariableDocumentIntent.UPDATED,
             variableDocumentRecord,
-            FollowUpEventMetadata.builder()
-                .operationReference(request.operationReference())
-                .build());
+            m -> m.operationReference(request.operationReference()));
 
         responseWriter.writeResponse(
             variableDocumentKey,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -52,7 +52,9 @@ public final class EventApplyingStateWriter implements StateWriter {
       final RecordValue value,
       final FollowUpEventMetadata metadata) {
     final int recordVersion =
-        metadata.getRecordVersion().orElse(RecordMetadata.DEFAULT_RECORD_VERSION);
+        metadata.getRecordVersion() == FollowUpEventMetadata.VERSION_NOT_SET
+            ? RecordMetadata.DEFAULT_RECORD_VERSION
+            : metadata.getRecordVersion();
 
     eventWriter.appendFollowUpEvent(key, intent, value, recordVersion);
     eventApplier.applyState(key, intent, value, recordVersion);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -42,8 +42,7 @@ public final class EventApplyingStateWriter implements StateWriter {
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
-    appendFollowUpEvent(
-        key, intent, value, FollowUpEventMetadata.builder().recordVersion(recordVersion).build());
+    appendFollowUpEvent(key, intent, value, m -> m.recordVersion(recordVersion));
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/EventApplyingStateWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.variable;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.camunda.zeebe.engine.state.EventApplier;
@@ -41,6 +42,19 @@ public final class EventApplyingStateWriter implements StateWriter {
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
+    appendFollowUpEvent(
+        key, intent, value, FollowUpEventMetadata.builder().recordVersion(recordVersion).build());
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final FollowUpEventMetadata metadata) {
+    final int recordVersion =
+        metadata.getRecordVersion().orElse(RecordMetadata.DEFAULT_RECORD_VERSION);
+
     eventWriter.appendFollowUpEvent(key, intent, value, recordVersion);
     eventApplier.applyState(key, intent, value, recordVersion);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -48,7 +48,9 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
       final FollowUpEventMetadata metadata) {
 
     final int recordVersion =
-        metadata.getRecordVersion().orElse(RecordMetadata.DEFAULT_RECORD_VERSION);
+        metadata.getRecordVersion() == FollowUpEventMetadata.VERSION_NOT_SET
+            ? RecordMetadata.DEFAULT_RECORD_VERSION
+            : metadata.getRecordVersion();
     events.add(new RecordedEvent<>(key, intent, value, recordVersion));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util;
 
+import io.camunda.zeebe.engine.processing.streamprocessor.FollowUpEventMetadata;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -35,6 +36,19 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
   @Override
   public void appendFollowUpEvent(
       final long key, final Intent intent, final RecordValue value, final int recordVersion) {
+    appendFollowUpEvent(
+        key, intent, value, FollowUpEventMetadata.builder().recordVersion(recordVersion).build());
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final FollowUpEventMetadata metadata) {
+
+    final int recordVersion =
+        metadata.getRecordVersion().orElse(RecordMetadata.DEFAULT_RECORD_VERSION);
     events.add(new RecordedEvent<>(key, intent, value, recordVersion));
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -58,7 +58,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
       final long key, final RecordValue value, final RecordMetadata metadata) {
 
     // `operationReference` from `metadata` should have a higher precedence
-    if (metadata.getOperationReference() == -1) {
+    if (metadata.getOperationReference() == operationReferenceNullValue()) {
       if (operationReference != operationReferenceNullValue()) {
         metadata.operationReference(operationReference);
       }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -57,8 +57,11 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
       final long key, final RecordValue value, final RecordMetadata metadata) {
 
-    if (operationReference != operationReferenceNullValue()) {
-      metadata.operationReference(operationReference);
+    // `operationReference` from `metadata` should have a higher precedence
+    if (metadata.getOperationReference() == -1) {
+      if (operationReference != operationReferenceNullValue()) {
+        metadata.operationReference(operationReference);
+      }
     }
 
     final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());


### PR DESCRIPTION
## Description

This PR addresses a bug in Zeebe that caused `ADD_VARIABLE` and `UPDATE_VARIABLE` operations triggered via Operate to remain in the `SENT` state indefinitely when "updating" task listeners were involved.

### 🐞 Problem
The root cause was the missing `operationReference` in follow-up `VariableDocument:UPDATED` events emitted after completing the user task update transition with `"updating"` task listeners. Since Operate relies on this reference to correlate and complete the variable operation, it was unable to mark it as completed — effectively blocking further user input in the UI.

### 🛠️ Solution
To enable proper operation tracking and correlation:
* A new `FollowUpEventMetadata` abstraction was introduced to support writing enriched follow-up events.
* The `TypedEventWriter` interface and its implementations were extended with a new method `appendFollowUpEvent(..., FollowUpEventMetadata)` and a builder-based overload.
* This metadata now allows attaching an `operationReference` and/or record version to any follow-up event.
* The `UserTaskProcessor` and `UserTaskUpdateProcessor` were updated to use this new method when writing `VariableDocument:UPDATED` and `VariableDocument:UPDATE_DENIED` events.
* `BufferedProcessingResultBuilder` was updated to ensure that `operationReference` is included in the follow-up response, if it was provided.

This ensures that `operationReference` is retained in `VariableDocument` terminal events, even when task listeners are involved.

### 💡 Why add `operationReference` to `VD:UPDATE_DENIED`?
While it is not required for the current Operate flow — since it awaits completion of the `UPDATE` command [itself](https://github.com/camunda/camunda/blob/a53e7e4e575d02f1e0e0274482707ca97725296e/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/adapter/ClientBasedAdapter.java#L112) – it will enabl tracking and correlation for other consumers of the `Update element instance variables` endpoint or future use cases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30686
