### PR TITLE
feat: add supports of fetching groups from claims to engine/grpc

### DIFF
--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
@@ -112,4 +112,19 @@ final class OidcGroupsLoaderTest {
     // then
     assertThat(groups).containsExactlyInAnyOrder("g1");
   }
+
+  @Test
+  void shouldLoadEmptyGroupsWithNonExistentClaim() {
+    // given
+    final var claims =
+        Map.<String, Object>of("groups", List.of("g1", "g2"), "other_claim", "other_value");
+
+    final var loader = new OidcGroupsLoader("group_names");
+
+    // when
+    final var groups = loader.load(claims);
+
+    // then
+    assertThat(groups).isEmpty();
+  }
 }

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
@@ -14,4 +14,5 @@ public class Authorization {
   public static final String AUTHORIZED_USERNAME = "authorized_username";
   public static final String AUTHORIZED_CLIENT_ID = "authorized_client_id";
   public static final String USER_TOKEN_CLAIMS = "user_token_claims";
+  public static final String USER_GROUPS_CLAIMS = "user_groups_claims";
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorGroupsClaimsTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_GROUPS_CLAIMS;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.state.appliers.AuthorizationCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.MappingCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.RoleCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.RoleEntityAddedApplier;
+import io.camunda.zeebe.engine.state.appliers.TenantCreatedApplier;
+import io.camunda.zeebe.engine.state.appliers.TenantEntityAddedApplier;
+import io.camunda.zeebe.engine.state.appliers.UserCreatedApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.test.util.Strings;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class AuthorizationCheckBehaviorGroupsClaimsTest {
+
+  @SuppressWarnings("unused") // injected by the extension
+  private MutableProcessingState processingState;
+
+  private AuthorizationCheckBehavior authorizationCheckBehavior;
+  private UserCreatedApplier userCreatedApplier;
+  private MappingCreatedApplier mappingCreatedApplier;
+  private AuthorizationCreatedApplier authorizationCreatedApplier;
+  private RoleCreatedApplier roleCreatedApplier;
+  private RoleEntityAddedApplier roleEntityAddedApplier;
+  private TenantCreatedApplier tenantCreatedApplier;
+  private TenantEntityAddedApplier tenantEntityAddedApplier;
+  private final Random random = new Random();
+
+  @BeforeEach
+  public void before() {
+    final var securityConfig = new SecurityConfiguration();
+    final var authConfig = new AuthorizationsConfiguration();
+    authConfig.setEnabled(true);
+    securityConfig.setAuthorizations(authConfig);
+    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+
+    userCreatedApplier = new UserCreatedApplier(processingState.getUserState());
+    mappingCreatedApplier = new MappingCreatedApplier(processingState.getMappingState());
+    authorizationCreatedApplier =
+        new AuthorizationCreatedApplier(processingState.getAuthorizationState());
+    roleCreatedApplier = new RoleCreatedApplier(processingState.getRoleState());
+    roleEntityAddedApplier = new RoleEntityAddedApplier(processingState);
+    tenantCreatedApplier = new TenantCreatedApplier(processingState.getTenantState());
+    tenantEntityAddedApplier = new TenantEntityAddedApplier(processingState);
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenGroupHasPermissions() {
+    // given
+    final var user = createUser();
+    final var groups = List.of("group1", "group2");
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        groups.get(0), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
+    final var command = mockCommand(user.getUsername(), groups);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldGetResourceIdentifiersWhenGroupHasPermissions() {
+    // given
+    final var user = createUser();
+    final var groups = List.of("group1", "group2");
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId1 = UUID.randomUUID().toString();
+    final var resourceId2 = UUID.randomUUID().toString();
+    addPermission(
+        groups.get(0),
+        AuthorizationOwnerType.GROUP,
+        resourceType,
+        permissionType,
+        resourceId1,
+        resourceId2);
+    final var command = mockCommand(user.getUsername(), groups);
+
+    // when
+    final var request = new AuthorizationRequest(command, resourceType, permissionType);
+    final var resourceIdentifiers =
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+
+    // then
+    assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
+  }
+
+  @Test
+  void shouldGetAuthorizationsForMappingThroughAssignedGroup() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    createMapping(claimName, claimValue);
+    final var groups = List.of("group1", "group2");
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        groups.get(0), AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue, groups);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorizations =
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+
+    // then
+    assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
+  }
+
+  @Test
+  void shouldBeAuthorizedForUserWithAssignedGroupWithAssignedRole() {
+    // given
+    final var user = createUser();
+    final var groups = List.of("group1", "group2");
+    final var role = createRoleAndAssignEntity(groups.get(0), EntityType.GROUP);
+
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        role.getRoleId(), AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
+    final var command = mockCommand(user.getUsername(), groups);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldBeAuthorizedForUserTenantThroughGroup() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    final var groups = List.of("group1", "group2");
+    final var tenantId = createAndAssignTenant(groups.get(0), EntityType.GROUP);
+    final var command = mockCommand(user.getUsername(), groups);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  private UserRecordValue createUser() {
+    final var userKey = random.nextLong();
+    final var user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(Strings.newRandomValidUsername())
+            .setName(UUID.randomUUID().toString())
+            .setEmail(UUID.randomUUID().toString())
+            .setPassword(UUID.randomUUID().toString());
+    userCreatedApplier.applyState(userKey, user);
+    return user;
+  }
+
+  private RoleRecord createRoleAndAssignEntity(final String entityId, final EntityType entityType) {
+    final var role =
+        new RoleRecord()
+            .setRoleId(Strings.newRandomValidIdentityId())
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString())
+            .setEntityId(entityId)
+            .setEntityType(entityType);
+    roleCreatedApplier.applyState(1L, role);
+    roleEntityAddedApplier.applyState(1L, role);
+    return role;
+  }
+
+  private TenantRecord createTenant() {
+    final var tenantKey = random.nextLong();
+    final var tenant =
+        new TenantRecord()
+            .setTenantKey(tenantKey)
+            .setTenantId(Strings.newRandomValidIdentityId())
+            .setName(UUID.randomUUID().toString())
+            .setDescription(UUID.randomUUID().toString());
+    tenantCreatedApplier.applyState(tenantKey, tenant);
+    return tenant;
+  }
+
+  private String createAndAssignTenant(final String entityId, final EntityType entityType) {
+    final var tenant = createTenant();
+    tenant.setEntityId(entityId).setEntityType(entityType);
+    tenantEntityAddedApplier.applyState(tenant.getTenantKey(), tenant);
+    return tenant.getTenantId();
+  }
+
+  private MappingRecordValue createMapping(final String claimName, final String claimValue) {
+    final var mapping =
+        new MappingRecord()
+            .setMappingId(UUID.randomUUID().toString())
+            .setName(Strings.newRandomValidUsername())
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
+    mappingCreatedApplier.applyState(random.nextLong(), mapping);
+    return mapping;
+  }
+
+  private void addPermission(
+      final String ownerId,
+      final AuthorizationOwnerType ownerType,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final String... resourceIds) {
+    for (final String resourceId : resourceIds) {
+      final var authorizationKey = random.nextLong();
+      final var authorization =
+          new AuthorizationRecord()
+              .setAuthorizationKey(authorizationKey)
+              .setOwnerId(ownerId)
+              .setOwnerType(ownerType)
+              .setResourceId(resourceId)
+              .setResourceType(resourceType)
+              .setPermissionTypes(Set.of(permissionType));
+      authorizationCreatedApplier.applyState(authorizationKey, authorization);
+    }
+  }
+
+  private TypedRecord<?> mockCommand(final String username, final List<String> groups) {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(Map.of(AUTHORIZED_USERNAME, username, USER_GROUPS_CLAIMS, groups));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
+  }
+
+  private TypedRecord<?> mockCommandWithMapping(
+      final String claimName, final String claimValue, final List<String> groups) {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(
+            Map.of(USER_TOKEN_CLAIMS, Map.of(claimName, claimValue), USER_GROUPS_CLAIMS, groups));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -74,6 +74,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -505,6 +506,12 @@ public final class EndpointManager {
     final String clientId = Context.current().call(AuthenticationHandler.CLIENT_ID::get);
     if (clientId != null) {
       claims.put(Authorization.AUTHORIZED_CLIENT_ID, clientId);
+    }
+
+    final List<String> groupsClaims =
+        Context.current().call(AuthenticationHandler.GROUPS_CLAIMS::get);
+    if (groupsClaims != null) {
+      claims.put(Authorization.USER_GROUPS_CLAIMS, groupsClaims);
     }
 
     brokerRequest.setAuthorization(claims);


### PR DESCRIPTION
## Description

Change AuthorizationCheckBehavior(Engine)to consider lookup the groups from the claims when the group claim is configured and pass along the group claim from gateway to broker

## Related issues

closes #31819 
