### PR TITLE
fix: fetch all items even when ES reports wrong total count

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -149,7 +149,10 @@ public class BatchOperationItemProvider {
       items.addAll(result.items);
       searchValues = result.lastSortValues();
 
-      if (items.size() >= result.total() || result.items.isEmpty()) {
+      // the result.total count can be incorrect when using elasticsearch and could be capped at
+      // 10_000. If the result.total is smaller than the queryPageSize, we can assume that we have
+      // fetched all items. Otherwise, we fetch again until we fetch an empty page
+      if (result.items.isEmpty() || result.total < queryPageSize) {
         break;
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -75,6 +75,11 @@ public class BatchOperationItemProvider {
       final Supplier<Boolean> shouldAbort) {
     final var processInstanceFilter = filter.toBuilder().partitionId(partitionId).build();
 
+    LOG.debug(
+        "Fetching process instance items for partition {} with filter: {}",
+        partitionId,
+        processInstanceFilter);
+
     return fetchEntityItems(
         new ProcessInstancePageFetcher(), processInstanceFilter, authentication, shouldAbort);
   }
@@ -93,6 +98,8 @@ public class BatchOperationItemProvider {
       final IncidentFilter filter,
       final Authentication authentication,
       final Supplier<Boolean> shouldAbort) {
+
+    LOG.debug("Fetching incident items with filter: {}", filter);
     return fetchEntityItems(new IncidentPageFetcher(), filter, authentication, shouldAbort);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProviderTest.java
@@ -47,8 +47,8 @@ class BatchOperationItemProviderTest {
     searchClientsProxy = mock(SearchClientsProxy.class);
 
     final EngineConfiguration engineConfiguration = mock(EngineConfiguration.class);
-    when(engineConfiguration.getBatchOperationQueryPageSize()).thenReturn(10);
-    when(engineConfiguration.getBatchOperationQueryInClauseSize()).thenReturn(10);
+    when(engineConfiguration.getBatchOperationQueryPageSize()).thenReturn(5);
+    when(engineConfiguration.getBatchOperationQueryInClauseSize()).thenReturn(5);
 
     when(searchClientsProxy.withSecurityContext(any())).thenReturn(searchClientsProxy);
 
@@ -106,21 +106,28 @@ class BatchOperationItemProviderTest {
                 List.of(
                     mockProcessInstanceEntity(1L),
                     mockProcessInstanceEntity(2L),
-                    mockProcessInstanceEntity(3L)))
-            .total(6)
+                    mockProcessInstanceEntity(3L),
+                    mockProcessInstanceEntity(4L),
+                    mockProcessInstanceEntity(5L)))
+            .total(10)
             .build();
     final var result2 =
         new SearchQueryResult.Builder<ProcessInstanceEntity>()
             .items(
                 List.of(
-                    mockProcessInstanceEntity(4L),
-                    mockProcessInstanceEntity(5L),
-                    mockProcessInstanceEntity(6L)))
-            .total(6)
+                    mockProcessInstanceEntity(6L),
+                    mockProcessInstanceEntity(7L),
+                    mockProcessInstanceEntity(8L),
+                    mockProcessInstanceEntity(9L),
+                    mockProcessInstanceEntity(10L)))
+            .total(10)
             .build();
+    final var result3 =
+        new SearchQueryResult.Builder<ProcessInstanceEntity>().items(List.of()).total(10).build();
     when(searchClientsProxy.searchProcessInstances(queryCaptor.capture()))
         .thenReturn(result)
-        .thenReturn(result2);
+        .thenReturn(result2)
+        .thenReturn(result3);
 
     // when
     final var filter = new ProcessInstanceFilter.Builder().build();
@@ -135,7 +142,11 @@ class BatchOperationItemProviderTest {
             new Item(3L, 3L),
             new Item(4L, 4L),
             new Item(5L, 5L),
-            new Item(6L, 6L));
+            new Item(6L, 6L),
+            new Item(7L, 7L),
+            new Item(8L, 8L),
+            new Item(9L, 9L),
+            new Item(10L, 10L));
 
     // and partitionId is set in filter
     final var query = queryCaptor.getValue();


### PR DESCRIPTION
## Description

When ES is used as secondaryDb, the result.total value in all queries is potentially wrong when having more than 10_000 entries. This is because ES caps this value to 10_000 matched documents. This PR fixed this issue, by continue fetching until an empty page is reached.

relates to #29942
