### PR TITLE
ci: fix Maven version sed expression to support multi-digits

### DIFF
--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -29,5 +29,5 @@ runs:
         MAVEN_VERSION: ${{ inputs.maven-version }}
         MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
       run: |
-        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        sed -i "/distributionUrl=/ s/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
         cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"


### PR DESCRIPTION
## Description

This PR fixes a problem with the `sed` logic we use to adjust Maven Wrapper configuration to overwrite the used Maven version.

Symptom: [[CI runs trying to download non-existing Maven 3.8.60](https://github.com/camunda/camunda/actions/runs/15487463984/job/43605300603#step:4:18)](https://github.com/camunda/camunda/actions/runs/15487463984/job/43605300603#step:4:18) on `stable/8.7` merge queue

Problem: [Maven 3.9.10](https://github.com/camunda/camunda/pull/33266) is out and updated to by Renovate on `stable/8.7`, and the sed logic replaces the `3.9.1` (in `3.9.10`) with `3.8.6` yielding `3.8.60`.

Solution: make the regex account for multi-digit numbers such as `.10`.

Reproduce locally:

1. Have `distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip` in https://github.com/camunda/camunda/blob/main/.mvn/wrapper/maven-wrapper.properties
2. Run `sed "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/3.8.6/g" .mvn/wrapper/maven-wrapper.properties` to confirm the problem
3. Run `sed "/distributionUrl=/ s/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+/3.8.6/g" .mvn/wrapper/maven-wrapper.properties` to see the fix

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
