### PR TITLE
When a new partition bootstrap subscribe to signal/message_start_event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -291,7 +291,12 @@ public final class EngineProcessors {
         commandDistributionBehavior);
 
     ScalingProcessors.addScalingProcessors(
-        commandDistributionBehavior, typedRecordProcessors, writers, keyGenerator, processingState);
+        commandDistributionBehavior,
+        bpmnBehaviors,
+        typedRecordProcessors,
+        writers,
+        keyGenerator,
+        processingState);
 
     TenantProcessors.addTenantProcessors(
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/StartEventSubscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/StartEventSubscriptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
+
+import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.model.bpmn.util.time.Timer;
+import io.camunda.zeebe.util.Either;
+
+public final class StartEventSubscriptions {
+
+  private final ExpressionProcessor expressionProcessor;
+  private final CatchEventBehavior catchEventBehavior;
+  private final StartEventSubscriptionManager startEventSubscriptionManager;
+
+  public StartEventSubscriptions(
+      final ExpressionProcessor expressionProcessor,
+      final CatchEventBehavior catchEventBehavior,
+      final StartEventSubscriptionManager startEventSubscriptionManager) {
+    this.expressionProcessor = expressionProcessor;
+    this.catchEventBehavior = catchEventBehavior;
+    this.startEventSubscriptionManager = startEventSubscriptionManager;
+  }
+
+  public void resubscribeToStartEvents(final DeployedProcess deployedProcess) {
+    final var process = deployedProcess.getProcess();
+    if (process.hasTimerStartEvent()) {
+      process.getStartEvents().stream()
+          .filter(ExecutableCatchEventElement::isTimer)
+          .forEach(
+              timerStartEvent -> {
+                final Either<Failure, Timer> failureOrTimer =
+                    timerStartEvent
+                        .getTimerFactory()
+                        .apply(expressionProcessor, NO_ELEMENT_INSTANCE);
+
+                if (failureOrTimer.isLeft()) {
+                  throw new EvaluationException(failureOrTimer.getLeft().getMessage());
+                }
+
+                catchEventBehavior.subscribeToTimerEvent(
+                    NO_ELEMENT_INSTANCE,
+                    NO_ELEMENT_INSTANCE,
+                    deployedProcess.getKey(),
+                    timerStartEvent.getId(),
+                    deployedProcess.getTenantId(),
+                    failureOrTimer.get());
+              });
+    }
+
+    startEventSubscriptionManager.openStartEventSubscriptions(deployedProcess);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
@@ -93,9 +93,10 @@ public class MarkPartitionBootstrappedProcessor
     final var scalingKey = command.getKey();
     final var wasAlreadyBootstrapped = areAllPartitionsBootstrapped();
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
-    // if the partition that has completed bootstrapping is the current one, resubscribe to all
-    // message start events and signals
-    if (scaleUp.getRedistributedPartitions().contains(command.getPartitionId())) {
+    // if the partition that has completed bootstrapping is the current one and the command was
+    // not already processed, resubscribe to all message start events and signals
+    if (scaleUp.getRedistributedPartitions().contains(command.getPartitionId())
+        && !routingState.currentPartitions().contains(command.getPartitionId())) {
       subscribeToStartEventsAndSignals();
     }
     if (!wasAlreadyBootstrapped && areAllPartitionsBootstrapped()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
@@ -95,7 +95,7 @@ public class MarkPartitionBootstrappedProcessor
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
     // if the partition that has completed bootstrapping is the current one, resubscribe to all
     // message start events and signals
-    if (scaleUp.getRedistributedPartitions().getFirst() == command.getPartitionId()) {
+    if (scaleUp.getRedistributedPartitions().contains(command.getPartitionId())) {
       subscribeToStartEventsAndSignals();
     }
     if (!wasAlreadyBootstrapped && areAllPartitionsBootstrapped()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
@@ -105,8 +105,7 @@ public class MarkPartitionBootstrappedProcessor
   }
 
   private void subscribeToStartEventsAndSignals() {
-    processState.forEachProcess(
-        null,
+    processState.forEachProcessWithLatestVersion(
         persistedProcess -> {
           final var deployed =
               processState.getLatestProcessVersionByProcessId(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
@@ -8,13 +8,17 @@
 package io.camunda.zeebe.engine.processing.scaling;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.resource.StartEventSubscriptions;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
@@ -35,18 +39,29 @@ public class MarkPartitionBootstrappedProcessor
   private final TypedResponseWriter responseWriter;
   private final RoutingState routingState;
   private final CommandDistributionBehavior distributionBehavior;
+  private final ProcessState processState;
+  private final StartEventSubscriptions startEventSubscriptions;
 
   public MarkPartitionBootstrappedProcessor(
       final KeyGenerator keyGenerator,
       final Writers writers,
       final ProcessingState processingState,
-      final CommandDistributionBehavior distributionBehavior) {
+      final CommandDistributionBehavior distributionBehavior,
+      final BpmnBehaviors bpmnBehaviors) {
     this.keyGenerator = keyGenerator;
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     stateWriter = writers.state();
     routingState = processingState.getRoutingState();
     this.distributionBehavior = distributionBehavior;
+    processState = processingState.getProcessState();
+    final var startEventSubscriptionManager =
+        new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
+    startEventSubscriptions =
+        new StartEventSubscriptions(
+            bpmnBehaviors.expressionBehavior(),
+            bpmnBehaviors.catchEventBehavior(),
+            startEventSubscriptionManager);
   }
 
   @Override
@@ -63,6 +78,7 @@ public class MarkPartitionBootstrappedProcessor
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
     responseWriter.writeEventOnCommand(
         scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp, command);
+
     // now the PARTITION_BOOTSTRAPPED event has been applied to the state, let's check if
     // it was the last partition missing.
     if (!wasAlreadyBootstrapped && areAllPartitionsBootstrapped()) {
@@ -77,10 +93,27 @@ public class MarkPartitionBootstrappedProcessor
     final var scalingKey = command.getKey();
     final var wasAlreadyBootstrapped = areAllPartitionsBootstrapped();
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
+    // if the partition that has completed bootstrapping is the current one, resubscribe to all
+    // message start events and signals
+    if (scaleUp.getRedistributedPartitions().getFirst() == command.getPartitionId()) {
+      subscribeToStartEventsAndSignals();
+    }
     if (!wasAlreadyBootstrapped && areAllPartitionsBootstrapped()) {
       stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, scaleUp);
     }
     distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void subscribeToStartEventsAndSignals() {
+    processState.forEachProcess(
+        null,
+        persistedProcess -> {
+          final var deployed =
+              processState.getLatestProcessVersionByProcessId(
+                  persistedProcess.getBpmnProcessId(), persistedProcess.getTenantId());
+          startEventSubscriptions.resubscribeToStartEvents(deployed);
+          return true;
+        });
   }
 
   private Optional<Tuple<RejectionType, String>> validate(final TypedRecord<ScaleRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.scaling;
 
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -21,6 +22,7 @@ public final class ScalingProcessors {
 
   public static void addScalingProcessors(
       final CommandDistributionBehavior distributionBehavior,
+      final BpmnBehaviors bpmnBehaviours,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final KeyGenerator keyGenerator,
@@ -37,6 +39,6 @@ public final class ScalingProcessors {
         ValueType.SCALE,
         ScaleIntent.MARK_PARTITION_BOOTSTRAPPED,
         new MarkPartitionBootstrappedProcessor(
-            keyGenerator, writers, processingState, distributionBehavior));
+            keyGenerator, writers, processingState, distributionBehavior, bpmnBehaviours));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -585,6 +585,21 @@ public final class DbProcessState implements MutableProcessState {
         });
   }
 
+  @Override
+  public void forEachProcessWithLatestVersion(final PersistedProcessVisitor visitor) {
+    versionManager.forEachResource(
+        (processId, tenantId, versionInfo) -> {
+          if (versionInfo.getLatestVersion() > 0) {
+            final var process =
+                getProcessByProcessIdAndVersion(
+                    processId, versionInfo.getLatestVersion().intValue(), tenantId);
+            return visitor.visit(process.getPersistedProcess());
+          } else {
+            return true;
+          }
+        });
+  }
+
   private DeployedProcess lookupProcessByIdAndPersistedVersion(
       final long latestVersion, final String tenantId) {
     tenantIdKey.wrapString(tenantId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
@@ -60,6 +60,10 @@ public final class DeployedProcess {
     return persistedProcess.getDeploymentKey();
   }
 
+  public PersistedProcess getPersistedProcess() {
+    return persistedProcess;
+  }
+
   @Override
   public String toString() {
     return "DeployedProcess{"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionManager.java
@@ -155,5 +155,16 @@ public final class VersionManager {
     return getVersionInfo().findVersionBefore(version);
   }
 
+  public void forEachResource(final ResourceVisitor resourceVisitor) {
+    versionInfoColumnFamily.forEach(
+        versionInfo ->
+            resourceVisitor.visit(
+                idKey.getBuffer(), tenantAwareIdKey.tenantKey().toString(), versionInfo));
+  }
+
   private record TenantIdAndResourceId(String tenantId, String resourceId) {}
+
+  public interface ResourceVisitor {
+    boolean visit(DirectBuffer resourceId, String tenantId, VersionInfo versionInfo);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -74,6 +74,8 @@ public interface ProcessState {
    */
   void forEachProcess(ProcessIdentifier previousProcess, PersistedProcessVisitor visitor);
 
+  void forEachProcessWithLatestVersion(PersistedProcessVisitor visitor);
+
   record ProcessIdentifier(String tenantId, long processDefinitionKey)
       implements ResourceIdentifier {}
 


### PR DESCRIPTION
## Description
When a partition receives the command `MARK_PARTITION_BOOTSTRAPPED` referring to itself, then it will subscribe to the start events for all processes in the database.

The logic from `ResourceDeleteProcessor` has been moved to a common class so that it can be used by both processors.


### Assumptions
- There is no distinct logic between signals & start_events as that should be handled inside `StartEventSubscriptionManager.openStartEventSubscriptions`.
- it's ok to resubscribe twice to the start events: this may happen if a process is deployed before the command `MARK_PARTITION_BOOTSTRAPPED` is received or if a distribution command is retried (is this possible?)
  - in case I think we can check if there is already a subscription for that and don't subscribe to it.

> [!Note]
> It's a bit hard to test the new code since EngineRule does not support yet a dynamic number of partitions. I'm not sure how feasible that is, considering that the bootstrap of a partition is performed via a `ClusterChangeOperation` which is outside this module.
We probably need to do something manual here to support it :thinking: 

## Related issues

closes #31787