### PR TITLE
test: use actual 8.7 properties

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/self-managed-extended.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/self-managed-extended.yaml
@@ -3,12 +3,13 @@ camunda:
     mode: self-managed
     tenant-id: <default>
     auth:
-      scope: scope # optional
-      audience: zeebe-api
       client-id: <your client id>
       client-secret: <your client secret>
       token-url: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
-    enabled: true
-    grpc-address: http://localhost:26500
-    rest-address: http://localhost:8080
-    prefer-rest-over-grpc: false
+    zeebe:
+      enabled: true
+      grpc-address: http://localhost:26500
+      rest-address: http://localhost:8080
+      prefer-rest-over-grpc: false
+      scope: scope # optional
+      audience: zeebe-api


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes a test that asserted on current properties, but should assert on old ones

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
