### PR TITLE
feat: global camunda process test environment

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -18,6 +18,7 @@
     <!-- Camunda Docker image properties. CI overrides the properties to use the current image. -->
     <io.camunda.process.test.camundaDockerImageName>camunda/camunda</io.camunda.process.test.camundaDockerImageName>
     <io.camunda.process.test.camundaDockerImageVersion>${project.version}</io.camunda.process.test.camundaDockerImageVersion>
+    <io.camunda.process.test.globalRuntimeDisabled>false</io.camunda.process.test.globalRuntimeDisabled>
   </properties>
 
   <dependencies>

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -18,7 +18,6 @@
     <!-- Camunda Docker image properties. CI overrides the properties to use the current image. -->
     <io.camunda.process.test.camundaDockerImageName>camunda/camunda</io.camunda.process.test.camundaDockerImageName>
     <io.camunda.process.test.camundaDockerImageVersion>${project.version}</io.camunda.process.test.camundaDockerImageVersion>
-    <io.camunda.process.test.globalRuntimeDisabled>false</io.camunda.process.test.globalRuntimeDisabled>
   </properties>
 
   <dependencies>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
@@ -55,6 +55,37 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *   }
  * }
  * </pre>
+ *
+ * <p>Depending on a test class' configuration, the CPT may create a local Camunda container runtime
+ * or use the global container runtime. Essentially, as long as no properties of the {@see
+ * CamundaProcessTestRuntimeBuilder} are changed from their defaults, the global runtime will be
+ * preferred to reduce startup and teardown performance.
+ *
+ * <p>However, the global runtime can be disabled on a per-test-class basis or for the entire
+ * project. To force a test class to create a local Camunda runtime, configure the extension using
+ * `withLocalRuntime` as shown:
+ *
+ * <pre>
+ *   @RegisterExtension
+ *   private static final CamundaProcessTestExtension EXTENSION =
+ *       new CamundaProcessTestExtension()
+ *          .withLocalRuntime() // Will create a new test-class specific Camunda runtime
+ * </pre>
+ *
+ * To disable the global container runtime, set the property
+ * `camunda.process.test.globalRuntimeDisabled` to false. You can do this either by setting the
+ * property in the maven POM:
+ *
+ * <pre>
+ *   <properties>
+ *     <io.camunda.process.test.globalRuntimeDisabled>false</io.camunda.process.test.globalRuntimeDisabled>
+ *   </properties>
+ * </pre>
+ *
+ * Or by configuring Maven with the flag `-Dio.camunda.process.test.globalRuntimeDisabled="false"`
+ *
+ * <p>Please note that disabling the global Camunda runtime may incur significant performance
+ * penalties as every test class must start and stop its own runtime.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
@@ -57,32 +57,45 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </pre>
  *
  * <p>Depending on a test class' configuration, the CPT may create a local Camunda container runtime
- * or use the global container runtime. Essentially, as long as no properties of the {@see
- * CamundaProcessTestRuntimeBuilder} are changed from their defaults, the global runtime will be
- * preferred to reduce startup and teardown performance.
+ * or use the global container runtime. You may configure the global runtime by editing the
+ * `camunda-container-runtime.properties` file. Then, whenever a new CPT class is initialized, the
+ * test's configuration is compared with that of the global runtime. If they're compatible, the
+ * global runtime is preferred over creating a new one.
  *
- * <p>However, the global runtime can be disabled on a per-test-class basis or for the entire
- * project. To force a test class to create a local Camunda runtime, configure the extension using
- * `withLocalRuntime` as shown:
+ * <p>However, the global runtime can be ignored on a per-class basis or disabled entirely. To force
+ * the extension to create a new Camunda runtime, regardless of its configuration, use
+ * `withIgnoringGlobalRuntime` as shown:
  *
  * <pre>
  *   @RegisterExtension
  *   private static final CamundaProcessTestExtension EXTENSION =
  *       new CamundaProcessTestExtension()
- *          .withLocalRuntime() // Will create a new test-class specific Camunda runtime
+ *          .withIgnoringGlobalRuntime() // Will create a new Camunda runtime for this test
  * </pre>
  *
- * To disable the global container runtime, set the property
- * `camunda.process.test.globalRuntimeDisabled` to false. You can do this either by setting the
- * property in the maven POM:
+ * You can also disable the global runtime. All test classes will then always create a new runtime.
+ * You can set the flag in your Maven POM, by adding a Maven flag, or by editing the
+ * `camunda-container-runtime.properties` file:
+ *
+ * <p>Editing the Maven POM:
  *
  * <pre>
  *   <properties>
- *     <io.camunda.process.test.globalRuntimeDisabled>false</io.camunda.process.test.globalRuntimeDisabled>
+ *     <io.camunda.process.test.globalRuntimeEnabled>false</io.camunda.process.test.globalRuntimeEnabled>
  *   </properties>
  * </pre>
  *
- * Or by configuring Maven with the flag `-Dio.camunda.process.test.globalRuntimeDisabled="false"`
+ * Adding a Maven flag:
+ *
+ * <pre>
+ *    -Dio.camunda.process.test.globalRuntimeEnabled="false"
+ * </pre>
+ *
+ * Changing the Camunda Container Runtime properties file:
+ *
+ * <pre>
+ *   camunda.process.test.globalRuntimeEnabled=false
+ * </pre>
  *
  * <p>Please note that disabling the global Camunda runtime may incur significant performance
  * penalties as every test class must start and stop its own runtime.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -398,6 +398,18 @@ public class CamundaProcessTestExtension
   }
 
   /**
+   * Forces the extension to run against a local Camunda container runtime instead of using the
+   * global runtime. This is *only* necessary if you haven't changed any other configurations, for
+   * example by invoking `withConnectorsDockerImageVersion`.
+   *
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withLocalRuntime() {
+    runtimeBuilder.withLocalRuntime();
+    return this;
+  }
+
+  /**
    * Configure the connection to the remote runtime using the given client builder.
    *
    * @param camundaClientBuilderFactory the client builder to configure the connection

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -123,6 +123,8 @@ public class CamundaProcessTestExtension
   @Override
   public void beforeAll(final ExtensionContext context) {
     // create runtime
+    initializeGlobalRuntime(context);
+
     runtime = runtimeBuilder.build();
     runtime.start();
 
@@ -137,6 +139,13 @@ public class CamundaProcessTestExtension
     final Store store = context.getStore(NAMESPACE);
     store.put(STORE_KEY_RUNTIME, runtime);
     store.put(STORE_KEY_CONTEXT, camundaProcessTestContext);
+  }
+
+  private void initializeGlobalRuntime(final ExtensionContext context) {
+    final CamundaProcessTestRuntimeBuilder defaultRuntimeBuilder =
+        CamundaProcessTestContainerRuntime.newBuilder().withLocalRuntime();
+
+    CamundaProcessTestGlobalRuntime.INSTANCE.initialize(defaultRuntimeBuilder);
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -20,6 +20,7 @@ import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaManagementClient;
 import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestContainerRuntime;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeBuilder;
 import io.camunda.process.test.impl.testresult.CamundaProcessTestResultCollector;
@@ -142,8 +143,13 @@ public class CamundaProcessTestExtension
   }
 
   private void initializeGlobalRuntime(final ExtensionContext context) {
+    /*
+     * The runtimeBuilder chooses the global runtime or creates a new one based on the configuration
+     * provided. Since we're using the runtimeBuilder to create a new runtime for our global
+     * instance, we don't want it to defer to the not-yet-initialized global runtime.
+     */
     final CamundaProcessTestRuntimeBuilder defaultRuntimeBuilder =
