### PR TITLE
[Backport stable/8.6] fix: pass tenant as prop to diagram header

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -148,6 +148,7 @@ const DiagramPanel: React.FC = observer(() => {
         processDefinitionId={processId}
         isVersionSelected={isVersionSelected}
         panelHeaderRef={panelHeaderRef}
+        tenant={tenant}
       />
       <DiagramShell
         status={getStatus()}


### PR DESCRIPTION
# Description
Backport of #32781 to `stable/8.6`.

relates to #25068