### PR TITLE
fix: deprecate `xCamundaVersion` in favor of `CamundaDockerImageVersion`

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -279,11 +279,24 @@ public class CamundaProcessTestExtension
    *
    * @param camundaVersion the version to use
    * @return the extension builder
+   * @deprecated use withCamundaDockerImageVersion instead.
+   * @since 8.8.0
    */
+  @Deprecated
   public CamundaProcessTestExtension withCamundaVersion(final String camundaVersion) {
-    runtimeBuilder
-        .withCamundaDockerImageVersion(camundaVersion)
-        .withConnectorsDockerImageVersion(camundaVersion);
+    return withCamundaDockerImageVersion(camundaVersion);
+  }
+
+  /**
+   * Configure the Camunda docker image version of the runtime.
+   *
+   * @param camundaDockerImageVersion the version to use
+   * @return the extension builder
+   */
+  public CamundaProcessTestExtension withCamundaDockerImageVersion(
+      final String camundaDockerImageVersion) {
+
+    runtimeBuilder.withCamundaDockerImageVersion(camundaDockerImageVersion);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
@@ -1,4 +1,3 @@
-camunda.version=${project.version}
 elasticsearch.version=${version.elasticsearch}
 camunda.dockerImageName=${io.camunda.process.test.camundaDockerImageName}
 camunda.dockerImageVersion=${io.camunda.process.test.camundaDockerImageVersion}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -257,8 +257,9 @@ public class JunitExtensionTest {
 
     final CamundaProcessTestExtension extension =
         new CamundaProcessTestExtension(camundaRuntimeBuilder, NOOP)
-            .withCamundaVersion(camundaVersion)
+            .withCamundaDockerImageVersion(camundaVersion)
             .withCamundaDockerImageName(camundaDockerImageName)
+            .withConnectorsDockerImageVersion(camundaVersion)
             .withCamundaEnv(camundaEnvVars)
             .withCamundaEnv("env-3", "test-3")
             .withCamundaExposedPort(100)

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -30,9 +30,10 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "io.camunda.process.test")
 public class CamundaProcessTestRuntimeConfiguration {
 
-  private String camundaVersion = CamundaProcessTestRuntimeDefaults.CAMUNDA_VERSION;
   private String camundaDockerImageName =
       CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_NAME;
+  private String camundaDockerImageVersion =
+      CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION;
   private Map<String, String> camundaEnvVars = Collections.emptyMap();
   private List<Integer> camundaExposedPorts = Collections.emptyList();
 
@@ -48,12 +49,46 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   @NestedConfigurationProperty private RemoteConfiguration remote = new RemoteConfiguration();
 
+  /**
+   * Gets the Camunda docker image version.
+   *
+   * @return the camunda docker image version
+   * @deprecated use getCamundaDockerImageVersion
+   * @since 8.8.0
+   */
+  @Deprecated
   public String getCamundaVersion() {
-    return camundaVersion;
+    return camundaDockerImageVersion;
   }
 
-  public void setCamundaVersion(final String camundaVersion) {
-    this.camundaVersion = camundaVersion;
+  /**
+   * Sets the Camunda docker image version.
+   *
+   * @param camundaDockerImageVersion the Camunda docker image version to set
+   * @deprecated use setCamundaDockerImageVersion
+   * @since 8.8.0
+   */
+  @Deprecated
+  public void setCamundaVersion(final String camundaDockerImageVersion) {
+    this.camundaDockerImageVersion = camundaDockerImageVersion;
+  }
+
+  /**
+   * Gets the Camunda docker image version.
+   *
+   * @return the camunda docker image version
+   */
+  public String getCamundaDockerImageVersion() {
+    return camundaDockerImageVersion;
+  }
+
+  /**
+   * Sets the Camunda docker image version.
+   *
+   * @param camundaDockerImageVersion the Camunda docker image version to set
+   */
+  public void setCamundaDockerImageVersion(final String camundaDockerImageVersion) {
+    this.camundaDockerImageVersion = camundaDockerImageVersion;
   }
 
   public String getCamundaDockerImageName() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -51,7 +51,7 @@ public class CamundaSpringProcessTestRuntimeBuilder {
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
 
     runtimeBuilder
-        .withCamundaDockerImageVersion(runtimeConfiguration.getCamundaVersion())
+        .withCamundaDockerImageVersion(runtimeConfiguration.getCamundaDockerImageVersion())
         .withCamundaDockerImageName(runtimeConfiguration.getCamundaDockerImageName())
         .withCamundaEnv(runtimeConfiguration.getCamundaEnvVars());
 

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -78,7 +78,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     final Map<String, String> camundaEnvVars =
         Map.ofEntries(entry("env-1", "test-1"), entry("env-2", "test-2"));
 
-    runtimeConfiguration.setCamundaVersion("8.6.0-custom");
+    runtimeConfiguration.setCamundaDockerImageVersion("8.6.0-custom");
     runtimeConfiguration.setCamundaDockerImageName("custom-camunda");
     runtimeConfiguration.setCamundaEnvVars(camundaEnvVars);
     final List<Integer> camundaExposedPorts = List.of(100, 200);


### PR DESCRIPTION
## Description

Currently the file `/camunda-container-runtime.properties` has a property called `camunda.version` you can set to configure the camunda docker image version. However, the property `camunda.dockerImageVersion` does the exact same thing and its usage is mixed between CPT-Java and CPT-Spring. This bugfix changes the naming to `camundaDockerImageVersion` and deprecates all other methods. 

The other issue the story mentions, that you can't set a custom version tag such as `8.8.0-alpha4-rc1`, was already fixed in [#31795](https://github.com/camunda/camunda/issues/31795).

## Related issues

closes https://github.com/camunda/camunda/issues/31797
closes https://github.com/camunda/camunda/issues/31799
