### PR TITLE
refactor: migrate processInstanceVariables.spec to core application test suite

### DIFF
--- a/qa/core-application-e2e-test-suite/fixtures.ts
+++ b/qa/core-application-e2e-test-suite/fixtures.ts
@@ -18,6 +18,7 @@ import {TaskDetailsPage} from '@pages/TaskDetailsPage';
 import {TasklistHeader} from '@pages/TasklistHeader';
 import {TasklistProcessesPage} from '@pages/TasklistProcessesPage';
 import {PublicFormsPage} from '@pages/PublicFormsPage';
+import {OperateFiltersPanel} from '@pages/operateFiltersPanel';
 import {sleep} from 'utils/sleep';
 
 type PlaywrightFixtures = {
@@ -25,6 +26,7 @@ type PlaywrightFixtures = {
   resetData: () => Promise<void>;
   operateLoginPage: OperateLoginPage;
   operateHomePage: OperateHomePage;
+  operateFiltersPanel: OperateFiltersPanel;
   taskListLoginPage: TaskListLoginPage;
   taskPanelPage: TaskPanelPage;
   operateProcessesPage: OperateProcessesPage;
@@ -65,6 +67,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateProcessInstancePage: async ({page}, use) => {
     await use(new OperateProcessInstancePage(page));
+  },
+  operateFiltersPanel: async ({page}, use) => {
+    await use(new OperateFiltersPanel(page));
   },
   taskDetailsPage: async ({page}, use) => {
     await use(new TaskDetailsPage(page));

--- a/qa/core-application-e2e-test-suite/pages/OperateFiltersPanel.ts
+++ b/qa/core-application-e2e-test-suite/pages/OperateFiltersPanel.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+
+type OptionalFilter =
+  | 'Variable'
+  | 'Process Instance Key(s)'
+  | 'Parent Process Instance Key'
+  | 'Operation Id'
+  | 'Error Message'
+  | 'Start Date Range'
+  | 'End Date Range'
+  | 'Failed job but retries left';
+
+export class OperateFiltersPanel {
+  private page: Page;
+  readonly activeCheckbox: Locator;
+  readonly incidentsCheckbox: Locator;
+  readonly runningInstancesCheckbox: Locator;
+  readonly completedCheckbox: Locator;
+  readonly canceledCheckbox: Locator;
+  readonly finishedInstancesCheckbox: Locator;
+  readonly processNameFilter: Locator;
+  readonly processVersionFilter: Locator;
+  readonly processInstanceKeysFilter: Locator;
+  readonly processInstanceKeysFilterOption: Locator;
+  readonly parentProcessInstanceKey: Locator;
+  readonly flowNodeFilter: Locator;
+  readonly operationIdFilter: Locator;
+  readonly resetFiltersButton: Locator;
+  readonly errorMessageFilter: Locator;
+  readonly startDateFilter: Locator;
+  readonly variableNameFilter: Locator;
+  readonly variableValueFilter: Locator;
+  readonly multipleVariablesSwitch: Locator;
+  readonly moreFiltersButton: Locator;
+  readonly dateFilterDialog: Locator;
+  readonly fromTimeInput: Locator;
+  readonly toTimeInput: Locator;
+  readonly fromDateInput: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.activeCheckbox = this.page.getByRole('checkbox', {name: 'Active'});
+    this.incidentsCheckbox = this.page.getByRole('checkbox', {
+      name: 'Incidents',
+    });
+    this.runningInstancesCheckbox = this.page.getByRole('checkbox', {
+      name: 'Running Instances',
+    });
+    this.completedCheckbox = this.page.getByRole('checkbox', {
+      name: 'Completed',
+    });
+    this.canceledCheckbox = this.page.getByRole('checkbox', {
+      name: 'Canceled',
+    });
+    this.finishedInstancesCheckbox = this.page.getByRole('checkbox', {
+      name: 'Finished Instances',
+    });
+    this.processNameFilter = this.page.getByRole('combobox', {
+      name: 'Name',
+    });
+    this.processVersionFilter = this.page.getByRole('combobox', {
+      name: 'Version',
+    });
+    this.processInstanceKeysFilterOption = this.page.getByRole('menuitem', {
+      name: 'Process Instance Key(s)',
+    });
+    this.processInstanceKeysFilter = page.getByRole('textbox', {
+      name: 'process instance key',
+    });
+    this.parentProcessInstanceKey = page.getByRole('textbox', {
+      name: 'parent process instance key',
+    });
+    this.flowNodeFilter = this.page.getByRole('combobox', {
+      name: 'flow node',
+    });
+    this.operationIdFilter = this.page.getByRole('textbox', {
+      name: 'operation id',
+    });
+    this.resetFiltersButton = this.page.getByRole('button', {
+      name: 'reset filters',
+    });
+    this.errorMessageFilter = this.page.getByRole('textbox', {
+      name: 'error message',
+    });
+    this.startDateFilter = this.page.getByRole('textbox', {
+      name: 'start date range',
+    });
+    this.variableNameFilter = this.page.getByRole('textbox', {
+      name: 'name',
+    });
+    this.variableValueFilter = this.page.getByRole('textbox', {
+      name: 'value',
+    });
+    this.multipleVariablesSwitch = this.page.getByText('multiple');
+    this.moreFiltersButton = this.page.getByRole('button', {
+      name: 'More Filters',
+    });
+    this.dateFilterDialog = this.page.getByRole('dialog');
+    this.fromTimeInput = page.getByTestId('fromTime');
+    this.toTimeInput = page.getByTestId('toTime');
+    this.fromDateInput = this.page.getByText('From date');
+  }
+
+  async validateCheckedState(
+    checked: Array<Locator>,
+    unChecked: Array<Locator>,
+  ) {
+    for (const filter of checked) {
+      await expect(filter).toBeChecked();
+    }
+
+    for (const filter of unChecked) {
+      await expect(filter).not.toBeChecked();
+    }
+  }
+
+  async displayOptionalFilter(filterName: OptionalFilter) {
+    await this.moreFiltersButton.click();
+    await this.page
+      .getByRole('menuitem', {
+        name: filterName,
+      })
+      .click();
+  }
+
+  async removeOptionalFilter(filterName: OptionalFilter) {
+    await this.page.getByLabel(filterName, {exact: true}).hover();
+    await this.page.getByLabel(`Remove ${filterName} Filter`).click();
+  }
+
+  async selectProcess(option: string) {
+    await this.processNameFilter.click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
+  }
+
+  async selectVersion(option: string) {
+    await this.processVersionFilter.click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
+  }
+
+  async selectFlowNode(option: string) {
+    await this.flowNodeFilter.click();
+    await this.page.getByRole('option', {name: option}).click();
+  }
+
+  async fillVariableNameFilter(name: string) {
+    await this.variableNameFilter.fill(name);
+  }
+
+  async fillVariableValueFilter(value: string) {
+    await this.variableValueFilter.fill(value);
+  }
+
+  async fillProcessInstanceKeyFilter(processInstanceKey: string) {
+    await this.processInstanceKeysFilter.fill(processInstanceKey);
+  }
+
+  async fillFromTimeInput(fromTime: string) {
+    await this.fromTimeInput.clear();
+    await this.fromTimeInput.fill(fromTime);
+  }
+
+  async fillToTimeInput(toTime: string) {
+    await this.toTimeInput.clear();
+    await this.toTimeInput.fill(toTime);
+  }
+
+  async pickDateTimeRange(
+    fromDay: string,
+    toDay: string,
+    fromTime?: string,
+    toTime?: string,
+  ) {
+    await expect(this.dateFilterDialog).toBeVisible();
+
+    const date = new Date();
+    const monthName = date.toLocaleString('default', {month: 'long'});
+    const year = date.getFullYear();
+
+    await this.fromDateInput.click();
+    await this.page.getByLabel(`${monthName} ${fromDay}, ${year}`).click();
+    await this.page.getByLabel(`${monthName} ${toDay}, ${year}`).click();
+
+    if (fromTime !== undefined) {
+      await this.fillFromTimeInput(fromTime);
+    }
+
+    if (toTime !== undefined) {
+      await this.fillToTimeInput(toTime);
+    }
+  }
+}

--- a/qa/core-application-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/core-application-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -18,6 +18,26 @@ class OperateProcessInstancePage {
   readonly variablesList: Locator;
   readonly messageVariable: Locator;
   readonly statusVariable: Locator;
+  readonly instanceHeader: Locator;
+  readonly instanceHistory: Locator;
+  readonly incidentsTable: Locator;
+  readonly incidentsBanner: Locator;
+  readonly variablePanelEmptyText: Locator;
+  readonly addVariableButton: Locator;
+  readonly saveVariableButton: Locator;
+  readonly newVariableNameField: Locator;
+  readonly newVariableValueField: Locator;
+  readonly editVariableValueField: Locator;
+  readonly variableSpinner: Locator;
+  readonly operationSpinner: Locator;
+  readonly executionCountToggleOn: Locator;
+  readonly executionCountToggleOff: Locator;
+  readonly listenersTabButton: Locator;
+  readonly metadataModal: Locator;
+  readonly modifyInstanceButton: Locator;
+  readonly listenerTypeFilter: Locator;
+  readonly editVariableButton: Locator;
+  readonly variableValueInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -32,6 +52,32 @@ class OperateProcessInstancePage {
     this.variablesList = page.getByTestId('variables-list');
     this.messageVariable = page.getByTestId('variable-message');
     this.statusVariable = page.getByTestId('variable-status');
+    this.editVariableButton = page.getByTestId('edit-variable-button');
+    this.variableValueInput = page.getByTestId('edit-variable-value');
+    this.instanceHeader = page.getByTestId('instance-header');
+    this.instanceHistory = page.getByTestId('instance-history');
+    this.incidentsTable = page.getByTestId('data-list');
+    this.incidentsBanner = page.getByTestId('incidents-banner');
+    this.variablePanelEmptyText = page.getByText(
+      'to view the variables, select a single flow node instance in the instance history',
+    );
+    this.addVariableButton = page.getByRole('button', {name: 'Add variable'});
+    this.saveVariableButton = page.getByRole('button', {name: 'Save variable'});
+    this.newVariableNameField = page.getByRole('textbox', {name: 'Name'});
+    this.newVariableValueField = page.getByRole('textbox', {name: 'Value'});
+    this.editVariableValueField = page.getByRole('textbox', {name: 'Value'});
+    this.variableSpinner = page.getByTestId('variable-operation-spinner');
+    this.operationSpinner = page.getByTestId('operation-spinner');
+    this.executionCountToggleOn = this.instanceHistory.getByLabel(
+      'show execution count',
+    );
+    this.executionCountToggleOff = this.instanceHistory.getByLabel(
+      'hide execution count',
+    );
+    this.listenersTabButton = page.getByTestId('listeners-tab-button');
+    this.metadataModal = this.page.getByRole('dialog', {name: 'metadata'});
+    this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
+    this.listenerTypeFilter = page.getByTestId('listener-type-filter');
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -52,14 +98,14 @@ class OperateProcessInstancePage {
         });
         return; // Exit the function if the expectation is met
       } catch {
-        // If the active icon isn't found, reload the page and try again
+        // If the completed icon isn't found, reload the page and try again
         retryCount++;
         console.log(`Attempt ${retryCount} failed. Retrying...`);
         await this.page.reload();
         await sleep(10000);
       }
     }
-    throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
+    throw new Error(`Completed icon not visible after ${maxRetries} attempts.`);
   }
 
   async activeIconAssertion(): Promise<void> {
@@ -80,6 +126,84 @@ class OperateProcessInstancePage {
       }
     }
     throw new Error(`Active icon not visible after ${maxRetries} attempts.`);
