### PR TITLE
fix: properly validate when optimize uses multipart auth cookies do proper cookie validation

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMAuthenticationCookieFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMAuthenticationCookieFilter.java
@@ -105,6 +105,7 @@ public class CCSMAuthenticationCookieFilter extends AbstractPreAuthenticatedProc
         .flatMap(
             cookies ->
                 AuthCookieService.extractJoinedCookieValueFromCookies(Arrays.asList(cookies))
+                    .flatMap(this::validToken)
                     .map(ccsmTokenService::getSubjectFromToken))
         .orElseGet(
             () ->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This is a fix for a security issue, [SEC-1432](https://jira.camunda.com/browse/SEC-1432)

When Optimize receives a header containing a multi-part Optimize Authorization token, it should properly validate the token if it coming from cookies. Optimize was previously only verifying Authorization tokens when it was coming through request attributes.

This PR applies token validation to multi-part tokens coming through as a header

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related https://jira.camunda.com/browse/SEC-1432
related https://github.com/camunda/camunda/pull/33544
closes #
