### PR TITLE
feat: fetch the snapshot in SnapshotStoreStep when configured to do so

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -17,6 +17,7 @@
 package io.atomix.cluster;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 public class NoopSnapshotStore implements ReceivableSnapshotStore {
 
@@ -84,4 +86,20 @@ public class NoopSnapshotStore implements ReceivableSnapshotStore {
 
   @Override
   public void close() {}
+
+  @Override
+  public Optional<PersistedSnapshot> getBootstrapSnapshot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ActorFuture<PersistedSnapshot> copyForBootstrap(
+      final PersistedSnapshot persistedSnapshot, final BiConsumer<Path, Path> copySnapshot) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> deleteBootstrapSnapshots() {
+    return CompletableActorFuture.completed();
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 public class TestSnapshotStore implements ReceivableSnapshotStore {
 
@@ -151,5 +152,21 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   /** The given interceptor wil be executed before the snapshot is committed. */
   public void interceptOnNewSnapshot(final Runnable interceptor) {
     interceptorOnNewSnapshot = interceptor;
+  }
+
+  @Override
+  public Optional<PersistedSnapshot> getBootstrapSnapshot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ActorFuture<PersistedSnapshot> copyForBootstrap(
+      final PersistedSnapshot persistedSnapshot, final BiConsumer<Path, Path> copySnapshot) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> deleteBootstrapSnapshots() {
+    return CompletableActorFuture.completed();
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -135,4 +136,8 @@ public interface BrokerStartupContext {
   PasswordEncoder getPasswordEncoder();
 
   JwtDecoder getJwtDecoder();
+
+  SnapshotApiRequestHandler getSnapshotApiRequestHandler();
+
+  void setSnapshotApiRequestHandler(SnapshotApiRequestHandler snapshotApiRequestHandler);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceImpl;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -79,6 +80,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private BrokerAdminServiceImpl brokerAdminService;
   private JobStreamService jobStreamService;
   private ClusterConfigurationService clusterConfigurationService;
+  private SnapshotApiRequestHandler snapshotApiRequestHandler;
 
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
@@ -388,5 +390,16 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public JwtDecoder getJwtDecoder() {
     return jwtDecoder;
+  }
+
+  @Override
+  public SnapshotApiRequestHandler getSnapshotApiRequestHandler() {
+    return snapshotApiRequestHandler;
+  }
+
+  @Override
+  public void setSnapshotApiRequestHandler(
+      final SnapshotApiRequestHandler snapshotApiRequestHandler) {
+    this.snapshotApiRequestHandler = snapshotApiRequestHandler;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -64,6 +64,7 @@ public final class BrokerStartupProcess {
     }
 
     result.add(new JobStreamServiceStep());
+    result.add(new SnapshotApiServiceStep());
     result.add(new PartitionManagerStep());
     result.add(new BrokerAdminServiceStep());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -42,6 +42,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getPartitionListeners(),
             brokerStartupContext.getPartitionRaftListeners(),
             brokerStartupContext.getCommandApiService(),
+            brokerStartupContext.getSnapshotApiRequestHandler(),
             brokerStartupContext.getExporterRepository(),
             brokerStartupContext.getGatewayBrokerTransport(),
             brokerStartupContext.getJobStreamService().jobStreamer(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/SnapshotApiServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/SnapshotApiServiceStep.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+public class SnapshotApiServiceStep extends AbstractBrokerStartupStep {
+
+  @Override
+  public String getName() {
+    return "Snapshot API";
+  }
+
+  @Override
+  void startupInternal(
+      final BrokerStartupContext brokerStartupContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    concurrencyControl.run(
+        () ->
+            startSnapshotApi(
+                brokerStartupContext,
+                brokerStartupContext.getGatewayBrokerTransport(),
+                concurrencyControl,
+                startupFuture));
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+    concurrencyControl.runOnCompletion(
+        brokerShutdownContext.getSnapshotApiRequestHandler().closeAsync(),
+        proceed(
+            () -> {
+              brokerShutdownContext.setSnapshotApiRequestHandler(null);
+              shutdownFuture.complete(brokerShutdownContext);
+            },
+            shutdownFuture));
+  }
+
+  private void startSnapshotApi(
+      final BrokerStartupContext brokerStartupContext,
+      final io.camunda.zeebe.transport.ServerTransport serverTransport,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> startupFuture) {
+    final var handler =
+        new SnapshotApiRequestHandler(serverTransport, brokerStartupContext.getBrokerClient());
+    final var schedulingService = brokerStartupContext.getActorSchedulingService();
+    concurrencyControl.runOnCompletion(
+        schedulingService.submitActor(handler),
+        proceed(
+            () -> {
+              brokerStartupContext.setSnapshotApiRequestHandler(handler);
+              startupFuture.complete(brokerStartupContext);
+            },
+            startupFuture));
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -176,7 +176,8 @@ public final class PartitionManagerImpl
             brokerCfg,
             initialPartitionConfig,
             initializeFromSnapshot,
-            brokerMeterRegistry);
+            brokerMeterRegistry,
+            brokerClient);
     final var partition = Partition.bootstrapping(context);
     if (partitions.putIfAbsent(id, partition) != null) {
       result.completeExceptionally(
@@ -208,7 +209,8 @@ public final class PartitionManagerImpl
             brokerCfg,
             initialPartitionConfig,
             false,
-            brokerMeterRegistry);
+            brokerMeterRegistry,
+            brokerClient);
     final var partition = Partition.joining(context);
     final var previousPartition = partitions.putIfAbsent(id, partition);
     if (previousPartition != null) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -69,6 +70,7 @@ public final class PartitionManagerImpl
   private final Map<Integer, Partition> partitions = new ConcurrentHashMap<>();
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private final BrokerClient brokerClient;
+  private final SnapshotApiRequestHandler snapshotApiRequestHandler;
   private final DefaultPartitionManagementService managementService;
   private final BrokerCfg brokerCfg;
   private final ZeebePartitionFactory zeebePartitionFactory;
@@ -88,6 +90,7 @@ public final class PartitionManagerImpl
       final List<PartitionListener> partitionListeners,
       final List<PartitionRaftListener> partitionRaftListeners,
       final CommandApiService commandApiService,
+      final SnapshotApiRequestHandler snapshotApiRequestHandler,
       final ExporterRepository exporterRepository,
       final AtomixServerTransport gatewayBrokerTransport,
       final JobStreamer jobStreamer,
@@ -102,6 +105,7 @@ public final class PartitionManagerImpl
     this.healthCheckService = healthCheckService;
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.brokerClient = brokerClient;
+    this.snapshotApiRequestHandler = snapshotApiRequestHandler;
     scalingExecutor = new BrokerClientPartitionScalingExecutor(brokerClient, concurrencyControl);
     final var featureFlags = brokerCfg.getExperimental().getFeatures().toFeatureFlags();
     this.clusterConfigurationService = clusterConfigurationService;
@@ -118,6 +122,7 @@ public final class PartitionManagerImpl
             brokerCfg,
             localBroker,
             commandApiService,
+            snapshotApiRequestHandler,
             clusterServices,
             exporterRepository,
             diskSpaceUsageMonitor,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -11,7 +11,6 @@ import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotTransferServiceClient;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -22,7 +21,6 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransfer;
-import io.camunda.zeebe.snapshots.transfer.SnapshotTransferImpl;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.nio.file.Path;
@@ -49,6 +47,7 @@ public class PartitionStartupContext {
   private FileBasedSnapshotStore snapshotStore;
   private RaftPartition raftPartition;
   private ZeebePartition zeebePartition;
+  private SnapshotTransfer snapshotTransfer;
 
   public PartitionStartupContext(
       final ActorSchedulingService schedulingService,
@@ -192,8 +191,11 @@ public class PartitionStartupContext {
     return brokerClient;
   }
 
+  public void setSnapshotTransfer(final SnapshotTransfer snapshotTransfer) {
+    this.snapshotTransfer = snapshotTransfer;
+  }
+
   public SnapshotTransfer snapshotTransfer() {
-    return new SnapshotTransferImpl(
-        new SnapshotTransferServiceClient(brokerClient), snapshotStore, concurrencyControl);
+    return snapshotTransfer;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -230,6 +230,7 @@ public final class ZeebePartitionFactory {
       runtimeDirectory = raftPartition.dataDirectory().toPath().resolve("runtime");
     }
     return new StateControllerImpl(
+        partitionId,
         zeebeRocksDbFactory,
         snapshotStore,
         runtimeDirectory,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -43,17 +43,22 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.MetricsStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.MigrationTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.QueryServicePartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotAfterMigrationTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotApiHandlerTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTransitionStep;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceTransitionStep;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.ZeebeDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDBSnapshotCopy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -92,6 +97,7 @@ public final class ZeebePartitionFactory {
           new CommandApiServiceTransitionStep(),
           new SnapshotDirectorPartitionTransitionStep(),
           new SnapshotAfterMigrationTransitionStep(),
+          new SnapshotApiHandlerTransitionStep(),
           new ExporterDirectorPartitionTransitionStep(),
           new BackupApiRequestHandlerStep(),
           new AdminApiRequestHandlerStep());
@@ -100,6 +106,7 @@ public final class ZeebePartitionFactory {
   private final BrokerCfg brokerCfg;
   private final BrokerInfo localBroker;
   private final CommandApiService commandApiService;
+  private final SnapshotApiRequestHandler snapshotApiRequestHandler;
   private final ClusterServices clusterServices;
   private final ExporterRepository exporterRepository;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -117,6 +124,7 @@ public final class ZeebePartitionFactory {
       final BrokerCfg brokerCfg,
       final BrokerInfo localBroker,
       final CommandApiService commandApiService,
+      final SnapshotApiRequestHandler snapshotApiRequestHandler,
       final ClusterServices clusterServices,
       final ExporterRepository exporterRepository,
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
@@ -132,6 +140,7 @@ public final class ZeebePartitionFactory {
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
     this.commandApiService = commandApiService;
+    this.snapshotApiRequestHandler = snapshotApiRequestHandler;
     this.clusterServices = clusterServices;
     this.exporterRepository = exporterRepository;
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
@@ -155,9 +164,19 @@ public final class ZeebePartitionFactory {
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
 
+    final var databaseCfg = brokerCfg.getExperimental().getRocksdb();
+    final var consistencyChecks = brokerCfg.getExperimental().getConsistencyChecks();
+    final var partitionId = raftPartition.id().id();
+    final var zeebeFactory =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+            databaseCfg.createRocksDbConfiguration(),
+            consistencyChecks.getSettings(),
+            new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), partitionId),
+            () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)));
     final StateController stateController =
-        createStateController(raftPartition, snapshotStore, snapshotStore, partitionMeterRegistry);
+        createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);
 
+    final var snapshotCopy = new RocksDBSnapshotCopy(zeebeFactory);
     final var context =
         new PartitionStartupAndTransitionContextImpl(
             localBroker.getNodeId(),
@@ -172,6 +191,8 @@ public final class ZeebePartitionFactory {
             brokerCfg,
             commandApiService,
             snapshotStore,
+            snapshotCopy,
+            snapshotApiRequestHandler,
             stateController,
             typedRecordProcessorsFactory,
             exporterRepository,
@@ -191,9 +212,9 @@ public final class ZeebePartitionFactory {
 
   private StateController createStateController(
       final RaftPartition raftPartition,
+      final ZeebeDbFactory<ZbColumnFamilies> zeebeRocksDbFactory,
       final ConstructableSnapshotStore snapshotStore,
-      final ConcurrencyControl concurrencyControl,
-      final MeterRegistry partitionMeterRegistry) {
+      final ConcurrencyControl concurrencyControl) {
     final Path runtimeDirectory;
     final var partitionId = raftPartition.id().id();
     if (brokerCfg.getData().useSeparateRuntimeDirectory()) {
@@ -208,14 +229,8 @@ public final class ZeebePartitionFactory {
     } else {
       runtimeDirectory = raftPartition.dataDirectory().toPath().resolve("runtime");
     }
-    final var databaseCfg = brokerCfg.getExperimental().getRocksdb();
-    final var consistencyChecks = brokerCfg.getExperimental().getConsistencyChecks();
     return new StateControllerImpl(
-        new ZeebeRocksDbFactory<>(
-            databaseCfg.createRocksDbConfiguration(),
-            consistencyChecks.getSettings(),
-            new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), partitionId),
-            () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId))),
+        zeebeRocksDbFactory,
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -57,7 +57,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                             snapshotStore);
                     return context
                         .schedulingService()
-                        .submitActor(snapshotTransfer)
+                        .submitActor(snapshotTransfer, SchedulingHints.IO_BOUND)
                         .thenApply(
                             empty -> {
                               context.setSnapshotTransfer(snapshotTransfer);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -66,7 +66,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                             context.concurrencyControl());
                   },
                   context.concurrencyControl())
-              .andThen(this::initializeFromSnapshot, context.concurrencyControl());
+              .andThen(this::initializeFromBootstrapSnapshot, context.concurrencyControl());
     }
     return result;
   }
@@ -78,7 +78,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
         .thenApply(ignored -> context.snapshotStore(null), context.concurrencyControl());
   }
 
-  ActorFuture<PartitionStartupContext> initializeFromSnapshot(
+  ActorFuture<PartitionStartupContext> initializeFromBootstrapSnapshot(
       final PartitionStartupContext context) {
     final var fut = context.snapshotTransfer().getLatestSnapshot(Protocol.DEPLOYMENT_PARTITION);
     return fut.andThen(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
@@ -73,6 +74,8 @@ public interface PartitionContext {
   DynamicPartitionConfig getDynamicPartitionConfig();
 
   void setDynamicPartitionConfig(DynamicPartitionConfig partitionConfig);
+
+  SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 
   ControllableStreamClock getStreamClock();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -56,7 +56,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -149,7 +148,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.raftPartition = raftPartition;
     messagingService = partitionCommunicationService;
     this.brokerCfg = brokerCfg;
-    this.snapshotApiRequestHandler = Objects.requireNonNull(snapshotApiRequestHandler);
+    this.snapshotApiRequestHandler = snapshotApiRequestHandler;
     this.stateController = stateController;
     this.snapshotCopy = snapshotCopy;
     this.typedRecordProcessorsFactory = typedRecordProcessorsFactory;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -34,6 +34,8 @@ import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
+import io.camunda.zeebe.db.SnapshotCopy;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
@@ -54,6 +56,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -81,6 +84,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final ExporterRepository exporterRepository;
   private final PartitionProcessingState partitionProcessingState;
   private final DiskSpaceUsageMonitor diskSpaceUsageMonitor;
+  private final SnapshotCopy snapshotCopy;
   private final StateController stateController;
   private DynamicPartitionConfig dynamicPartitionConfig;
   private StreamProcessor streamProcessor;
@@ -113,6 +117,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final MeterRegistry startupMeterRegistry;
   private MeterRegistry transitionMeterRegistry;
   private volatile boolean migrationsPerformed = false;
+  private final SnapshotApiRequestHandler snapshotApiRequestHandler;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -126,6 +131,8 @@ public class PartitionStartupAndTransitionContextImpl
       final BrokerCfg brokerCfg,
       final CommandApiService commandApiService,
       final PersistedSnapshotStore persistedSnapshotStore,
+      final SnapshotCopy snapshotCopy,
+      final SnapshotApiRequestHandler snapshotApiRequestHandler,
       final StateController stateController,
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory,
       final ExporterRepository exporterRepository,
@@ -142,7 +149,9 @@ public class PartitionStartupAndTransitionContextImpl
     this.raftPartition = raftPartition;
     messagingService = partitionCommunicationService;
     this.brokerCfg = brokerCfg;
+    this.snapshotApiRequestHandler = Objects.requireNonNull(snapshotApiRequestHandler);
     this.stateController = stateController;
+    this.snapshotCopy = snapshotCopy;
     this.typedRecordProcessorsFactory = typedRecordProcessorsFactory;
     this.commandApiService = commandApiService;
     this.persistedSnapshotStore = persistedSnapshotStore;
@@ -451,6 +460,11 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
+  public SnapshotApiRequestHandler getSnapshotApiRequestHandler() {
+    return snapshotApiRequestHandler;
+  }
+
+  @Override
   public ControllableStreamClock getStreamClock() {
     return clock;
   }
@@ -498,6 +512,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public StateController getStateController() {
     return stateController;
+  }
+
+  @Override
+  public SnapshotCopy snapshotCopy() {
+    return snapshotCopy;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;
+import io.camunda.zeebe.db.SnapshotCopy;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.state.QueryService;
@@ -52,6 +53,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   void setSnapshotDirector(AsyncSnapshotDirector snapshotDirector);
 
   StateController getStateController();
+
+  SnapshotCopy snapshotCopy();
 
   PersistedSnapshotStore getPersistedSnapshotStore();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -10,8 +10,9 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
 
-public interface StateController extends AutoCloseable {
+public interface StateController extends AutoCloseable, SnapshotTransferService.TakeSnapshot {
   /**
    * Takes a snapshot based on the given position. The position is a last processed lower bound
    * event position. When the returned future completes successfully the transient snapshot will be

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -286,7 +286,7 @@ public class StateControllerImpl implements StateController {
 
   @Override
   public ActorFuture<PersistedSnapshot> takeSnapshot(
-      final int partition, final long lastProcessedPosition) {
+      final int partition, final long lastProcessedPosition, final ConcurrencyControl control) {
     if (partition != partitionId) {
       return CompletableActorFuture.completedExceptionally(
           new IllegalArgumentException(
@@ -295,7 +295,7 @@ public class StateControllerImpl implements StateController {
                   partitionId, partition)));
     }
     return takeTransientSnapshot(lastProcessedPosition)
-        .andThen(PersistableSnapshot::persist, concurrencyControl);
+        .andThen(PersistableSnapshot::persist, control);
   }
 
   private record NextSnapshotId(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -19,7 +19,9 @@ import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
+import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.StateClosedException;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
@@ -42,6 +44,7 @@ public class StateControllerImpl implements StateController {
   private final ZeebeDbFactory zeebeDbFactory;
   private final ToLongFunction<ZeebeDb> exporterPositionSupplier;
   private final AtomixRecordEntrySupplier entrySupplier;
+  private final int partitionId;
   private final ConstructableSnapshotStore constructableSnapshotStore;
   private final ConcurrencyControl concurrencyControl;
 
@@ -49,12 +52,14 @@ public class StateControllerImpl implements StateController {
   private ScheduledTimer metricsExportTimer;
 
   public StateControllerImpl(
+      final int partitionId,
       final ZeebeDbFactory zeebeDbFactory,
       final ConstructableSnapshotStore constructableSnapshotStore,
       final Path runtimeDirectory,
       final AtomixRecordEntrySupplier entrySupplier,
       final ToLongFunction<ZeebeDb> exporterPositionSupplier,
       final ConcurrencyControl concurrencyControl) {
+    this.partitionId = partitionId;
     this.constructableSnapshotStore = requireNonNull(constructableSnapshotStore);
     this.runtimeDirectory = requireNonNull(runtimeDirectory);
     this.zeebeDbFactory = requireNonNull(zeebeDbFactory);
@@ -277,6 +282,20 @@ public class StateControllerImpl implements StateController {
             transientSnapshotFuture.complete(snapshot);
           }
         });
+  }
+
+  @Override
+  public ActorFuture<PersistedSnapshot> takeSnapshot(
+      final int partition, final long lastProcessedPosition) {
+    if (partition != partitionId) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalArgumentException(
+              String.format(
+                  "Expected to take snapshot for partition %d, but was called for partition %d",
+                  partitionId, partition)));
+    }
+    return takeTransientSnapshot(lastProcessedPosition)
+        .andThen(PersistableSnapshot::persist, concurrencyControl);
   }
 
   private record NextSnapshotId(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -35,6 +35,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
       final var service =
           new SnapshotTransferServiceImpl(
               context.getPersistedSnapshotStore(),
+              context.getStateController(),
               context.getPartitionId(),
               (from, to) ->
                   context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.protocol.ColumnFamilyScope;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.transfer.SnapshotTransferServiceImpl;
+import java.util.Set;
+
+public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep {
+
+  // Register a snapshot transfer service when transitioning to leader
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    if (context.getCurrentRole().isLeader()) {
+      context.getSnapshotApiRequestHandler().removeTransferService(context.getPartitionId());
+    }
+    return CompletableActorFuture.completed();
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    if (targetRole.isLeader()) {
+      final var service =
+          new SnapshotTransferServiceImpl(
+              context.getPersistedSnapshotStore(),
+              context.getPartitionId(),
+              (from, to) ->
+                  context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),
+              context.getSnapshotApiRequestHandler());
+      context.getSnapshotApiRequestHandler().addTransferService(context.getPartitionId(), service);
+    }
+    return CompletableActorFuture.completed();
+  }
+
+  @Override
+  public String getName() {
+    return "SnapshotApiHandlerTransitionStep";
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
 import io.camunda.zeebe.transport.RequestType;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.transport.ServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,11 +32,11 @@ public class SnapshotApiRequestHandler
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotApiRequestHandler.class);
   private final ConcurrentMap<Integer, SnapshotTransferService> transferServices =
       new ConcurrentHashMap<>();
-  private final AtomixServerTransport serverTransport;
+  private final ServerTransport serverTransport;
   private final BrokerClient brokerClient;
 
-  protected SnapshotApiRequestHandler(
-      final AtomixServerTransport serverTransport, final BrokerClient brokerClient) {
+  public SnapshotApiRequestHandler(
+      final ServerTransport serverTransport, final BrokerClient brokerClient) {
     super(SnapshotApiRequestReader::new, SnapshotApiResponseWriter::new);
     this.serverTransport = serverTransport;
     this.brokerClient = brokerClient;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionBootstrapTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionBootstrapTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker.partitioning;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl.PartitionAlreadyExistsException;
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -55,27 +54,6 @@ public final class PartitionBootstrapTest {
     assertThat(result).succeedsWithin(Duration.ofSeconds(10));
     assertThat(partitionManager.getRaftPartition(partitionId)).isNotNull();
     assertThat(partitionManager.getRaftPartitions()).hasSize(2); // Original 1 + new 1
-  }
-
-  @Test
-  public void shouldNotBootstrapPartitionWithSnapshotInitializationWhenNotScaling() {
-    // given
-    final var partitionId = 2;
-    final var priority = 1;
-    final var config = DynamicPartitionConfig.init();
-
-    // when
-    final var result = partitionManager.bootstrap(partitionId, priority, config, true);
-
-    // then
-    assertThat(result)
-        .failsWithin(Duration.ofSeconds(10))
-        .withThrowableOfType(ExecutionException.class)
-        .withCauseInstanceOf(BrokerRejectionException.class)
-        .withMessageStartingWith("Command (MARK_PARTITION_BOOTSTRAPPED) rejected");
-
-    assertThat(brokerRule.getBroker().getBrokerContext().getPartitionManager().getRaftPartition(2))
-        .isNull();
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -71,6 +71,7 @@ public final class AsyncSnapshottingTest {
 
     snapshotController =
         new StateControllerImpl(
+            1,
             DefaultZeebeDbFactory.defaultFactory(),
             persistedSnapshotStore,
             rootDirectory.resolve("runtime"),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -31,6 +31,8 @@ import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;
+import io.camunda.zeebe.broker.transport.snapshotapi.SnapshotApiRequestHandler;
+import io.camunda.zeebe.db.SnapshotCopy;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
@@ -88,6 +90,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private String brokerVersion = PartitionTransitionContext.super.getBrokerVersion();
   private boolean migrationsPerformed;
   private final ComponentTreeListener healthMetrics;
+  private SnapshotCopy snapshotCopy;
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
@@ -185,6 +188,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public void setDynamicPartitionConfig(final DynamicPartitionConfig partitionConfig) {
     this.partitionConfig = partitionConfig;
+  }
+
+  @Override
+  public SnapshotApiRequestHandler getSnapshotApiRequestHandler() {
+    return null;
   }
 
   @Override
@@ -484,6 +492,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public StateController getStateController() {
     return stateController;
+  }
+
+  @Override
+  public SnapshotCopy snapshotCopy() {
+    return snapshotCopy;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -469,6 +470,12 @@ public class RandomizedPartitionTransitionTest {
     @Override
     public void close() throws Exception {
       throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public ActorFuture<PersistedSnapshot> takeSnapshot(
+        final int partition, final long lastProcessedPosition) {
+      return CompletableActorFuture.completed(null);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTran
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -474,7 +475,7 @@ public class RandomizedPartitionTransitionTest {
 
     @Override
     public ActorFuture<PersistedSnapshot> takeSnapshot(
-        final int partition, final long lastProcessedPosition) {
+        final int partition, final long lastProcessedPosition, final ConcurrencyControl control) {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -74,6 +74,7 @@ public final class StateControllerImplTest {
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");
     snapshotController =
         new StateControllerImpl(
+            1,
             DefaultZeebeDbFactory.defaultFactory(),
             store,
             runtimeDirectory,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -83,6 +83,7 @@ public class LargeStateControllerPerformanceTest {
     // given
     final var controller =
         new StateControllerImpl(
+            1,
             context.dbFactory(),
             context.snapshotStore(),
             context.temporaryFolder().resolve("runtime"),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -162,7 +163,7 @@ public class SnapshotApiRequestHandlerTest {
     scheduler.workUntilDone();
     assertThat(takeFuture).succeedsWithin(Duration.ofSeconds(30));
     if (position > snapshotProcessedPosition) {
-      when(takeSnapshotMock.takeSnapshot(eq(1), eq(position)))
+      when(takeSnapshotMock.takeSnapshot(eq(1), eq(position), any()))
           .thenReturn(takePersistedSnapshot(position));
     }
     mockBootstrappedAtWith(position);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionBootstrappedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/PartitionBootstrappedApplier.java
@@ -30,9 +30,7 @@ public class PartitionBootstrappedApplier implements TypedEventApplier<ScaleInte
       final var partitionId = value.getRedistributedPartitions().getFirst();
       final var allActivated = routingState.activatePartition(partitionId);
       if (allActivated) {
-        LOG.debug(
-            "All partitions for scale operation to {} have been activated.",
-            value.getDesiredPartitionCount());
+        LOG.debug("All new partitions have been activated.");
       }
     } else {
       LOG.warn(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -56,6 +56,7 @@ public class ScaleUpPartitionsTest {
 
   @Test
   void shouldDeployProcessesToNewPartitionsAndStartNewInstances() {
+    cluster.awaitHealthyTopology();
     // when
     final var response =
         clusterActuator.patchCluster(

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/AsyncClosable.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.scheduler;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
 public interface AsyncClosable {
 
@@ -18,4 +19,12 @@ public interface AsyncClosable {
    * @return the future, which is completed when resources are closed
    */
   ActorFuture<Void> closeAsync();
+
+  static ActorFuture<Void> closeHelper(final AsyncClosable closeable) {
+    if (closeable != null) {
+      return closeable.closeAsync();
+    } else {
+      return CompletableActorFuture.completed();
+    }
+  }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/BootstrapSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/BootstrapSnapshotStore.java
@@ -19,7 +19,7 @@ import java.util.function.BiConsumer;
  *
  * <p>One backup can be taken at a time, as only one scaling up operation can be done at a time.
  */
-public interface BootstrapSnapshotStore extends PersistedSnapshotStore {
+public interface BootstrapSnapshotStore {
 
   /**
    * @return the latest snapshot that was copied if present.

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshotStore.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * <p>Only one {@link PersistedSnapshot} at a time is stored in the {@link PersistedSnapshotStore}
  * and can be received via {@link PersistedSnapshotStore#getLatestSnapshot()}.
  */
-public interface PersistedSnapshotStore extends CloseableSilently {
+public interface PersistedSnapshotStore extends CloseableSilently, BootstrapSnapshotStore {
 
   /**
    * Returns true if the given identifier is equal to the snapshot id of the current persisted

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/RestorableSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/RestorableSnapshotStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.snapshots;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -23,4 +24,7 @@ public interface RestorableSnapshotStore {
    * @throws IOException
    */
   void restore(final String snapshotId, final Map<String, Path> snapshotFiles) throws IOException;
+
+  /** Restore a PersistedSnapshot using the actor context in order to be thread safe */
+  ActorFuture<Void> restore(PersistedSnapshot snapshot);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -161,6 +161,11 @@ public final class FileBasedSnapshotStore extends Actor
   }
 
   @Override
+  public ActorFuture<Void> restore(final PersistedSnapshot snapshot) {
+    return snapshotStore.restore(snapshot);
+  }
+
+  @Override
   public String toString() {
     return "FileBasedSnapshotStore{"
         + "actorName='"

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -703,6 +703,14 @@ public final class FileBasedSnapshotStoreImpl {
     }
   }
 
+  public ActorFuture<Void> restore(final PersistedSnapshot snapshot) {
+    return actor.call(
+        () -> {
+          restore(snapshot.getId(), snapshot.files());
+          return null;
+        });
+  }
+
   private void moveNamedFileToDirectory(
       final String name, final Path source, final Path targetDirectory) {
     final var targetFilePath = targetDirectory.resolve(name);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.snapshots.transfer;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
@@ -41,9 +40,7 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
         .andThen(
             snapshot -> {
               if (snapshot == null) {
-                return CompletableActorFuture.completedExceptionally(
-                    new IllegalArgumentException(
-                        "No initial chunk for latest snapshot in partition " + partitionId));
+                return null;
               }
               return snapshotStore
                   .newReceivedSnapshot(snapshot.getSnapshotId())

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.transfer;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
@@ -40,7 +41,7 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
         .andThen(
             snapshot -> {
               if (snapshot == null) {
-                return null;
+                return CompletableActorFuture.completed(null);
               }
               return snapshotStore
                   .newReceivedSnapshot(snapshot.getSnapshotId())
@@ -53,6 +54,9 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
             actor)
         .andThen(
             tuple -> {
+              if (tuple == null) {
+                return CompletableActorFuture.completed(null);
+              }
               final var future =
                   receiveAllChunks(partitionId, tuple.getLeft(), tuple.getRight(), transferId);
               future.onError(error -> tuple.getRight().abort());

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.snapshots.transfer;
 
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
@@ -49,6 +50,7 @@ public interface SnapshotTransferService {
      * @param lastProcessedPosition the minimum value for lastProcessedPosition in the snapshot
      * @return
      */
-    ActorFuture<PersistedSnapshot> takeSnapshot(int partition, long lastProcessedPosition);
+    ActorFuture<PersistedSnapshot> takeSnapshot(
+        int partition, long lastProcessedPosition, ConcurrencyControl control);
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -63,6 +63,9 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
     return getLatestSnapshotForBootstrap(lastProcessedPosition, transferId)
         .andThen(
             snapshot -> {
+              if (snapshot == null) {
+                return CompletableActorFuture.completed(null);
+              }
               final var snapshotId = snapshot.getId();
               try {
                 final var reader = new FileBasedSnapshotChunkReader(snapshot.getPath());

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -11,8 +11,8 @@ package io.camunda.zeebe.snapshots.transfer;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.BootstrapSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
@@ -29,7 +29,7 @@ import org.agrona.CloseHelper;
 
 public class SnapshotTransferServiceImpl implements SnapshotTransferService {
 
-  private final BootstrapSnapshotStore snapshotStore;
+  private final PersistedSnapshotStore snapshotStore;
   private final Map<UUID, PendingTransfer> pendingTransfers = new HashMap<>();
   private final TakeSnapshot takeSnapshot;
   private final int partitionId;
@@ -37,7 +37,7 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
   private final ConcurrencyControl concurrency;
 
   public SnapshotTransferServiceImpl(
-      final BootstrapSnapshotStore snapshotStore,
+      final PersistedSnapshotStore snapshotStore,
       final TakeSnapshot takeSnapshot,
       final int partitionId,
       final BiConsumer<Path, Path> copyForBootstrap,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -136,7 +136,7 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
         lastPersistedSnapshot.isEmpty()
                 || lastPersistedSnapshot.get().getMetadata().processedPosition()
                     < lastProcessedPosition
-            ? takeSnapshot.takeSnapshot(partitionId, lastProcessedPosition)
+            ? takeSnapshot.takeSnapshot(partitionId, lastProcessedPosition, concurrency)
             : CompletableActorFuture.completed(lastPersistedSnapshot.get());
 
     return lastSnapshot.andThen(

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
@@ -11,6 +11,7 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.zip.CRC32C;
@@ -139,6 +141,22 @@ public class TestFileBasedSnapshotStore implements ReceivableSnapshotStore {
       throw new UncheckedIOException(e);
     }
     return true;
+  }
+
+  @Override
+  public Optional<PersistedSnapshot> getBootstrapSnapshot() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ActorFuture<PersistedSnapshot> copyForBootstrap(
+      final PersistedSnapshot persistedSnapshot, final BiConsumer<Path, Path> copySnapshot) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> deleteBootstrapSnapshots() {
+    return CompletableActorFuture.completed();
   }
 
   private static final class TestChecksumProvider implements CRC32CChecksumProvider {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -118,13 +118,13 @@ public class SnapshotTransferTest {
   public void shouldTakeSnapshotIfNoneIsPresent() {
     // given
     final int partitionId = 1;
-    when(takeSnapshotMock.takeSnapshot(anyInt(), anyLong()))
+    when(takeSnapshotMock.takeSnapshot(anyInt(), anyLong(), any()))
         .thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final var persistedSnapshotFuture = snapshotTransfer.getLatestSnapshot(partitionId);
 
     // then
-    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(1), eq(-1L));
+    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(1), eq(-1L), any());
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -77,6 +77,7 @@ public class SnapshotTransferTest {
                         control)),
             receiverSnapshotStore);
     actorScheduler.submitActor(snapshotTransfer);
+    actorScheduler.workUntilDone();
 
     actorScheduler.workUntilDone();
   }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -39,7 +39,7 @@ public interface SnapshotCopy {
    * @param toPath the path where the copied snapshot will be located
    * @param scope the scope of the columns to copy
    */
-  void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope) throws Exception;
+  void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope);
 
   interface CopyContextConsumer {
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -8,10 +8,8 @@
 package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.SnapshotCopy;
-import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.transaction.RawTransactionalColumnFamily;
 import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
@@ -23,19 +21,17 @@ import org.slf4j.LoggerFactory;
 public class RocksDBSnapshotCopy implements SnapshotCopy {
 
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotCopy.class);
-  private final ZeebeDbFactory<ZbColumnFamilies> factory;
+  private final ZeebeRocksDbFactory<ZbColumnFamilies> factory;
 
-  public RocksDBSnapshotCopy(final ZeebeDbFactory<ZbColumnFamilies> factory) {
+  public RocksDBSnapshotCopy(final ZeebeRocksDbFactory<ZbColumnFamilies> factory) {
     this.factory = factory;
   }
 
   @Override
   public void withContexts(
       final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer) {
-    try (final var toDB =
-        (ZeebeTransactionDb<ZbColumnFamilies>) factory.createDb(toDBPath.toFile())) {
-      try (final var fromDB =
-          (ZeebeTransactionDb<ZbColumnFamilies>) factory.createDb(fromPath.toFile())) {
+    try (final var toDB = factory.createDb(toDBPath.toFile())) {
+      try (final var fromDB = factory.createDb(fromPath.toFile())) {
         final var fromCtx = fromDB.createContext();
         final var toCtx = toDB.createContext();
         consumer.accept(fromDB, fromCtx, toDB, toCtx);


### PR DESCRIPTION
## Description

When `context.initializeFromSnapshot` is true, then fetch the snapshot from partition 1 and restore it in the `SnapshotStore`.

`SnapshotTransfer` construction has been put into the `PartitionStartupContext` to make it testable.

Added tests for `SnapshotStoreTest` as they were missing.

## Checklist
- [x] #33335 for sending the snapshot for bootstrap
## Related issues
closes #32041 
