### PR TITLE
refactor: minimal spring config for identity migration

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneIdentityMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneIdentityMigration.java
@@ -28,7 +28,7 @@ public class StandaloneIdentityMigration {
     final SpringApplication application =
         new SpringApplicationBuilder()
             .logStartupInfo(true)
-            .web(WebApplicationType.SERVLET)
+            .web(WebApplicationType.NONE)
             .sources(MigrationsRunner.class)
             .profiles(Profile.IDENTITY_MIGRATION.getId())
             .addCommandLineProperties(true)

--- a/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
@@ -7,22 +7,105 @@
  */
 package io.camunda.application.commons.migration;
 
-import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.application.commons.security.CamundaSecurityConfiguration;
-import io.camunda.application.commons.service.CamundaServicesConfiguration;
-import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
+import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.camunda.search.clients.AuthorizationSearchClient;
+import io.camunda.search.clients.GroupSearchClient;
+import io.camunda.search.clients.MappingSearchClient;
+import io.camunda.search.clients.RoleSearchClient;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.clients.TenantSearchClient;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
+import io.camunda.service.AuthorizationServices;
+import io.camunda.service.GroupServices;
+import io.camunda.service.MappingServices;
+import io.camunda.service.RoleServices;
+import io.camunda.service.TenantServices;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 
 @Configuration(proxyBeanMethods = false)
-@ComponentScan(basePackages = {"io.camunda.migration.identity"})
+@ComponentScan(
+    basePackages = {
+      "io.camunda.migration.identity",
+      // broker client setup requires actor and clustering setup as well
+      "io.camunda.application.commons.actor",
+      "io.camunda.application.commons.broker.client",
+      "io.camunda.application.commons.clustering",
+      // security setup is needed for service layer
+      "io.camunda.application.commons.security"
+    })
 @Profile("identity-migration")
-@Import({
-  CommonsModuleConfiguration.class,
-  GatewayModuleConfiguration.class,
-  CamundaSecurityConfiguration.class,
-  CamundaServicesConfiguration.class
-})
-public class IdentityMigrationModuleConfiguration {}
+@EnableAutoConfiguration
+@Import({GatewayBasedConfiguration.class})
+public class IdentityMigrationModuleConfiguration {
+  @Bean
+  public AuthorizationServices authorizationServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final AuthorizationSearchClient authorizationSearchClient,
+      final SecurityConfiguration securityConfiguration) {
+    return new AuthorizationServices(
+        brokerClient,
+        securityContextProvider,
+        authorizationSearchClient,
+        null,
+        securityConfiguration);
+  }
+
+  @Bean
+  public GroupServices groupServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final GroupSearchClient groupSearchClient) {
+    return new GroupServices(brokerClient, securityContextProvider, groupSearchClient, null);
+  }
+
+  @Bean
+  public MappingServices mappingServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final MappingSearchClient mappingSearchClient) {
+    return new MappingServices(brokerClient, securityContextProvider, mappingSearchClient, null);
+  }
+
+  @Bean
+  public RoleServices roleServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final RoleSearchClient roleSearchClient) {
+    return new RoleServices(brokerClient, securityContextProvider, roleSearchClient, null);
+  }
+
+  @Bean
+  public TenantServices tenantServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final TenantSearchClient tenantSearchClient) {
+    return new TenantServices(brokerClient, securityContextProvider, tenantSearchClient, null);
+  }
+
+  @Bean
+  public SearchClientsProxy noopSearchClientsProxy() {
+    return SearchClientsProxy.noop();
+  }
+
+  @Bean
+  public SecurityContextProvider securityContextProvider(
+      final SecurityConfiguration securityConfiguration,
+      final AuthorizationChecker authorizationChecker) {
+    return new SecurityContextProvider(securityConfiguration, authorizationChecker);
+  }
+
+  @Bean
+  public AuthorizationChecker authorizationChecker(
+      final AuthorizationSearchClient authorizationSearchClient) {
+    return new AuthorizationChecker(authorizationSearchClient);
+  }
+}


### PR DESCRIPTION
## Description

Reduced identity migration spring configuration to a minimal set:
* only services needed as well as a broker client are setup
* search endpoints are not needed thus a noop impl is used

This is a refactoring to reduce the config amount needed to get the single app running. Previously it required database setup as well as schema management and search clients etc were initialized.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates #26973
