### PR TITLE
[Backport stable/8.7] fix: pass tenant as prop to diagram header

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -149,6 +149,7 @@ const DiagramPanel: React.FC = observer(() => {
         processDefinitionId={processId}
         isVersionSelected={isVersionSelected}
         panelHeaderRef={panelHeaderRef}
+        tenant={tenant}
       />
       <DiagramShell
         status={getStatus()}


### PR DESCRIPTION
# Description
Backport of #32781 to `stable/8.7`.

relates to #25068