### PR TITLE
Migrate roles from SaaS to the OC

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
@@ -7,13 +7,10 @@
  */
 package io.camunda.migration.identity;
 
-import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Role;
-import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
-import io.camunda.service.AuthorizationServices;
 import io.camunda.service.RoleServices;
+import io.camunda.service.RoleServices.CreateRoleRequest;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,58 +18,39 @@ import org.slf4j.LoggerFactory;
 public class RoleMigrationHandler extends MigrationHandler<Role> {
   private static final Logger LOG = LoggerFactory.getLogger(RoleMigrationHandler.class);
   private final RoleServices roleServices;
-  private final AuthorizationServices authorizationServices;
-  private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
+  private final List<CreateRoleRequest> roles =
+      List.of(
+          new CreateRoleRequest("developer", "Developer", ""),
+          new CreateRoleRequest("operationsEngineer", "Operations Engineer", ""),
+          new CreateRoleRequest("taskUser", "Task User", ""),
+          new CreateRoleRequest("visitor", "Visitor", ""));
 
   public RoleMigrationHandler(
-      final RoleServices roleServices,
-      final AuthorizationServices authorizationServices,
-      final Authentication servicesAuthentication,
-      final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer) {
-    this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
+      final RoleServices roleServices, final Authentication servicesAuthentication) {
     this.roleServices = roleServices.withAuthentication(servicesAuthentication);
-    this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
   }
 
-  // TODO: this will be revisited
   @Override
   protected List<Role> fetchBatch(final int page) {
-    return managementIdentityClient.fetchRoles(SIZE);
+    // Roles are created statically
+    return List.of();
   }
 
   @Override
   protected void process(final List<Role> batch) {
-    managementIdentityClient.updateMigrationStatus(batch.stream().map(this::createRole).toList());
+    createRoles();
   }
 
-  private MigrationStatusUpdateRequest createRole(final Role role) {
-    final long roleKey;
-    try {
-      // TODO revisit with https://github.com/camunda/camunda/issues/26973
-      //      roleKey =
-      //          roleServices
-      //              .findRole(role.name())
-      //              .map(RoleEntity::roleKey)
-      //              .orElseGet(() -> roleServices.createRole(role.name()).join().getRoleKey());
-    } catch (final Exception e) {
-      LOG.error("create or finding role with name {} failed", role.name(), e);
-      return managementIdentityTransformer.toMigrationStatusUpdateRequest(role, e);
-    }
-
-    try {
-      // TODO: this part needs to be revisited
-      //      transform(roleKey, role.permissions()).stream()
-      //          .map(authorizationServices::patchAuthorization)
-      //          .forEach(CompletableFuture::join);
-    } catch (final Exception e) {
-      LOG.error("patch authorization for role failed", e);
-      if (!isConflictError(e)) {
-        return managementIdentityTransformer.toMigrationStatusUpdateRequest(role, e);
-      }
-    }
-    return managementIdentityTransformer.toMigrationStatusUpdateRequest(role, null);
+  private void createRoles() {
+    roles.forEach(
+        role -> {
+          try {
+            roleServices.createRole(role);
+          } catch (final Exception e) {
+            if (!isConflictError(e)) {
+              throw new RuntimeException("Failed to migrate role with ID: " + role.roleId(), e);
+            }
+          }
+        });
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -8,9 +8,11 @@
 package io.camunda.migration.identity.config;
 
 import io.camunda.migration.identity.GroupMigrationHandler;
+import io.camunda.migration.identity.RoleMigrationHandler;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
+import io.camunda.service.RoleServices;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,5 +25,11 @@ public class MigrationHandlerConfig {
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices) {
     return new GroupMigrationHandler(authentication, managementIdentityClient, groupServices);
+  }
+
+  @Bean
+  public RoleMigrationHandler roleMigrationHandler(
+      final Authentication authentication, final RoleServices roleServices) {
+    return new RoleMigrationHandler(roleServices, authentication);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -11,7 +11,6 @@ import io.camunda.identity.sdk.users.dto.User;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.dto.MappingRule.MappingRuleType;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
-import io.camunda.migration.identity.dto.Role;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.TenantMappingRule;
 import io.camunda.migration.identity.dto.UserResourceAuthorization;
@@ -30,7 +29,6 @@ public class ManagementIdentityClient {
   private static final String URL_PARAMS = "pageSize={0}";
   private static final String MIGRATION_MARK_STATUS_ENDPOINT = "/api/migration";
   private static final String MIGRATION_TENANTS_ENDPOINT = "/api/migration/tenant?" + URL_PARAMS;
-  private static final String MIGRATION_ROLES_ENDPOINT = "/api/migration/role?" + URL_PARAMS;
   private static final String MIGRATION_USER_TENANTS_ENDPOINT =
       "/api/migration/tenant/user?" + URL_PARAMS;
   private static final String MIGRATION_MAPPING_RULE_ENDPOINT =
@@ -84,13 +82,6 @@ public class ManagementIdentityClient {
             Objects.requireNonNull(
                 restTemplate.getForObject(
                     MIGRATION_GROUPS_ENDPOINT, Group[].class, page, organizationId)))
-        .toList();
-  }
-
-  public List<Role> fetchRoles(final int pageSize) {
-    return Arrays.stream(
-            Objects.requireNonNull(
-                restTemplate.getForObject(MIGRATION_ROLES_ENDPOINT, Role[].class, pageSize)))
         .toList();
   }
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/RoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/RoleMigrationHandlerTest.java
@@ -8,201 +8,83 @@
 package io.camunda.migration.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
-import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
-import io.camunda.migration.identity.dto.Role;
-import io.camunda.migration.identity.dto.Role.Permission;
-import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
-import io.camunda.service.AuthorizationServices;
 import io.camunda.service.RoleServices;
+import io.camunda.service.RoleServices.CreateRoleRequest;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.apache.commons.lang3.NotImplementedException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@Disabled("https://github.com/camunda/camunda/issues/26973")
 @ExtendWith(MockitoExtension.class)
 public class RoleMigrationHandlerTest {
-  private final ManagementIdentityClient managementIdentityClient;
-
   private final RoleServices roleServices;
-
-  private final AuthorizationServices authorizationServices;
-
-  private final ManagementIdentityTransformer managementIdentityTransformer =
-      new ManagementIdentityTransformer();
 
   private final RoleMigrationHandler migrationHandler;
 
-  //  @Captor private ArgumentCaptor<PatchAuthorizationRequest> patchAuthorizationRequestCaptor;
-
   public RoleMigrationHandlerTest(
-      @Mock final ManagementIdentityClient managementIdentityClient,
-      @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices,
       @Mock(answer = Answers.RETURNS_SELF) final RoleServices roleServices) {
-    this.managementIdentityClient = managementIdentityClient;
     this.roleServices = roleServices;
-    this.authorizationServices = authorizationServices;
-    migrationHandler =
-        new RoleMigrationHandler(
-            roleServices,
-            authorizationServices,
-            Authentication.none(),
-            managementIdentityClient,
-            managementIdentityTransformer);
-    //    when(this.roleServices.createRole(anyString()))
-    //        .thenReturn(CompletableFuture.completedFuture(new RoleRecord().setRoleKey(1L)))
-    //        .thenReturn(CompletableFuture.completedFuture(new RoleRecord().setRoleKey(2L)));
-    //    when(authorizationServices.patchAuthorization(any()))
-    //        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    migrationHandler = new RoleMigrationHandler(roleServices, Authentication.none());
   }
 
   @Test
-  void stopWhenIdentityEndpointNotFound() {
-    when(managementIdentityClient.fetchRoles(anyInt())).thenThrow(new NotImplementedException());
-
-    // when
-    assertThrows(NotImplementedException.class, migrationHandler::migrate);
-
-    // then
-    verify(managementIdentityClient).fetchRoles(anyInt());
-    verifyNoMoreInteractions(managementIdentityClient);
-  }
-
-  @Test
-  void stopWhenNoMoreRecords() {
-    // given
-    givenRoles();
-
-    // when
+  public void shouldMigrateRoles() {
     migrationHandler.migrate();
 
-    // then
-    verify(managementIdentityClient, times(2)).fetchRoles(anyInt());
-    verify(roleServices, times(2)).createRole(any());
-    // TODO: this part needs to be revisited
-    //    verify(authorizationServices, times(8))
-    //        .patchAuthorization(patchAuthorizationRequestCaptor.capture());
-    //    final var authorizations = patchAuthorizationRequestCaptor.getAllValues();
-    //    final Map<PermissionType, Set<String>> defaultPermissionMap =
-    //        Arrays.stream(PermissionType.values())
-    //            .collect(
-    //                Collectors.toMap(permissionType -> permissionType, permissionType ->
-    // Set.of("*")));
-    //    Arrays.asList(
-    //            AuthorizationResourceType.PROCESS_DEFINITION,
-    //            AuthorizationResourceType.DECISION_DEFINITION,
-    //            AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION)
-    //        .forEach(
-    //            resourceType ->
-    //                assertThat(authorizations)
-    //                    .contains(
-    //                        new PatchAuthorizationRequest(
-    //                            1, PermissionAction.ADD, resourceType, defaultPermissionMap)));
-    //    assertThat(authorizations)
-    //        .contains(
-    //            new PatchAuthorizationRequest(
-    //                1,
-    //                PermissionAction.ADD,
-    //                AuthorizationResourceType.APPLICATION,
-    //                Map.of(PermissionType.ACCESS, Set.of("operate"))));
-    //    assertThat(authorizations)
-    //        .contains(
-    //            new PatchAuthorizationRequest(
-    //                2,
-    //                PermissionAction.ADD,
-    //                AuthorizationResourceType.APPLICATION,
-    //                Map.of(PermissionType.ACCESS, Set.of("tasklist", "operate"))));
+    final var rolesResult = ArgumentCaptor.forClass(CreateRoleRequest.class);
+    verify(roleServices, times(4)).createRole(rolesResult.capture());
+    final List<CreateRoleRequest> requests = rolesResult.getAllValues();
+    assertThat(requests).hasSize(4);
+    assertThat(requests.getFirst().roleId()).isEqualTo("developer");
+    assertThat(requests.getFirst().name()).isEqualTo("Developer");
+    assertThat(requests.get(1).roleId()).isEqualTo("operationsEngineer");
+    assertThat(requests.get(1).name()).isEqualTo("Operations Engineer");
+    assertThat(requests.get(2).roleId()).isEqualTo("taskUser");
+    assertThat(requests.get(2).name()).isEqualTo("Task User");
+    assertThat(requests.get(3).roleId()).isEqualTo("visitor");
+    assertThat(requests.get(3).name()).isEqualTo("Visitor");
   }
 
   @Test
-  void setErrorWhenRoleAlreadyExists() {
-    // given
-
-    when(roleServices.createRole(any()))
-        .thenReturn(
+  public void shouldContinueMigrationIfOnRoleAlreadyExists() {
+    doReturn(CompletableFuture.completedFuture(null))
+        .doReturn(
             CompletableFuture.failedFuture(
                 new BrokerRejectionException(
                     new BrokerRejection(
-                        RoleIntent.CREATE,
+                        GroupIntent.CREATE,
                         -1,
                         RejectionType.ALREADY_EXISTS,
-                        "role already exists"))));
-    givenRoles();
+                        "role already exists"))))
+        .doReturn(CompletableFuture.completedFuture(null))
+        .doReturn(CompletableFuture.completedFuture(null))
+        .when(roleServices)
+        .createRole(any(CreateRoleRequest.class));
 
-    // when
     migrationHandler.migrate();
 
-    // then
-    verify(managementIdentityClient, times(2)).fetchRoles(anyInt());
-    verify(roleServices, times(2)).createRole(any());
-    verify(managementIdentityClient, times(2))
-        .updateMigrationStatus(
-            assertArg(
-                migrationStatusUpdateRequests -> {
-                  assertThat(migrationStatusUpdateRequests)
-                      .describedAs("No migrations has succeeded")
-                      .noneMatch(MigrationStatusUpdateRequest::success);
-                }));
-  }
+    final var rolesResult = ArgumentCaptor.forClass(CreateRoleRequest.class);
+    verify(roleServices, times(4)).createRole(rolesResult.capture());
 
-  @Test
-  void setErrorWhenRoleCreationHasError() {
-    // given
-    when(roleServices.createRole(any())).thenThrow(new RuntimeException());
-    givenRoles();
-
-    // when
-    migrationHandler.migrate();
-
-    // then
-    verify(managementIdentityClient, times(2))
-        .updateMigrationStatus(
-            assertArg(
-                statusUpdateRequests -> {
-                  assertThat(statusUpdateRequests)
-                      .describedAs("All migrations have failed")
-                      .noneMatch(MigrationStatusUpdateRequest::success);
-                }));
-    verify(managementIdentityClient, times(2)).fetchRoles(anyInt());
-    verify(roleServices, times(2)).createRole(any());
-  }
-
-  private void givenRoles() {
-    when(managementIdentityClient.fetchRoles(anyInt()))
-        .thenReturn(
-            List.of(
-                new Role(
-                    "r1",
-                    "d1",
-                    List.of(
-                        new Permission("write", "d1", "operate", "aud1"),
-                        new Permission("write", "d2", "operate", "aud2"))),
-                new Role(
-                    "r2",
-                    "d2",
-                    List.of(
-                        new Permission("read", "d1", "operate", "aud1"),
-                        new Permission("read", "d2", "tasklist", "aud1")))))
-        .thenReturn(List.of());
+    final List<CreateRoleRequest> requests = rolesResult.getAllValues();
+    assertThat(requests).hasSize(4);
+    assertThat(requests.getFirst().roleId()).isEqualTo("developer");
+    assertThat(requests.get(1).roleId()).isEqualTo("operationsEngineer");
+    assertThat(requests.get(2).roleId()).isEqualTo("taskUser");
+    assertThat(requests.get(3).roleId()).isEqualTo("visitor");
   }
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/RoleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/RoleMigrationHandlerTest.java
@@ -60,7 +60,7 @@ public class RoleMigrationHandlerTest {
   }
 
   @Test
-  public void shouldContinueMigrationIfOnRoleAlreadyExists() {
+  public void shouldContinueMigrationIfOneRoleAlreadyExists() {
     doReturn(CompletableFuture.completedFuture(null))
         .doReturn(
             CompletableFuture.failedFuture(


### PR DESCRIPTION
## Description

Roles in SaaS are static, so the migration handler needs to create them statically in the OC. There is no need to retrieve the roles from anywhere

## Related issues

closes #33067 
