### PR TITLE
refactor: dedicated cluster config for identity migration

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -149,7 +149,6 @@
     <dependency>
       <groupId>io.camunda.migration</groupId>
       <artifactId>identity-migration</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -47,7 +47,7 @@ public class DynamicClusterServices {
   }
 
   @Bean
-  @Profile("!broker")
+  @Profile({"!broker & !identity-migration"})
   public GatewayClusterConfigurationService gatewayClusterTopologyService(
       final BrokerTopologyManager brokerTopologyManager, final GatewayCfg gatewayCfg) {
     final var service =

--- a/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java
@@ -7,7 +7,18 @@
  */
 package io.camunda.application.commons.migration;
 
-import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
+import io.atomix.cluster.ClusterConfig;
+import io.atomix.cluster.MemberConfig;
+import io.atomix.cluster.NodeConfig;
+import io.atomix.cluster.discovery.BootstrapDiscoveryConfig;
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
+import io.atomix.utils.net.Address;
+import io.camunda.application.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
+import io.camunda.application.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.migration.identity.config.cluster.ClusterProperties;
+import io.camunda.migration.identity.config.cluster.MembershipConfig;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.clients.MappingSearchClient;
@@ -23,11 +34,15 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 
 @Configuration(proxyBeanMethods = false)
@@ -42,9 +57,17 @@ import org.springframework.context.annotation.Profile;
       "io.camunda.application.commons.security"
     })
 @Profile("identity-migration")
+@EnableConfigurationProperties(IdentityMigrationProperties.class)
 @EnableAutoConfiguration
