### PR TITLE
fix: update flaky test

### DIFF
--- a/qa/core-application-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/core-application-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -48,7 +48,7 @@ class OperateProcessInstancePage {
     while (retryCount < maxRetries) {
       try {
         await expect(this.completedIcon).toBeVisible({
-          timeout: 90000,
+          timeout: 120000,
         });
         return; // Exit the function if the expectation is met
       } catch {
@@ -59,7 +59,7 @@ class OperateProcessInstancePage {
         await sleep(10000);
       }
     }
-    throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
+    throw new Error(`Completed icon not visible after ${maxRetries} attempts.`);
   }
 
   async activeIconAssertion(): Promise<void> {

--- a/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -167,7 +167,7 @@ test.describe('process page', () => {
     await taskPanelPage.openTask('processStartedByForm_user_task');
     await expect(
       page.getByText('{"name":"jon","address":"earth"}'),
-    ).toBeVisible();
+    ).toBeVisible({timeout: 60000});
     await expect(page.getByText('EUR')).toBeVisible();
     await expect(page.getByText('3000-01-01')).toBeVisible();
     await expect(page.getByText('3000-01-02')).toBeVisible();
@@ -179,6 +179,8 @@ test.describe('process page', () => {
     ).toBeVisible();
     await taskDetailsPage.clickAssignToMeButton();
     await taskDetailsPage.clickCompleteTaskButton();
-    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
+      timeout: 60000,
+    });
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In the nightly test runs it has been noticed that `complete process with start node having deployed form` has been flaky. This PR adds some timeouts to fix this

🧪 Successful runs:
- [#1](https://github.com/camunda/camunda/actions/runs/15558603316/job/43805132251)
- [#2](https://github.com/camunda/camunda/actions/runs/15558669418/job/43805343447)
- [#3](https://github.com/camunda/camunda/actions/runs/15558669418/job/43806629517)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
