### PR TITLE
fix: substitute missing and broken docs links with docs homepage link

### DIFF
--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -35,11 +35,7 @@ const List: FC = () => {
 
   return (
     <Page>
-      <PageHeader
-        title="Authorizations"
-        linkText="authorizations"
-        linkUrl="/concepts/authorizations/"
-      />
+      <PageHeader title="Authorizations" linkText="authorizations" linkUrl="" />
       <TabsTitle>{t("resourceType")}</TabsTitle>
       <TabsContainer>
         <TabsVertical

--- a/identity/client/src/pages/authorizations/modals/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/AddModal.tsx
@@ -183,7 +183,7 @@ const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
           <PermissionsSectionLabel>
             <Translate i18nKey="selectPermission">
               Select at least one permission. Visit{" "}
-              <DocumentationLink path="/concepts/authorizations/" withIcon>
+              <DocumentationLink path="" withIcon>
                 authorizations
               </DocumentationLink>{" "}
               for a full overview.

--- a/identity/client/src/pages/forbidden/ForbiddenPage.tsx
+++ b/identity/client/src/pages/forbidden/ForbiddenPage.tsx
@@ -32,7 +32,7 @@ const ForbiddenPage: FC = () => {
           </Description>
         </Stack>
         <Link
-          href="https://docs.camunda.io/docs/next/components/concepts/access-control/authorizations/"
+          href="https://docs.camunda.io/"
           target="_blank"
           renderIcon={Launch}
         >

--- a/identity/client/src/pages/groups/List.tsx
+++ b/identity/client/src/pages/groups/List.tsx
@@ -37,9 +37,7 @@ const List: FC = () => {
   const [deleteGroup, deleteModal] = useEntityModal(DeleteModal, reload);
   const showDetails = ({ groupId }: Group) => navigate(groupId);
 
-  const pageHeader = (
-    <PageHeader title="Groups" linkText="groups" linkUrl="/concepts/groups/" />
-  );
+  const pageHeader = <PageHeader title="Groups" linkText="groups" linkUrl="" />;
 
   if (success && !groupSearchResults?.items.length) {
     return (
@@ -54,7 +52,7 @@ const List: FC = () => {
             icon: Add,
           }}
           link={{
-            href: documentationHref("/concepts/access-control/groups", ""),
+            href: documentationHref("https://docs.camunda.io/", ""),
             label: t("learnMoreAboutGroups"),
           }}
         />

--- a/identity/client/src/pages/groups/detail/clients/index.tsx
+++ b/identity/client/src/pages/groups/detail/clients/index.tsx
@@ -62,7 +62,7 @@ const Clients: FC<ClientsProps> = ({ groupId }) => {
           }}
           link={{
             label: t("learnMoreAboutGroups"),
-            href: `/identity/concepts/access-control/groups`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignClientModal}

--- a/identity/client/src/pages/groups/detail/mappings/index.tsx
+++ b/identity/client/src/pages/groups/detail/mappings/index.tsx
@@ -72,7 +72,7 @@ const Mappings: FC<MappingsProps> = ({ groupId }) => {
           }}
           link={{
             label: t("learnMoreAboutGroups"),
-            href: `/identity/concepts/access-control/groups`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignMappingsModal}

--- a/identity/client/src/pages/groups/detail/members/index.tsx
+++ b/identity/client/src/pages/groups/detail/members/index.tsx
@@ -68,7 +68,7 @@ const Members: FC<MembersProps> = ({ groupId }) => {
           }}
           link={{
             label: t("learnMoreAboutGroups"),
-            href: `/identity/concepts/access-control/groups`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignUsersModal}

--- a/identity/client/src/pages/groups/detail/roles/index.tsx
+++ b/identity/client/src/pages/groups/detail/roles/index.tsx
@@ -72,7 +72,7 @@ const Roles: FC<RolesProps> = ({ groupId }) => {
           }}
           link={{
             label: t("learnMoreAboutGroups"),
-            href: `/identity/concepts/access-control/groups`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignRolesModal}

--- a/identity/client/src/pages/mappings/List.tsx
+++ b/identity/client/src/pages/mappings/List.tsx
@@ -38,11 +38,7 @@ const List: FC = () => {
   );
 
   const pageHeader = (
-    <PageHeader
-      title={t("mappings")}
-      linkText={t("mappings")}
-      linkUrl="/concepts/mappings/"
-    />
+    <PageHeader title={t("mappings")} linkText={t("mappings")} linkUrl="" />
   );
 
   if (success && !mappingSearchResults?.items.length) {
@@ -58,7 +54,7 @@ const List: FC = () => {
             icon: Add,
           }}
           link={{
-            href: documentationHref("/concepts/mapping/", ""),
+            href: documentationHref("https://docs.camunda.io/", ""),
             label: t("learnMoreMapping"),
           }}
         />

--- a/identity/client/src/pages/roles/List.tsx
+++ b/identity/client/src/pages/roles/List.tsx
@@ -32,11 +32,7 @@ const List: FC = () => {
   const showDetails = ({ roleId }: Role) => navigate(roleId);
 
   const pageHeader = (
-    <PageHeader
-      title={t("roles")}
-      linkText="roles"
-      linkUrl="/concepts/roles/"
-    />
+    <PageHeader title={t("roles")} linkText="roles" linkUrl="" />
   );
 
   if (success && !roles?.items.length) {
@@ -51,7 +47,7 @@ const List: FC = () => {
             onClick: addRole,
           }}
           link={{
-            href: documentationHref("/concepts/roles/", ""),
+            href: documentationHref("https://docs.camunda.io/", ""),
             label: t("learnMoreAboutRoles"),
           }}
         />

--- a/identity/client/src/pages/roles/detail/clients/index.tsx
+++ b/identity/client/src/pages/roles/detail/clients/index.tsx
@@ -68,7 +68,7 @@ const Clients: FC<ClientsProps> = ({ roleId }) => {
           }}
           link={{
             label: t("learnMoreAboutRoles"),
-            href: `/identity/concepts/access-control/roles`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignClientModal}

--- a/identity/client/src/pages/roles/detail/mappings/index.tsx
+++ b/identity/client/src/pages/roles/detail/mappings/index.tsx
@@ -72,7 +72,7 @@ const Mappings: FC<MappingsProps> = ({ roleId }) => {
           }}
           link={{
             label: t("learnMoreAboutRoles"),
-            href: `/identity/concepts/access-control/roles`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignMappingsModal}

--- a/identity/client/src/pages/roles/detail/members/index.tsx
+++ b/identity/client/src/pages/roles/detail/members/index.tsx
@@ -69,7 +69,7 @@ const Members: FC<MembersProps> = ({ roleId }) => {
           }}
           link={{
             label: t("learnMoreAboutRoles"),
-            href: `/identity/concepts/access-control/roles`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignUsersModal}

--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -37,11 +37,7 @@ const List: FC = () => {
   const showDetails = ({ tenantId }: Tenant) => navigate(`${tenantId}`);
 
   const pageHeader = (
-    <PageHeader
-      title="Tenants"
-      linkText="tenants"
-      linkUrl="/concepts/tenants/"
-    />
+    <PageHeader title="Tenants" linkText="tenants" linkUrl="" />
   );
 
   if (success && !tenantSearchResults?.items.length) {
@@ -56,7 +52,7 @@ const List: FC = () => {
             onClick: addTenant,
           }}
           link={{
-            href: documentationHref("/concepts/multi-tenancy/", ""),
+            href: documentationHref("https://docs.camunda.io/", ""),
             label: t("learnMoreAboutTenants"),
           }}
         />

--- a/identity/client/src/pages/tenants/detail/clients/index.tsx
+++ b/identity/client/src/pages/tenants/detail/clients/index.tsx
@@ -68,7 +68,7 @@ const Clients: FC<ClientsProps> = ({ tenantId }) => {
           }}
           link={{
             label: t("learnMoreAboutTenants"),
-            href: `/identity/concepts/access-control/tenants`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignClientModal}

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -72,7 +72,7 @@ const Groups: FC<GroupsProps> = ({ tenantId }) => {
           }}
           link={{
             label: t("learnMoreAboutTenants"),
-            href: `/identity/concepts/access-control/tenants`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignGroupsModal}

--- a/identity/client/src/pages/tenants/detail/mappings/index.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/index.tsx
@@ -72,7 +72,7 @@ const Mappings: FC<MappingsProps> = ({ tenantId }) => {
           }}
           link={{
             label: t("learnMoreAboutTenants"),
-            href: `/identity/concepts/access-control/tenants`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignMappingsModal}

--- a/identity/client/src/pages/tenants/detail/members/index.tsx
+++ b/identity/client/src/pages/tenants/detail/members/index.tsx
@@ -70,7 +70,7 @@ const Members: FC<MembersProps> = ({ tenantId }) => {
           }}
           link={{
             label: t("learnMoreAboutTenants"),
-            href: `/identity/concepts/access-control/tenants`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignUsersModal}

--- a/identity/client/src/pages/tenants/detail/roles/index.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/index.tsx
@@ -72,7 +72,7 @@ const Roles: FC<RolesProps> = ({ tenantId }) => {
           }}
           link={{
             label: t("learnMoreAboutTenants"),
-            href: `/identity/concepts/access-control/tenants`,
+            href: "https://docs.camunda.io/",
           }}
         />
         {assignRolesModal}

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -41,11 +41,7 @@ const List: FC = () => {
   const showDetails = ({ username }: User) => navigate(`${username}`);
 
   const pageHeader = (
-    <PageHeader
-      title={t("users")}
-      linkText="users"
-      linkUrl="/concepts/users/"
-    />
+    <PageHeader title={t("users")} linkText="users" linkUrl="" />
   );
 
   if (success && !userSearchResults?.items.length) {
@@ -57,7 +53,7 @@ const List: FC = () => {
           description={
             <>
               {t("startBy")}{" "}
-              <DocumentationLink path="/concepts/access-control/users">
+              <DocumentationLink path="">
                 {t("creatingANewUser")}
               </DocumentationLink>{" "}
               {t("toGetStarted")}
@@ -69,7 +65,7 @@ const List: FC = () => {
             icon: Add,
           }}
           link={{
-            href: documentationHref("/concepts/access-control/users", ""),
+            href: documentationHref("https://docs.camunda.io/", ""),
             label: t("learnMoreAboutUsers"),
           }}
         />


### PR DESCRIPTION
## Description

Substitute all missing and broken docs links with docs homepage link so we avoid broken links in the application.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33457
