### PR TITLE
Resurrect Operate and Tasklist backup restore CI

### DIFF
--- a/.github/workflows/operate-test-backup-restore.yml
+++ b/.github/workflows/operate-test-backup-restore.yml
@@ -1,11 +1,65 @@
-name: Operate Run Test Backup/Restore
+name: "[Legacy] Operate / Test Backup Restore"
 on:
-  schedule:
-    - cron: "0 5 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - 'stable/**'
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+  pull_request:
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate/**'
+      - 'pom.xml'
+      - 'operate.Dockerfile'
+      - 'parent/*'
+      - 'webapps-common/**'
 jobs:
   run-backup-restore-tests:
-    uses: ./.github/workflows/operate-run-tests.yml
-    with:
-      command: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify
-    secrets: inherit
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    env:
+      DOCKER_IMAGE_TAG: current-test
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-operate-docker
+        with:
+          repository: localhost:5000/camunda/operate
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: operate.Dockerfile
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Run Operate backup restore Tests
+        run: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify
+      - name: Upload Test Report
+        if: failure()
+        uses: ./.github/actions/collect-test-artifacts
+        with:
+          name: "[Legacy] Operate Test Backup Restore"

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -9,86 +9,42 @@ on:
         required: true
         type: string
 
-# define constants for later use
-env:
-  JAVA_VERSION: "21"
-
 jobs:
-  build-and-test:
+  run-backup-restore-tests:
     name: "with '${{ inputs.database }}'"
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    env:
+      DOCKER_IMAGE_TAG: current-test
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
-      # Setup: checkout
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      # Setup: import secrets from vault
-      - name: Import Secrets
-        id: secrets # important to refer to it in later steps
-        uses: hashicorp/vault-action@b022ecdb0c75c75ceb164232485b392254f981f4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false # we rely on step outputs, no need for environment variables
-          secrets: |
-            secret/data/github.com/organizations/camunda NEXUS_USR;
-            secret/data/github.com/organizations/camunda NEXUS_PSW;
-            secret/data/products/tasklist/ci/tasklist TASKLIST_CI_ALERT_WEBHOOK_URL;
-
-      # Setup: configure Java, Maven, settings.xml
-      - name: Setup Java ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
         with:
-          distribution: "adopt"
-          java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Setup Maven
-        uses: ./.github/actions/setup-maven-dist
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-tasklist-docker
         with:
-          maven-version: 3.8.6
-          set-mvnw: true
-
-      - name: Configure Maven
-        uses: ./.github/actions/setup-maven-cache
-        with:
-          maven-cache-key-modifier: tasklist-tests
-
-      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
-      - name: Create Maven settings.xml
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          githubServer: false
-          servers: |
-            [{
-              "id": "camunda-nexus",
-              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
-              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
-            }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
-
-      # Build: maven artifacts
-      - name: Build backend
-        run: |
-          ./mvnw clean install -B -T1C -DskipChecks -P skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
-
-      # Tests: run backup and restore tests
-      - name: Run backup and restore tests
-        run: |
-          ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -P -skipTests verify
-
-      # Notify: send Slack notification on tests failure
-      - name: Send Slack notification on failure
+          repository: localhost:5000/camunda/tasklist
+          version: ${{ env.DOCKER_IMAGE_TAG }}
+          dockerfile: tasklist.Dockerfile
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Run Tasklist backup restore Tests
+        run: ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -DskipTests=false verify
+      - name: Upload Test Report
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.1
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.TASKLIST_CI_ALERT_WEBHOOK_URL }}
+        uses: ./.github/actions/collect-test-artifacts
         with:
-          payload: |
-            {
-              "workflow_name": "Backup and restore tests",
-              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
-              "branch": "${{ github.head_ref || github.ref_name }}"
-            }
+          name: "[Legacy] Tasklist Test Backup Restore"

--- a/.github/workflows/tasklist-backup-restore-tests.yml
+++ b/.github/workflows/tasklist-backup-restore-tests.yml
@@ -1,19 +1,30 @@
 # Backup and restore tests workflow
 # This workflow is designed to automate the backup and restore tests for databases.
 
-name: Tasklist Backup and restore tests
+name: "[Legacy] Tasklist / Test Backup Restore"
 
-# This workflow can be triggered manually using the GitHub UI
-# and is also scheduled to run daily at 03:00 AM.
 on:
   workflow_dispatch:
-  schedule:
-  # Define schedule to run this workflow every day at 03:00 AM.
-    - cron: '0 3 * * *'
-
-# define constants for later use
-env:
-  JAVA_VERSION: "21"
+  push:
+    branches:
+      - "stable/**"
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/tasklist-*"
+      - "bom/*"
+      - "parent/*"
+      - "pom.xml"
+      - "tasklist/**"
+      - "tasklist.Dockerfile"
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/tasklist-*"
+      - "bom/*"
+      - "parent/*"
+      - "pom.xml"
+      - "tasklist/**"
+      - "tasklist.Dockerfile"
 
 jobs:
   elasticsearch:

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -7,17 +7,18 @@
  */
 package io.camunda.operate.qa.backup;
 
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
 import static io.camunda.operate.util.CollectionUtil.asMap;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.COMPLETED;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.IN_PROGRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
 import io.camunda.operate.util.RetryOperation;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.operate.webapp.management.dto.TakeBackupResponseDto;
