### PR TITLE
fix: change backpressure orientation

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1438,7 +1438,7 @@
               "placement": "bottom",
               "showLegend": true
             },
-            "orientation": "vertical",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "lastNotNull"


### PR DESCRIPTION
## Description

![2025-06-11_10-55](https://github.com/user-attachments/assets/0960754f-01f1-4bf0-8f31-98a9a4c626b6)


 * The backpressure panel was always broken in SaaS, because the orientation was set to: vertical 
 * This was somehow never a problem in our Grafana instance, as it simply ignored it, but in SaaS it looked odd all the time.
 * The orientation could not be changed in the UI, but only in the JSON

![2025-06-11_11-05](https://github.com/user-attachments/assets/c3135028-c4e6-4910-9e14-d29e92d9d1a2)


Kudos to @multani @Sijoma https://github.com/camunda-cloud/grafana-dashboards/issues/268#issuecomment-2935657477 for finding it