### PR TITLE
feat: all backup stores share the same logging implementation

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/BackupStoreComponent.java
@@ -51,25 +51,24 @@ final class BackupStoreComponent {
     };
   }
 
-  private static S3BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
+  private static BackupStore buildS3BackupStore(final BackupStoreCfg backupStoreCfg) {
     final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupStoreCfg.getS3());
-    return new S3BackupStore(storeConfig);
+    return S3BackupStore.of(storeConfig);
   }
 
-  private static GcsBackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
+  private static BackupStore buildGcsBackupStore(final BackupStoreCfg backupStoreCfg) {
     final var storeConfig = GcsBackupStoreConfig.toStoreConfig(backupStoreCfg.getGcs());
-    return new GcsBackupStore(storeConfig);
+    return GcsBackupStore.of(storeConfig);
   }
 
-  private static AzureBackupStore buildAzureBackupStore(final BackupStoreCfg backupStoreCfg) {
+  private static BackupStore buildAzureBackupStore(final BackupStoreCfg backupStoreCfg) {
     final var storeConfig = AzureBackupStoreConfig.toStoreConfig(backupStoreCfg.getAzure());
-    return new AzureBackupStore(storeConfig);
+    return AzureBackupStore.of(storeConfig);
   }
 
-  private static FilesystemBackupStore buildFilesystemBackupStore(
-      final BackupStoreCfg backupStoreCfg) {
+  private static BackupStore buildFilesystemBackupStore(final BackupStoreCfg backupStoreCfg) {
     final var storeConfig =
         FilesystemBackupStoreConfig.toStoreConfig(backupStoreCfg.getFilesystem());
-    return new FilesystemBackupStore(storeConfig, Executors.newVirtualThreadPerTaskExecutor());
+    return FilesystemBackupStore.of(storeConfig, Executors.newVirtualThreadPerTaskExecutor());
   }
 }

--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * {@link BackupStore} for Azure. Stores all backups in a given bucket.
@@ -51,11 +52,11 @@ public final class AzureBackupStore implements BackupStore {
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
 
-  public AzureBackupStore(final AzureBackupConfig config) {
+  AzureBackupStore(final AzureBackupConfig config) {
     this(config, buildClient(config));
   }
 
-  public AzureBackupStore(final AzureBackupConfig config, final BlobServiceClient client) {
+  AzureBackupStore(final AzureBackupConfig config, final BlobServiceClient client) {
     executor = Executors.newVirtualThreadPerTaskExecutor();
     final BlobContainerClient blobContainerClient = getContainerClient(client, config);
 
@@ -124,6 +125,7 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
+    LOG.info("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var persistedManifest = manifestManager.createInitialManifest(backup);
@@ -274,5 +276,9 @@ public final class AzureBackupStore implements BackupStore {
       }
     }
     return false;
+  }
+
+  public static BackupStore of(final AzureBackupConfig storeConfig) {
+    return new AzureBackupStore(storeConfig).logging(LOG, Level.INFO);
   }
 }

--- a/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
+++ b/zeebe/backup-stores/filesystem/src/main/java/io/camunda/zeebe/backup/filesystem/FilesystemBackupStore.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * {@link BackupStore} for local filesystem. Stores all backups in a given baseDir.
@@ -44,8 +45,7 @@ public final class FilesystemBackupStore implements BackupStore {
   private final FileSetManager fileSetManager;
   private final ManifestManager manifestManager;
 
-  public FilesystemBackupStore(
-      final FilesystemBackupConfig config, final ExecutorService executor) {
+  FilesystemBackupStore(final FilesystemBackupConfig config, final ExecutorService executor) {
     validateConfig(config);
     this.executor = executor;
 
@@ -55,6 +55,7 @@ public final class FilesystemBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
+    LOG.info("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var manifest = manifestManager.createInitialManifest(backup);
@@ -161,5 +162,10 @@ public final class FilesystemBackupStore implements BackupStore {
     if (config.basePath() == null || config.basePath().isBlank()) {
       throw new IllegalArgumentException("Base directory is required");
     }
+  }
+
+  public static BackupStore of(
+      final FilesystemBackupConfig storeConfig, final ExecutorService executorService) {
+    return new FilesystemBackupStore(storeConfig, executorService).logging(LOG, Level.INFO);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupStore.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.zeebe.backup.api;
 
+import io.camunda.zeebe.backup.common.LoggingBackupStore;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 /** A store where the backup is stored * */
 public interface BackupStore {
@@ -40,4 +43,8 @@ public interface BackupStore {
   CompletableFuture<BackupStatusCode> markFailed(BackupIdentifier id, final String failureReason);
 
   CompletableFuture<Void> closeAsync();
+
+  default BackupStore logging(final Logger logger, final Level level) {
+    return new LoggingBackupStore(this, logger, level);
+  }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.common;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+public class LoggingBackupStore implements BackupStore {
+
+  private final BackupStore store;
+  private final Logger logger;
+  private final Level level;
+
+  public LoggingBackupStore(final BackupStore store, final Logger logger, final Level level) {
+    this.store = store;
+    this.logger = logger;
+    this.level = level;
+  }
+
+  @Override
+  public CompletableFuture<Void> save(final Backup backup) {
+    logger.atLevel(level).log("Saving {}", backup.id());
+    return store.save(backup);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+    logger.atLevel(level).log("Querying status of {}", id);
+    return store.getStatus(id);
+  }
+
+  @Override
+  public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
+    logger.atLevel(level).log("Querying status with wildcard {}", wildcard);
+    return store.list(wildcard);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(final BackupIdentifier id) {
+    logger.atLevel(level).log("Deleting {}", id);
+    return store.delete(id);
+  }
+
+  @Override
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
+    logger.atLevel(level).log("Restoring {} to {}", id, targetFolder);
+    return store.restore(id, targetFolder);
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
+    logger.atLevel(level).log("Marking {} as failed", id, failureReason);
+    return store.markFailed(id, failureReason);
+  }
+
+  @Override
+  public CompletableFuture<Void> closeAsync() {
+    logger.atLevel(level).log("Closing backup store");
+    return store.closeAsync();
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupStoreTransitionStep.java
@@ -87,7 +87,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final ActorFuture<Void> installed) {
     try {
       final var storeConfig = S3BackupStoreConfig.toStoreConfig(backupCfg.getS3());
-      final var backupStore = new S3BackupStore(storeConfig);
+      final var backupStore = S3BackupStore.of(storeConfig);
       context.setBackupStore(backupStore);
       installed.complete(null);
     } catch (final Exception error) {
@@ -102,7 +102,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     try {
       final var brokerGcsConfig = backupCfg.getGcs();
       final var storeGcsConfig = GcsBackupStoreConfig.toStoreConfig(brokerGcsConfig);
-      final var gcsStore = new GcsBackupStore(storeGcsConfig);
+      final var gcsStore = GcsBackupStore.of(storeGcsConfig);
       context.setBackupStore(gcsStore);
       installed.complete(null);
     } catch (final Exception error) {
@@ -117,7 +117,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
     try {
       final var brokerAzureConfig = backupCfg.getAzure();
       final var storeAzureConfig = AzureBackupStoreConfig.toStoreConfig(brokerAzureConfig);
-      final var azureStore = new AzureBackupStore(storeAzureConfig);
+      final var azureStore = AzureBackupStore.of(storeAzureConfig);
       context.setBackupStore(azureStore);
       installed.complete(null);
     } catch (final Exception error) {
@@ -134,7 +134,7 @@ public final class BackupStoreTransitionStep implements PartitionTransitionStep 
       final var storeFilesystemConfig =
           FilesystemBackupStoreConfig.toStoreConfig(brokerFilesystemConfig);
       final var filesystemStore =
-          new FilesystemBackupStore(
+          FilesystemBackupStore.of(
               storeFilesystemConfig, Executors.newVirtualThreadPerTaskExecutor());
       context.setBackupStore(filesystemStore);
       installed.complete(null);

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -492,6 +492,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureBackupAcceptanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.backup;
 
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.azure.AzureBackupConfig;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -58,7 +59,7 @@ final class AzureBackupAcceptanceIT implements BackupAcceptance {
           .withEmbeddedGateway(false)
           .build();
 
-  private AzureBackupStore store;
+  private BackupStore store;
 
   @BeforeEach
   void beforeEach() {
@@ -67,7 +68,7 @@ final class AzureBackupAcceptanceIT implements BackupAcceptance {
             .withConnectionString(AZURITE_CONTAINER.getConnectString())
             .withContainerName(CONTAINER_NAME)
             .build();
-    store = new AzureBackupStore(config);
+    store = AzureBackupStore.of(config);
 
     // we have to configure the cluster here, after azurite is started, as otherwise we won't have
     // access to the exposed port

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
@@ -77,7 +78,7 @@ class BackupMultiPartitionTest {
           .endEvent()
           .done();
   private static final String CORRELATION_KEY_VALUE_FOR_PARTITION_2 = "item-1";
-  private S3BackupStore s3BackupStore;
+  private BackupStore s3BackupStore;
   private S3BackupConfig s3ClientConfig;
   private String bucketName = null;
   private GrpcClientRule client;
@@ -128,7 +129,7 @@ class BackupMultiPartitionTest {
             .withApiCallTimeout(Duration.ofSeconds(15))
             .forcePathStyleAccess(true)
             .build();
-    s3BackupStore = new S3BackupStore(s3ClientConfig);
+    s3BackupStore = S3BackupStore.of(s3ClientConfig);
     try (final var s3Client = S3BackupStore.buildClient(s3ClientConfig)) {
       s3Client.createBucket(builder -> builder.bucket(bucketName).build()).join();
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.backup;
 
+import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
@@ -63,7 +64,7 @@ final class S3BackupAcceptanceIT implements BackupAcceptance {
           .withNodeConfig(this::configureNode)
           .build();
 
-  private S3BackupStore store;
+  private BackupStore store;
 
   @BeforeEach
   void beforeEach() {
@@ -76,7 +77,7 @@ final class S3BackupAcceptanceIT implements BackupAcceptance {
             .withApiCallTimeout(Duration.ofSeconds(25))
             .forcePathStyleAccess(true)
             .build();
-    store = new S3BackupStore(config);
+    store = S3BackupStore.of(config);
 
     try (final var client = S3BackupStore.buildClient(config)) {
       // it's possible to query to fast and get a 503 from the server here, so simply retry after


### PR DESCRIPTION
## Description
Added LoggingBackupStore, which is a simple implementation of BackupStore that delegates all implementation to a delegate, while adding logging to all method calls from the interface.


# Related issues
Problems found when analyzing logs in [SUPPORT-27617](https://jira.camunda.com/browse/SUPPORT-27617?focusedCommentId=434685&atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258Y29tbWVudA%3D%3D)