+  }
+  getEditVariableFieldSelector(variableName: string) {
+    return this.page
+      .getByTestId(`variable-${variableName}`)
+      .getByRole('textbox', {
+        name: 'value',
+      });
+  }
+
+  getNewVariableNameFieldSelector = (variableName: string) => {
+    return this.page
+      .getByTestId(`variable-${variableName}`)
+      .getByTestId('new-variable-name');
+  };
+
+  getNewVariableValueFieldSelector = (variableName: string) => {
+    return this.page
+      .getByTestId(`variable-${variableName}`)
+      .getByTestId('new-variable-value');
+  };
+
+  getListenerTypeFilterOption = (
+    option: 'Execution listeners' | 'User task listeners' | 'All listeners',
+  ) => {
+    return this.listenerTypeFilter.getByText(option, {exact: true});
+  };
+
+  async undoModification() {
+    await this.page
+      .getByRole('button', {
+        name: 'undo',
+      })
+      .click();
+  }
+
+  async navigateToProcessInstance(id: string) {
+    await this.page.goto(`operate/processes/${id}`);
+  }
+
+  async getNthTreeNodeTestId(n: number) {
+    return this.page
+      .getByTestId(/^tree-node-/)
+      .nth(n)
+      .getAttribute('data-testid');
+  }
+  async clickEditVariableButton(variableName: string): Promise<void> {
+    const editVariableButton = 'Edit variable ' + variableName;
+    await this.page.getByLabel(editVariableButton).click();
+  }
+
+  async clickVariableValueInput(): Promise<void> {
+    await this.variableValueInput.click();
+  }
+
+  async clearVariableValueInput(): Promise<void> {
+    await this.variableValueInput.clear();
+  }
+
+  async fillVariableValueInput(value: string): Promise<void> {
+    await this.variableValueInput.fill(value);
+  }
+
+  async clickSaveVariableButton(): Promise<void> {
+    await this.saveVariableButton.click();
+  }
+
+  async clickAddVariableButton(): Promise<void> {
+    await this.addVariableButton.click();
+  }
+
+  async fillNewVariable(name: string, value: string): Promise<void> {
+    await this.newVariableNameField.fill(name);
+    await this.newVariableValueField.fill(value);
+  }
+
+  async getProcessInstanceKey(): Promise<string> {
+    const processInstanceKey = this.page.locator('table tbody tr td').nth(1);
+    return (await processInstanceKey.textContent()) ?? '';
   }
 }
 

