### PR TITLE
fix: validate mappingRule in engine

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import org.springframework.util.StringUtils;
 
 public class MappingCreateProcessor implements DistributedTypedRecordProcessor<MappingRecord> {
 
@@ -71,10 +70,14 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
     }
 
     final var record = command.getValue();
-    if (!StringUtils.hasText(record.getMappingId())
-        || !StringUtils.hasText(record.getName())
-        || !StringUtils.hasText(record.getClaimName())
-        || !StringUtils.hasText(record.getClaimValue())) {
+    if (record.getMappingId() == null
+        || record.getMappingId().isBlank()
+        || record.getName() == null
+        || record.getName().isBlank()
+        || record.getClaimName() == null
+        || record.getClaimName().isBlank()
+        || record.getClaimValue() == null
+        || record.getClaimValue().isBlank()) {
       final var errorMessage =
           MAPPING_NULL_VALUE_ERROR_MESSAGE.formatted(
               record.getClaimName(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
@@ -23,11 +23,13 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.springframework.util.StringUtils;
 
 public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<MappingRecord> {
-
+  private static final String MAPPING_NULL_VALUE_ERROR_MESSAGE =
+      "Expected to update mappingRule with claimName '%s' and claimValue '%s' and name '%s' and mappingRuleId '%s', but at least one of them is null.";
   private static final String MAPPING_SAME_CLAIM_ALREADY_EXISTS_ERROR_MESSAGE =
-      "Expected to create mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists.";
+      "Expected to update mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists.";
   private static final String MAPPING_ID_DOES_NOT_EXIST_ERROR_MESSAGE =
       "Expected to update mapping with id '%s', but a mapping with this id does not exist.";
 
@@ -59,6 +61,21 @@ public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<M
 
     final var record = command.getValue();
     final var mappingId = record.getMappingId();
+    if (!StringUtils.hasText(record.getMappingId())
+        || !StringUtils.hasText(record.getName())
+        || !StringUtils.hasText(record.getClaimName())
+        || !StringUtils.hasText(record.getClaimValue())) {
+      final var errorMessage =
+          MAPPING_NULL_VALUE_ERROR_MESSAGE.formatted(
+              record.getClaimName(),
+              record.getClaimValue(),
+              record.getName(),
+              record.getMappingId());
+      rejectionWriter.appendRejection(command, RejectionType.NULL_VAL, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NULL_VAL, errorMessage);
+      return;
+    }
+
     final var persistedRecord = mappingState.get(mappingId);
     if (persistedRecord.isEmpty()) {
       final var errorMessage = MAPPING_ID_DOES_NOT_EXIST_ERROR_MESSAGE.formatted(mappingId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import org.springframework.util.StringUtils;
 
 public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<MappingRecord> {
   private static final String MAPPING_NULL_VALUE_ERROR_MESSAGE =
@@ -61,10 +60,14 @@ public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<M
 
     final var record = command.getValue();
     final var mappingId = record.getMappingId();
-    if (!StringUtils.hasText(record.getMappingId())
-        || !StringUtils.hasText(record.getName())
-        || !StringUtils.hasText(record.getClaimName())
-        || !StringUtils.hasText(record.getClaimValue())) {
+    if (record.getMappingId() == null
+        || record.getMappingId().isBlank()
+        || record.getName() == null
+        || record.getName().isBlank()
+        || record.getClaimName() == null
+        || record.getClaimName().isBlank()
+        || record.getClaimValue() == null
+        || record.getClaimValue().isBlank()) {
       final var errorMessage =
           MAPPING_NULL_VALUE_ERROR_MESSAGE.formatted(
               record.getClaimName(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -347,11 +347,13 @@ public class IdentitySetupInitializeTest {
     final var mapping1 =
         new MappingRecord()
             .setMappingId(UUID.randomUUID().toString())
+            .setName(UUID.randomUUID().toString())
             .setClaimName(UUID.randomUUID().toString())
             .setClaimValue(UUID.randomUUID().toString());
     final var mapping2 =
         new MappingRecord()
             .setMappingId(UUID.randomUUID().toString())
+            .setName(UUID.randomUUID().toString())
             .setClaimName(UUID.randomUUID().toString())
             .setClaimValue(UUID.randomUUID().toString());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -430,7 +430,13 @@ public class CommandDistributionIdempotencyTest {
                 MappingIntent.UPDATE,
                 () -> {
                   final var mapping = createMapping();
-                  return ENGINE.mapping().updateMapping(mapping.getValue().getMappingId()).update();
+                  return ENGINE
+                      .mapping()
+                      .updateMapping(mapping.getValue().getMappingId())
+                      .withName(mapping.getValue().getName())
+                      .withClaimName(mapping.getValue().getClaimName())
+                      .withClaimValue(mapping.getValue().getClaimValue())
+                      .update();
                 }),
             MappingUpdateProcessor.class
           },
@@ -771,6 +777,7 @@ public class CommandDistributionIdempotencyTest {
         .newMapping(UUID.randomUUID().toString())
         .withClaimName(UUID.randomUUID().toString())
         .withClaimValue(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
         .create();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/CreateMappingMultiPartitionTest.java
@@ -42,9 +42,11 @@ public class CreateMappingMultiPartitionTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
+        .withName(name)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
         .create();
@@ -94,11 +96,13 @@ public class CreateMappingMultiPartitionTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
+        .withName(name)
         .create();
 
     // then
@@ -122,11 +126,13 @@ public class CreateMappingMultiPartitionTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
+        .withName(name)
         .create();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
@@ -40,12 +40,14 @@ public class DeleteMappingMultiPartitionTest {
     // when
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var mappingId = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimValue(claimValue)
         .withClaimName(claimName)
+        .withName(name)
         .create();
     engine.mapping().deleteMapping(mappingId).delete();
 
@@ -95,12 +97,14 @@ public class DeleteMappingMultiPartitionTest {
     // when
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var mappingId = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimValue(claimValue)
         .withClaimName(claimName)
+        .withName(name)
         .create();
     engine.mapping().deleteMapping(mappingId).delete();
 
@@ -121,6 +125,7 @@ public class DeleteMappingMultiPartitionTest {
     }
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var mappingId = UUID.randomUUID().toString();
 
     engine
@@ -128,6 +133,7 @@ public class DeleteMappingMultiPartitionTest {
         .newMapping(mappingId)
         .withClaimValue(claimValue)
         .withClaimName(claimName)
+        .withName(name)
         .create();
     engine.mapping().deleteMapping(mappingId).delete();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
@@ -56,6 +56,7 @@ public class MappingCreateAuthorizationTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
 
     // when
     engine
@@ -63,6 +64,7 @@ public class MappingCreateAuthorizationTest {
         .newMapping(mappingId)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
+        .withName(name)
         .create(DEFAULT_USER.getUsername());
 
     // then
@@ -81,6 +83,7 @@ public class MappingCreateAuthorizationTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var user = createUser();
     addPermissionsToUser(user, AuthorizationResourceType.MAPPING_RULE, PermissionType.CREATE);
 
@@ -90,6 +93,7 @@ public class MappingCreateAuthorizationTest {
         .newMapping(mappingId)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
+        .withName(name)
         .create(user.getUsername());
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -58,11 +58,13 @@ public class MappingTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimName(claimName)
         .withClaimValue(claimValue)
+        .withName(name)
         .create();
 
     // when
@@ -72,6 +74,7 @@ public class MappingTest {
             .newMapping(mappingId)
             .withClaimName(claimName)
             .withClaimValue(claimValue)
+            .withName(name)
             .expectRejection()
             .create();
 
@@ -88,8 +91,15 @@ public class MappingTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(id).withClaimName(claimName).withClaimValue(claimValue).create();
+    engine
+        .mapping()
+        .newMapping(id)
+        .withClaimName(claimName)
+        .withClaimValue(claimValue)
+        .withName(name)
+        .create();
 
     // when
     final var duplicatedMappingRecord =
@@ -98,6 +108,7 @@ public class MappingTest {
             .newMapping(id)
             .withClaimValue(UUID.randomUUID().toString())
             .withClaimName(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
             .expectRejection()
             .create();
 
@@ -178,11 +189,13 @@ public class MappingTest {
     final var mappingId = Strings.newRandomValidIdentityId();
     final var existingClaimName = UUID.randomUUID().toString();
     final var existingClaimValue = UUID.randomUUID().toString();
+    final var existingName = UUID.randomUUID().toString();
     engine
         .mapping()
         .newMapping(mappingId)
         .withClaimName(existingClaimName)
         .withClaimValue(existingClaimValue)
+        .withName(existingName)
         .create();
 
     final var claimName = UUID.randomUUID().toString();
@@ -204,7 +217,7 @@ public class MappingTest {
             .updateMapping(id)
             .withClaimName(existingClaimName)
             .withClaimValue(existingClaimValue)
-            .withName(name)
+            .withName(existingName)
             .expectRejection()
             .update();
 
@@ -212,7 +225,7 @@ public class MappingTest {
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             String.format(
-                "Expected to create mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists.",
+                "Expected to update mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists.",
                 existingClaimName, existingClaimValue));
   }
 
@@ -244,6 +257,7 @@ public class MappingTest {
   public void shouldCleanupGroupAndRoleMembership() {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
+    final var name = UUID.randomUUID().toString();
     final var mappingId = Strings.newRandomValidIdentityId();
     final var mappingRecord =
         engine
@@ -251,6 +265,7 @@ public class MappingTest {
             .newMapping(mappingId)
             .withClaimName(claimName)
             .withClaimValue(claimValue)
+            .withName(name)
             .create();
     final var groupId = Strings.newRandomValidIdentityId();
     engine.group().newGroup(groupId).withName("group").create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -289,6 +289,7 @@ public class RoleTest {
         .newMapping(mappingId)
         .withClaimName("claimName")
         .withClaimValue("claimValue")
+        .withName("name")
         .create();
     final var roleId = UUID.randomUUID().toString();
     engine.role().newRole(roleId).create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -326,6 +326,7 @@ public class AddEntityTenantTest {
         .newMapping(Strings.newRandomValidIdentityId())
         .withClaimName("claimName")
         .withClaimValue("claimValue")
+        .withName("name")
         .create()
         .getValue()
         .getMappingId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
@@ -288,7 +288,13 @@ public class RemoveEntityTenantTest {
     final var tenantId = UUID.randomUUID().toString();
     engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     final var mappingId = Strings.newRandomValidIdentityId();
-    engine.mapping().newMapping(mappingId).create();
+    engine
+        .mapping()
+        .newMapping(mappingId)
+        .withName("name")
+        .withClaimName("cn")
+        .withClaimValue("cv")
+        .create();
     engine
         .tenant()
         .addEntity(tenantId)
@@ -317,7 +323,13 @@ public class RemoveEntityTenantTest {
     final var tenantId = UUID.randomUUID().toString();
     final var mappingId = Strings.newRandomValidIdentityId();
     final var tenantRecord = engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine.mapping().newMapping(mappingId).create();
+    engine
+        .mapping()
+        .newMapping(mappingId)
+        .withName("name")
+        .withClaimName("cn")
+        .withClaimValue("cv")
+        .create();
 
     // when
     final var createdTenant = tenantRecord.getValue();
@@ -347,7 +359,13 @@ public class RemoveEntityTenantTest {
 
     // when
     final var mappingId = "123";
-    engine.mapping().newMapping(mappingId).create();
+    engine
+        .mapping()
+        .newMapping(mappingId)
+        .withName("name")
+        .withClaimName("cn")
+        .withClaimValue("cv")
+        .create();
     final var notAssignedUpdateRecord =
         engine
             .tenant()


### PR DESCRIPTION
## Description
Running CommandDistributionIdempotencyTest, specifically the User.UPDATE case, sometimes triggers a segfault, it seems it happens because of the Mapping.Update testcase creates a mapping with no name and claim name and value. So this is a bug in the MappingUpdateProcessor because it doesn't validate the updated mapping

## Related issues

closes #33186 
