### PR TITLE
fix: Operate cannot deserialize IN_PROGRESS snapshot state in Opensearch

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/response/SnapshotState.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/response/SnapshotState.java
@@ -8,18 +8,8 @@
 package io.camunda.operate.store.opensearch.response;
 
 public enum SnapshotState {
-  FAILED("FAILED"),
-  PARTIAL("PARTIAL"),
-  STARTED("STARTED"),
-  SUCCESS("SUCCESS");
-  private final String state;
-
-  SnapshotState(final String state) {
-    this.state = state;
-  }
-
-  @Override
-  public String toString() {
-    return state;
-  }
+  FAILED,
+  PARTIAL,
+  IN_PROGRESS,
+  SUCCESS;
 }

--- a/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
@@ -98,7 +98,7 @@ class OpenSearchSnapshotOperationsTest {
                     "uuid",
                     "uuid-value",
                     "state",
-                    "STARTED",
+                    "IN_PROGRESS",
                     "start_time_in_millis",
                     23L,
                     "metadata",
@@ -136,7 +136,7 @@ class OpenSearchSnapshotOperationsTest {
   }
 
   private void assertSnapshotInfo(final OpenSearchSnapshotInfo snapshotInfo) {
-    assertThat(snapshotInfo.getState()).isEqualTo(SnapshotState.STARTED);
+    assertThat(snapshotInfo.getState()).isEqualTo(SnapshotState.IN_PROGRESS);
     assertThat(snapshotInfo.getStartTimeInMillis()).isEqualTo(23L);
     assertThat(snapshotInfo.getMetadata()).isEmpty();
     assertThat(snapshotInfo.getFailures()).isEmpty();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -262,7 +262,7 @@ public class OpensearchBackupRepository implements BackupRepository {
                     // No need to continue
                     onFailure.run();
                     break;
-                  } else if (STARTED.equals(maybeCurrentSnapshot.get().getState())) {
+                  } else if (IN_PROGRESS.equals(maybeCurrentSnapshot.get().getState())) {
                     ThreadUtil.sleepFor(100);
                   } else {
                     handleSnapshotReceived(maybeCurrentSnapshot.get(), onSuccess, onFailure);
@@ -370,7 +370,9 @@ public class OpensearchBackupRepository implements BackupRepository {
         .map(OpenSearchSnapshotInfo::getState)
         .anyMatch(s -> FAILED.equals(s) || PARTIAL.equals(s))) {
       return BackupStateDto.FAILED;
-    } else if (snapshots.stream().map(OpenSearchSnapshotInfo::getState).anyMatch(STARTED::equals)) {
+    } else if (snapshots.stream()
+        .map(OpenSearchSnapshotInfo::getState)
+        .anyMatch(IN_PROGRESS::equals)) {
       return BackupStateDto.IN_PROGRESS;
     } else if (snapshots.size() < expectedSnapshotsCount) {
       return BackupStateDto.INCOMPLETE;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -93,7 +93,7 @@ class OpensearchBackupRepositoryTest {
         List.of(
             new OpenSearchSnapshotInfo()
                 .setSnapshot("test-snapshot")
-                .setState(SnapshotState.STARTED)
+                .setState(SnapshotState.IN_PROGRESS)
                 .setStartTimeInMillis(23L));
     final var response = new OpenSearchGetSnapshotResponse(snapshotInfos);
 
@@ -125,7 +125,7 @@ class OpensearchBackupRepositoryTest {
         List.of(
             new OpenSearchSnapshotInfo()
                 .setSnapshot("test-snapshot")
-                .setState(SnapshotState.STARTED));
+                .setState(SnapshotState.IN_PROGRESS));
     final var response = new OpenSearchGetSnapshotResponse(snapshotInfos);
     mockObjectMapperForMetadata(metadata);
     when(openSearchSnapshotOperations.get(any())).thenReturn(response);
@@ -151,7 +151,7 @@ class OpensearchBackupRepositoryTest {
         List.of(
             new OpenSearchSnapshotInfo()
                 .setSnapshot("test-snapshot")
-                .setState(SnapshotState.STARTED));
+                .setState(SnapshotState.IN_PROGRESS));
     final var response = new OpenSearchGetSnapshotResponse(snapshotInfos);
     mockObjectMapperForMetadata(metadata);
     when(openSearchSnapshotOperations.get(any())).thenReturn(response);

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -112,7 +112,7 @@ class OpensearchBackupRepositoryTest {
     assertThat(snapshotDtoDetails).hasSize(1);
     final var snapshotDtoDetail = snapshotDtoDetails.get(0);
     assertThat(snapshotDtoDetail.getSnapshotName()).isEqualTo("test-snapshot");
-    assertThat(snapshotDtoDetail.getState()).isEqualTo("STARTED");
+    assertThat(snapshotDtoDetail.getState()).isEqualTo("IN_PROGRESS");
     assertThat(snapshotDtoDetail.getFailures()).isNull();
     assertThat(snapshotDtoDetail.getStartTime().toInstant().toEpochMilli()).isEqualTo(23L);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Replacing STARTED by IN_PROGRESS snapshot status
There is not such status STARTED according to Opensearch docs https://docs.opensearch.org/docs/latest/api-reference/snapshots/get-snapshot-status/#snapshot-states


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33516 
