### PR TITLE
ci: fix Maven version sed expression to support multi-digits

### DIFF
--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -29,5 +29,5 @@ runs:
         MAVEN_VERSION: ${{ inputs.maven-version }}
         MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
       run: |
-        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        sed -i "/distributionUrl=/ s/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
         cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"


### PR DESCRIPTION
## Description

Manual backport of https://github.com/camunda/camunda/pull/33336 for `stable/8.6` to speedup the process

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
