### PR TITLE
feat: implement readonly admin role

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/RolesSearchTest.java
@@ -79,7 +79,7 @@ public class RolesSearchTest {
         camundaClient.newRolesSearchRequest().sort(s -> s.name().desc()).send().join();
 
     assertThat(roleSearchResponse.items())
-        .hasSize(5)
+        .hasSizeGreaterThanOrEqualTo(2)
         .map(Role::getName)
         // filtering here as "RPA", "Connectors" and "Admin" roles are also initialized in
         // IdentitySetupInitializer

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -291,5 +291,6 @@ public class FailOverReplicationTest {
     data.setLogSegmentSize(maxSize);
     data.setLogIndexDensity(1);
     brokerCfg.getNetwork().setMaxMessageSize(maxSize);
+    brokerCfg.getExperimental().getFeatures().setEnableIdentitySetup(false);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -32,6 +32,7 @@ public class InstallRequestHandlingTest {
             config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
             config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
             config.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
+            config.getExperimental().getFeatures().setEnableIdentitySetup(false);
           });
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -31,6 +31,7 @@ public class ReaderCloseTest {
           config -> {
             config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(32));
             config.getData().setLogSegmentSize(DataSize.ofKilobytes(32));
+            config.getExperimental().getFeatures().setEnableIdentitySetup(false);
             // no exporters so that segments are immediately compacted after a snapshot.
             config.setExporters(Map.of());
           });

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SingleBrokerDataDeletionTest.java
@@ -235,6 +235,7 @@ public class SingleBrokerDataDeletionTest {
     data.setLogSegmentSize(LOG_SEGMENT_SIZE);
     data.setLogIndexDensity(5);
     brokerCfg.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE);
+    brokerCfg.getExperimental().getFeatures().setEnableIdentitySetup(false);
 
     final ExporterCfg exporterCfg = new ExporterCfg();
     exporterCfg.setClassName(ControllableExporter.class.getName());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -81,9 +81,9 @@ final class IdentitySetupInitializerIT {
     final var passwordMatches = passwordEncoder.matches(password, createdUser.getPassword());
     assertTrue(passwordMatches);
 
-    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).limit(3))
+    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).limit(4))
         .extracting(record -> record.getValue().getName())
-        .containsExactlyInAnyOrder("Admin", "RPA", "Connectors");
+        .containsExactlyInAnyOrder("Readonly Admin", "Admin", "RPA", "Connectors");
 
     final var createdTenant =
         RecordingExporter.tenantRecords(TenantIntent.CREATED).getFirst().getValue();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces the `Readonly Admin` role required to support the Support Agent workflows. In a later PR to the Controller I will use this role to initialise the mapping rule for Support Agent roles on SaaS clusters.

## Related issues

related to https://github.com/camunda/camunda-operator/issues/4081
