### PR TITLE
fix: OS backup manager snapshot response handler

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -419,11 +419,11 @@ public class BackupManagerOpenSearch extends BackupManager {
   }
 
   private void handleSnapshotResponse(final SnapshotInfo snapshotInfo) {
-    String snapshotId = getSnapshotId(snapshotInfo);
-    String snapshotState = Objects.requireNonNullElse(snapshotInfo.state(), "null");
+    final String snapshotId = getSnapshotId(snapshotInfo);
+    final String snapshotState = Objects.requireNonNullElse(snapshotInfo.state(), "null");
     switch (snapshotState) {
       case "SUCCESS" -> {
-        LOGGER.info("Snapshot done: " + snapshotId);
+        LOGGER.info("Snapshot done: {}", snapshotId);
         scheduleNextSnapshot();
       }
       case "FAILED" -> {
@@ -431,7 +431,7 @@ public class BackupManagerOpenSearch extends BackupManager {
         requestsQueue.clear(); // no need to continue
       }
       default -> {
-        LOGGER.error("Unexpected snapshot status '{}' for {}", snapshotState, snapshotId);
+        LOGGER.error("Unexpected snapshot state '{}' for {}", snapshotState, snapshotId);
         requestsQueue.clear();
       }
     }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -419,22 +419,19 @@ public class BackupManagerOpenSearch extends BackupManager {
   }
 
   private void handleSnapshotResponse(final SnapshotInfo snapshotInfo) {
-    switch (Objects.requireNonNullElse(snapshotInfo.snapshot(), "null")) {
+    String snapshotId = getSnapshotId(snapshotInfo);
+    String snapshotState = Objects.requireNonNullElse(snapshotInfo.state(), "null");
+    switch (snapshotState) {
       case "SUCCESS" -> {
-        LOGGER.info("Snapshot done: " + getSnapshotId(snapshotInfo));
+        LOGGER.info("Snapshot done: " + snapshotId);
         scheduleNextSnapshot();
       }
       case "FAILED" -> {
-        LOGGER.error(
-            "Snapshot taking failed for {}, reason {}",
-            getSnapshotId(snapshotInfo),
-            snapshotInfo.reason());
-        // no need to continue
-        requestsQueue.clear();
+        LOGGER.error("Snapshot failed for {}, reason {}", snapshotId, snapshotInfo.reason());
+        requestsQueue.clear(); // no need to continue
       }
       default -> {
-        LOGGER.error(
-            "Snapshot status {} for the {}", snapshotInfo.state(), getSnapshotId(snapshotInfo));
+        LOGGER.error("Unexpected snapshot status '{}' for {}", snapshotState, snapshotId);
         requestsQueue.clear();
       }
     }


### PR DESCRIPTION
## Description

Context:
https://github.com/camunda/camunda/issues/33310

Local test worked:
```
07:59:05.924 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_1_of_6/dEnnzjzZS7ChgVDhtPeSZw
07:59:05.970 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_2_of_6/eOuNjrzlSBKBxZEXlKb9aQ
07:59:06.004 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_3_of_6/CgD1DByPTAmoOwEU8puz2g
07:59:06.064 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_4_of_6/ZW83GhmpQOOJgTM4LbLC0g
07:59:06.102 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_5_of_6/MuPL0oSFQSeXXxVcQuJaYw
07:59:06.189 [] [httpclient-dispatch-2] [] INFO  io.camunda.tasklist.webapp.es.backup.os.BackupManagerOpenSearch - Snapshot done: camunda_tasklist_2010_8.6.18-snapshot_part_6_of_6/-KP-DHJ9RvG02KlUCQLdFg
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/33310
