### PR TITLE
feat: add job search endpoint in v2 api using document based data layer

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -18,6 +18,7 @@ import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.clients.FormSearchClient;
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.clients.IncidentSearchClient;
+import io.camunda.search.clients.JobSearchClient;
 import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
@@ -81,8 +82,10 @@ public class CamundaServicesConfiguration {
   public JobServices<JobActivationResult> jobServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ActivateJobsHandler<JobActivationResult> activateJobsHandler) {
-    return new JobServices<>(brokerClient, securityContextProvider, activateJobsHandler, null);
+      final ActivateJobsHandler<JobActivationResult> activateJobsHandler,
+      final JobSearchClient jobSearchClient) {
+    return new JobServices<>(
+        brokerClient, securityContextProvider, activateJobsHandler, jobSearchClient, null);
   }
 
   @Bean

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
@@ -57,6 +58,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
@@ -270,6 +272,11 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
                 new ProcessInstanceStatisticsFilter(processInstanceKey)),
             ProcessInstanceFlowNodeStatisticsAggregationResult.class)
         .items();
+  }
+
+  @Override
+  public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
+    return getSearchExecutor().search(query, io.camunda.webapps.schema.entities.JobEntity.class);
   }
 
   public SearchQueryResult<ProcessInstanceEntity> executeSearchProcessInstances(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -34,6 +34,7 @@ import io.camunda.search.clients.transformers.entity.FormEntityTransformer;
 import io.camunda.search.clients.transformers.entity.GroupEntityTransformer;
 import io.camunda.search.clients.transformers.entity.GroupMemberEntityTransformer;
 import io.camunda.search.clients.transformers.entity.IncidentEntityTransformer;
+import io.camunda.search.clients.transformers.entity.JobEntityTransformer;
 import io.camunda.search.clients.transformers.entity.MappingEntityTransformer;
 import io.camunda.search.clients.transformers.entity.ProcessDefinitionEntityTransfomer;
 import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
@@ -58,6 +59,7 @@ import io.camunda.search.clients.transformers.filter.FlownodeInstanceFilterTrans
 import io.camunda.search.clients.transformers.filter.FormFilterTransformer;
 import io.camunda.search.clients.transformers.filter.GroupFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
+import io.camunda.search.clients.transformers.filter.JobFilterTransformer;
 import io.camunda.search.clients.transformers.filter.MappingFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionStatisticsFilterTransformer;
@@ -86,6 +88,7 @@ import io.camunda.search.clients.transformers.sort.FlowNodeInstanceFieldSortingT
 import io.camunda.search.clients.transformers.sort.FormFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.GroupFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.IncidentFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.JobFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.MappingFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessInstanceFieldSortingTransformer;
@@ -107,6 +110,7 @@ import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.FormFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
@@ -130,6 +134,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionFlowNodeStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
@@ -156,6 +161,7 @@ import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.FormSort;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.search.sort.IncidentSort;
+import io.camunda.search.sort.JobSort;
 import io.camunda.search.sort.MappingSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
@@ -183,11 +189,13 @@ import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
+import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.webapps.schema.entities.UsageMetricsEntity;
@@ -296,7 +304,8 @@ public final class ServiceTransformers {
             UserQuery.class,
             VariableQuery.class,
             UsageMetricsQuery.class,
-            SequenceFlowQuery.class)
+            SequenceFlowQuery.class,
+            JobQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
 
     // document entity -> domain entity
@@ -323,6 +332,7 @@ public final class ServiceTransformers {
     mappers.put(BatchOperationEntity.class, new BatchOperationEntityTransformer());
     mappers.put(OperationEntity.class, new BatchOperationItemEntityTransformer());
     mappers.put(SequenceFlowEntity.class, new SequenceFlowEntityTransformer());
+    mappers.put(JobEntity.class, new JobEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
@@ -345,6 +355,7 @@ public final class ServiceTransformers {
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
     mappers.put(BatchOperationSort.class, new BatchOperationFieldSortingTransformer());
     mappers.put(BatchOperationItemSort.class, new BatchOperationItemFieldSortingTransformer());
+    mappers.put(JobSort.class, new JobFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -416,6 +427,7 @@ public final class ServiceTransformers {
     mappers.put(
         SequenceFlowFilter.class,
         new SequenceFlowFilterTransformer(indexDescriptors.get(SequenceFlowTemplate.class)));
+    mappers.put(JobFilter.class, new JobFilterTransformer(indexDescriptors.get(JobTemplate.class)));
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobEntity.JobKind;
+import io.camunda.search.entities.JobEntity.JobState;
+import io.camunda.search.entities.JobEntity.ListenerEventType;
+
+public class JobEntityTransformer
+    implements ServiceTransformer<io.camunda.webapps.schema.entities.JobEntity, JobEntity> {
+
+  @Override
+  public JobEntity apply(final io.camunda.webapps.schema.entities.JobEntity value) {
+    return new JobEntity(
+        value.getKey(),
+        value.getType(),
+        value.getWorker(),
+        toState(value.getState()),
+        toJobKind(value.getJobKind()),
+        toListenerEventType(value.getListenerEventType()),
+        value.getRetries(),
+        value.isDenied(),
+        value.getDeniedReason(),
+        value.isJobFailedWithRetriesLeft(),
+        value.getErrorCode(),
+        value.getErrorMessage(),
+        value.getCustomHeaders(),
+        value.getDeadline(),
+        value.getEndTime(),
+        value.getBpmnProcessId(),
+        value.getProcessDefinitionKey(),
+        value.getProcessInstanceKey(),
+        value.getFlowNodeId(),
+        value.getFlowNodeInstanceId(),
+        value.getTenantId());
+  }
+
+  private ListenerEventType toListenerEventType(final String value) {
+    if (value == null) {
+      return null;
+    }
+
+    return switch (value) {
+      case "UNSPECIFIED" -> ListenerEventType.UNSPECIFIED;
+      case "START" -> ListenerEventType.START;
+      case "END" -> ListenerEventType.END;
+      case "CREATING" -> ListenerEventType.CREATING;
+      case "ASSIGNING" -> ListenerEventType.ASSIGNING;
+      case "UPDATING" -> ListenerEventType.UPDATING;
+      case "COMPLETING" -> ListenerEventType.COMPLETING;
+      case "CANCELING" -> ListenerEventType.CANCELING;
+      default -> throw new IllegalArgumentException("Unknown listener event type: " + value);
+    };
+  }
+
+  private JobKind toJobKind(final String value) {
+    if (value == null) {
+      return null;
+    }
+    return switch (value) {
+      case "BPMN_ELEMENT" -> JobKind.BPMN_ELEMENT;
+      case "EXECUTION_LISTENER" -> JobKind.EXECUTION_LISTENER;
+      case "TASK_LISTENER" -> JobKind.TASK_LISTENER;
+      default -> throw new IllegalArgumentException("Unknown job kind: " + value);
+    };
+  }
+
+  private JobState toState(final String value) {
+    if (value == null) {
+      return null;
+    }
+    return switch (value) {
+      case "CREATED" -> JobState.CREATED;
+      case "COMPLETED" -> JobState.COMPLETED;
+      case "FAILED" -> JobState.FAILED;
+      case "RETRIES_UPDATED" -> JobState.RETRIES_UPDATED;
+      case "TIMED_OUT" -> JobState.TIMED_OUT;
+      case "CANCELED" -> JobState.CANCELED;
+      case "ERROR_THROWN" -> JobState.ERROR_THROWN;
+      case "MIGRATED" -> JobState.MIGRATED;
+      default -> throw new IllegalArgumentException("Unknown job state: " + value);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/JobFilterTransformer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.ProcessInstanceDependant.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_INSTANCE_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DENIED;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DENIED_REASON;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KIND;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.JobFilter;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+
+public class JobFilterTransformer extends IndexFilterTransformer<JobFilter> {
+
+  public JobFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final JobFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    of(dateTimeOperations(JOB_DEADLINE, filter.deadlineOperations())).ifPresent(queries::addAll);
+    of(stringOperations(JOB_DENIED_REASON, filter.deniedReasonOperations()))
+        .ifPresent(queries::addAll);
+    of(stringOperations(FLOW_NODE_ID, filter.elementIdOperations())).ifPresent(queries::addAll);
+    of(longOperations(FLOW_NODE_INSTANCE_ID, filter.elementInstanceKeyOperations()))
+        .ifPresent(queries::addAll);
+    of(dateTimeOperations(TIME, filter.endTimeOperations())).ifPresent(queries::addAll);
+    of(stringOperations(ERROR_CODE, filter.errorCodeOperations())).ifPresent(queries::addAll);
+    of(stringOperations(ERROR_MESSAGE, filter.errorMessageOperations())).ifPresent(queries::addAll);
+    of(longOperations(JOB_KEY, filter.jobKeyOperations())).ifPresent(queries::addAll);
+    of(stringOperations(JOB_KIND, filter.kindOperations())).ifPresent(queries::addAll);
+    of(stringOperations(LISTENER_EVENT_TYPE, filter.listenerEventTypeOperations()))
+        .ifPresent(queries::addAll);
+    of(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()))
+        .ifPresent(queries::addAll);
+    of(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()))
+        .ifPresent(queries::addAll);
+    of(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))
+        .ifPresent(queries::addAll);
+    of(intOperations(RETRIES, filter.retriesOperations())).ifPresent(queries::addAll);
+    of(stringOperations(JOB_STATE, filter.stateOperations())).ifPresent(queries::addAll);
+    of(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
+    of(stringOperations(JOB_TYPE, filter.typeOperations())).ifPresent(queries::addAll);
+    of(stringOperations(JOB_WORKER, filter.workerOperations())).ifPresent(queries::addAll);
+    ofNullable(filter.hasFailedWithRetriesLeft())
+        .ifPresent(f -> queries.add(term(JOB_FAILED_WITH_RETRIES_LEFT, f)));
+    ofNullable(filter.isDenied()).ifPresent(f -> queries.add(term(JOB_DENIED, f)));
+
+    return and(queries);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/JobFieldSortingTransformer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_CODE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.FLOW_NODE_INSTANCE_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DENIED;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_DENIED_REASON;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_KIND;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LISTENER_EVENT_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
+
+public class JobFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "elementInstanceKey" -> FLOW_NODE_INSTANCE_ID;
+      case "elementId" -> FLOW_NODE_ID;
+      case "jobKey" -> JOB_KEY;
+      case "type" -> JOB_TYPE;
+      case "worker" -> JOB_WORKER;
+      case "state" -> JOB_STATE;
+      case "jobKind" -> JOB_KIND;
+      case "listenerEventType" -> LISTENER_EVENT_TYPE;
+      case "endTime" -> TIME;
+      case "tenantId" -> TENANT_ID;
+      case "retries" -> RETRIES;
+      case "isDenied" -> JOB_DENIED;
+      case "deniedReason" -> JOB_DENIED_REASON;
+      case "hasFailedWithRetriesLeft" -> JOB_FAILED_WITH_RETRIES_LEFT;
+      case "errorCode" -> ERROR_CODE;
+      case "errorMessage" -> ERROR_MESSAGE;
+      case "deadline" -> JOB_DEADLINE;
+      case "processDefinitionId" -> BPMN_PROCESS_ID;
+      default -> throw new IllegalArgumentException("Unknown field: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/JobQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/JobQueryTransformerTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchTermsQuery;
+import io.camunda.search.entities.JobEntity.JobKind;
+import io.camunda.search.entities.JobEntity.JobState;
+import io.camunda.search.entities.JobEntity.ListenerEventType;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
+import org.junit.jupiter.api.Test;
+
+public class JobQueryTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  public void shouldQueryByJobKey() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.jobKeys(123L));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("key");
+              assertThat(t.value().longValue()).isEqualTo(123L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByJobType() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.types("externalTask"));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("type");
+              assertThat(t.value().stringValue()).isEqualTo("externalTask");
+            });
+  }
+
+  @Test
+  public void shouldQueryByJobWorker() {
+    // Given a JobFilter with job workers
+    final var filter = FilterBuilders.job(b -> b.workers("worker1"));
+
+    // When transforming the filter to a search query
+    final var searchQuery = transformQuery(filter);
+
+    // Then the search query should contain the correct job worker condition
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("worker");
+              assertThat(t.value().stringValue()).isEqualTo("worker1");
+            });
+  }
+
+  @Test
+  public void shouldQueryByJobState() {
+    // Given a JobFilter with job states
+    final var filter =
+        FilterBuilders.job(
+            b ->
+                b.stateOperations(
+                    Operation.in(JobState.CREATED.name(), JobState.COMPLETED.name())));
+
+    // When transforming the filter to a search query
+    final var searchQuery = transformQuery(filter);
+
+    // Then the search query should contain the correct job state condition
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermsQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("state");
+              assertThat(t.values())
+                  .extracting("stringValue")
+                  .containsExactlyInAnyOrder("CREATED", "COMPLETED");
+            });
+  }
+
+  @Test
+  public void shouldQueryByKind() {
+    // Given
+    final var filter =
+        FilterBuilders.job(b -> b.kindOperations(Operation.neq(JobKind.TASK_LISTENER.name())));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            t -> {
+              assertThat(t.mustNot()).hasSize(1);
+              assertThat(t.mustNot().getFirst())
+                  .isInstanceOfSatisfying(
+                      SearchQuery.class,
+                      query -> {
+                        assertThat(query.queryOption())
+                            .isInstanceOfSatisfying(
+                                SearchTermQuery.class,
+                                term -> {
+                                  assertThat(term.field()).isEqualTo("jobKind");
+                                  assertThat(term.value().stringValue())
+                                      .isEqualTo(JobKind.TASK_LISTENER.name());
+                                });
+                      });
+            });
+  }
+
+  @Test
+  public void shouldQueryByListenerEventType() {
+    // Given
+    final var filter =
+        FilterBuilders.job(b -> b.listenerEventTypes(ListenerEventType.START.name()));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("listenerEventType");
+              assertThat(t.value().stringValue()).isEqualTo("START");
+            });
+  }
+
+  @Test
+  public void shouldQueryByProcessDefinitionId() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.processDefinitionIds("process_123"));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("bpmnProcessId");
+              assertThat(t.value().stringValue()).isEqualTo("process_123");
+            });
+  }
+
+  @Test
+  public void shouldQueryByProcessDefinitionKey() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.processDefinitionKeys(456L));
+    // When
+    final var searchQuery = transformQuery(filter);
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processDefinitionKey");
+              assertThat(t.value().longValue()).isEqualTo(456L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByProcessInstanceKey() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.processInstanceKeys(789L));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("processInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(789L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByElementId() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.elementIds("task_1"));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("flowNodeId");
+              assertThat(t.value().stringValue()).isEqualTo("task_1");
+            });
+  }
+
+  @Test
+  public void shouldQueryByElementInstanceKey() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.elementInstanceKeys(101L));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("flowNodeInstanceId");
+              assertThat(t.value().longValue()).isEqualTo(101L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByTenantId() {
+    // Given
+    final var filter = FilterBuilders.job(b -> b.tenantIds("tenant_1"));
+
+    // When
+    final var searchQuery = transformQuery(filter);
+
+    // Then
+    final var queryVariant = searchQuery.queryOption();
+
+    assertThat(queryVariant)
+        .isNotNull()
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("tenantId");
+              assertThat(t.value().stringValue()).isEqualTo("tenant_1");
+            });
+  }
+}

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
@@ -43,6 +44,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -326,5 +328,10 @@ public class RdbmsSearchClient implements SearchClientsProxy {
     LOG.debug("[RDBMS Search Client] Search for batch operation items: {}", query);
 
     return rdbmsService.getBatchOperationItemReader().search(query);
+  }
+
+  @Override
+  public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
+    throw new UnsupportedOperationException("JobSearchClient searchJobs not implemented yet.");
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/JobSearchClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface JobSearchClient {
+
+  SearchQueryResult<JobEntity> searchJobs(JobQuery query);
+
+  JobSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -29,7 +29,8 @@ public interface SearchClientsProxy
         GroupSearchClient,
         UsageMetricsSearchClient,
         BatchOperationSearchClient,
-        SequenceFlowSearchClient {
+        SequenceFlowSearchClient,
+        JobSearchClient {
 
   @Override
   SearchClientsProxy withSecurityContext(SecurityContext securityContext);

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -21,6 +21,7 @@ import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.GroupMemberEntity;
 import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
@@ -44,6 +45,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -234,5 +236,10 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public Long countDecisionInstances(final UsageMetricsQuery query) {
     return 0L;
+  }
+
+  @Override
+  public SearchQueryResult<JobEntity> searchJobs(final JobQuery query) {
+    return SearchQueryResult.empty();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record JobEntity(
+    Long jobKey,
+    String type,
+    String worker,
+    JobState state,
+    JobKind kind,
+    ListenerEventType listenerEventType,
+    Integer retries,
+    Boolean isDenied,
+    String deniedReason,
+    Boolean hasFailedWithRetriesLeft,
+    String errorCode,
+    String errorMessage,
+    Map<String, String> customHeaders,
+    OffsetDateTime deadline,
+    OffsetDateTime endTime,
+    String processDefinitionId,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    String elementId,
+    Long elementInstanceKey,
+    String tenantId) {
+
+  public enum JobState {
+    CREATED,
+    COMPLETED,
+    FAILED,
+    RETRIES_UPDATED,
+    TIMED_OUT,
+    CANCELED,
+    ERROR_THROWN,
+    MIGRATED,
+  }
+
+  public enum JobKind {
+    BPMN_ELEMENT,
+    EXECUTION_LISTENER,
+    TASK_LISTENER
+  }
+
+  public enum ListenerEventType {
+    UNSPECIFIED,
+    START,
+    END,
+    CREATING,
+    ASSIGNING,
+    UPDATING,
+    COMPLETING,
+    CANCELING
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -225,4 +225,12 @@ public final class FilterBuilders {
   public static FormFilter form(final Function<FormFilter.Builder, ObjectBuilder<FormFilter>> fn) {
     return fn.apply(form()).build();
   }
+
+  public static JobFilter.Builder job() {
+    return new JobFilter.Builder();
+  }
+
+  public static JobFilter job(final Function<JobFilter.Builder, ObjectBuilder<JobFilter>> fn) {
+    return fn.apply(job()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/JobFilter.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record JobFilter(
+    List<Operation<OffsetDateTime>> deadlineOperations,
+    List<Operation<String>> deniedReasonOperations,
+    List<Operation<Long>> elementInstanceKeyOperations,
+    List<Operation<String>> elementIdOperations,
+    List<Operation<OffsetDateTime>> endTimeOperations,
+    List<Operation<String>> errorCodeOperations,
+    List<Operation<String>> errorMessageOperations,
+    Boolean hasFailedWithRetriesLeft,
+    Boolean isDenied,
+    List<Operation<Long>> jobKeyOperations,
+    List<Operation<String>> kindOperations,
+    List<Operation<String>> listenerEventTypeOperations,
+    List<Operation<Long>> processDefinitionKeyOperations,
+    List<Operation<String>> processDefinitionIdOperations,
+    List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<Integer>> retriesOperations,
+    List<Operation<String>> stateOperations,
+    List<Operation<String>> tenantIdOperations,
+    List<Operation<String>> typeOperations,
+    List<Operation<String>> workerOperations)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<JobFilter> {
+    private List<Operation<OffsetDateTime>> deadlineOperations;
+    private List<Operation<String>> deniedReasonOperations;
+    private List<Operation<OffsetDateTime>> endTimeOperations;
+    private List<Operation<String>> errorCodeOperations;
+    private List<Operation<String>> errorMessageOperations;
+    private Boolean hasFailedWithRetriesLeft;
+    private Boolean isDenied;
+    private List<Operation<Integer>> retriesOperations;
+    private List<Operation<Long>> jobKeyOperations;
+    private List<Operation<String>> kindOperations;
+    private List<Operation<String>> listenerEventTypeOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
+    private List<Operation<String>> tenantIdOperations;
+    private List<Operation<String>> typeOperations;
+    private List<Operation<String>> workerOperations;
+    private List<Operation<String>> stateOperations;
+    private List<Operation<Long>> processDefinitionKeyOperations;
+    private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<String>> elementIdOperation;
+    private List<Operation<Long>> elementInstanceKeyOperations;
+
+    public Builder deadlineOperations(final List<Operation<OffsetDateTime>> operations) {
+      deadlineOperations = addValuesToList(deadlineOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder deadlineOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return deadlineOperations(collectValues(operation, operations));
+    }
+
+    public Builder deadlines(final OffsetDateTime value, final OffsetDateTime... values) {
+      return deadlineOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder deniedReasonOperations(final List<Operation<String>> operations) {
+      deniedReasonOperations = addValuesToList(deniedReasonOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder deniedReasonOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return deniedReasonOperations(collectValues(operation, operations));
+    }
+
+    public Builder deniedReasons(final String value, final String... values) {
+      return deniedReasonOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder endTimeOperations(final List<Operation<OffsetDateTime>> operations) {
+      endTimeOperations = addValuesToList(endTimeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder endTimeOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return endTimeOperations(collectValues(operation, operations));
+    }
+
+    public Builder endTimes(final OffsetDateTime value, final OffsetDateTime... values) {
+      return endTimeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder errorCodeOperations(final List<Operation<String>> operations) {
+      errorCodeOperations = addValuesToList(errorCodeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorCodeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorCodeOperations(collectValues(operation, operations));
+    }
+
+    public Builder errorCodes(final String value, final String... values) {
+      return errorCodeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder errorMessageOperations(final List<Operation<String>> operations) {
+      errorMessageOperations = addValuesToList(errorMessageOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorMessageOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorMessageOperations(collectValues(operation, operations));
+    }
+
+    public Builder errorMessages(final String value, final String... values) {
+      return errorMessageOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder hasFailedWithRetriesLeft(final Boolean hasFailedWithRetriesLeft) {
+      this.hasFailedWithRetriesLeft = hasFailedWithRetriesLeft;
+      return this;
+    }
+
+    public Builder isDenied(final Boolean isDenied) {
+      this.isDenied = isDenied;
+      return this;
+    }
+
+    public Builder retriesOperations(final List<Operation<Integer>> operations) {
+      retriesOperations = addValuesToList(retriesOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder retriesOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return retriesOperations(collectValues(operation, operations));
+    }
+
+    public Builder retries(final Integer value, final Integer... values) {
+      return retriesOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder jobKeyOperations(final List<Operation<Long>> operations) {
+      jobKeyOperations = addValuesToList(jobKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder jobKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return jobKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder jobKeys(final Long value, final Long... values) {
+      return jobKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder kindOperations(final List<Operation<String>> operations) {
+      kindOperations = addValuesToList(kindOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder kindOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return kindOperations(collectValues(operation, operations));
+    }
+
+    public Builder kinds(final String value, final String... values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder listenerEventTypeOperations(final List<Operation<String>> operations) {
+      listenerEventTypeOperations = addValuesToList(listenerEventTypeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder listenerEventTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return listenerEventTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder listenerEventTypes(final String value, final String... values) {
+      return listenerEventTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder stateOperations(final List<Operation<String>> operations) {
+      stateOperations = addValuesToList(stateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder stateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return stateOperations(collectValues(operation, operations));
+    }
+
+    public Builder states(final String value, final String... values) {
+      return stateOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder typeOperations(final List<Operation<String>> operations) {
+      typeOperations = addValuesToList(typeOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder typeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return typeOperations(collectValues(operation, operations));
+    }
+
+    public Builder types(final String value, final String... values) {
+      return typeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder workerOperations(final List<Operation<String>> operations) {
+      workerOperations = addValuesToList(workerOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder workerOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return workerOperations(collectValues(operation, operations));
+    }
+
+    public Builder workers(final String value, final String... values) {
+      return workerOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = addValuesToList(processDefinitionKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionKeys(final Long value, final Long... values) {
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder elementInstanceKeyOperations(final List<Operation<Long>> operations) {
+      elementInstanceKeyOperations = addValuesToList(elementInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder elementInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return elementInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder elementInstanceKeys(final Long value, final Long... values) {
+      return elementInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder elementIdOperations(final List<Operation<String>> operations) {
+      elementIdOperation = addValuesToList(elementIdOperation, operations);
+      return this;
+    }
+
+    public Builder elementIds(final String value, final String... values) {
+      return elementIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder elementIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return elementIdOperations(collectValues(operation, operations));
+    }
+
+    @Override
+    public JobFilter build() {
+      return new JobFilter(
+          Objects.requireNonNullElse(deadlineOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(deniedReasonOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(elementIdOperation, Collections.emptyList()),
+          Objects.requireNonNullElse(endTimeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorCodeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()),
+          hasFailedWithRetriesLeft,
+          isDenied,
+          Objects.requireNonNullElse(jobKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(kindOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(listenerEventTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(retriesOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(typeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(workerOperations, Collections.emptyList()));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/JobQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/JobQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.JobFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.JobSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record JobQuery(JobFilter filter, JobSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<JobFilter, JobSort> {
+
+  public static JobQuery of(final Function<Builder, ObjectBuilder<JobQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<JobQuery.Builder>
+      implements TypedSearchQueryBuilder<JobQuery, JobQuery.Builder, JobFilter, JobSort> {
+
+    private static final JobFilter EMPTY_FILTER = FilterBuilders.job().build();
+    private static final JobSort EMPTY_SORT = SortOptionBuilders.job().build();
+
+    private JobFilter filter;
+    private JobSort sort;
+
+    @Override
+    public Builder filter(final JobFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final JobSort value) {
+      sort = value;
+      return this;
+    }
+
+    public JobQuery.Builder filter(final Function<JobFilter.Builder, ObjectBuilder<JobFilter>> fn) {
+      return filter(FilterBuilders.job(fn));
+    }
+
+    public JobQuery.Builder sort(final Function<JobSort.Builder, ObjectBuilder<JobSort>> fn) {
+      return sort(SortOptionBuilders.job(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new JobQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -185,4 +185,13 @@ public final class SearchQueryBuilders {
       final Function<BatchOperationItemQuery.Builder, ObjectBuilder<BatchOperationItemQuery>> fn) {
     return fn.apply(batchOperationItemQuery()).build();
   }
+
+  public static JobQuery.Builder jobSearchQuery() {
+    return new JobQuery.Builder();
+  }
+
+  public static JobQuery jobSearchQuery(
+      final Function<JobQuery.Builder, ObjectBuilder<JobQuery>> fn) {
+    return fn.apply(jobSearchQuery()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record JobSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static JobSort of(final Function<Builder, ObjectBuilder<JobSort>> fn) {
+    return SortOptionBuilders.job(fn);
+  }
+
+  public static final class Builder extends SortOption.AbstractBuilder<JobSort.Builder>
+      implements ObjectBuilder<JobSort> {
+
+    public JobSort.Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public JobSort.Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public JobSort.Builder elementInstanceKey() {
+      currentOrdering = new FieldSorting("elementInstanceKey", null);
+      return this;
+    }
+
+    public JobSort.Builder elementId() {
+      currentOrdering = new FieldSorting("elementId", null);
+      return this;
+    }
+
+    public JobSort.Builder jobKey() {
+      currentOrdering = new FieldSorting("jobKey", null);
+      return this;
+    }
+
+    public JobSort.Builder type() {
+      currentOrdering = new FieldSorting("type", null);
+      return this;
+    }
+
+    public JobSort.Builder worker() {
+      currentOrdering = new FieldSorting("worker", null);
+      return this;
+    }
+
+    public JobSort.Builder state() {
+      currentOrdering = new FieldSorting("state", null);
+      return this;
+    }
+
+    public JobSort.Builder jobKind() {
+      currentOrdering = new FieldSorting("jobKind", null);
+      return this;
+    }
+
+    public JobSort.Builder listenerEventType() {
+      currentOrdering = new FieldSorting("listenerEventType", null);
+      return this;
+    }
+
+    public JobSort.Builder endTime() {
+      currentOrdering = new FieldSorting("endTime", null);
+      return this;
+    }
+
+    public JobSort.Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
+      return this;
+    }
+
+    public JobSort.Builder retries() {
+      currentOrdering = new FieldSorting("retries", null);
+      return this;
+    }
+
+    public JobSort.Builder isDenied() {
+      currentOrdering = new FieldSorting("isDenied", null);
+      return this;
+    }
+
+    public JobSort.Builder deniedReason() {
+      currentOrdering = new FieldSorting("deniedReason", null);
+      return this;
+    }
+
+    public JobSort.Builder hasFailedWithRetriesLeft() {
+      currentOrdering = new FieldSorting("hasFailedWithRetriesLeft", null);
+      return this;
+    }
+
+    public JobSort.Builder errorCode() {
+      currentOrdering = new FieldSorting("errorCode", null);
+      return this;
+    }
+
+    public JobSort.Builder errorMessage() {
+      currentOrdering = new FieldSorting("errorMessage", null);
+      return this;
+    }
+
+    public JobSort.Builder deadline() {
+      currentOrdering = new FieldSorting("deadline", null);
+      return this;
+    }
+
+    public JobSort.Builder processDefinitionId() {
+      currentOrdering = new FieldSorting("processDefinitionId", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public JobSort build() {
+      return new JobSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -181,4 +181,12 @@ public final class SortOptionBuilders {
       final Function<AuthorizationSort.Builder, ObjectBuilder<AuthorizationSort>> fn) {
     return fn.apply(authorization()).build();
   }
+
+  public static JobSort.Builder job() {
+    return new JobSort.Builder();
+  }
+
+  public static JobSort job(final Function<JobSort.Builder, ObjectBuilder<JobSort>> fn) {
+    return fn.apply(job()).build();
+  }
 }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -7,7 +7,13 @@
  */
 package io.camunda.service;
 
+import io.camunda.search.clients.JobSearchClient;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
@@ -24,23 +30,30 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public final class JobServices<T> extends ApiServices<JobServices<T>> {
+public final class JobServices<T> extends SearchQueryService<JobServices<T>, JobQuery, JobEntity> {
 
   private final ActivateJobsHandler<T> activateJobsHandler;
+  private final JobSearchClient jobSearchClient;
 
   public JobServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<T> activateJobsHandler,
+      final JobSearchClient jobSearchClient,
       final Authentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.activateJobsHandler = activateJobsHandler;
+    this.jobSearchClient = jobSearchClient;
   }
 
   @Override
   public JobServices<T> withAuthentication(final Authentication authentication) {
     return new JobServices<>(
-        brokerClient, securityContextProvider, activateJobsHandler, authentication);
+        brokerClient,
+        securityContextProvider,
+        activateJobsHandler,
+        jobSearchClient,
+        authentication);
   }
 
   public void activateJobs(
@@ -98,6 +111,15 @@ public final class JobServices<T> extends ApiServices<JobServices<T>> {
       brokerRequest.setOperationReference(operationReference);
     }
     return sendBrokerRequest(brokerRequest);
+  }
+
+  @Override
+  public SearchQueryResult<JobEntity> search(final JobQuery query) {
+    return jobSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
+        .searchJobs(query);
   }
 
   public record ActivateJobsRequest(

--- a/service/src/test/java/io/camunda/service/JobServiceTest.java
+++ b/service/src/test/java/io/camunda/service/JobServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.JobSearchClient;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JobServiceTest {
+
+  private JobServices<SearchQueryResult<JobEntity>> services;
+  private JobSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
+
+  @BeforeEach
+  public void before() {
+    client = mock(JobSearchClient.class);
+    when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = mock(Authentication.class);
+    services =
+        new JobServices<>(
+            mock(BrokerClient.class), securityContextProvider, null, client, authentication);
+  }
+
+  @Test
+  public void shouldReturnJob() {
+    // given
+    final var result = mock(SearchQueryResult.class);
+    when(client.searchJobs(any())).thenReturn(result);
+
+    final var searchQuery = SearchQueryBuilders.jobSearchQuery().build();
+
+    // when
+    final var searchQueryResult = services.search(searchQuery);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(result);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -131,6 +131,34 @@ paths:
           $ref: "#/components/responses/InvalidData"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /jobs/search:
+    post:
+      tags:
+        - Job
+      operationId: searchJobs
+      summary: Search jobs
+      description: Search for jobs based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JobSearchQuery"
+      responses:
+        "200":
+          description: The job search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobSearchQueryResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /jobs/{jobKey}/failure:
     post:
       tags:
@@ -5955,16 +5983,7 @@ components:
         - type: object
           properties:
             $like:
-              description: |
-                Checks if the property matches the provided like value.
-
-                Supported wildcard characters are:
-
-                * `*`: matches zero, one, or multiple characters.
-                * `?`: matches one, single character.
-
-                Wildcard characters can be escaped with backslash, for instance: `\*`.
-              type: string
+              $ref: "#/components/schemas/LikeFilterProperty"
     AdvancedProcessInstanceStateFilter:
       title: Advanced filter
       description: Advanced ProcessInstanceStateEnum filter.
@@ -5987,16 +6006,7 @@ components:
           items:
             $ref: "#/components/schemas/ProcessInstanceStateEnum"
         $like:
-          description: |
-            Checks if the property matches the provided like value.
-
-            Supported wildcard characters are:
-
-            * `*`: matches zero, one, or multiple characters.
-            * `?`: matches one, single character.
-
-            Wildcard characters can be escaped with backslash, for instance: `\*`.
-          type: string
+          $ref: "#/components/schemas/LikeFilterProperty"
     AdvancedElementInstanceStateFilter:
       title: Advanced filter
       description: Advanced ElementInstanceStateEnum filter.
@@ -6019,16 +6029,7 @@ components:
           items:
             $ref: "#/components/schemas/ElementInstanceStateEnum"
         $like:
-          description: |
-            Checks if the property matches the provided like value.
-
-            Supported wildcard characters are:
-
-            * `*`: matches zero, one, or multiple characters.
-            * `?`: matches one, single character.
-
-            Wildcard characters can be escaped with backslash, for instance: `\*`.
-          type: string
+          $ref: "#/components/schemas/LikeFilterProperty"
     AdvancedDateTimeFilter:
       title: Advanced filter
       description: Advanced date-time filter.
@@ -6083,6 +6084,17 @@ components:
           title: Exact match
           description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedStringFilter"
+    LikeFilterProperty:
+      type: string
+      description: |
+        Checks if the property matches the provided like value.
+
+        Supported wildcard characters are:
+
+        * `*`: matches zero, one, or multiple characters.
+        * `?`: matches one, single character.
+
+        Wildcard characters can be escaped with backslash, for instance: `\*`.
     ProcessInstanceStateFilterProperty:
       description: ProcessInstanceStateEnum property with full advanced search capabilities.
       type: object
@@ -8451,6 +8463,345 @@ components:
           format: int64
           description: The duration of the new timeout in ms, starting from the current moment.
           nullable: true
+    JobSearchQuery:
+      description: Job search request.
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/JobSearchQuerySortRequest"
+        filter:
+          description: The job search filters.
+          allOf:
+            - $ref: "#/components/schemas/JobFilter"
+    JobSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - deadline
+            - deniedReason
+            - elementId
+            - elementInstanceKey
+            - endTime
+            - errorCode
+            - errorMessage
+            - hasFailedWithRetriesLeft
+            - isDenied
+            - jobKey
+            - kind
+            - listenerEventType
+            - processDefinitionId
+            - processDefinitionKey
+            - processInstanceKey
+            - retries
+            - state
+            - tenantId
+            - type
+            - worker
+        order:
+          $ref: "#/components/schemas/SortOrderEnum"
+      required:
+          - field
+    JobFilter:
+      description: Job search filter.
+      type: object
+      properties:
+        deadline:
+          description: When the job can be activated.
+          allOf:
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
+        deniedReason:
+          description: The reason provided by the user task listener for denying the work.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        elementId:
+            description: The element ID associated with the job.
+            allOf:
+                - $ref: "#/components/schemas/StringFilterProperty"
+        elementInstanceKey:
+            description: The element instance key associated with the job.
+            allOf:
+                - $ref: "#/components/schemas/BasicStringFilterProperty"
+        endTime:
+            description: When the job ended.
+            allOf:
+                - $ref: "#/components/schemas/DateTimeFilterProperty"
+        errorCode:
+            description: The error code provided for the failed job.
+            allOf:
+                - $ref: "#/components/schemas/StringFilterProperty"
+        errorMessage:
+            description: The error message that provides additional context for a failed job.
+            allOf:
+                - $ref: "#/components/schemas/StringFilterProperty"
+        hasFailedWithRetriesLeft:
+            description: Indicates whether the job has failed with retries left.
+            type: boolean
+        isDenied:
+          description: Indicates whether the user task listener denies the work.
+          type: boolean
+        jobKey:
+          description: The key, a unique identifier for the job.
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
+        kind:
+          description: The kind of the job.
+          allOf:
+            - $ref: "#/components/schemas/JobKindFilterProperty"
+        listenerEventType:
+          description: The listener event type of the job.
+          allOf:
+            - $ref: "#/components/schemas/JobListenerEventTypeFilterProperty"
+        processDefinitionId:
+          description: The process definition ID associated with the job.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        processDefinitionKey:
+          description: The process definition key associated with the job.
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
+        processInstanceKey:
+          description: The process instance key associated with the job.
+          allOf:
+            - $ref: "#/components/schemas/BasicStringFilterProperty"
+        retries:
+          description: The number of retries left.
+          allOf:
+            - $ref: "#/components/schemas/IntegerFilterProperty"
+        state:
+          description: The state of the job.
+          allOf:
+            - $ref: "#/components/schemas/JobStateFilterProperty"
+        tenantId:
+          description: The tenant ID.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        type:
+          description: The type of the job.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        worker:
+          description: The name of the worker for this job.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+    JobSearchQueryResult:
+      description: Job search response.
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching jobs.
+          type: array
+          items:
+            $ref: "#/components/schemas/JobSearchResult"
+    JobSearchResult:
+      type: object
+      properties:
+        customHeaders:
+          description: A set of custom headers defined during modelling.
+          type: object
+          additionalProperties:
+            type: string
+        deadline:
+          description: When the job can be activated.
+          type: string
+          format: date-time
+        deniedReason:
+          description: The reason provided by the user task listener for denying the work.
+          type: string
+          nullable: true
+        elementId:
+          description: The element ID associated with the job.
+          type: string
+        elementInstanceKey:
+          description: The element instance key associated with the job.
+          type: string
+        endTime:
+          description: When the job ended.
+          type: string
+          format: date-time
+        errorCode:
+          description: The error code provided for the failed job.
+          type: string
+          nullable: true
+        errorMessage:
+          description: The error message that provides additional context for a failed job.
+          type: string
+          nullable: true
+        hasFailedWithRetriesLeft:
+          description: Indicates whether the job has failed with retries left.
+          type: boolean
+        isDenied:
+          description: Indicates whether the user task listener denies the work.
+          type: boolean
+          nullable: true
+        jobKey:
+          description: The key, a unique identifier for the job.
+          type: string
+        kind:
+          $ref: "#/components/schemas/JobKindEnum"
+        listenerEventType:
+          $ref: "#/components/schemas/JobListenerEventTypeEnum"
+        processDefinitionId:
+          description: The process definition ID associated with the job.
+          type: string
+        processDefinitionKey:
+          description: The process definition key associated with the job.
+          type: string
+        processInstanceKey:
+          description: The process instance key associated with the job.
+          type: string
+        retries:
+          description: The amount of retries left to this job.
+          type: integer
+          format: int32
+        state:
+          $ref: "#/components/schemas/JobStateEnum"
+        tenantId:
+          description: The tenant ID.
+          type: string
+        type:
+          description: The type of the job.
+          type: string
+        worker:
+          description: The name of the worker of this job.
+          type: string
+    JobStateEnum:
+      description: The state of the job.
+      enum:
+        - CANCELED
+        - COMPLETED
+        - CREATED
+        - ERROR_THROWN
+        - FAILED
+        - MIGRATED
+        - RETRIES_UPDATED
+        - TIMED_OUT
+    JobKindEnum:
+      description: The job kind.
+      enum:
+        - BPMN_ELEMENT
+        - EXECUTION_LISTENER
+        - TASK_LISTENER
+    JobListenerEventTypeEnum:
+      description: The listener event type of the job.
+      enum:
+        - ASSIGNING
+        - CANCELING
+        - COMPLETING
+        - CREATING
+        - END
+        - START
+        - UNSPECIFIED
+        - UPDATING
+    JobStateFilterProperty:
+      description: JobStateEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/JobStateEnum"
+        - $ref: "#/components/schemas/AdvancedJobStateFilter"
+    AdvancedJobStateFilter:
+      title: Advanced filter
+      description: Advanced JobStateEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobStateEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobStateEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/JobStateEnum"
+        $like:
+          $ref: "#/components/schemas/LikeFilterProperty"
+    JobKindFilterProperty:
+      description: JobKindEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/JobKindEnum"
+        - $ref: "#/components/schemas/AdvancedJobKindFilter"
+    AdvancedJobKindFilter:
+      title: Advanced filter
+      description: Advanced JobKindEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobKindEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobKindEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/JobKindEnum"
+        $like:
+          $ref: "#/components/schemas/LikeFilterProperty"
+    JobListenerEventTypeFilterProperty:
+      description: JobListenerEventTypeEnum property with full advanced search capabilities.
+      type: object
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/JobListenerEventTypeEnum"
+        - $ref: "#/components/schemas/AdvancedJobListenerEventTypeFilter"
+    AdvancedJobListenerEventTypeFilter:
+      title: Advanced filter
+      description: Advanced JobListenerEventTypeEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobListenerEventTypeEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/JobListenerEventTypeEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/JobListenerEventTypeEnum"
+        $like:
+          $ref: "#/components/schemas/LikeFilterProperty"
+
     ProblemDetail:
       description: >
         A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457).
@@ -9711,16 +10062,7 @@ components:
           items:
             $ref: "#/components/schemas/BatchOperationTypeEnum"
         $like:
-          description: |
-            Checks if the property matches the provided like value.
-
-            Supported wildcard characters are:
-
-            * `*`: matches zero, one, or multiple characters.
-            * `?`: matches one, single character.
-
-            Wildcard characters can be escaped with backslash, for instance: `\*`.
-          type: string
+          $ref: "#/components/schemas/LikeFilterProperty"
     BatchOperationStateFilterProperty:
       description: BatchOperationStateEnum property with full advanced search capabilities.
       type: object
@@ -9753,16 +10095,7 @@ components:
           items:
             $ref: "#/components/schemas/BatchOperationStateEnum"
         $like:
-          description: |
-            Checks if the property matches the provided like value.
-
-            Supported wildcard characters are:
-
-            * `*`: matches zero, one, or multiple characters.
-            * `?`: matches one, single character.
-
-            Wildcard characters can be escaped with backslash, for instance: `\*`.
-          type: string
+          $ref: "#/components/schemas/LikeFilterProperty"
     BatchOperationStateEnum:
       description: The state, one of ACTIVE, COMPLETED, TERMINATED.
       enum:
@@ -9856,16 +10189,7 @@ components:
           items:
             $ref: "#/components/schemas/BatchOperationItemStateEnum"
         $like:
-          description: |
-            Checks if the property matches the provided like value.
-
-            Supported wildcard characters are:
-
-            * `*`: matches zero, one, or multiple characters.
-            * `?`: matches one, single character.
-
-            Wildcard characters can be escaped with backslash, for instance: `\*`.
-          type: string
+          $ref: "#/components/schemas/LikeFilterProperty"
     BatchOperationItemStateEnum:
       description: The state, one of ACTIVE, COMPLETED, TERMINATED.
       enum:

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -122,6 +122,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- rest api dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -28,6 +28,7 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.JobFilter;
 import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionFilter;
@@ -51,6 +52,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
@@ -71,6 +73,7 @@ import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.GroupSort;
 import io.camunda.search.sort.IncidentSort;
+import io.camunda.search.sort.JobSort;
 import io.camunda.search.sort.MappingSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
@@ -264,6 +267,86 @@ public final class SearchQueryRequestMapper {
             SearchQueryRequestMapper::applyProcessInstanceSortField);
     final var filter = toProcessInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processInstanceSearchQuery);
+  }
+
+  public static Either<ProblemDetail, JobQuery> toJobQuery(final JobSearchQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.jobSearchQuery().build());
+    }
+
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromJobSearchQuerySortRequest(request.getSort()),
+            SortOptionBuilders::job,
+            SearchQueryRequestMapper::applyJobSortField);
+    final var filter = toJobFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::jobSearchQuery);
+  }
+
+  private static JobFilter toJobFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.JobFilter filter) {
+    final var builder = FilterBuilders.job();
+    if (filter != null) {
+      ofNullable(filter.getJobKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::jobKeyOperations);
+      ofNullable(filter.getType())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::typeOperations);
+      ofNullable(filter.getWorker())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::workerOperations);
+      ofNullable(filter.getState())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::stateOperations);
+      ofNullable(filter.getKind())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::kindOperations);
+      ofNullable(filter.getListenerEventType())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::listenerEventTypeOperations);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::processDefinitionIdOperations);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::processDefinitionKeyOperations);
+      ofNullable(filter.getProcessInstanceKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::processInstanceKeyOperations);
+      ofNullable(filter.getElementId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::elementIdOperations);
+      ofNullable(filter.getElementInstanceKey())
+          .map(mapToOperations(Long.class))
+          .ifPresent(builder::elementInstanceKeyOperations);
+      ofNullable(filter.getTenantId())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::tenantIdOperations);
+      ofNullable(filter.getDeadline())
+          .map(mapToOperations(OffsetDateTime.class))
+          .ifPresent(builder::deadlineOperations);
+      ofNullable(filter.getDeniedReason())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::deniedReasonOperations);
+      ofNullable(filter.getIsDenied()).ifPresent(builder::isDenied);
+      ofNullable(filter.getEndTime())
+          .map(mapToOperations(OffsetDateTime.class))
+          .ifPresent(builder::endTimeOperations);
+      ofNullable(filter.getErrorCode())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::errorCodeOperations);
+      ofNullable(filter.getErrorMessage())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::errorMessageOperations);
+      ofNullable(filter.getHasFailedWithRetriesLeft()).ifPresent(builder::hasFailedWithRetriesLeft);
+      ofNullable(filter.getRetries())
+          .map(mapToOperations(Integer.class))
+          .ifPresent(builder::retriesOperations);
+    }
+
+    return builder.build();
   }
 
   public static Either<ProblemDetail, RoleQuery> toRoleQuery(final RoleSearchQueryRequest request) {
@@ -1178,6 +1261,39 @@ public final class SearchQueryRequestMapper {
         case STATE -> builder.state();
         case HAS_INCIDENT -> builder.hasIncident();
         case TENANT_ID -> builder.tenantId();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  private static List<String> applyJobSortField(
+      final JobSearchQuerySortRequest.FieldEnum field, final JobSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case PROCESS_DEFINITION_KEY -> builder.processDefinitionKey();
+        case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        case ELEMENT_INSTANCE_KEY -> builder.elementInstanceKey();
+        case ELEMENT_ID -> builder.elementId();
+        case JOB_KEY -> builder.jobKey();
+        case TYPE -> builder.type();
+        case WORKER -> builder.worker();
+        case STATE -> builder.state();
+        case KIND -> builder.jobKind();
+        case LISTENER_EVENT_TYPE -> builder.listenerEventType();
+        case END_TIME -> builder.endTime();
+        case TENANT_ID -> builder.tenantId();
+        case RETRIES -> builder.retries();
+        case IS_DENIED -> builder.isDenied();
+        case DENIED_REASON -> builder.deniedReason();
+        case HAS_FAILED_WITH_RETRIES_LEFT -> builder.hasFailedWithRetriesLeft();
+        case ERROR_CODE -> builder.errorCode();
+        case ERROR_MESSAGE -> builder.errorMessage();
+        case DEADLINE -> builder.deadline();
+        case PROCESS_DEFINITION_ID -> builder.processDefinitionId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQuerySortRequestMapper.java
@@ -24,6 +24,11 @@ public class SearchQuerySortRequestMapper {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
+  public static List<SearchQuerySortRequest<JobSearchQuerySortRequest.FieldEnum>>
+      fromJobSearchQuerySortRequest(final List<JobSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
   public static List<SearchQuerySortRequest<RoleSearchQuerySortRequest.FieldEnum>>
       fromRoleSearchQuerySortRequest(final List<RoleSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -16,6 +16,9 @@ import io.camunda.zeebe.gateway.protocol.rest.BatchOperationTypeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.DateTimeFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.IntegerFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.JobKindFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeFilterProperty;
+import io.camunda.zeebe.gateway.protocol.rest.JobStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateFilterProperty;
 import io.camunda.zeebe.gateway.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeserializer;
@@ -25,6 +28,9 @@ import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationTypeFilterProper
 import io.camunda.zeebe.gateway.rest.deserializer.DateTimeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ElementInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.IntegerFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.JobKindFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.JobListenerEventTypeFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.JobStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ProcessInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.StringFilterPropertyDeserializer;
 import java.util.function.Consumer;
@@ -57,6 +63,11 @@ public class JacksonConfig {
     module.addDeserializer(
         BatchOperationItemStateFilterProperty.class,
         new BatchOperatioItemStateFilterPropertyDeserializer());
+    module.addDeserializer(JobStateFilterProperty.class, new JobStateFilterPropertyDeserializer());
+    module.addDeserializer(JobKindFilterProperty.class, new JobKindFilterPropertyDeserializer());
+    module.addDeserializer(
+        JobListenerEventTypeFilterProperty.class,
+        new JobListenerEventTypeFilterPropertyDeserializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobKindFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobKindFilterPropertyDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedJobKindFilter;
+import io.camunda.zeebe.gateway.protocol.rest.JobKindEnum;
+import io.camunda.zeebe.gateway.protocol.rest.JobKindFilterProperty;
+
+public class JobKindFilterPropertyDeserializer
+    extends FilterDeserializer<JobKindFilterProperty, JobKindEnum> {
+
+  @Override
+  protected Class<? extends JobKindFilterProperty> getFinalType() {
+    return AdvancedJobKindFilter.class;
+  }
+
+  @Override
+  protected Class<JobKindEnum> getImplicitValueType() {
+    return JobKindEnum.class;
+  }
+
+  @Override
+  protected JobKindFilterProperty createFromImplicitValue(final JobKindEnum value) {
+    final var filter = new AdvancedJobKindFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobListenerEventTypeFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobListenerEventTypeFilterPropertyDeserializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedJobListenerEventTypeFilter;
+import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeFilterProperty;
+
+public class JobListenerEventTypeFilterPropertyDeserializer
+    extends FilterDeserializer<JobListenerEventTypeFilterProperty, JobListenerEventTypeEnum> {
+
+  @Override
+  protected Class<? extends JobListenerEventTypeFilterProperty> getFinalType() {
+    return AdvancedJobListenerEventTypeFilter.class;
+  }
+
+  @Override
+  protected Class<JobListenerEventTypeEnum> getImplicitValueType() {
+    return JobListenerEventTypeEnum.class;
+  }
+
+  @Override
+  protected AdvancedJobListenerEventTypeFilter createFromImplicitValue(
+      final JobListenerEventTypeEnum value) {
+    final var filter = new AdvancedJobListenerEventTypeFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobStateFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/JobStateFilterPropertyDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdvancedJobStateFilter;
+import io.camunda.zeebe.gateway.protocol.rest.JobStateEnum;
+import io.camunda.zeebe.gateway.protocol.rest.JobStateFilterProperty;
+
+public class JobStateFilterPropertyDeserializer
+    extends FilterDeserializer<JobStateFilterProperty, JobStateEnum> {
+
+  @Override
+  protected Class<? extends JobStateFilterProperty> getFinalType() {
+    return AdvancedJobStateFilter.class;
+  }
+
+  @Override
+  protected Class<JobStateEnum> getImplicitValueType() {
+    return JobStateEnum.class;
+  }
+
+  @Override
+  protected JobStateFilterProperty createFromImplicitValue(final JobStateEnum value) {
+    final var filter = new AdvancedJobStateFilter();
+    filter.set$Eq(value);
+    return filter;
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -422,6 +422,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           brokerClient,
           new SecurityContextProvider(new SecurityConfiguration(), null),
           activateJobsHandler,
+          null,
           null);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -397,6 +397,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           brokerClient,
           new SecurityContextProvider(new SecurityConfiguration(), null),
           activateJobsHandler,
+          null,
           null);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.JobEntity.JobKind;
+import io.camunda.search.entities.JobEntity.JobState;
+import io.camunda.search.entities.JobEntity.ListenerEventType;
+import io.camunda.search.filter.JobFilter;
+import io.camunda.search.query.JobQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.JobServices;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResult;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(value = JobController.class)
+public class JobQueryControllerTest extends RestControllerTest {
+
+  static final String JOB_URL = "/v2/jobs/";
+  static final String JOB_SEARCH_URL = JOB_URL + "search";
+  static final String EXPECTED_SEARCH_RESPONSE =
+      """
+        {
+            "items": [
+                {
+                    "jobKey": "1",
+                    "type": "testJob",
+                    "worker": "testWorker",
+                    "state": "COMPLETED",
+                    "kind": "TASK_LISTENER",
+                    "listenerEventType": "COMPLETING",
+                    "retries": 3,
+                    "isDenied": true,
+                    "deniedReason": "test denied reason",
+                    "hasFailedWithRetriesLeft": false,
+                    "errorCode": "123",
+                    "errorMessage": "test error message",
+                    "customHeaders": {
+                        "foo": "bar"
+                    },
+                    "deadline": "2025-06-05T09:05:00.000Z",
+                    "endTime": "2025-06-05T10:05:00.000Z",
+                    "processDefinitionId": "processDefinitionId",
+                    "processDefinitionKey": "2",
+                    "processInstanceKey": "3",
+                    "elementId": "elementId",
+                    "elementInstanceKey": "4",
+                    "tenantId": "<default>"
+                }
+            ],
+            "page": {
+                "totalItems": 1,
+                "startCursor": "123base64",
+                "endCursor": "456base64"
+            }
+        }
+        """;
+  private static final SearchQueryResult<JobEntity> SEARCH_QUERY_RESULT =
+      new SearchQueryResult.Builder<JobEntity>()
+          .total(1L)
+          .items(
+              List.of(
+                  new JobEntity(
+                      1L,
+                      "testJob",
+                      "testWorker",
+                      JobState.COMPLETED,
+                      JobKind.TASK_LISTENER,
+                      ListenerEventType.COMPLETING,
+                      3,
+                      true,
+                      "test denied reason",
+                      false,
+                      "123",
+                      "test error message",
+                      Map.of("foo", "bar"),
+                      OffsetDateTime.parse("2025-06-05T09:05:00.000Z"),
+                      OffsetDateTime.parse("2025-06-05T10:05:00.000Z"),
+                      "processDefinitionId",
+                      2L,
+                      3L,
+                      "elementId",
+                      4L,
+                      "<default>")))
+          .startCursor("123base64")
+          .endCursor("456base64")
+          .build();
+  @MockBean JobServices<JobActivationResult> jobServices;
+  @MockBean MultiTenancyConfiguration multiTenancyCfg;
+  @MockBean ResponseObserverProvider responseObserverProvider;
+
+  @BeforeEach
+  void setupJobServices() {
+    when(jobServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+        .thenReturn(jobServices);
+  }
+
+  @Test
+  void shouldSearchJobWithEmptyBody() {
+    // given
+    when(jobServices.search(any(JobQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(JOB_SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(jobServices).search(new JobQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSearchJobWithAllFilters() {
+    // given
+    when(jobServices.search(any(JobQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+
+    final var request =
+        """
+      {
+      "filter": {
+        "deadline": "2025-06-05T09:05:00.000Z",
+        "deniedReason": "test denied reason",
+        "elementId": "elementId",
+        "elementInstanceKey": 4,
+        "endTime": "2025-06-05T10:05:00.000Z",
+        "errorCode": "123",
+        "errorMessage": "test error message",
+        "hasFailedWithRetriesLeft": false,
+        "isDenied": true,
+        "jobKey": 1,
+        "kind": "TASK_LISTENER",
+        "listenerEventType": "COMPLETING",
+        "processDefinitionId": "processDefinitionId",
+        "processDefinitionKey": 2,
+        "processInstanceKey": 3,
+        "retries": 3,
+        "state": "COMPLETED",
+        "tenantId": "<default>",
+        "type": "testJob",
+        "worker": "testWorker"
+          }
+        }
+    """;
+
+    // when / then
+    webClient
+        .post()
+        .uri(JOB_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(jobServices)
+        .search(
+            new JobQuery.Builder()
+                .filter(
+                    new JobFilter.Builder()
+                        .deniedReasons("test denied reason")
+                        .deadlines(OffsetDateTime.parse("2025-06-05T09:05:00.000Z"))
+                        .elementIds("elementId")
+                        .elementInstanceKeys(4L)
+                        .endTimes(OffsetDateTime.parse("2025-06-05T10:05:00.000Z"))
+                        .errorCodes("123")
+                        .errorMessages("test error message")
+                        .hasFailedWithRetriesLeft(false)
+                        .isDenied(true)
+                        .jobKeys(1L)
+                        .kinds(JobEntity.JobKind.TASK_LISTENER.name())
+                        .listenerEventTypes(JobEntity.ListenerEventType.COMPLETING.name())
+                        .processDefinitionIds("processDefinitionId")
+                        .processDefinitionKeys(2L)
+                        .processInstanceKeys(3L)
+                        .retries(3)
+                        .states(JobEntity.JobState.COMPLETED.name())
+                        .tenantIds("<default>")
+                        .types("testJob")
+                        .workers("testWorker")
+                        .build())
+                .build());
+  }
+
+  @Test
+  void shouldSearchJobWithFullSorting() {
+    // given
+    when(jobServices.search(any(JobQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+
+    final var request =
+        """
+  {
+    "sort": [
+      { "field": "jobKey", "order": "asc" },
+      { "field": "type", "order": "desc" },
+      { "field": "worker", "order": "asc" },
+      { "field": "state", "order": "desc" },
+      { "field": "kind", "order": "asc" },
+      { "field": "listenerEventType", "order": "desc" },
+      { "field": "retries", "order": "asc" },
+      { "field": "isDenied", "order": "desc" },
+      { "field": "deniedReason", "order": "asc" },
+      { "field": "hasFailedWithRetriesLeft", "order": "desc" },
+      { "field": "errorCode", "order": "asc" },
+      { "field": "errorMessage", "order": "desc" },
+      { "field": "deadline", "order": "asc" },
+      { "field": "endTime", "order": "desc" },
+      { "field": "processDefinitionId", "order": "asc" },
+      { "field": "processDefinitionKey", "order": "desc" },
+      { "field": "processInstanceKey", "order": "asc" },
+      { "field": "elementId", "order": "desc" },
+      { "field": "elementInstanceKey", "order": "asc" },
+      { "field": "tenantId", "order": "desc" }
+    ]
+  }
+  """;
+
+    // when / then
+    webClient
+        .post()
+        .uri(JOB_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(jobServices)
+        .search(
+            new JobQuery.Builder()
+                .sort(
+                    b ->
+                        b.jobKey()
+                            .asc()
+                            .type()
+                            .desc()
+                            .worker()
+                            .asc()
+                            .state()
+                            .desc()
+                            .jobKind()
+                            .asc()
+                            .listenerEventType()
+                            .desc()
+                            .retries()
+                            .asc()
+                            .isDenied()
+                            .desc()
+                            .deniedReason()
+                            .asc()
+                            .hasFailedWithRetriesLeft()
+                            .desc()
+                            .errorCode()
+                            .asc()
+                            .errorMessage()
+                            .desc()
+                            .deadline()
+                            .asc()
+                            .endTime()
+                            .desc()
+                            .processDefinitionId()
+                            .asc()
+                            .processDefinitionKey()
+                            .desc()
+                            .processInstanceKey()
+                            .asc()
+                            .elementId()
+                            .desc()
+                            .elementInstanceKey()
+                            .asc()
+                            .tenantId()
+                            .desc())
+                .build());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR introduces a new` POST /v2/jobs/search` endpoint to the V2 API. It enables clients to search for jobs using a rich set of filter criteria and supports sorting and pagination. The implementation covers the Elasticsearch/OpenSearch.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31897
