### PR TITLE
feat: added ability to disable variable import with Optimize

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/SpringC8VariableImportDisabledITConfig.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/SpringC8VariableImportDisabledITConfig.java
@@ -10,9 +10,7 @@ package io.camunda.optimize;
 import static io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder.createConfigurationFromLocations;
 
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import io.camunda.optimize.service.util.configuration.condition.CCSMCondition;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
@@ -20,13 +18,13 @@ import org.springframework.context.annotation.Profile;
 
 @Import(io.camunda.optimize.Main.class)
 @Configuration
-@Conditional(CCSMCondition.class)
-@Profile("!variable-import-disabled")
-public class SpringDefaultC8ITConfig {
+@Profile("variable-import-disabled")
+public class SpringC8VariableImportDisabledITConfig {
 
   @Bean
   @Primary
   public static ConfigurationService configurationService() {
-    return createConfigurationFromLocations("service-config.yaml", "it/it-config-ccsm.yaml");
+    return createConfigurationFromLocations(
+        "service-config.yaml", "it/it-config-ccsm-variables-disabled.yaml");
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableImportDisabledIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableImportDisabledIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing;
+
+import static io.camunda.optimize.util.ZeebeBpmnModels.createStartEndProcess;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.response.Process;
+import io.camunda.optimize.AbstractCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.exception.OptimizeIntegrationTestException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("variable-import-disabled")
+public class ZeebeVariableImportDisabledIT extends AbstractCCSMIT {
+
+  private static final String PROCESS_ID = "demoProcess";
+  private static final Map<String, Object> BASIC_VARIABLES =
+      Map.of("var1", "someValue", "var2", false, "var3", 123, "var4", 123.3, "var5", "");
+
+  @Test
+  public void zeebeVariableImport_processStartedWithVariables() {
+    // given
+    final Long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables();
+
+    // when
+    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    final ProcessInstanceDto savedProcessInstance =
+        getProcessInstanceForId(String.valueOf(processInstanceKey));
+    assertThatVariablesNotImported(savedProcessInstance);
+  }
+
+  private Long deployProcessAndStartProcessInstanceWithVariables() {
+    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    return zeebeExtension.startProcessInstanceWithVariables(
+        deployedProcess.getBpmnProcessId(), BASIC_VARIABLES);
+  }
+
+  private ProcessInstanceDto getProcessInstanceForId(final String processInstanceId) {
+    return databaseIntegrationTestExtension.getAllProcessInstances().stream()
+        .filter(instance -> instance.getProcessInstanceId().equals(processInstanceId))
+        .collect(Collectors.toList())
+        .stream()
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new OptimizeIntegrationTestException(
+                    "No process instance with id " + processInstanceId + " found"));
+  }
+
+  private void assertThatVariablesNotImported(final ProcessInstanceDto processInstanceDto) {
+    assertThat(processInstanceDto.getVariables()).hasSize(0);
+  }
+}

--- a/optimize/backend/src/it/resources/it/it-config-ccsm-variables-disabled.yaml
+++ b/optimize/backend/src/it/resources/it/it-config-ccsm-variables-disabled.yaml
@@ -1,0 +1,15 @@
+---
+container:
+  ports:
+    http: 8095
+    https: 8096
+zeebe:
+  partitionCount: 2
+  enabled: true
+  variableImportEnabled: false
+
+import:
+  currentTimeBackoffMilliseconds: 0
+
+es:
+  scrollTimeoutInSeconds: 5

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportSchedulerManagerService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportSchedulerManagerService.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.importing.ingested.mediator.factory.AbstractI
 import io.camunda.optimize.service.importing.zeebe.ZeebeImportScheduler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeImportIndexHandlerProvider;
 import io.camunda.optimize.service.importing.zeebe.mediator.factory.AbstractZeebeImportMediatorFactory;
+import io.camunda.optimize.service.importing.zeebe.mediator.factory.ZeebeVariableImportMediatorFactory;
 import io.camunda.optimize.service.util.configuration.ConfigurationReloadable;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ZeebeConfiguration;
@@ -64,7 +65,17 @@ public class ImportSchedulerManagerService implements ConfigurationReloadable {
     this.beanFactory = beanFactory;
     this.configurationService = configurationService;
     this.ingestedMediatorFactories = ingestedMediatorFactories;
-    this.zeebeMediatorFactories = zeebeMediatorFactories;
+    // https://github.com/camunda/product-hub/issues/2891
+    // If the factory is not a ZeebeVariableImportMediatorFactory, object passes through
+    // If the factory is a ZeebeVariableImportMediatorFactory, it only passes when enabled
+    // When disabled, ZeebeVariableImportMediatorFactory objects are filtered out
+    this.zeebeMediatorFactories =
+        zeebeMediatorFactories.stream()
+            .filter(
+                factory ->
+                    !(factory instanceof ZeebeVariableImportMediatorFactory)
+                        || configurationService.getConfiguredZeebe().isVariableImportEnabled())
+            .collect(Collectors.toList());
     initSchedulers();
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ZeebeConfiguration.java
@@ -14,6 +14,7 @@ public class ZeebeConfiguration {
   private int partitionCount;
   private int maxImportPageSize;
   private boolean includeObjectVariableValue;
+  private boolean variableImportEnabled;
   private ZeebeImportConfiguration importConfig;
 
   public ZeebeConfiguration(
@@ -22,12 +23,14 @@ public class ZeebeConfiguration {
       final int partitionCount,
       final int maxImportPageSize,
       final boolean includeObjectVariableValue,
+      final boolean variableImportEnabled,
       final ZeebeImportConfiguration importConfig) {
     this.enabled = enabled;
     this.name = name;
     this.partitionCount = partitionCount;
     this.maxImportPageSize = maxImportPageSize;
     this.includeObjectVariableValue = includeObjectVariableValue;
+    this.variableImportEnabled = variableImportEnabled;
     this.importConfig = importConfig;
   }
 
@@ -73,6 +76,14 @@ public class ZeebeConfiguration {
     this.includeObjectVariableValue = includeObjectVariableValue;
   }
 
+  public boolean isVariableImportEnabled() {
+    return variableImportEnabled;
+  }
+
+  public void setVariableImportEnabled(final boolean variableImportEnabled) {
+    this.variableImportEnabled = variableImportEnabled;
+  }
+
   public ZeebeImportConfiguration getImportConfig() {
     return importConfig;
   }
@@ -107,6 +118,8 @@ public class ZeebeConfiguration {
         + getMaxImportPageSize()
         + ", includeObjectVariableValue="
         + isIncludeObjectVariableValue()
+        + ", variableImportEnabled="
+        + isVariableImportEnabled()
         + ", importConfig="
         + getImportConfig()
         + ")";

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -147,6 +147,8 @@ zeebe:
   maxImportPageSize: ${CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE:200}
   # Determines whether Optimize should convert and store object variables from Zeebe
   includeObjectVariableValue: ${CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE:true}
+  # Indicates whether variable import is enabled
+  variableImportEnabled: ${CAMUNDA_OPTIMIZE_ZEEBE_VARIABLE_IMPORT_ENABLED:true}
   importConfig:
     # The number of successful fetches that should be attempted before increasing the batch size during fetching
     dynamicBatchSuccessAttempts: ${CAMUNDA_OPTIMIZE_ZEEBE_IMPORT_DYNAMIC_BATCH_SUCCESS_ATTEMPTS:10}


### PR DESCRIPTION
## Description

feat: added ability to disable variable import with Optimize

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to https://github.com/camunda/product-hub/issues/2891
