### PR TITLE
feat: add env flag that enables or disables groups ui

### DIFF
--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -14,14 +14,14 @@ import Roles from "src/pages/roles";
 import Tenants from "src/pages/tenants";
 import Mappings from "src/pages/mappings";
 import Authorizations from "src/pages/authorizations";
-import { isOIDC } from "src/configuration";
+import { isOIDC, isInternalGroupsEnabled } from "src/configuration";
 import { Paths } from "src/components/global/routePaths";
 
 export const useGlobalRoutes = () => {
   const { t } = useTranslate();
   const { pathname } = useLocation();
 
-  const authTypeDependentRoutes = isOIDC
+  const OIDCDependentRoutes = isOIDC
     ? [
         {
           path: `${Paths.mappings()}/*`,
@@ -39,14 +39,20 @@ export const useGlobalRoutes = () => {
         },
       ];
 
+  const internalGroupsDependentRoutes = isInternalGroupsEnabled
+    ? [
+        {
+          path: `${Paths.groups()}/*`,
+          key: Paths.groups(),
+          label: t("groups"),
+          element: <Groups />,
+        },
+      ]
+    : [];
+
   const routes = [
-    ...authTypeDependentRoutes,
-    {
-      path: `${Paths.groups()}/*`,
-      key: Paths.groups(),
-      label: t("groups"),
-      element: <Groups />,
-    },
+    ...OIDCDependentRoutes,
+    ...internalGroupsDependentRoutes,
     {
       path: `${Paths.roles()}/*`,
       key: Paths.roles(),

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -14,8 +14,11 @@ const apiBaseUrl = "/v2";
 
 const loginApiUrl = "/login";
 
-export const isOIDC = getEnvBoolean("IS_OIDC");
-export const isInternalGroupsEnabled = getEnvBoolean("INTERNAL_GROUPS_ENABLED");
+export const isOIDC = getEnvBoolean("IS_OIDC", false);
+export const isInternalGroupsEnabled = getEnvBoolean(
+  "INTERNAL_GROUPS_ENABLED",
+  true,
+);
 
 export const docsUrl = "https://docs.camunda.io";
 

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -15,6 +15,7 @@ const apiBaseUrl = "/v2";
 const loginApiUrl = "/login";
 
 export const isOIDC = getEnvBoolean("IS_OIDC");
+export const isInternalGroupsEnabled = getEnvBoolean("INTERNAL_GROUPS_ENABLED");
 
 export const docsUrl = "https://docs.camunda.io";
 

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -31,7 +31,7 @@ import {
   IS_TENANT_GROUPS_SUPPORTED,
   IS_TENANT_ROLES_SUPPORTED,
 } from "src/feature-flags";
-import { isOIDC } from "src/configuration";
+import { isInternalGroupsEnabled, isOIDC } from "src/configuration";
 
 const Details: FC = () => {
   const { t } = useTranslate("tenants");
@@ -93,7 +93,7 @@ const Details: FC = () => {
                   label: t("users"),
                   content: <Members tenantId={tenant.tenantId} />,
                 },
-                ...(IS_TENANT_GROUPS_SUPPORTED
+                ...(IS_TENANT_GROUPS_SUPPORTED && isInternalGroupsEnabled
                   ? [
                       {
                         key: "groups",


### PR DESCRIPTION
## Description

- Adds `isInternalGroupsEnabled` flag that gets its value from the variable `INTERNAL_GROUPS_ENABLED` sent by the backend to the frontend via `clientConfig`.
- Use `isInternalGroupsEnabled` flag control visibility of Groups page as well as of the groups tab in the Tenant details page in the UI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31448