--- a/qa/core-application-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/core-application-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 
 class OperateProcessesPage {
   private page: Page;
@@ -96,6 +96,14 @@ class OperateProcessesPage {
     throw new Error(
       `Failed to click on process instance link after ${maxRetries} attempts.`,
     );
+  }
+
+  async assertProcessInstanceLink(processInstanceKey: string): Promise<void> {
+    await expect(
+      this.page.getByRole('link', {
+        name: `View instance ${processInstanceKey}`,
+      }),
+    ).toBeVisible();
   }
 }
 

--- a/qa/core-application-e2e-test-suite/resources/onlyIncidentsProcess_scrolling.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/onlyIncidentsProcess_scrolling.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcessScrolling" name="Only Incidents Process Scrolling" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
+++ b/qa/core-application-e2e-test-suite/resources/onlyIncidentsProcess_v_1.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="onlyIncidentsProcess" name="Only Incidents Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="alwaysFails" />
+    <bpmn:serviceTask id="alwaysFails" name="Always fails">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="alwaysFails" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="alwaysFails" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="onlyIncidentsProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="alwaysFails">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/core-application-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
+++ b/qa/core-application-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {
+  deploy,
+  createInstances,
+  generateManyVariables,
+} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/onlyIncidentsProcess_v_1.bpmn',
+    './resources/onlyIncidentsProcess_scrolling.bpmn',
+  ]);
+  const manyVariables = generateManyVariables();
+  await createInstances('onlyIncidentsProcessScrolling', 1, 1, manyVariables);
+  await createInstances('onlyIncidentsProcess', 1, 1);
+});
+
+test.describe('Process Instance Variables', () => {
+  test.beforeEach(async ({page, operateLoginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await operateLoginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Edit variables', async ({
+    page,
+    operateProcessInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await operateHomePage.clickProcessesTab();
+    await operateProcessesPage.filterByProcessName(
+      'Only Incidents Process Scrolling',
+    );
+    await operateProcessesPage.clickProcessInstanceLink();
+    await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
+
+    // open process instance page, after clicking the edit variable button see that save variable button is disabled.
+    await operateProcessInstancePage.clickEditVariableButton('aa');
+    await operateProcessInstancePage.clickVariableValueInput();
+    await operateProcessInstancePage.clearVariableValueInput();
+    await operateProcessInstancePage.fillVariableValueInput(
+      '"editedTestValue"',
+    );
+
+    // click save variable button and see that both edit variable spinner and operation spinner are displayed.
+    await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled({
+      timeout: 30000,
+    });
+    await operateProcessInstancePage.saveVariableButton.click();
+    await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+    await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
+
+    // see that spinners both disappear after save variable operation completes.
+    await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+      timeout: 60000,
+    });
+    await expect(operateProcessInstancePage.operationSpinner).toBeHidden({
+      timeout: 60000,
+    });
+
+    // refresh the page and see the variable is still there.
+    await page.reload();
+    // await expect(page.getByText('editedtestvalue')).toBeVisible();
+    await expect(page.getByText(/"\\"editedtestvalue\\""/i)).toBeVisible();
+  });
+
+  test('Add variables', async ({
+    page,
+    operateProcessInstancePage,
+    operateHomePage,
+    operateFiltersPanel,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await operateHomePage.clickProcessesTab();
+    await operateProcessesPage.filterByProcessName('Only Incidents Process');
+    await operateProcessesPage.clickProcessInstanceLink();
+    await expect(operateProcessInstancePage.addVariableButton).toBeEnabled();
+
+    // add a new variable
+    await operateProcessInstancePage.clickAddVariableButton();
+    await operateProcessInstancePage.fillNewVariable(
+      'secondTestKey',
+      '"secondTestValue"',
+    );
+
+    await expect(operateProcessInstancePage.saveVariableButton).toBeEnabled();
+
+    // click save variable button and see that both variable spinner and operation spinner are displayed.
+    await operateProcessInstancePage.clickSaveVariableButton();
+    await expect(operateProcessInstancePage.variableSpinner).toBeVisible();
+    await expect(operateProcessInstancePage.operationSpinner).toBeVisible();
+
+    // see that spinners both disappear after save variable operation completes
+    await expect(operateProcessInstancePage.variableSpinner).toBeHidden({
+      timeout: 60000,
+    });
+    await expect(operateProcessInstancePage.operationSpinner).toBeHidden({
+      timeout: 60000,
+    });
+
+    // refresh the page and see the variable is still there.
+    await page.reload();
+    await expect(page.getByText('secondTestKey', {exact: true})).toBeVisible();
+    // await expect(page.getByText('"secondTestValue"')).toBeVisible();
+    await expect(page.getByText(/"\\"secondTestValue\\""/i)).toBeVisible();
+
+    // get process instance key
+    const processInstanceKey =
+      await operateProcessInstancePage.getProcessInstanceKey();
+
+    // go to instance page, filter and find the instance by added variable
+    await operateHomePage.clickProcessesTab();
+
+    await operateFiltersPanel.displayOptionalFilter('Process Instance Key(s)');
+    await operateFiltersPanel.displayOptionalFilter('Variable');
+
+    await operateFiltersPanel.fillVariableNameFilter('secondTestKey');
+
+    await operateFiltersPanel.fillVariableValueFilter(
+      '"\\\"secondTestValue\\\""',
+    );
+    // await operateFiltersPanel.fillVariableValueFilter('"secondTestValue"');
+    await operateFiltersPanel.fillProcessInstanceKeyFilter(processInstanceKey);
+
+    await expect(page.getByText('1 result')).toBeVisible();
+
+    await operateProcessesPage.assertProcessInstanceLink(processInstanceKey);
+  });
+
+  test('Infinite scrolling', async ({
+    page,
+    operateHomePage,
+    operateProcessesPage,
+    operateProcessInstancePage,
+  }) => {
+    await operateHomePage.clickProcessesTab();
+    await operateProcessesPage.filterByProcessName(
+      'Only Incidents Process Scrolling',
+    );
+    await operateProcessesPage.clickProcessInstanceLink();
+
+    await expect(operateProcessInstancePage.variablesList).toBeVisible();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(51);
+
+    await expect(page.getByText('aa', {exact: true})).toBeVisible();
+    await expect(page.getByText('bx', {exact: true})).toBeVisible();
+
+    await page.getByText('bx', {exact: true}).scrollIntoViewIfNeeded();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(101);
+
+    await expect(page.getByText('aa', {exact: true})).toBeVisible();
+    await expect(page.getByText('dv', {exact: true})).toBeVisible();
+
+    await page.getByText('dv', {exact: true}).scrollIntoViewIfNeeded();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(151);
+
+    await expect(page.getByText('aa', {exact: true})).toBeVisible();
+    await expect(page.getByText('ft', {exact: true})).toBeVisible();
+
+    await page.getByText('ft', {exact: true}).scrollIntoViewIfNeeded();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(201);
+
+    await expect(page.getByText('aa', {exact: true})).toBeVisible();
+    await expect(page.getByText('hr', {exact: true})).toBeVisible();
+
+    await page.getByText('hr', {exact: true}).scrollIntoViewIfNeeded();
+
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(201);
+
+    await expect(page.getByText('aa', {exact: true})).toBeHidden();
+    await expect(page.getByText('by', {exact: true})).toBeVisible();
+    await expect(page.getByText('jp', {exact: true})).toBeVisible();
+
+    await page.getByText('by', {exact: true}).scrollIntoViewIfNeeded();
+    await expect(
+      operateProcessInstancePage.variablesList.getByRole('row'),
+    ).toHaveCount(201);
+
+    await expect(page.getByText('jp', {exact: true})).toBeHidden();
+    await expect(page.getByText('aa', {exact: true})).toBeVisible();
+    await expect(page.getByText('by', {exact: true})).toBeVisible();
+  });
+});

