### PR TITLE
[Backport main] fix: Operate cannot deserialize IN_PROGRESS snapshot state in Opensearch

### DIFF
--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -12,8 +12,8 @@ import static io.camunda.webapps.backup.repository.opensearch.OpensearchRequestD
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchRequestDSL.getSnapshotRequestBuilder;
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchRequestDSL.repositoryRequestBuilder;
 import static io.camunda.webapps.backup.repository.opensearch.SnapshotState.FAILED;
+import static io.camunda.webapps.backup.repository.opensearch.SnapshotState.IN_PROGRESS;
 import static io.camunda.webapps.backup.repository.opensearch.SnapshotState.PARTIAL;
-import static io.camunda.webapps.backup.repository.opensearch.SnapshotState.STARTED;
 import static io.camunda.webapps.backup.repository.opensearch.SnapshotState.SUCCESS;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
@@ -317,7 +317,7 @@ public class OpensearchBackupRepository implements BackupRepository {
                     // No need to continue
                     onFailure.run();
                     break;
-                  } else if (STARTED.equals(maybeCurrentSnapshot.get().getState())) {
+                  } else if (IN_PROGRESS.equals(maybeCurrentSnapshot.get().getState())) {
                     try {
                       Thread.sleep(100);
                     } catch (final InterruptedException ex) {
@@ -449,7 +449,9 @@ public class OpensearchBackupRepository implements BackupRepository {
         .map(OpenSearchSnapshotInfo::getState)
         .anyMatch(s -> FAILED.equals(s) || PARTIAL.equals(s))) {
       return BackupStateDto.FAILED;
-    } else if (snapshots.stream().map(OpenSearchSnapshotInfo::getState).anyMatch(STARTED::equals)) {
+    } else if (snapshots.stream()
+        .map(OpenSearchSnapshotInfo::getState)
+        .anyMatch(IN_PROGRESS::equals)) {
       return BackupStateDto.IN_PROGRESS;
     } else if (snapshots.size() < expectedSnapshotsCount) {
       if (isIncompleteCheckTimedOut(

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/SnapshotState.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/SnapshotState.java
@@ -10,7 +10,6 @@ package io.camunda.webapps.backup.repository.opensearch;
 public enum SnapshotState {
   FAILED,
   PARTIAL,
-  STARTED,
-  SUCCESS,
-  IN_PROGRESS;
+  IN_PROGRESS,
+  SUCCESS;
 }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -93,7 +93,7 @@ class OpensearchBackupRepositoryTest {
                 bi ->
                     defaultFields(bi, metadata)
                         .snapshot("test-snapshot")
-                        .state(SnapshotState.STARTED.name())
+                        .state(SnapshotState.IN_PROGRESS.name())
                         .startTimeInMillis("23")));
     final var response = GetSnapshotResponse.of(b -> defaultFields(b).snapshots(snapshotInfos));
 
@@ -110,7 +110,7 @@ class OpensearchBackupRepositoryTest {
     assertThat(snapshotDtoDetails).hasSize(1);
     final var snapshotDtoDetail = snapshotDtoDetails.get(0);
     assertThat(snapshotDtoDetail.getSnapshotName()).isEqualTo("test-snapshot");
-    assertThat(snapshotDtoDetail.getState()).isEqualTo("STARTED");
+    assertThat(snapshotDtoDetail.getState()).isEqualTo("IN_PROGRESS");
     assertThat(snapshotDtoDetail.getFailures()).isNull();
     assertThat(snapshotDtoDetail.getStartTime().toInstant().toEpochMilli()).isEqualTo(23L);
   }
@@ -455,7 +455,7 @@ class OpensearchBackupRepositoryTest {
         .satisfies(
             backup -> {
               assertThat(backup.getBackupId()).isEqualTo(5L);
-              assertThat(backup.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+              assertThat(backup.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
               assertThat(backup.getDetails())
                   .allSatisfy(
                       d -> {


### PR DESCRIPTION
# Description
Backport of #33520 to `main`.

relates to #33516