### PR TITLE
feat: added .execute() which is a shortcut for .send().join()

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/FinalCommandStep.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/FinalCommandStep.java
@@ -45,4 +45,18 @@ public interface FinalCommandStep<T> {
    * @return a future tracking state of success/failure of the command.
    */
   CamundaFuture<T> send();
+
+  /**
+   * Sends the command to the Camunda gateway and returns the response. This operation is
+   * synchronous.
+   *
+   * <pre>
+   * JobEvent event = command.execute();
+   * </pre>
+   *
+   * @return the response of the command.
+   */
+  default T execute() {
+    return send().join();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the `.execute()` method to the final command step interface which provides a common way to do `.send().join()`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