--- a/qa/core-application-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/core-application-e2e-test-suite/utils/zeebeClient.ts
@@ -15,6 +15,18 @@ const c8 = new Camunda8({
   CAMUNDA_BASIC_AUTH_PASSWORD: process.env.CAMUNDA_BASIC_AUTH_PASSWORD,
   ZEEBE_REST_ADDRESS: process.env.ZEEBE_REST_ADDRESS,
 });
+
+function generateManyVariables(): Record<string, string> {
+  const variables: Record<string, string> = {};
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+  alphabet.forEach((letter1) => {
+    alphabet.forEach((letter2) => {
+      variables[`${letter1}${letter2}`] = `${letter1}${letter2}`;
+    });
+  });
+  return variables;
+}
+
 const zeebe = c8.getCamundaRestClient();
 const deploy = async (processFilePaths: string[]) => {
   try {
@@ -41,4 +53,4 @@ const createInstances = async (
   }
 };
 
-export {deploy, createInstances};
+export {deploy, createInstances, generateManyVariables};


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

### ✅ Migrated Tests to New Test Suite Structure

This PR migrates the [**Process Instance Variables**](https://github.com/camunda/camunda/blob/main/operate/client/e2e-playwright/tests/processInstanceVariables.spec.ts) tests to the new test suite. The following changes were made:

#### 🔄 Changes:

- Replaced old test setup using `zeebeGrpcApi` (`deployProcesses`, `createSingleInstance`) from the [**mocks file**](https://github.com/camunda/camunda/blob/main/operate/client/e2e-playwright/tests/processInstanceVariables.mocks.ts) with the unified helper functions in [`utils/zeebeClient.ts`](https://github.com/camunda/camunda/blob/migrate-Operate-processInstanceVariables.spec-to-core-applocation-test-suite/qa/core-application-e2e-test-suite/utils/zeebeClient.ts)
    ⬆️ Note: zeebeGrpcApi is deprecated and scheduled for removal, so this migration aligns with [upcoming changes](https://github.com/camunda/product-hub/issues/2840).
- Removed the custom navigation helper in favor of consistent UI navigation that reflects the real user scenario:
  - Navigates to the **Processes** tab
  - Filters by process name
  - Clicks on the process instance link

#### ✅ Other Improvements:

- Added `beforeEach` and `afterEach` hooks in [`processInstanceVariables.spec.ts`](https://github.com/camunda/camunda/blob/migrate-Operate-processInstanceVariables.spec-to-core-applocation-test-suite/qa/core-application-e2e-test-suite/tests/operate/processInstanceVariables.spec.ts):
  - Logs in before each test
  - Captures screenshots and failure videos

✅ Aligned test structure and flow with the Tasklist E2E tests to maintain consistency across Core Application test suites

❗🗒️ I've temporarily commented out lines like `// await operateFiltersPanel.fillVariableValueFilter('"secondTestValue"');` as a workaround for the known backslash [issue](https://github.com/camunda/camunda/issues/32439). I’ll clean them up after our meeting.


🧪 This has been tested locally as attached
https://github.com/user-attachments/assets/6a546a91-de4d-4331-9863-4df1c842cad5


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
