### PR TITLE
fix: wrap simple claim mappings to jsonPath if not already a jsonPath

### DIFF
--- a/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/OidcPrincipalLoader.java
@@ -30,8 +30,10 @@ public final class OidcPrincipalLoader {
   private final JsonPath clientIdPath;
 
   public OidcPrincipalLoader(final String usernameClaim, final String clientIdClaim) {
-    usernamePath = usernameClaim != null ? JsonPath.compile(usernameClaim) : null;
-    clientIdPath = clientIdClaim != null ? JsonPath.compile(clientIdClaim) : null;
+    usernamePath =
+        usernameClaim != null ? JsonPath.compile(sanitizeClaimPath(usernameClaim)) : null;
+    clientIdPath =
+        clientIdClaim != null ? JsonPath.compile(sanitizeClaimPath(clientIdClaim)) : null;
   }
 
   public OidcPrincipals load(final Map<String, Object> claims) {
@@ -56,6 +58,14 @@ public final class OidcPrincipalLoader {
       LOG.debug("Failed to evaluate expression {} on claims {}", path, claims, e);
       return null;
     }
+  }
+
+  private String sanitizeClaimPath(final String claim) {
+    // If the claim starts with a dollar sign, it is already a JSONPath expression.
+    // Otherwise, we wrap it with the dollar sign to denote a JSONPath.
+    // We also ensure that the claim is wrapped in single quotes to handle cases where the claim
+    // name contains special characters.
+    return claim.startsWith("$") ? claim : "$['" + claim + "']";
   }
 
   public record OidcPrincipals(String username, String clientId) {}

--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcPrincipalLoaderTest.java
@@ -66,6 +66,26 @@ final class OidcPrincipalLoaderTest {
   }
 
   @Test
+  void shouldLoadUsernameAndClientIdWhenConfigurationIsNotJsonPath() {
+    // given
+    final var claims =
+        Map.<String, Object>of(
+            "username", "testuser",
+            "client_id", "testclient",
+            "other_claim", "other_value",
+            "http://example.com/username", "testuser");
+
+    final var loader = new OidcPrincipalLoader("http://example.com/username", "client_id");
+
+    // when
+    final var principals = loader.load(claims);
+
+    // then
+    assertThat(principals.username()).isEqualTo("testuser");
+    assertThat(principals.clientId()).isEqualTo("testclient");
+  }
+
+  @Test
   void shouldLoadUsernameAndClientId() {
     // given
     final var claims =

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -56,8 +56,8 @@ public sealed interface AuthenticationHandler {
           Objects.requireNonNull(oidcAuthenticationConfiguration);
       oidcPrincipalLoader =
           new OidcPrincipalLoader(
-              oidcAuthenticationConfiguration.getUsernameClaim(),
-              oidcAuthenticationConfiguration.getClientIdClaim());
+              sanitizeClaimPath(oidcAuthenticationConfiguration.getUsernameClaim()),
+              sanitizeClaimPath(oidcAuthenticationConfiguration.getClientIdClaim()));
     }
 
     @Override
@@ -106,6 +106,14 @@ public sealed interface AuthenticationHandler {
                   .formatted(
                       oidcAuthenticationConfiguration.getUsernameClaim(),
                       oidcAuthenticationConfiguration.getClientIdClaim())));
+    }
+
+    private String sanitizeClaimPath(final String claim) {
+      // If the claim starts with a dollar sign, it is already a JSONPath expression.
+      // Otherwise, we wrap it with the dollar sign to denote a JSONPath.
+      // We also ensure that the claim is wrapped in single quotes to handle cases where the claim
+      // name contains special characters.
+      return claim.startsWith("$") ? claim : "$['" + claim + "']";
     }
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -56,8 +56,8 @@ public sealed interface AuthenticationHandler {
           Objects.requireNonNull(oidcAuthenticationConfiguration);
       oidcPrincipalLoader =
           new OidcPrincipalLoader(
-              sanitizeClaimPath(oidcAuthenticationConfiguration.getUsernameClaim()),
-              sanitizeClaimPath(oidcAuthenticationConfiguration.getClientIdClaim()));
+              oidcAuthenticationConfiguration.getUsernameClaim(),
+              oidcAuthenticationConfiguration.getClientIdClaim());
     }
 
     @Override


### PR DESCRIPTION
## Description
On SaaS currently there are errors thrown as we are not able to parse the special characters in the username / client ID claim. This is a short term fix that wraps a non json path value, to be a path value longer term we should look to refine this