-import io.camunda.zeebe.client.ZeebeClient;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -48,11 +49,11 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 public class BackupRestoreTest {
 
   public static final String ZEEBE_INDEX_PREFIX = "backup-restore-test";
-  public static final String VERSION = "SNAPSHOT";
+  public static final String VERSION = "current-test";
   public static final String REPOSITORY_NAME = "testRepository";
   public static final Long BACKUP_ID = 123L;
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreTest.class);
-  private static final String OPERATE_TEST_DOCKER_IMAGE = "camunda/operate";
+  private static final String OPERATE_TEST_DOCKER_IMAGE = "localhost:5000/camunda/operate";
   @Autowired private OperateAPICaller operateAPICaller;
 
   @Autowired private DataGenerator dataGenerator;
@@ -145,10 +146,8 @@ public class BackupRestoreTest {
                 new HttpHost(testContext.getExternalElsHost(), testContext.getExternalElsPort()))));
     createSnapshotRepository(testContext);
 
-    String zeebeVersion = ZeebeClient.class.getPackage().getImplementationVersion();
-    if (zeebeVersion.toLowerCase().contains("snapshot")) {
-      zeebeVersion = "SNAPSHOT";
-    }
+    final String zeebeVersion =
+        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_PROPERTY_NAME);
     testContainerUtil.startZeebe(zeebeVersion, testContext);
 
     operateContainer =

--- a/operate/qa/backup-restore-tests/src/test/resources/container-versions.properties
+++ b/operate/qa/backup-restore-tests/src/test/resources/container-versions.properties
@@ -1,0 +1,1 @@
+zeebe.currentVersion=@version.zeebe.docker.current@

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>8.6.0-alpha5</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.6.17</version.zeebe.docker.current>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 
   </properties>

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -52,11 +52,11 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 public class BackupRestoreTest {
 
   public static final String ZEEBE_INDEX_PREFIX = "backup-restore-test";
-  public static final String VERSION = "SNAPSHOT";
+  public static final String VERSION = "current-test";
   public static final String REPOSITORY_NAME = "testRepository";
   public static final Long BACKUP_ID = 123L;
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreTest.class);
-  private static final String TASKLIST_TEST_DOCKER_IMAGE = "camunda/tasklist";
+  private static final String TASKLIST_TEST_DOCKER_IMAGE = "localhost:5000/camunda/tasklist";
 
   @Autowired private TasklistAPICaller tasklistAPICaller;
 

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -21,7 +21,7 @@
   </modules>
 
   <properties>
-    <version.zeebe.docker.current>8.6.8</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.6.17</version.zeebe.docker.current>
     <version.identity.docker.current>8.6.8</version.identity.docker.current>
   </properties>
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -24,7 +24,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -285,13 +284,11 @@ public class TestContainerUtil {
     LOGGER.info("************ Starting Elasticsearch ************");
     elsContainer =
         new ElasticsearchContainer(
-                String.format(
-                    "%s:%s",
-                    DOCKER_ELASTICSEARCH_IMAGE_NAME,
-                    ElasticsearchClient.class.getPackage().getImplementationVersion()))
+                String.format("%s:%s", DOCKER_ELASTICSEARCH_IMAGE_NAME, "8.13.4"))
             .withNetwork(Network.SHARED)
             .withEnv("xpack.security.enabled", "false")
             .withEnv("path.repo", "~/")
+            .withEnv("action.destructive_requires_name", "false")
             .withNetworkAliases(ELS_NETWORK_ALIAS)
             .withExposedPorts(ELS_PORT);
     elsContainer.setWaitStrategy(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We have observed lately there are some regressions in backup use cases in 8.6. 
Operate backup restore CI was only run in main branch (nightly run)
So I am resurrecting the workflow in to be run in push and pull requests to stable/8.6, stable/8.7 and likely in stable/operate-8.5 branches

Operate job: https://github.com/camunda/camunda/actions/runs/15588896638/job/43902442487?pr=33621
Tasklist job: https://github.com/camunda/camunda/actions/runs/15595070245?pr=33621

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