-        CamundaProcessTestContainerRuntime.newBuilder().withLocalRuntime();
+        CamundaProcessTestContainerRuntime.newBuilder().withIgnoringGlobalRuntime();
 
     CamundaProcessTestGlobalRuntime.INSTANCE.initialize(defaultRuntimeBuilder);
   }
@@ -408,13 +414,12 @@ public class CamundaProcessTestExtension
 
   /**
    * Forces the extension to run against a local Camunda container runtime instead of using the
-   * global runtime. This is *only* necessary if you haven't changed any other configurations, for
-   * example by invoking `withConnectorsDockerImageVersion`.
+   * global runtime.
    *
    * @return the extension builder
    */
-  public CamundaProcessTestExtension withLocalRuntime() {
-    runtimeBuilder.withLocalRuntime();
+  public CamundaProcessTestExtension withIgnoringGlobalRuntime() {
+    runtimeBuilder.withIgnoringGlobalRuntime();
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestGlobalRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestGlobalRuntime.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.process.test.impl.containers.ContainerFactory;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestGlobalContainerRuntime;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
+
+/** Singleton for a long-running Camunda runtime used during Camunda Process Tests. */
+public enum CamundaProcessTestGlobalRuntime {
+  INSTANCE;
+
+  private CamundaProcessTestGlobalContainerRuntime runtime = null;
+
+  public CamundaProcessTestRuntime getRuntime(final ContainerFactory containerFactory) {
+    if (runtime == null) {
+      runtime = new CamundaProcessTestGlobalContainerRuntime(containerFactory);
+    }
+
+    return runtime;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalContainerRuntime.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import io.camunda.process.test.impl.containers.ContainerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CamundaProcessTestGlobalContainerRuntime extends CamundaProcessTestContainerRuntime {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CamundaProcessTestGlobalContainerRuntime.class);
+
+  private static boolean isRuntimeStarted = false;
+
+  public CamundaProcessTestGlobalContainerRuntime(final ContainerFactory containerFactory) {
+    super(newBuilder(), containerFactory);
+  }
+
+  @Override
+  public void start() {
+    if (!isRuntimeStarted) {
+      LOGGER.info("Starting global CPT container runtime.");
+      super.start();
+      isRuntimeStarted = true;
+    } else {
+      LOGGER.debug("CPT global container runtime already started.");
+    }
+  }
+
+  @Override
+  public void close() {
+    LOGGER.debug("Ignoring request to close global Camunda runtime.");
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalContainerRuntime.java
@@ -15,26 +15,28 @@
  */
 package io.camunda.process.test.impl.runtime;
 
-import io.camunda.process.test.impl.containers.ContainerFactory;
+import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import java.net.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CamundaProcessTestGlobalContainerRuntime extends CamundaProcessTestContainerRuntime {
+public class CamundaProcessTestGlobalContainerRuntime implements CamundaProcessTestRuntime {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(CamundaProcessTestGlobalContainerRuntime.class);
 
-  private static boolean isRuntimeStarted = false;
+  private CamundaProcessTestRuntime runtime = null;
+  private boolean isRuntimeStarted = false;
 
-  public CamundaProcessTestGlobalContainerRuntime(final ContainerFactory containerFactory) {
-    super(newBuilder(), containerFactory);
+  public CamundaProcessTestGlobalContainerRuntime(final CamundaProcessTestRuntime runtime) {
+    this.runtime = runtime;
   }
 
   @Override
   public void start() {
     if (!isRuntimeStarted) {
       LOGGER.info("Starting global CPT container runtime.");
-      super.start();
+      this.runtime.start();
       isRuntimeStarted = true;
     } else {
       LOGGER.debug("CPT global container runtime already started.");
@@ -44,5 +46,30 @@ public class CamundaProcessTestGlobalContainerRuntime extends CamundaProcessTest
   @Override
   public void close() {
     LOGGER.debug("Ignoring request to close global Camunda runtime.");
+  }
+
+  @Override
+  public URI getCamundaRestApiAddress() {
+    return runtime.getCamundaRestApiAddress();
+  }
+
+  @Override
+  public URI getCamundaGrpcApiAddress() {
+    return runtime.getCamundaGrpcApiAddress();
+  }
+
+  @Override
+  public URI getCamundaMonitoringApiAddress() {
+    return runtime.getCamundaMonitoringApiAddress();
+  }
+
+  @Override
+  public URI getConnectorsRestApiAddress() {
+    return runtime.getConnectorsRestApiAddress();
+  }
+
+  @Override
+  public CamundaClientBuilderFactory getCamundaClientBuilderFactory() {
+    return runtime.getCamundaClientBuilderFactory();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestGlobalRuntime.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.process.test.api;
+package io.camunda.process.test.impl.runtime;
 
-import io.camunda.process.test.impl.runtime.CamundaProcessTestGlobalContainerRuntime;
-import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
-import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeBuilder;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** Singleton for a long-running Camunda runtime used during Camunda Process Tests. */

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -17,7 +17,6 @@ package io.camunda.process.test.impl.runtime;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
-import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
@@ -62,9 +61,9 @@ public class CamundaProcessTestRuntimeBuilder {
   private boolean connectorsEnabled = false;
   private final Map<String, String> connectorsSecrets = new HashMap<>();
 
-  private final boolean isGlobalRuntimeDisabled =
-      CamundaProcessTestRuntimeDefaults.GLOBAL_CPT_RUNTIME_DISABLED;
-  private boolean forceLocalRuntime = false;
+  private final boolean isGlobalRuntimeEnabled =
+      CamundaProcessTestRuntimeDefaults.GLOBAL_CPT_RUNTIME_ENABLED;
+  private boolean ignoreGlobalRuntime = false;
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
 
   private CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =
@@ -201,8 +200,8 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
-  public CamundaProcessTestRuntimeBuilder withLocalRuntime() {
-    this.forceLocalRuntime = true;
+  public CamundaProcessTestRuntimeBuilder withIgnoringGlobalRuntime() {
+    this.ignoreGlobalRuntime = true;
     return this;
   }
 
@@ -228,11 +227,9 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public CamundaProcessTestRuntime build() {
     if (shouldUseGlobalRuntime()) {
-      System.out.println("Using the global runtime!");
       return CamundaProcessTestGlobalRuntime.INSTANCE.getRuntime();
     }
 
-    System.out.println("Using a local runtime");
     return buildRuntime();
   }
 
@@ -318,8 +315,8 @@ public class CamundaProcessTestRuntimeBuilder {
     return runtimeMode;
   }
 
-  public boolean isForceLocalRuntime() {
-    return forceLocalRuntime;
+  public boolean isIgnoreGlobalRuntime() {
+    return ignoreGlobalRuntime;
   }
 
   public CamundaClientBuilderFactory getRemoteCamundaClientBuilderFactory() {
@@ -337,8 +334,8 @@ public class CamundaProcessTestRuntimeBuilder {
   // ============ Global Runtime =================
 
   private boolean shouldUseGlobalRuntime() {
-    return !isGlobalRuntimeDisabled
-        && !forceLocalRuntime
+    return isGlobalRuntimeEnabled
+        && !ignoreGlobalRuntime
         && hasCompatibleConfiguration(CamundaProcessTestGlobalRuntime.INSTANCE.getRuntimeBuilder());
   }
 
@@ -366,68 +363,5 @@ public class CamundaProcessTestRuntimeBuilder {
         && Objects.equals(
             remoteCamundaMonitoringApiAddress, other.remoteCamundaMonitoringApiAddress)
         && Objects.equals(remoteConnectorsRestApiAddress, other.remoteConnectorsRestApiAddress);
-  }
-
-  @Override
-  public String toString() {
-    return "CamundaProcessTestRuntimeBuilder{"
-        + "containerFactory="
-        + containerFactory
-        + ", camundaDockerImageName='"
-        + camundaDockerImageName
-        + '\''
-        + ", camundaDockerImageVersion='"
-        + camundaDockerImageVersion
-        + '\''
-        + ", elasticsearchDockerImageName='"
-        + elasticsearchDockerImageName
-        + '\''
-        + ", elasticsearchDockerImageVersion='"
-        + elasticsearchDockerImageVersion
-        + '\''
-        + ", connectorsDockerImageName='"
-        + connectorsDockerImageName
-        + '\''
-        + ", connectorsDockerImageVersion='"
-        + connectorsDockerImageVersion
-        + '\''
-        + ", camundaEnvVars="
-        + camundaEnvVars
-        + ", elasticsearchEnvVars="
-        + elasticsearchEnvVars
-        + ", connectorsEnvVars="
-        + connectorsEnvVars
-        + ", camundaExposedPorts="
-        + camundaExposedPorts
-        + ", elasticsearchExposedPorts="
-        + elasticsearchExposedPorts
-        + ", connectorsExposedPorts="
-        + connectorsExposedPorts
-        + ", camundaLoggerName='"
-        + camundaLoggerName
-        + '\''
-        + ", elasticsearchLoggerName='"
-        + elasticsearchLoggerName
-        + '\''
-        + ", connectorsLoggerName='"
-        + connectorsLoggerName
-        + '\''
-        + ", connectorsEnabled="
-        + connectorsEnabled
-        + ", connectorsSecrets="
-        + connectorsSecrets
-        + ", isGlobalRuntimeDisabled="
-        + isGlobalRuntimeDisabled
-        + ", forceLocalRuntime="
-        + forceLocalRuntime
-        + ", runtimeMode="
-        + runtimeMode
-        + ", remoteCamundaClientBuilderFactory="
-        + remoteCamundaClientBuilderFactory
-        + ", remoteCamundaMonitoringApiAddress="
-        + remoteCamundaMonitoringApiAddress
-        + ", remoteConnectorsRestApiAddress="
-        + remoteConnectorsRestApiAddress
-        + '}';
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -52,4 +52,7 @@ public class CamundaProcessTestRuntimeDefaults {
       PROPERTIES_UTIL.getConnectorsDockerImageName();
   public static final String CONNECTORS_DOCKER_IMAGE_VERSION =
       PROPERTIES_UTIL.getConnectorsDockerImageVersion();
+
+  public static final boolean GLOBAL_CPT_RUNTIME_DISABLED =
+      PROPERTIES_UTIL.getGlobalCptRuntimeDisabled();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -53,6 +53,6 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final String CONNECTORS_DOCKER_IMAGE_VERSION =
       PROPERTIES_UTIL.getConnectorsDockerImageVersion();
 
-  public static final boolean GLOBAL_CPT_RUNTIME_DISABLED =
-      PROPERTIES_UTIL.getGlobalCptRuntimeDisabled();
+  public static final boolean GLOBAL_CPT_RUNTIME_ENABLED =
+      PROPERTIES_UTIL.getGlobalCptRuntimeEnabled();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -39,6 +39,8 @@ public final class ContainerRuntimePropertiesUtil {
   public static final String PROPERTY_NAME_CONNECTORS_DOCKER_IMAGE_VERSION =
       "connectors.dockerImageVersion";
   public static final String PROPERTY_NAME_ELASTICSEARCH_VERSION = "elasticsearch.version";
+  public static final String PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED =
+      "camunda.process.test.globalRuntimeDisabled";
 
   public static final String SNAPSHOT_VERSION = "SNAPSHOT";
 
@@ -61,6 +63,7 @@ public final class ContainerRuntimePropertiesUtil {
   private final String connectorsDockerImageName;
   private final String connectorsDockerImageVersion;
   private final String elasticsearchVersion;
+  private final boolean isGlobalCptRuntimeDisabled;
 
   public ContainerRuntimePropertiesUtil(final Properties properties) {
     camundaVersion =
@@ -95,6 +98,11 @@ public final class ContainerRuntimePropertiesUtil {
             properties,
             PROPERTY_NAME_CONNECTORS_DOCKER_IMAGE_VERSION,
             CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION);
+
+    isGlobalCptRuntimeDisabled =
+        getPropertyOrDefault(properties, PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED, "false")
+            .trim()
+            .equalsIgnoreCase("true");
   }
 
   private static String getLatestReleasedVersion(
@@ -193,5 +201,9 @@ public final class ContainerRuntimePropertiesUtil {
 
   public String getConnectorsDockerImageVersion() {
     return connectorsDockerImageVersion;
+  }
+
+  public boolean getGlobalCptRuntimeDisabled() {
+    return isGlobalCptRuntimeDisabled;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtil.java
@@ -39,8 +39,8 @@ public final class ContainerRuntimePropertiesUtil {
   public static final String PROPERTY_NAME_CONNECTORS_DOCKER_IMAGE_VERSION =
       "connectors.dockerImageVersion";
   public static final String PROPERTY_NAME_ELASTICSEARCH_VERSION = "elasticsearch.version";
-  public static final String PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED =
-      "camunda.process.test.globalRuntimeDisabled";
+  public static final String PROPERTY_NAME_GLOBAL_CPT_RUNTIME_ENABLED =
+      "camunda.process.test.globalRuntimeEnabled";
 
   public static final String SNAPSHOT_VERSION = "SNAPSHOT";
 
@@ -63,7 +63,7 @@ public final class ContainerRuntimePropertiesUtil {
   private final String connectorsDockerImageName;
   private final String connectorsDockerImageVersion;
   private final String elasticsearchVersion;
-  private final boolean isGlobalCptRuntimeDisabled;
+  private final boolean isGlobalCptRuntimeEnabled;
 
   public ContainerRuntimePropertiesUtil(final Properties properties) {
     camundaVersion =
@@ -99,8 +99,8 @@ public final class ContainerRuntimePropertiesUtil {
             PROPERTY_NAME_CONNECTORS_DOCKER_IMAGE_VERSION,
             CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_DOCKER_IMAGE_VERSION);
 
-    isGlobalCptRuntimeDisabled =
-        getPropertyOrDefault(properties, PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED, "false")
+    isGlobalCptRuntimeEnabled =
+        getPropertyOrDefault(properties, PROPERTY_NAME_GLOBAL_CPT_RUNTIME_ENABLED, "true")
             .trim()
             .equalsIgnoreCase("true");
   }
@@ -203,7 +203,7 @@ public final class ContainerRuntimePropertiesUtil {
     return connectorsDockerImageVersion;
   }
 
-  public boolean getGlobalCptRuntimeDisabled() {
-    return isGlobalCptRuntimeDisabled;
+  public boolean getGlobalCptRuntimeEnabled() {
+    return isGlobalCptRuntimeEnabled;
   }
 }

--- a/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
@@ -4,3 +4,4 @@ camunda.dockerImageName=${io.camunda.process.test.camundaDockerImageName}
 camunda.dockerImageVersion=${io.camunda.process.test.camundaDockerImageVersion}
 connectors.dockerImageName=camunda/connectors-bundle
 connectors.dockerImageVersion=${project.version}
+camunda.process.test.globalRuntimeDisabled=${io.camunda.process.test.globalRuntimeDisabled}

--- a/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
@@ -4,4 +4,4 @@ camunda.dockerImageName=${io.camunda.process.test.camundaDockerImageName}
 camunda.dockerImageVersion=${io.camunda.process.test.camundaDockerImageVersion}
 connectors.dockerImageName=camunda/connectors-bundle
 connectors.dockerImageVersion=${project.version}
-camunda.process.test.globalRuntimeDisabled=${io.camunda.process.test.globalRuntimeDisabled}
+camunda.process.test.globalRuntimeEnabled=${io.camunda.process.test.globalRuntimeEnabled}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -262,7 +262,8 @@ public class JunitExtensionTest {
             .withCamundaEnv(camundaEnvVars)
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)
-            .withCamundaExposedPort(200);
+            .withCamundaExposedPort(200)
+            .withLocalRuntime();
 
     // when
     extension.beforeAll(extensionContext);
@@ -279,6 +280,8 @@ public class JunitExtensionTest {
 
     verify(camundaRuntimeBuilder).withCamundaExposedPort(100);
     verify(camundaRuntimeBuilder).withCamundaExposedPort(200);
+
+    verify(camundaRuntimeBuilder).withLocalRuntime();
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -263,7 +263,7 @@ public class JunitExtensionTest {
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)
             .withCamundaExposedPort(200)
-            .withLocalRuntime();
+            .withIgnoringGlobalRuntime();
 
     // when
     extension.beforeAll(extensionContext);
@@ -281,7 +281,7 @@ public class JunitExtensionTest {
     verify(camundaRuntimeBuilder).withCamundaExposedPort(100);
     verify(camundaRuntimeBuilder).withCamundaExposedPort(200);
 
-    verify(camundaRuntimeBuilder).withLocalRuntime();
+    verify(camundaRuntimeBuilder).withIgnoringGlobalRuntime();
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -24,17 +24,27 @@ import static org.mockito.Mockito.when;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(
+    strictness = Strictness.LENIENT) // prevent error when global instance doesn't require mocking
 public class CamundaProcessTestContainerRuntimeTest {
 
   private static final Map<String, String> ENV_VARS;
@@ -65,6 +75,100 @@ public class CamundaProcessTestContainerRuntimeTest {
     when(containerFactory.createConnectorsContainer(any(), any())).thenReturn(connectorsContainer);
   }
 
+  private static Stream<Arguments> provideCptConfigurations() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "withCamundaEnv",
+                CamundaProcessTestContainerRuntime.newBuilder().withCamundaEnv(ENV_VARS))),
+        Arguments.of(
+            Named.of(
+                "withCamundaEnv",
+                CamundaProcessTestContainerRuntime.newBuilder().withCamundaEnv("key", "value"))),
+        Arguments.of(
+            Named.of(
+                "withCamundaDockerImageName",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withCamundaDockerImageName("image"))),
+        Arguments.of(
+            Named.of(
+                "withCamundaDockerImageVersion",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withCamundaDockerImageVersion("version"))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchDockerImageName",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withElasticsearchDockerImageName("image"))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchDockerImageVersion",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withElasticsearchDockerImageVersion("version"))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsDockerImageName",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withConnectorsDockerImageName("image"))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsDockerImageVersion",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withConnectorsDockerImageVersion("version"))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchEnv",
+                CamundaProcessTestContainerRuntime.newBuilder().withElasticsearchEnv(ENV_VARS))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchEnv",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withElasticsearchEnv("key", "value"))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsEnv",
+                CamundaProcessTestContainerRuntime.newBuilder().withConnectorsEnv(ENV_VARS))),
+        Arguments.of(
+            Named.of(
+                "withCamundaExposedPort",
+                CamundaProcessTestContainerRuntime.newBuilder().withCamundaExposedPort(8080))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchExposedPort",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withElasticsearchExposedPort(8080))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsExposedPort",
+                CamundaProcessTestContainerRuntime.newBuilder().withConnectorsExposedPort(8080))),
+        Arguments.of(
+            Named.of(
+                "withCamundaLogger",
+                CamundaProcessTestContainerRuntime.newBuilder().withCamundaLogger("logger"))),
+        Arguments.of(
+            Named.of(
+                "withElasticsearchLogger",
+                CamundaProcessTestContainerRuntime.newBuilder().withElasticsearchLogger("logger"))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsLogger",
+                CamundaProcessTestContainerRuntime.newBuilder().withConnectorsLogger("logger"))),
+        Arguments.of(
+            Named.of(
+                "withConnectorsEnabled",
+                CamundaProcessTestContainerRuntime.newBuilder().withConnectorsEnabled(true))),
+        Arguments.of(
+            Named.of(
+                "withRemoteCamundaMonitoringApiAddress",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withRemoteCamundaMonitoringApiAddress(URI.create("https://www.example.com")))),
+        Arguments.of(
+            Named.of(
+                "withRemoteConnectorsRestApiAddress",
+                CamundaProcessTestContainerRuntime.newBuilder()
+                    .withRemoteConnectorsRestApiAddress(URI.create("https://www.example.com")))));
+  }
+
   @Test
   void shouldCreateContainers() {
     // given/when
@@ -72,6 +176,7 @@ public class CamundaProcessTestContainerRuntimeTest {
         (CamundaProcessTestContainerRuntime)
             CamundaProcessTestContainerRuntime.newBuilder()
                 .withContainerFactory(containerFactory)
+                .withLocalRuntime()
                 .build();
 
     // then
@@ -90,6 +195,7 @@ public class CamundaProcessTestContainerRuntimeTest {
         (CamundaProcessTestContainerRuntime)
             CamundaProcessTestContainerRuntime.newBuilder()
                 .withContainerFactory(containerFactory)
+                .withLocalRuntime()
                 .build();
 
     // when
@@ -110,7 +216,10 @@ public class CamundaProcessTestContainerRuntimeTest {
   @Test
   void shouldCreateWithDefaults() {
     // given/when
-    CamundaProcessTestContainerRuntime.newBuilder().withContainerFactory(containerFactory).build();
+    CamundaProcessTestContainerRuntime.newBuilder()
+        .withContainerFactory(containerFactory)
+        .withLocalRuntime()
+        .build();
 
     // then
     verify(containerFactory)
@@ -121,6 +230,30 @@ public class CamundaProcessTestContainerRuntimeTest {
         .createConnectorsContainer(
             CamundaProcessTestRuntimeDefaults.CONNECTORS_DOCKER_IMAGE_NAME,
             CamundaProcessTestRuntimeDefaults.CONNECTORS_DOCKER_IMAGE_VERSION);
+  }
+
+  @Test
+  void shouldUseGlobalRuntimeWithDefaults() {
+    // given/when
+    final CamundaProcessTestRuntime runtime =
+        CamundaProcessTestContainerRuntime.newBuilder()
+            .withContainerFactory(containerFactory)
+            .build();
+
+    // then
+    assertThat(runtime).isNotNull().isInstanceOf(CamundaProcessTestGlobalContainerRuntime.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideCptConfigurations")
+  void shouldUseLocalRuntimeIfConfigurationChanged(CamundaProcessTestRuntimeBuilder builder) {
+
+    // given/when
+    final CamundaProcessTestRuntime runtime =
+        builder.withContainerFactory(containerFactory).build();
+
+    // then
+    assertThat(runtime).isNotNull().isNotInstanceOf(CamundaProcessTestGlobalContainerRuntime.class);
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
@@ -193,7 +192,7 @@ public class CamundaProcessTestContainerRuntimeTest {
         (CamundaProcessTestContainerRuntime)
             CamundaProcessTestContainerRuntime.newBuilder()
                 .withContainerFactory(containerFactory)
-                .withLocalRuntime()
+                .withIgnoringGlobalRuntime()
                 .build();
 
     // then
@@ -212,7 +211,7 @@ public class CamundaProcessTestContainerRuntimeTest {
         (CamundaProcessTestContainerRuntime)
             CamundaProcessTestContainerRuntime.newBuilder()
                 .withContainerFactory(containerFactory)
-                .withLocalRuntime()
+                .withIgnoringGlobalRuntime()
                 .build();
 
     // when
@@ -235,7 +234,7 @@ public class CamundaProcessTestContainerRuntimeTest {
     // given/when
     CamundaProcessTestContainerRuntime.newBuilder()
         .withContainerFactory(containerFactory)
-        .withLocalRuntime()
+        .withIgnoringGlobalRuntime()
         .build();
 
     // then
@@ -263,7 +262,8 @@ public class CamundaProcessTestContainerRuntimeTest {
 
   @ParameterizedTest
   @MethodSource("provideCptConfigurations")
-  void shouldUseLocalRuntimeIfConfigurationChanged(CamundaProcessTestRuntimeBuilder builder) {
+  void shouldIgnoreGlobalRuntimeIfConfigurationIsDifferent(
+      CamundaProcessTestRuntimeBuilder builder) {
 
     // given/when
     final CamundaProcessTestRuntime runtime =

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -21,13 +21,17 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
+import io.camunda.process.test.utils.GlobalCptRuntimeInvalidator;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
@@ -68,6 +72,19 @@ public class CamundaProcessTestContainerRuntimeTest {
 
   @Mock(answer = Answers.RETURNS_SELF)
   private ConnectorsContainer connectorsContainer;
+
+  @BeforeAll
+  static void configureGlobalRuntime() throws Exception {
+    GlobalCptRuntimeInvalidator.invalidate();
+
+    CamundaProcessTestGlobalRuntime.INSTANCE.initialize(
+        CamundaProcessTestContainerRuntime.newBuilder());
+  }
+
+  @AfterAll
+  static void resetGlobalRuntime() throws Exception {
+    GlobalCptRuntimeInvalidator.invalidate();
+  }
 
   @BeforeEach
   void configureMocks() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
@@ -31,7 +31,6 @@ import io.camunda.client.api.response.PartitionBrokerHealth;
 import io.camunda.client.api.response.PartitionInfo;
 import io.camunda.client.api.response.Topology;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
-import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.utils.GlobalCptRuntimeInvalidator;
 import java.net.URI;

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRemoteRuntimeTest.java
@@ -31,9 +31,13 @@ import io.camunda.client.api.response.PartitionBrokerHealth;
 import io.camunda.client.api.response.PartitionInfo;
 import io.camunda.client.api.response.Topology;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
+import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.utils.GlobalCptRuntimeInvalidator;
 import java.net.URI;
 import java.util.Collections;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -49,6 +53,19 @@ public class CamundaProcessTestRemoteRuntimeTest {
   private CamundaClient camundaClient;
 
   @Mock private Topology topology;
+
+  @BeforeAll
+  static void configureGlobalRuntime() {
+    GlobalCptRuntimeInvalidator.invalidate();
+
+    CamundaProcessTestGlobalRuntime.INSTANCE.initialize(
+        CamundaProcessTestContainerRuntime.newBuilder());
+  }
+
+  @AfterAll
+  static void resetGlobalRuntime() {
+    GlobalCptRuntimeInvalidator.invalidate();
+  }
 
   @Test
   void shouldCreateRuntime() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -41,6 +41,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(false);
   }
 
   @Test
@@ -77,6 +78,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
+    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(false);
   }
 
   @ParameterizedTest
@@ -227,5 +229,28 @@ public class ContainerRuntimePropertiesUtilTest {
 
     // then
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo(expectedVersion);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "true, true",
+    "TRUE, true",
+    "tRuE, true",
+    "  tRuE, true",
+    "tRuE  , true",
+  })
+  void shouldEnableGlobalContainerRuntimeIfTrue(
+      final String propertyValue, final boolean expectedValue) {
+    // given
+    final Properties properties = new Properties();
+    properties.put(
+        ContainerRuntimePropertiesUtil.PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED, propertyValue);
+
+    // when
+    final ContainerRuntimePropertiesUtil propertiesUtil =
+        new ContainerRuntimePropertiesUtil(properties);
+
+    // then
+    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(expectedValue);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/ContainerRuntimePropertiesUtilTest.java
@@ -41,7 +41,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
-    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(false);
+    assertThat(propertiesUtil.getGlobalCptRuntimeEnabled()).isEqualTo(true);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class ContainerRuntimePropertiesUtilTest {
     assertThat(propertiesUtil.getConnectorsDockerImageName())
         .isEqualTo("camunda/connectors-bundle");
     assertThat(propertiesUtil.getConnectorsDockerImageVersion()).isEqualTo("SNAPSHOT");
-    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(false);
+    assertThat(propertiesUtil.getGlobalCptRuntimeEnabled()).isEqualTo(true);
   }
 
   @ParameterizedTest
@@ -244,13 +244,13 @@ public class ContainerRuntimePropertiesUtilTest {
     // given
     final Properties properties = new Properties();
     properties.put(
-        ContainerRuntimePropertiesUtil.PROPERTY_NAME_GLOBAL_CPT_RUNTIME_DISABLED, propertyValue);
+        ContainerRuntimePropertiesUtil.PROPERTY_NAME_GLOBAL_CPT_RUNTIME_ENABLED, propertyValue);
 
     // when
     final ContainerRuntimePropertiesUtil propertiesUtil =
         new ContainerRuntimePropertiesUtil(properties);
 
     // then
-    assertThat(propertiesUtil.getGlobalCptRuntimeDisabled()).isEqualTo(expectedValue);
+    assertThat(propertiesUtil.getGlobalCptRuntimeEnabled()).isEqualTo(expectedValue);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/GlobalCptRuntimeInvalidator.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/GlobalCptRuntimeInvalidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.utils;
+
+import io.camunda.process.test.api.CamundaProcessTestGlobalRuntime;
+import java.lang.reflect.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GlobalCptRuntimeInvalidator {
+  private static final Logger LOG = LoggerFactory.getLogger(GlobalCptRuntimeInvalidator.class);
+
+  private static final String GLOBAL_RUNTIME_RESET_METHOD = "resetRuntime";
+
+  public static void invalidate() {
+    try {
+      final Method method =
+          CamundaProcessTestGlobalRuntime.INSTANCE
+              .getClass()
+              .getDeclaredMethod(GLOBAL_RUNTIME_RESET_METHOD);
+      method.setAccessible(true);
+      method.invoke(CamundaProcessTestGlobalRuntime.INSTANCE);
+    } catch (final Throwable t) {
+      LOG.warn(
+          "Unable to reset the CPT global runtime. Subsequent tests may behave erratically or fail.",
+          t);
+    }
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -25,6 +25,7 @@ import io.camunda.process.test.impl.proxy.CamundaClientProxy;
 import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
 import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestContainerRuntime;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestGlobalRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeBuilder;
 import io.camunda.process.test.impl.runtime.CamundaSpringProcessTestRuntimeBuilder;
@@ -67,8 +68,6 @@ import org.springframework.test.context.TestExecutionListener;
  *   <li>Close created {@link CamundaClient}s
  *   <li>Purge the runtime (i.e. delete all data)
  * </ul>
- *
- * <p>The container runtime is closed once all tests have run.
  */
 public class CamundaProcessTestExecutionListener implements TestExecutionListener, Ordered {
 
@@ -226,8 +225,13 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
             .getApplicationContext()
             .getBean("globalRuntimeConfiguration", CamundaProcessTestRuntimeConfiguration.class);
 
+    /*
+     * The runtimeBuilder chooses the global runtime or creates a new one based on the configuration
+     * provided. Since we're using the runtimeBuilder to create a new runtime for our global
+     * instance, we don't want it to defer to the not-yet-initialized global runtime.
+     */
     final CamundaProcessTestRuntimeBuilder defaultRuntimeBuilder =
-        CamundaProcessTestContainerRuntime.newBuilder().withLocalRuntime();
+        CamundaProcessTestContainerRuntime.newBuilder().withIgnoringGlobalRuntime();
 
     final CamundaProcessTestRuntimeBuilder globalRuntimeBuilder =
         CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -100,6 +100,8 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
   @Override
   public void beforeTestClass(final TestContext testContext) {
     // create runtime
+    initializeGlobalRuntime(testContext);
+
     runtime = buildRuntime(testContext);
     runtime.start();
 
@@ -218,12 +220,29 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     }
   }
 
+  private void initializeGlobalRuntime(final TestContext testContext) {
+    final CamundaProcessTestRuntimeConfiguration globalRuntimeConfiguration =
+        testContext
+            .getApplicationContext()
+            .getBean("globalRuntimeConfiguration", CamundaProcessTestRuntimeConfiguration.class);
+
+    final CamundaProcessTestRuntimeBuilder defaultRuntimeBuilder =
+        CamundaProcessTestContainerRuntime.newBuilder().withLocalRuntime();
+
+    final CamundaProcessTestRuntimeBuilder globalRuntimeBuilder =
+        CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+            defaultRuntimeBuilder, globalRuntimeConfiguration);
+
+    CamundaProcessTestGlobalRuntime.INSTANCE.initialize(globalRuntimeBuilder);
+  }
+
   private CamundaProcessTestRuntime buildRuntime(final TestContext testContext) {
     final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
         testContext.getApplicationContext().getBean(CamundaProcessTestRuntimeConfiguration.class);
 
-    return CamundaSpringProcessTestRuntimeBuilder.buildRuntime(
-        containerRuntimeBuilder, runtimeConfiguration);
+    return CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+            containerRuntimeBuilder, runtimeConfiguration)
+        .build();
   }
 
   private static CamundaClient createClient(

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
@@ -59,6 +59,64 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
  *   }
  * }
  * </pre>
+ *
+ * <p>Depending on a test class' configuration, the CPT may create a local Camunda container runtime
+ * or use the global container runtime. You may configure the global runtime in your Spring
+ * application configuration ({@see CamundaProcessTestGlobalRuntimeConfiguration} for more
+ * information) like so:
+ *
+ * <pre>
+ *   io:
+ *     camunda:
+ *       process:
+ *         test:
+ *           global:
+ *             camunda-docker-image-name: "custom-image"
+ *             connectors-enabled: true
+ * </pre>
+ *
+ * Then, whenever a new CPT test class is initialized, the test's configuration is compared with
+ * that of the global runtime. If they're compatible, the global runtime is preferred over creating
+ * a new one.
+ *
+ * <p>However, the global runtime can be ignored on a per-class basis or disabled entirely. To force
+ * the extension to create a new Camunda runtime, regardless of its configuration, set the
+ * `ignore-global-runtime` property to `true`:
+ *
+ * <pre>
+ *   @SpringBootTest(
+ *     classes = {CamundaSpringProcessTestConnectorsIT.class},
+ *     properties = {
+ *       "io.camunda.process.test.ignore-global-runtime=true"
+ *     })
+ * </pre>
+ *
+ * You can also disable the global runtime. All test classes will then always create a new runtime.
+ * You can set the flag in your Maven POM, as a Maven flag, or by editing the
+ * `camunda-container-runtime.properties` file:
+ *
+ * <p>Editing the Maven POM:
+ *
+ * <pre>
+ *   <properties>
+ *     <io.camunda.process.test.globalRuntimeEnabled>false</io.camunda.process.test.globalRuntimeEnabled>
+ *   </properties>
+ * </pre>
+ *
+ * Adding a Maven flag:
+ *
+ * <pre>
+ *    -Dio.camunda.process.test.globalRuntimeEnabled="false"
+ * </pre>
+ *
+ * Changing the Camunda Container Runtime properties file:
+ *
+ * <pre>
+ *   camunda.process.test.globalRuntimeEnabled=false
+ * </pre>
+ *
+ * <p>Please note that disabling the global Camunda runtime may incur significant performance
+ * penalties as every test class must start and stop its own runtime.
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
@@ -27,7 +27,8 @@ import org.springframework.context.annotation.Bean;
   CamundaProcessTestProxyConfiguration.class,
   CamundaProcessTestDefaultConfiguration.class,
   CamundaAutoConfiguration.class,
-  CamundaProcessTestRuntimeConfiguration.class
+  CamundaProcessTestRuntimeConfiguration.class,
+  CamundaProcessTestGlobalRuntimeConfiguration.class
 })
 @AutoConfigureBefore(CamundaAutoConfiguration.class)
 public class CamundaProcessTestAutoConfiguration {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestGlobalRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestGlobalRuntimeConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CamundaProcessTestGlobalRuntimeConfiguration {
+
+  @Bean
+  @ConfigurationProperties(prefix = "io.camunda.process.test.global")
+  public CamundaProcessTestRuntimeConfiguration globalRuntimeConfiguration() {
+    return new CamundaProcessTestRuntimeConfiguration();
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -45,6 +45,7 @@ public class CamundaProcessTestRuntimeConfiguration {
   private Map<String, String> connectorsSecrets = Collections.emptyMap();
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
+  private boolean forceLocalRuntime = false;
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
@@ -126,6 +127,14 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   public void setRuntimeMode(final CamundaProcessTestRuntimeMode runtimeMode) {
     this.runtimeMode = runtimeMode;
+  }
+
+  public boolean isForceLocalRuntime() {
+    return forceLocalRuntime;
+  }
+
+  public void setForceLocalRuntime(final boolean forceLocalRuntime) {
+    this.forceLocalRuntime = forceLocalRuntime;
   }
 
   public RemoteConfiguration getRemote() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -25,7 +25,9 @@ import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
+@Primary
 @Configuration
 @ConfigurationProperties(prefix = "io.camunda.process.test")
 public class CamundaProcessTestRuntimeConfiguration {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -47,7 +47,7 @@ public class CamundaProcessTestRuntimeConfiguration {
   private Map<String, String> connectorsSecrets = Collections.emptyMap();
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
-  private boolean forceLocalRuntime = false;
+  private boolean ignoreGlobalRuntime = false;
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
@@ -131,12 +131,12 @@ public class CamundaProcessTestRuntimeConfiguration {
     this.runtimeMode = runtimeMode;
   }
 
-  public boolean isForceLocalRuntime() {
-    return forceLocalRuntime;
+  public boolean isIgnoreGlobalRuntime() {
+    return ignoreGlobalRuntime;
   }
 
-  public void setForceLocalRuntime(final boolean forceLocalRuntime) {
-    this.forceLocalRuntime = forceLocalRuntime;
+  public void setIgnoreGlobalRuntime(final boolean ignoreGlobalRuntime) {
+    this.ignoreGlobalRuntime = ignoreGlobalRuntime;
   }
 
   public RemoteConfiguration getRemote() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -34,13 +34,12 @@ public class CamundaSpringProcessTestRuntimeBuilder {
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
 
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
+
     runtimeBuilder.withRuntimeMode(runtimeMode);
-
-    if (runtimeMode == CamundaProcessTestRuntimeMode.MANAGED || runtimeMode == null) {
-      configureManagedRuntime(runtimeBuilder, runtimeConfiguration);
-
-    } else if (runtimeMode == CamundaProcessTestRuntimeMode.REMOTE) {
+    if (runtimeMode == CamundaProcessTestRuntimeMode.REMOTE) {
       configureRemoteRuntime(runtimeBuilder, runtimeConfiguration);
+    } else {
+      configureManagedRuntime(runtimeBuilder, runtimeConfiguration);
     }
 
     return runtimeBuilder.build();
@@ -49,6 +48,10 @@ public class CamundaSpringProcessTestRuntimeBuilder {
   private static void configureManagedRuntime(
       final CamundaProcessTestRuntimeBuilder runtimeBuilder,
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
+
+    if (runtimeConfiguration.isForceLocalRuntime()) {
+      runtimeBuilder.withLocalRuntime();
+    }
 
     runtimeBuilder
         .withCamundaDockerImageVersion(runtimeConfiguration.getCamundaVersion())

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -29,11 +29,14 @@ import io.camunda.spring.client.properties.CamundaClientProperties.ClientMode;
 
 public class CamundaSpringProcessTestRuntimeBuilder {
 
-  public static CamundaProcessTestRuntime buildRuntime(
+  public static CamundaProcessTestRuntimeBuilder mergeRuntimeConfiguration(
       final CamundaProcessTestRuntimeBuilder runtimeBuilder,
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
 
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
+    if (runtimeConfiguration.isForceLocalRuntime()) {
+      runtimeBuilder.withLocalRuntime();
+    }
 
     runtimeBuilder.withRuntimeMode(runtimeMode);
     if (runtimeMode == CamundaProcessTestRuntimeMode.REMOTE) {
@@ -42,16 +45,12 @@ public class CamundaSpringProcessTestRuntimeBuilder {
       configureManagedRuntime(runtimeBuilder, runtimeConfiguration);
     }
 
-    return runtimeBuilder.build();
+    return runtimeBuilder;
   }
 
   private static void configureManagedRuntime(
       final CamundaProcessTestRuntimeBuilder runtimeBuilder,
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
-
-    if (runtimeConfiguration.isForceLocalRuntime()) {
-      runtimeBuilder.withLocalRuntime();
-    }
 
     runtimeBuilder
         .withCamundaDockerImageVersion(runtimeConfiguration.getCamundaVersion())

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -34,8 +34,8 @@ public class CamundaSpringProcessTestRuntimeBuilder {
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
 
     final CamundaProcessTestRuntimeMode runtimeMode = runtimeConfiguration.getRuntimeMode();
-    if (runtimeConfiguration.isForceLocalRuntime()) {
-      runtimeBuilder.withLocalRuntime();
+    if (runtimeConfiguration.isIgnoreGlobalRuntime()) {
+      runtimeBuilder.withIgnoringGlobalRuntime();
     }
 
     runtimeBuilder.withRuntimeMode(runtimeMode);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -36,7 +36,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
-      "io.camunda.process.test.force-local-runtime=true",
+      "io.camunda.process.test.ignore-global-runtime=true",
       "io.camunda.process.test.connectors-enabled=true",
       "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness"
     })

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {
+      "io.camunda.process.test.force-local-runtime=true",
       "io.camunda.process.test.connectors-enabled=true",
       "io.camunda.process.test.connectors-secrets.CONNECTORS_URL=http://connectors:8080/actuator/health/readiness"
     })

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -109,6 +109,9 @@ public class ExecutionListenerTest {
         .thenReturn(camundaProcessTestContextProxy);
     when(applicationContext.getBean(CamundaProcessTestRuntimeConfiguration.class))
         .thenReturn(new CamundaProcessTestRuntimeConfiguration());
+    when(applicationContext.getBean(
+            "globalRuntimeConfiguration", CamundaProcessTestRuntimeConfiguration.class))
+        .thenReturn(new CamundaProcessTestRuntimeConfiguration());
   }
 
   @Test

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -54,7 +54,9 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
 
     // when
     final CamundaProcessTestRuntime camundaRuntime =
-        CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+        CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+                runtimeBuilder, runtimeConfiguration)
+            .build();
 
     // then
     assertThat(camundaRuntime)
@@ -72,24 +74,6 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
   }
 
   @Test
-  void shouldBuildLocalRuntimeIfAnyConfigurationIsChanged() {
-    // given
-    final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
-    final CamundaProcessTestRuntimeConfiguration runtimeConfiguration =
-        new CamundaProcessTestRuntimeConfiguration();
-
-    runtimeConfiguration.setConnectorsEnabled(true);
-
-    // when
-    final CamundaProcessTestRuntime camundaRuntime =
-        CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
-
-    // then
-    assertThat(camundaRuntime).isNotNull().isInstanceOf(CamundaProcessTestContainerRuntime.class);
-    assertThat(runtimeBuilder.isConnectorsEnabled()).isTrue();
-  }
-
-  @Test
   void shouldForceBuildLocalRuntimeIfConfigured() {
     // given
     final CamundaProcessTestRuntimeBuilder runtimeBuilder = new CamundaProcessTestRuntimeBuilder();
@@ -100,7 +84,9 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
 
     // when
     final CamundaProcessTestRuntime camundaRuntime =
-        CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+        CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+                runtimeBuilder, runtimeConfiguration)
+            .build();
 
     // then
     assertThat(camundaRuntime).isNotNull().isInstanceOf(CamundaProcessTestContainerRuntime.class);
@@ -125,7 +111,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setCamundaExposedPorts(camundaExposedPorts);
 
     // when
-    CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+    CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+        runtimeBuilder, runtimeConfiguration);
 
     // then
     assertThat(runtimeBuilder.getCamundaDockerImageName()).isEqualTo("custom-camunda");
@@ -155,7 +142,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setConnectorsSecrets(connectorsSecrets);
 
     // when
-    CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+    CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+        runtimeBuilder, runtimeConfiguration);
 
     // then
     assertThat(runtimeBuilder.isConnectorsEnabled()).isTrue();
@@ -173,10 +161,13 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         new CamundaProcessTestRuntimeConfiguration();
 
     runtimeConfiguration.setRuntimeMode(CamundaProcessTestRuntimeMode.REMOTE);
+    runtimeConfiguration.setForceLocalRuntime(true);
 
     // when
     final CamundaProcessTestRuntime camundaRuntime =
-        CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+        CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+                runtimeBuilder, runtimeConfiguration)
+            .build();
 
     // then
     assertThat(camundaRuntime).isNotNull().isInstanceOf(CamundaProcessTestRemoteRuntime.class);
@@ -226,7 +217,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     remoteClientProperties.setGrpcAddress(remoteCamundaGrpcApiAddress);
 
     // when
-    CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+    CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+        runtimeBuilder, runtimeConfiguration);
 
     // then
     assertThat(runtimeBuilder.getRemoteCamundaMonitoringApiAddress())
@@ -268,7 +260,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     authProperties.setClientSecret("my-client-secret");
 
     // when
-    CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
+    CamundaSpringProcessTestRuntimeBuilder.mergeRuntimeConfiguration(
+        runtimeBuilder, runtimeConfiguration);
 
     // then
     final CamundaClientBuilderFactory remoteCamundaClientBuilderFactory =

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/util/GlobalCptRuntimeInvalidator.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/util/GlobalCptRuntimeInvalidator.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.process.test.utils;
+package io.camunda.process.test.util;
 
 import io.camunda.process.test.impl.runtime.CamundaProcessTestGlobalRuntime;
 import java.lang.reflect.Method;


### PR DESCRIPTION
## Description

Creates a new global CPT container runtime that is preferred whenever a CPT integration test runs with default configuration parameters, usually because the dev user used the @CamundaProcessTest annotation. 

Features:

- Creates a singleton global runtime instance that is shared by all CPT test classes that feature no custom configuration.
- Can be disabled on a per-test-class basis by calling `withLocalRuntime`
- The global environment can be disabled by setting `io.camunda.process.test.globalRuntimeDisabled` to false
- The runtimeBuilder is compared to a default configuration to determine if a global or local runtime should be used.

The new environment has been implemented for both camunda-process-test-java and camunda-process-test-spring. 

closes https://github.com/camunda/camunda/issues/29131
