### PR TITLE
[Backport stable/8.7] fix: OS get-snapshot checks that verbose is null to shape the request

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
@@ -58,16 +58,19 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
           snapshots.getFirst());
     }
     final var snapshot = snapshots.getFirst();
+
+    final String path;
+    if (verbose != null) {
+      path = String.format("/_snapshot/%s/%s?verbose=%s", repository, snapshot, verbose);
+    } else {
+      path = String.format("/_snapshot/%s/%s", repository, snapshot);
+    }
+
     final var result =
         withExtendedOpenSearchClient(
             extendedOpenSearchClient ->
                 safe(
-                    () ->
-                        extendedOpenSearchClient.arbitraryRequest(
-                            "GET",
-                            String.format(
-                                "/_snapshot/%s/%s?verbose=%s", repository, snapshot, verbose),
-                            "{}"),
+                    () -> extendedOpenSearchClient.arbitraryRequest("GET", path, "{}"),
                     e ->
                         format(
                             "Failed to get snapshot %s in repository %s", snapshot, repository)));


### PR DESCRIPTION
# Description
Backport of #33404 to `stable/8.7`.

relates to camunda/camunda#33400 camunda/camunda#33400