### PR TITLE
fix: OS get-snapshot checks that verbose is null to shape the request

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
@@ -58,16 +58,19 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
           snapshots.getFirst());
     }
     final var snapshot = snapshots.getFirst();
+
+    final String path;
+    if (verbose != null) {
+      path = String.format("/_snapshot/%s/%s?verbose=%s", repository, snapshot, verbose);
+    } else {
+      path = String.format("/_snapshot/%s/%s", repository, snapshot);
+    }
+
     final var result =
         withExtendedOpenSearchClient(
             extendedOpenSearchClient ->
                 safe(
-                    () ->
-                        extendedOpenSearchClient.arbitraryRequest(
-                            "GET",
-                            String.format(
-                                "/_snapshot/%s/%s?verbose=%s", repository, snapshot, verbose),
-                            "{}"),
+                    () -> extendedOpenSearchClient.arbitraryRequest("GET", path, "{}"),
                     e ->
                         format(
                             "Failed to get snapshot %s in repository %s", snapshot, repository)));


### PR DESCRIPTION
## Description

Context:
https://github.com/camunda/camunda/issues/33400

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/33400
