### PR TITLE
feat: add identity migration mode config

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationsRunner.java
@@ -21,7 +21,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("migration | identity-migration | process-migration")
+@Profile("identity-migration | process-migration")
 @ComponentScan(basePackages = "io.camunda.application.commons.migration")
 public class MigrationsRunner implements ApplicationRunner {
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
@@ -22,9 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
-@Component
 public class AuthorizationMigrationHandler extends MigrationHandler<UserResourceAuthorization> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuthorizationMigrationHandler.class);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -15,9 +15,7 @@ import io.camunda.service.GroupServices.GroupDTO;
 import io.camunda.service.GroupServices.GroupMemberDTO;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
 public class GroupMigrationHandler extends MigrationHandler<Group> {
 
   private final ManagementIdentityClient managementIdentityClient;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
@@ -10,6 +10,7 @@ package io.camunda.migration.identity;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.camunda.migration.api.Migrator;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
@@ -23,26 +24,10 @@ public class MigrationRunner implements Migrator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MigrationRunner.class);
 
-  private final AuthorizationMigrationHandler authorizationMigrationHandler;
-  private final TenantMigrationHandler tenantMigrationHandler;
-  private final TenantMappingRuleMigrationHandler tenantMappingRuleMigrationHandler;
-  private final UserTenantsMigrationHandler userTenantsMigrationHandler;
-  private final RoleMigrationHandler roleMigrationHandler;
-  private final GroupMigrationHandler groupMigrationHandler;
+  private final List<MigrationHandler<?>> handlers;
 
-  public MigrationRunner(
-      final AuthorizationMigrationHandler authorizationMigrationHandler,
-      final TenantMigrationHandler tenantMigrationHandler,
-      final TenantMappingRuleMigrationHandler tenantMappingRuleMigrationHandler,
-      final UserTenantsMigrationHandler userTenantsMigrationHandler,
-      final RoleMigrationHandler roleMigrationHandler,
-      final GroupMigrationHandler groupMigrationHandler) {
-    this.authorizationMigrationHandler = authorizationMigrationHandler;
-    this.tenantMigrationHandler = tenantMigrationHandler;
-    this.tenantMappingRuleMigrationHandler = tenantMappingRuleMigrationHandler;
-    this.userTenantsMigrationHandler = userTenantsMigrationHandler;
-    this.roleMigrationHandler = roleMigrationHandler;
-    this.groupMigrationHandler = groupMigrationHandler;
+  public MigrationRunner(final List<MigrationHandler<?>> handlers) {
+    this.handlers = handlers;
   }
 
   @Override
@@ -54,12 +39,9 @@ public class MigrationRunner implements Migrator {
   private void migrate() {
     while (true) {
       try {
-        tenantMigrationHandler.migrate();
-        tenantMappingRuleMigrationHandler.migrate();
-        userTenantsMigrationHandler.migrate();
-        groupMigrationHandler.migrate();
-        roleMigrationHandler.migrate();
-        authorizationMigrationHandler.migrate();
+        for (final MigrationHandler<?> handler : handlers) {
+          handler.migrate();
+        }
         break;
       } catch (final NotImplementedException e) {
         LOGGER.error("Identity endpoint is not implemented {}", e.getCode());

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/RoleMigrationHandler.java
@@ -17,9 +17,7 @@ import io.camunda.service.RoleServices;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
-@Component
 public class RoleMigrationHandler extends MigrationHandler<Role> {
   private static final Logger LOG = LoggerFactory.getLogger(RoleMigrationHandler.class);
   private final RoleServices roleServices;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
@@ -20,9 +20,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TenantMappingRuleMigrationHandler extends MigrationHandler<TenantMappingRule> {
 
   private final ManagementIdentityClient managementIdentityClient;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -15,9 +15,7 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TenantMigrationHandler extends MigrationHandler<Tenant> {
 
   private final ManagementIdentityClient managementIdentityClient;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
@@ -19,9 +19,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantMemberRequest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
 public class UserTenantsMigrationHandler extends MigrationHandler<UserTenants> {
   private static final String USERNAME_CLAIM = "sub";
   private final ManagementIdentityClient managementIdentityClient;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ConditionalOnCloud.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ConditionalOnCloud.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config;
+
+import static io.camunda.migration.identity.config.IdentityMigrationProperties.PROP_CAMUNDA_MIGRATION_IDENTITY_MODE;
+
+import io.camunda.migration.identity.config.ConditionalOnCloud.ConditionalOnCloudCondition;
+import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(ConditionalOnCloudCondition.class)
+public @interface ConditionalOnCloud {
+  final class ConditionalOnCloudCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Mode mode =
+          Optional.ofNullable(
+                  context.getEnvironment().getProperty(PROP_CAMUNDA_MIGRATION_IDENTITY_MODE))
+              .map(Mode::valueOf)
+              .orElse(Mode.CLOUD);
+      return Mode.CLOUD.equals(mode);
+    }
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
@@ -9,10 +9,16 @@ package io.camunda.migration.identity.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "camunda.migration.identity")
-public class IdentityMigrationProperties {
+@ConfigurationProperties(
+    prefix = IdentityMigrationProperties.CONFIG_PREFIX_CAMUNDA_MIGRATION_IDENTITY)
+public final class IdentityMigrationProperties {
+  public static final String CONFIG_PREFIX_CAMUNDA_MIGRATION_IDENTITY =
+      "camunda.migration.identity";
+  public static final String PROP_CAMUNDA_MIGRATION_IDENTITY_MODE =
+      CONFIG_PREFIX_CAMUNDA_MIGRATION_IDENTITY + ".mode";
   private ManagementIdentityProperties managementIdentity;
   private String organizationId;
+  private Mode mode = Mode.CLOUD;
 
   public ManagementIdentityProperties getManagementIdentity() {
     return managementIdentity;
@@ -28,5 +34,19 @@ public class IdentityMigrationProperties {
 
   public void setOrganizationId(final String organizationId) {
     this.organizationId = organizationId;
+  }
+
+  public Mode getMode() {
+    return mode;
+  }
+
+  public void setMode(final Mode mode) {
+    this.mode = mode;
+  }
+
+  public enum Mode {
+    CLOUD,
+    KEYCLOAK,
+    OIDC
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
@@ -12,6 +12,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import java.io.IOException;
 import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
 @Configuration
+@EnableConfigurationProperties(IdentityMigrationProperties.class)
 public class ManagementIdentityConnector {
 
   @Bean

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
@@ -36,7 +36,7 @@ public class ManagementIdentityConnector {
             properties.getClientId(),
             properties.getClientSecret(),
             properties.getAudience(),
-            properties.getIssuerType());
+            properties.getIssuerType().toUpperCase());
     return new Identity(configuration);
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config;
+
+import io.camunda.migration.identity.GroupMigrationHandler;
+import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.GroupServices;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnCloud
+public class MigrationHandlerConfig {
+  @Bean
+  public GroupMigrationHandler groupMigrationHandler(
+      final Authentication authentication,
+      final ManagementIdentityClient managementIdentityClient,
+      final GroupServices groupServices) {
+    return new GroupMigrationHandler(authentication, managementIdentityClient, groupServices);
+  }
+}


### PR DESCRIPTION
## Description

Only initialize specific migration handlers based on mode.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33374