-@Import({GatewayBasedConfiguration.class})
 public class IdentityMigrationModuleConfiguration {
+
+  private final IdentityMigrationProperties properties;
+
+  @Autowired
+  public IdentityMigrationModuleConfiguration(final IdentityMigrationProperties properties) {
+    this.properties = properties;
+  }
+
   @Bean
   public AuthorizationServices authorizationServices(
       final BrokerClient brokerClient,
@@ -107,5 +130,87 @@ public class IdentityMigrationModuleConfiguration {
   public AuthorizationChecker authorizationChecker(
       final AuthorizationSearchClient authorizationSearchClient) {
     return new AuthorizationChecker(authorizationSearchClient);
+  }
+
+  @Bean
+  public BrokerClientTimeoutConfiguration brokerClientConfig() {
+    return new BrokerClientTimeoutConfiguration(properties.getCluster().getRequestTimeout());
+  }
+
+  @Bean
+  public ClusterConfig clusterConfig() {
+    final var cluster = properties.getCluster();
+    final var name = cluster.getClusterName();
+    final var messaging = messagingConfig(cluster);
+    final var discovery = discoveryConfig(cluster.getInitialContactPoints());
+    final var membership = membershipConfig(cluster.getMembership());
+    final var member = memberConfig(cluster);
+
+    return new ClusterConfig()
+        .setClusterId(name)
+        .setNodeConfig(member)
+        .setDiscoveryConfig(discovery)
+        .setMessagingConfig(messaging)
+        .setProtocolConfig(membership);
+  }
+
+  private MemberConfig memberConfig(final ClusterProperties cluster) {
+    final var advertisedAddress =
+        Address.from(cluster.getAdvertisedHost(), cluster.getAdvertisedPort());
+
+    return new MemberConfig().setId(cluster.getMemberId()).setAddress(advertisedAddress);
+  }
+
+  private SwimMembershipProtocolConfig membershipConfig(final MembershipConfig config) {
+    return new SwimMembershipProtocolConfig()
+        .setBroadcastDisputes(config.isBroadcastDisputes())
+        .setBroadcastUpdates(config.isBroadcastUpdates())
+        .setFailureTimeout(config.getFailureTimeout())
+        .setGossipFanout(config.getGossipFanout())
+        .setGossipInterval(config.getGossipInterval())
+        .setNotifySuspect(config.isNotifySuspect())
+        .setProbeInterval(config.getProbeInterval())
+        .setProbeTimeout(config.getProbeTimeout())
+        .setSuspectProbes(config.getSuspectProbes())
+        .setSyncInterval(config.getSyncInterval());
+  }
+
+  private BootstrapDiscoveryConfig discoveryConfig(final Collection<String> contactPoints) {
+    final var nodes =
+        contactPoints.stream()
+            .map(Address::from)
+            .map(address -> new NodeConfig().setAddress(address))
+            .collect(Collectors.toSet());
+    return new BootstrapDiscoveryConfig().setNodes(nodes);
+  }
+
+  private MessagingConfig messagingConfig(final ClusterProperties cluster) {
+    final var messaging =
+        new MessagingConfig()
+            .setCompressionAlgorithm(cluster.getMessageCompression())
+            .setInterfaces(Collections.singletonList(cluster.getHost()))
+            .setPort(cluster.getPort());
+
+    final var security = cluster.getSecurity();
+    if (security.isEnabled()) {
+      messaging
+          .setTlsEnabled(true)
+          .configureTls(
+              security.getKeyStore().getFilePath(),
+              security.getKeyStore().getPassword(),
+              security.getPrivateKeyPath(),
+              security.getCertificateChainPath());
+    }
+    return messaging;
+  }
+
+  @Bean
+  public SchedulerConfiguration schedulerConfiguration() {
+    final var cpuThreads = 1;
+    // We set ioThreads to zero as the migration app isn't using any io threads
+    final var ioThreads = 0;
+    final var metricsEnabled = false;
+    final var nodeId = properties.getCluster().getMemberId();
+    return new SchedulerConfiguration(cpuThreads, ioThreads, metricsEnabled, "Migration", nodeId);
   }
 }

--- a/migration/identity-migration/pom.xml
+++ b/migration/identity-migration/pom.xml
@@ -86,6 +86,22 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-cluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
     </dependency>
     <dependency>

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ConfigManagerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ConfigManagerConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config;
+
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import java.util.Optional;
+
+public record ConfigManagerConfig(ClusterConfigurationGossiperConfig gossip) {
+
+  public ConfigManagerConfig(final ClusterConfigurationGossiperConfig gossip) {
+    this.gossip = Optional.ofNullable(gossip).orElse(ClusterConfigurationGossiperConfig.DEFAULT);
+  }
+
+  public static ConfigManagerConfig defaultConfig() {
+    return new ConfigManagerConfig(null);
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/IdentityMigrationProperties.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.migration.identity.config;
 
+import io.camunda.migration.identity.config.cluster.ClusterProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(
     prefix = IdentityMigrationProperties.CONFIG_PREFIX_CAMUNDA_MIGRATION_IDENTITY)
-public final class IdentityMigrationProperties {
+public class IdentityMigrationProperties {
   public static final String CONFIG_PREFIX_CAMUNDA_MIGRATION_IDENTITY =
       "camunda.migration.identity";
   public static final String PROP_CAMUNDA_MIGRATION_IDENTITY_MODE =
@@ -20,6 +21,7 @@ public final class IdentityMigrationProperties {
   private String organizationId;
   private Mode mode = Mode.CLOUD;
   private ConsoleProperties console = new ConsoleProperties();
+  private ClusterProperties cluster = new ClusterProperties();
 
   public ManagementIdentityProperties getManagementIdentity() {
     return managementIdentity;
@@ -51,6 +53,14 @@ public final class IdentityMigrationProperties {
 
   public void setConsole(final ConsoleProperties console) {
     this.console = console;
+  }
+
+  public ClusterProperties getCluster() {
+    return cluster;
+  }
+
+  public void setCluster(final ClusterProperties cluster) {
+    this.cluster = cluster;
   }
 
   public enum Mode {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/ClusterProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/ClusterProperties.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.cluster;
+
+import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
+
+import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
+import io.atomix.utils.net.Address;
+import io.camunda.migration.identity.config.ConfigManagerConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ClusterProperties {
+
+  public static final String DEFAULT_CONTACT_POINT_HOST = "127.0.0.1";
+  public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
+  public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);
+
+  public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  public static final String DEFAULT_CLUSTER_MEMBER_ID = "migration";
+  public static final String DEFAULT_CLUSTER_HOST = "0.0.0.0";
+  public static final int DEFAULT_CLUSTER_PORT = 26502;
+
+  private static final String DEFAULT_ADVERTISED_HOST =
+      Address.defaultAdvertisedHost().getHostAddress();
+  private List<String> initialContactPoints =
+      Collections.singletonList(DEFAULT_CONTACT_POINT_HOST + ":" + DEFAULT_CONTACT_POINT_PORT);
+  private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+  private String clusterName = DEFAULT_CLUSTER_NAME;
+  private String memberId = DEFAULT_CLUSTER_MEMBER_ID;
+  // leave host and advertised host to null, so we can distinguish if they are set explicitly or not
+  private String host = null;
+  private String advertisedHost = null;
+  private int port = DEFAULT_CLUSTER_PORT;
+  private Integer advertisedPort = null;
+  private MembershipConfig membership = new MembershipConfig();
+  private SecurityConfig security = new SecurityConfig();
+  private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
+  private ConfigManagerConfig configManager = ConfigManagerConfig.defaultConfig();
+
+  public String getMemberId() {
+    return memberId;
+  }
+
+  public ClusterProperties setMemberId(final String memberId) {
+    this.memberId = memberId;
+    return this;
+  }
+
+  public String getHost() {
+    return host != null ? host : DEFAULT_CLUSTER_HOST;
+  }
+
+  public ClusterProperties setHost(final String host) {
+    this.host = host;
+    return this;
+  }
+
+  public String getAdvertisedHost() {
+    if (advertisedHost != null) {
+      return advertisedHost;
+    }
+
+    if (host != null) {
+      return host;
+    }
+
+    return DEFAULT_ADVERTISED_HOST;
+  }
+
+  public ClusterProperties setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+    return this;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public ClusterProperties setPort(final int port) {
+    this.port = port;
+    return this;
+  }
+
+  public int getAdvertisedPort() {
+    return Optional.ofNullable(advertisedPort).orElseGet(this::getPort);
+  }
+
+  public ClusterProperties setAdvertisedPort(final int advertisedPort) {
+    this.advertisedPort = advertisedPort;
+    return this;
+  }
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public ClusterProperties setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public ClusterProperties setClusterName(final String name) {
+    clusterName = name;
+    return this;
+  }
+
+  public MembershipConfig getMembership() {
+    return membership;
+  }
+
+  public void setMembership(final MembershipConfig membership) {
+    this.membership = membership;
+  }
+
+  public SecurityConfig getSecurity() {
+    return security;
+  }
+
+  public ClusterProperties setSecurity(final SecurityConfig security) {
+    this.security = security;
+    return this;
+  }
+
+  public CompressionAlgorithm getMessageCompression() {
+    return messageCompression;
+  }
+
+  public void setMessageCompression(final CompressionAlgorithm compressionAlgorithm) {
+    messageCompression = compressionAlgorithm;
+  }
+
+  public List<String> getInitialContactPoints() {
+    return initialContactPoints;
+  }
+
+  public ClusterProperties setInitialContactPoints(final List<String> initialContactPoints) {
+    this.initialContactPoints = LIST_SANITIZER.apply(initialContactPoints);
+    return this;
+  }
+
+  public ConfigManagerConfig getConfigManager() {
+    return configManager;
+  }
+
+  public ClusterProperties setConfigManager(final ConfigManagerConfig configManagerCfg) {
+    configManager = configManagerCfg;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        initialContactPoints,
+        requestTimeout,
+        clusterName,
+        memberId,
+        host,
+        port,
+        membership,
+        security,
+        messageCompression,
+        configManager);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ClusterProperties that = (ClusterProperties) o;
+    return port == that.port
+        && Objects.equals(initialContactPoints, that.initialContactPoints)
+        && Objects.equals(requestTimeout, that.requestTimeout)
+        && Objects.equals(clusterName, that.clusterName)
+        && Objects.equals(memberId, that.memberId)
+        && Objects.equals(host, that.host)
+        && Objects.equals(membership, that.membership)
+        && Objects.equals(security, that.security)
+        && Objects.equals(messageCompression, that.messageCompression)
+        && Objects.equals(configManager, that.configManager);
+  }
+
+  @Override
+  public String toString() {
+    return "ClusterProperties{"
+        + "initialContactPoints="
+        + initialContactPoints
+        + ", requestTimeout="
+        + requestTimeout
+        + ", clusterName='"
+        + clusterName
+        + '\''
+        + ", memberId='"
+        + memberId
+        + '\''
+        + ", host='"
+        + host
+        + '\''
+        + ", port="
+        + port
+        + ", membership="
+        + membership
+        + ", security="
+        + security
+        + ", messageCompression="
+        + messageCompression
+        + ", configManagerCfg="
+        + configManager
+        + '}';
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/KeyStoreConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/KeyStoreConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.cluster;
+
+import java.io.File;
+import java.util.Objects;
+
+public class KeyStoreConfig {
+  private File filePath;
+  private String password;
+
+  public File getFilePath() {
+    return filePath;
+  }
+
+  public KeyStoreConfig setFilePath(final File filePath) {
+    this.filePath = filePath;
+    return this;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public KeyStoreConfig setPassword(final String password) {
+    this.password = password;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filePath, password);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KeyStoreConfig that = (KeyStoreConfig) o;
+    return Objects.equals(filePath, that.filePath) && Objects.equals(password, that.password);
+  }
+
+  @Override
+  public String toString() {
+    final var passStr = password == null ? "" : "*****";
+    return "KeyStoreCfg{" + "filePath=" + filePath + ", password='" + passStr + '\'' + '}';
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/MembershipConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/MembershipConfig.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.cluster;
+
+import java.time.Duration;
+
+public final class MembershipConfig {
+  // the following values are from atomix per default
+  private static final boolean DEFAULT_BROADCAST_UPDATES = false;
+  private static final boolean DEFAULT_BROADCAST_DISPUTES = true;
+  private static final boolean DEFAULT_NOTIFY_SUSPECT = false;
+  private static final Duration DEFAULT_GOSSIP_INTERVAL = Duration.ofMillis(250);
+  private static final int DEFAULT_GOSSIP_FANOUT = 2;
+  private static final Duration DEFAULT_PROBE_INTERVAL = Duration.ofMillis(1000);
+  private static final Duration DEFAULT_PROBE_TIMEOUT = Duration.ofMillis(100);
+  private static final int DEFAULT_SUSPECT_PROBES = 3;
+  private static final Duration DEFAULT_FAILURE_TIMEOUT = Duration.ofMillis(10_000);
+  private static final Duration DEFAULT_SYNC_INTERVAL = Duration.ofMillis(10_000);
+
+  private boolean broadcastUpdates = DEFAULT_BROADCAST_UPDATES;
+  private boolean broadcastDisputes = DEFAULT_BROADCAST_DISPUTES;
+  private boolean notifySuspect = DEFAULT_NOTIFY_SUSPECT;
+  private Duration gossipInterval = DEFAULT_GOSSIP_INTERVAL;
+  private int gossipFanout = DEFAULT_GOSSIP_FANOUT;
+  private Duration probeInterval = DEFAULT_PROBE_INTERVAL;
+  private Duration probeTimeout = DEFAULT_PROBE_TIMEOUT;
+  private int suspectProbes = DEFAULT_SUSPECT_PROBES;
+  private Duration failureTimeout = DEFAULT_FAILURE_TIMEOUT;
+  private Duration syncInterval = DEFAULT_SYNC_INTERVAL;
+
+  public boolean isBroadcastUpdates() {
+    return broadcastUpdates;
+  }
+
+  public MembershipConfig setBroadcastUpdates(final boolean broadcastUpdates) {
+    this.broadcastUpdates = broadcastUpdates;
+    return this;
+  }
+
+  public boolean isBroadcastDisputes() {
+    return broadcastDisputes;
+  }
+
+  public MembershipConfig setBroadcastDisputes(final boolean broadcastDisputes) {
+    this.broadcastDisputes = broadcastDisputes;
+    return this;
+  }
+
+  public boolean isNotifySuspect() {
+    return notifySuspect;
+  }
+
+  public MembershipConfig setNotifySuspect(final boolean notifySuspect) {
+    this.notifySuspect = notifySuspect;
+    return this;
+  }
+
+  public Duration getGossipInterval() {
+    return gossipInterval;
+  }
+
+  public MembershipConfig setGossipInterval(final Duration gossipInterval) {
+    this.gossipInterval = gossipInterval;
+    return this;
+  }
+
+  public int getGossipFanout() {
+    return gossipFanout;
+  }
+
+  public MembershipConfig setGossipFanout(final int gossipFanout) {
+    this.gossipFanout = gossipFanout;
+    return this;
+  }
+
+  public Duration getProbeInterval() {
+    return probeInterval;
+  }
+
+  public MembershipConfig setProbeInterval(final Duration probeInterval) {
+    this.probeInterval = probeInterval;
+    return this;
+  }
+
+  public Duration getProbeTimeout() {
+    return probeTimeout;
+  }
+
+  public MembershipConfig setProbeTimeout(final Duration probeTimeout) {
+    this.probeTimeout = probeTimeout;
+    return this;
+  }
+
+  public int getSuspectProbes() {
+    return suspectProbes;
+  }
+
+  public MembershipConfig setSuspectProbes(final int suspectProbes) {
+    this.suspectProbes = suspectProbes;
+    return this;
+  }
+
+  public Duration getFailureTimeout() {
+    return failureTimeout;
+  }
+
+  public MembershipConfig setFailureTimeout(final Duration failureTimeout) {
+    this.failureTimeout = failureTimeout;
+    return this;
+  }
+
+  public Duration getSyncInterval() {
+    return syncInterval;
+  }
+
+  public MembershipConfig setSyncInterval(final Duration syncInterval) {
+    this.syncInterval = syncInterval;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (broadcastUpdates ? 1 : 0);
+    result = 31 * result + (broadcastDisputes ? 1 : 0);
+    result = 31 * result + (notifySuspect ? 1 : 0);
+    result = 31 * result + (gossipInterval != null ? gossipInterval.hashCode() : 0);
+    result = 31 * result + gossipFanout;
+    result = 31 * result + (probeInterval != null ? probeInterval.hashCode() : 0);
+    result = 31 * result + (probeTimeout != null ? probeTimeout.hashCode() : 0);
+    result = 31 * result + suspectProbes;
+    result = 31 * result + (failureTimeout != null ? failureTimeout.hashCode() : 0);
+    result = 31 * result + (syncInterval != null ? syncInterval.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final MembershipConfig that = (MembershipConfig) o;
+
+    if (broadcastUpdates != that.broadcastUpdates) {
+      return false;
+    }
+    if (broadcastDisputes != that.broadcastDisputes) {
+      return false;
+    }
+    if (notifySuspect != that.notifySuspect) {
+      return false;
+    }
+    if (gossipFanout != that.gossipFanout) {
+      return false;
+    }
+    if (suspectProbes != that.suspectProbes) {
+      return false;
+    }
+    if (gossipInterval != null
+        ? !gossipInterval.equals(that.gossipInterval)
+        : that.gossipInterval != null) {
+      return false;
+    }
+    if (probeInterval != null
+        ? !probeInterval.equals(that.probeInterval)
+        : that.probeInterval != null) {
+      return false;
+    }
+    if (probeTimeout != null
+        ? !probeTimeout.equals(that.probeTimeout)
+        : that.probeTimeout != null) {
+      return false;
+    }
+    if (failureTimeout != null
+        ? !failureTimeout.equals(that.failureTimeout)
+        : that.failureTimeout != null) {
+      return false;
+    }
+    return syncInterval != null
+        ? syncInterval.equals(that.syncInterval)
+        : that.syncInterval == null;
+  }
+
+  @Override
+  public String toString() {
+    return "MembershipCfg{"
+        + "broadcastUpdates="
+        + broadcastUpdates
+        + ", broadcastDisputes="
+        + broadcastDisputes
+        + ", notifySuspect="
+        + notifySuspect
+        + ", gossipInterval="
+        + gossipInterval
+        + ", gossipFanout="
+        + gossipFanout
+        + ", probeInterval="
+        + probeInterval
+        + ", probeTimeout="
+        + probeTimeout
+        + ", suspectProbes="
+        + suspectProbes
+        + ", failureTimeout="
+        + failureTimeout
+        + ", syncInterval="
+        + syncInterval
+        + '}';
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/SecurityConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/SecurityConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.cluster;
+
+import java.io.File;
+import java.util.Objects;
+
+public final class SecurityConfig {
+  public static final boolean DEFAULT_TLS_ENABLED = false;
+
+  private boolean enabled = DEFAULT_TLS_ENABLED;
+  private File certificateChainPath;
+  private File privateKeyPath;
+  private KeyStoreConfig keyStore = new KeyStoreConfig();
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public SecurityConfig setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  public File getCertificateChainPath() {
+    return certificateChainPath;
+  }
+
+  public SecurityConfig setCertificateChainPath(final File certificateChainPath) {
+    this.certificateChainPath = certificateChainPath;
+    return this;
+  }
+
+  public File getPrivateKeyPath() {
+    return privateKeyPath;
+  }
+
+  public SecurityConfig setPrivateKeyPath(final File privateKeyPath) {
+    this.privateKeyPath = privateKeyPath;
+    return this;
+  }
+
+  public KeyStoreConfig getKeyStore() {
+    return keyStore;
+  }
+
+  public void setKeyStore(final KeyStoreConfig keyStore) {
+    this.keyStore = keyStore;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled, certificateChainPath, privateKeyPath, keyStore);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SecurityConfig that = (SecurityConfig) o;
+    return enabled == that.enabled
+        && Objects.equals(certificateChainPath, that.certificateChainPath)
+        && Objects.equals(privateKeyPath, that.privateKeyPath)
+        && Objects.equals(keyStore, that.keyStore);
+  }
+
+  @Override
+  public String toString() {
+    return "SecurityConfig{"
+        + "enabled="
+        + enabled
+        + ", certificateChainPath="
+        + certificateChainPath
+        + ", privateKeyPath="
+        + privateKeyPath
+        + ", keyStore="
+        + keyStore
+        + '}';
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
-import io.camunda.application.commons.configuration.GatewayBasedConfiguration.GatewayBasedProperties;
 import io.camunda.application.commons.migration.MigrationsRunner;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -24,21 +23,18 @@ public final class TestStandaloneIdentityMigration
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TestStandaloneIdentityMigration.class);
 
-  private final GatewayBasedProperties config;
+  private final IdentityMigrationProperties config;
 
   public TestStandaloneIdentityMigration(final IdentityMigrationProperties migrationProperties) {
     super(MigrationsRunner.class);
-    config = new GatewayBasedProperties();
+    config = migrationProperties;
 
-    config.getNetwork().setHost("0.0.0.0");
-    config.getCluster().setMemberId("migration");
-    config.getCluster().setPort(SocketUtil.getNextAddress().getPort());
+    migrationProperties.getCluster().setPort(SocketUtil.getNextAddress().getPort());
 
     LOGGER.info("-> Cluster Port: {}", mappedPort(TestZeebePort.CLUSTER));
 
     //noinspection resource
-    withBean("config", config, GatewayBasedProperties.class)
-        .withBean("migrationConfig", migrationProperties, IdentityMigrationProperties.class)
+    withBean("migrationConfig", migrationProperties, IdentityMigrationProperties.class)
         .withAdditionalProfile(Profile.IDENTITY_MIGRATION);
   }
 
@@ -54,7 +50,7 @@ public final class TestStandaloneIdentityMigration
 
   @Override
   public String host() {
-    return config.getNetwork().getHost();
+    return config.getCluster().getHost();
   }
 
   @Override
@@ -68,7 +64,7 @@ public final class TestStandaloneIdentityMigration
   }
 
   public TestStandaloneIdentityMigration withAppConfig(
-      final Consumer<GatewayBasedProperties> modifier) {
+      final Consumer<IdentityMigrationProperties> modifier) {
     modifier.accept(config);
     return this;
   }


### PR DESCRIPTION
## Description

This adds dedicated cluster config classes for the identity migration app. This introduces a dedicated `camunda.migration.identity.cluster.*` section, offering the same properties as available for a gateway cluster setup but within the migration app namespace.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33553
