### PR TITLE
fix: in AsyncApiHandler do not try to read result when error != null

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
@@ -116,11 +116,12 @@ public abstract class AsyncApiRequestHandler<R extends RequestReader<?>, W exten
                   .internalError(
                       "Failed to handle request due to internal error; see the broker logs for more")
                   .tryWriteResponse(serverOutput, partitionId, requestId);
-            }
-            if (result.isLeft()) {
-              result.getLeft().tryWriteResponse(serverOutput, partitionId, requestId);
             } else {
-              result.get().tryWriteResponse(serverOutput, partitionId, requestId);
+              if (result.isLeft()) {
+                result.getLeft().tryWriteResponse(serverOutput, partitionId, requestId);
+              } else {
+                result.get().tryWriteResponse(serverOutput, partitionId, requestId);
+              }
             }
           });
     } catch (final Exception e) {


### PR DESCRIPTION
## Description
When `throwable != null`, `result` is always null, we should not try to read from it as it will cause a `NullPointerException`.
