### PR TITLE
[Backport stable/8.7] ci: fix Maven version sed expression to support multi-digits

### DIFF
--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -29,5 +29,5 @@ runs:
         MAVEN_VERSION: ${{ inputs.maven-version }}
         MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
       run: |
-        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        sed -i "/distributionUrl=/ s/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
         cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"


### PR DESCRIPTION
# Description
Backport of #33336 to `stable/8.7`.

relates to 