### PR TITLE
Integrate groups tab in tenant details page

### DIFF
--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -6,5 +6,4 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-// Tenant details page - Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
-export const IS_TENANT_GROUPS_SUPPORTED = false;
+export const featureFlags = [];

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -27,7 +27,6 @@ import Groups from "src/pages/tenants/detail/groups";
 import Roles from "src/pages/tenants/detail/roles";
 import Mappings from "src/pages/tenants/detail/mappings";
 import Clients from "src/pages/tenants/detail/clients";
-import { IS_TENANT_GROUPS_SUPPORTED } from "src/feature-flags";
 import { isInternalGroupsEnabled, isOIDC } from "src/configuration";
 
 const Details: FC = () => {
@@ -90,7 +89,7 @@ const Details: FC = () => {
                   label: t("users"),
                   content: <Members tenantId={tenant.tenantId} />,
                 },
-                ...(IS_TENANT_GROUPS_SUPPORTED && isInternalGroupsEnabled
+                ...(isInternalGroupsEnabled
                   ? [
                       {
                         key: "groups",


### PR DESCRIPTION
## Description

- Removes Feature flag that was hiding Groups tab in Tenant details page
- Manually test integration (in this case the pre-integration was already correct, so no changes needed)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29409
