### PR TITLE
When sending the snapshot require that it's done after processing SCALING_UP event

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutor.java
@@ -68,7 +68,7 @@ public class BrokerClientPartitionScalingExecutor implements PartitionScalingCha
     final var result = concurrencyControl.<Void>createFuture();
 
     brokerClient.sendRequestWithRetry(
-        new GetScaleUpProgress(desiredPartitionCount),
+        new GetScaleUpProgress(),
         (key, response) -> {
           if (response.getDesiredPartitionCount() != desiredPartitionCount) {
             LOGGER.warn("Invalid GetScaleUpProgress response: got {}", response);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/scaling/snapshot/SnapshotTransferServiceClient.java
@@ -28,7 +28,8 @@ public class SnapshotTransferServiceClient implements SnapshotTransferService {
   }
 
   @Override
-  public ActorFuture<SnapshotChunk> getLatestSnapshot(final int partition, final UUID transferId) {
+  public ActorFuture<SnapshotChunk> getLatestSnapshot(
+      final int partition, final long lastProcessedPosition, final UUID transferId) {
     return sendRequest(partition, Optional.empty(), Optional.empty(), transferId);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotChunkResponse;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
+import io.camunda.zeebe.gateway.impl.broker.request.scaling.GetScaleUpProgress;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
@@ -17,30 +19,39 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SnapshotApiRequestHandler
     extends AsyncApiRequestHandler<SnapshotApiRequestReader, SnapshotApiResponseWriter> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotApiRequestHandler.class);
   private final ConcurrentMap<Integer, SnapshotTransferService> transferServices =
       new ConcurrentHashMap<>();
   private final AtomixServerTransport serverTransport;
+  private final BrokerClient brokerClient;
 
-  protected SnapshotApiRequestHandler(final AtomixServerTransport serverTransport) {
+  protected SnapshotApiRequestHandler(
+      final AtomixServerTransport serverTransport, final BrokerClient brokerClient) {
     super(SnapshotApiRequestReader::new, SnapshotApiResponseWriter::new);
     this.serverTransport = serverTransport;
+    this.brokerClient = brokerClient;
   }
 
   public void addTransferService(
       final int partitionId, final SnapshotTransferService transferService) {
     serverTransport.subscribe(partitionId, RequestType.SNAPSHOT, this);
     transferServices.put(partitionId, transferService);
+    LOG.debug("Added SnapshotTransferService for partition {}.", partitionId);
   }
 
   public void removeTransferService(final int partitionId) {
     serverTransport.unsubscribe(partitionId, RequestType.SNAPSHOT);
     transferServices.remove(partitionId);
+    LOG.debug("Removed SnapshotTransferService for partition {}.", partitionId);
   }
 
   @Override
@@ -70,21 +81,48 @@ public class SnapshotApiRequestHandler
                   return Either.right(responseWriter);
                 });
       } else {
-        return service
-            .getLatestSnapshot(partitionId, request.transferId())
-            .thenApply(
-                chunk -> {
-                  responseWriter.setResponse(
-                      new SnapshotChunkResponse(request.transferId(), Optional.ofNullable(chunk)));
-                  return Either.right(responseWriter);
-                });
+        LOG.debug(
+            "[{}] Received request to get the latest snapshot for partition {}",
+            request.transferId(),
+            partitionId);
+        return getLastProcessedPositionRequired(request.transferId())
+            .andThen(
+                lastProcessedPosition -> {
+                  LOG.debug("Last processed position is {}", lastProcessedPosition);
+                  return service
+                      .getLatestSnapshot(partitionId, lastProcessedPosition, request.transferId())
+                      .thenApply(
+                          chunk -> {
+                            responseWriter.setResponse(
+                                new SnapshotChunkResponse(
+                                    request.transferId(), Optional.ofNullable(chunk)));
+                            return Either.right(responseWriter);
+                          });
+                },
+                actor);
       }
     }
   }
 
   @Override
   public void close() {
+    LOG.debug(
+        "Closing SnapshotApiRequestHandler. Removing transfer services. Registered partitions {}",
+        transferServices.keySet());
     transferServices.forEach((partitionId, service) -> removeTransferService(partitionId));
     super.close();
+  }
+
+  private ActorFuture<Long> getLastProcessedPositionRequired(final UUID transferId) {
+    final ActorFuture<Long> lastProcessedPosition = actor.createFuture();
+    brokerClient
+        .sendRequestWithRetry(new GetScaleUpProgress())
+        .thenApply(
+            r -> {
+              LOG.debug("[{}] Received response from broker {}", transferId, r.getResponse());
+              return r.getResponse().getBootstrappedAt();
+            })
+        .whenComplete(lastProcessedPosition);
+    return lastProcessedPosition;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/scaling/BrokerClientPartitionScalingExecutorTest.java
@@ -115,12 +115,6 @@ public class BrokerClientPartitionScalingExecutorTest {
     assertThat(request).isInstanceOf(GetScaleUpProgress.class);
     final var getScaleUpProgress = (GetScaleUpProgress) request;
     assertThat(request.getPartitionId()).isEqualTo(1);
-    assertThat(getScaleUpProgress.getRequestWriter())
-        .satisfies(
-            writer -> {
-              final var requestRecord = (ScaleRecord) writer;
-              assertThat(requestRecord.getDesiredPartitionCount()).isEqualTo(5);
-            });
 
     scaleRecord.ifRightOrLeft(
         record -> responseConsumerCaptor.getValue().accept(1L, record),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.transport.snapshotapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +21,10 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientImpl;
 import io.camunda.zeebe.broker.client.impl.BrokerClusterStateImpl;
 import io.camunda.zeebe.broker.partitioning.scaling.snapshot.SnapshotTransferServiceClient;
+import io.camunda.zeebe.broker.transport.commandapi.CommandResponseWriterImpl;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
@@ -30,20 +35,25 @@ import io.camunda.zeebe.snapshots.transfer.SnapshotTransferImpl;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService.TakeSnapshot;
 import io.camunda.zeebe.snapshots.transfer.SnapshotTransferServiceImpl;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.camunda.zeebe.transport.impl.ServerResponseImpl;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.util.NetUtil;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SnapshotApiRequestHandlerTest {
 
@@ -63,6 +73,7 @@ public class SnapshotApiRequestHandlerTest {
   private SnapshotTransferServiceClient client;
   private BrokerClientImpl brokerClient;
   private TakeSnapshot takeSnapshotMock;
+  private AtomicInteger scaleUpProgressInvocationCount;
 
   @BeforeEach
   void setup() {
@@ -100,7 +111,9 @@ public class SnapshotApiRequestHandlerTest {
     serverTransport =
         submitActor(new AtomixServerTransport(messagingService, new SnowflakeIdGenerator(1L)));
 
-    snapshotHandler = submitActor(new SnapshotApiRequestHandler(serverTransport));
+    scaleUpProgressInvocationCount = new AtomicInteger();
+
+    snapshotHandler = submitActor(new SnapshotApiRequestHandler(serverTransport, brokerClient));
 
     takeSnapshotMock = mock(TakeSnapshot.class);
     // Snapshot actors:
@@ -138,12 +151,21 @@ public class SnapshotApiRequestHandlerTest {
     scheduler.workUntilDone();
   }
 
-  @Test
-  void shouldSendAllChunksCorrectly() {
-
-    final var takeFuture = takePersistedSnapshot();
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 11L, 100L})
+  // last processed position in the snapshot.
+  // required position is always bootstrappedAt
+  void shouldSendAllChunksCorrectly(final long position) {
+    // given
+    final var snapshotProcessedPosition = 11L;
+    final var takeFuture = takePersistedSnapshot(snapshotProcessedPosition);
     scheduler.workUntilDone();
     assertThat(takeFuture).succeedsWithin(Duration.ofSeconds(30));
+    if (position > snapshotProcessedPosition) {
+      when(takeSnapshotMock.takeSnapshot(eq(1), eq(position)))
+          .thenReturn(takePersistedSnapshot(position));
+    }
+    mockBootstrappedAtWith(position);
 
     final var transfer =
         submitActor(new SnapshotTransferImpl(ignore -> client, receiverSnapshotStore));
@@ -161,9 +183,12 @@ public class SnapshotApiRequestHandlerTest {
             });
   }
 
-  private ActorFuture<PersistedSnapshot> takePersistedSnapshot() {
+  private ActorFuture<PersistedSnapshot> takePersistedSnapshot(final long processedPosition) {
     return SnapshotTransferUtil.takePersistedSnapshot(
-        senderSnapshotStore, SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS, receiverSnapshotStore);
+        senderSnapshotStore,
+        SnapshotTransferUtil.SNAPSHOT_FILE_CONTENTS,
+        processedPosition,
+        receiverSnapshotStore);
   }
 
   private <A extends Actor> A submitActor(final A actor) {
@@ -171,5 +196,26 @@ public class SnapshotApiRequestHandlerTest {
     scheduler.workUntilDone();
     assertThat(future).succeedsWithin(Duration.ofSeconds(30));
     return actor;
+  }
+
+  private void mockBootstrappedAtWith(final long position) {
+    serverTransport.subscribe(
+        1,
+        RequestType.COMMAND,
+        (output, partition, requestId, buffer, offset, length) -> {
+          // assume the request is a GetScaleUpProgress
+          scaleUpProgressInvocationCount.incrementAndGet();
+          final var writer =
+              new CommandResponseWriterImpl(output)
+                  .partitionId(partitionId)
+                  .valueWriter(new ScaleRecord().statusResponse(3, List.of(), position))
+                  .recordType(RecordType.COMMAND)
+                  .valueType(ValueType.SCALE);
+          output.sendResponse(
+              new ServerResponseImpl()
+                  .writer(writer)
+                  .setPartitionId(partitionId)
+                  .setRequestId(requestId));
+        });
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotTransferUtil.java
@@ -32,8 +32,10 @@ public final class SnapshotTransferUtil {
   public static ActorFuture<PersistedSnapshot> takePersistedSnapshot(
       final ConstructableSnapshotStore senderSnapshotStore,
       final Map<String, String> snapshotFileContents,
+      final long lastProcessedPosition,
       final ConcurrencyControl control) {
-    final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).get();
+    final var transientSnapshot =
+        senderSnapshotStore.newTransientSnapshot(1L, 0L, lastProcessedPosition, 0).get();
     return transientSnapshot
         .take(p -> writeSnapshot(p, snapshotFileContents))
         .andThen(ignored -> transientSnapshot.persist(), control);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/scaling/GetScaleUpProgress.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/scaling/GetScaleUpProgress.java
@@ -24,11 +24,6 @@ public class GetScaleUpProgress extends BrokerExecuteCommand<ScaleRecord> {
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public GetScaleUpProgress(final int desiredPartitionCount) {
-    this();
-    requestDto.status(desiredPartitionCount);
-  }
-
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -96,8 +96,7 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
     return this;
   }
 
-  public ScaleRecord status(final int desiredPartitionCount) {
-    setDesiredPartitionCount(desiredPartitionCount);
+  public ScaleRecord status() {
     return this;
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransfer.java
@@ -19,5 +19,10 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
  * <p>Snapshots are received in the {@param snapshotStore}.
  */
 public interface SnapshotTransfer extends AsyncClosable {
+
+  /**
+   * @param partitionId the partition to get the snapshot from
+   * @return a persisted snapshot satisfying the parameters' requirements
+   */
   ActorFuture<PersistedSnapshot> getLatestSnapshot(final int partitionId);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
@@ -36,7 +36,8 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
   public ActorFuture<PersistedSnapshot> getLatestSnapshot(final int partitionId) {
     final var transferId = UUID.randomUUID();
     return service
-        .getLatestSnapshot(partitionId, transferId)
+        // no requirements on last processing position
+        .getLatestSnapshot(partitionId, -1, transferId)
         .andThen(
             snapshot -> {
               if (snapshot == null) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
@@ -18,10 +18,14 @@ public interface SnapshotTransferService {
    * Initiate the transfer of the latest snapshot for a partition.
    *
    * @param partition the partition to get the snapshot from
+   * @param lastProcessedPosition the minimum value of lastProcessedPosition that the snapshot must
+   *     have
+   * @param transferId an identifier to trace the transfer
    * @return the first {@link SnapshotChunk}. It must be used in subsequent calls to {@link
    *     SnapshotTransferService#getNextChunk}
    */
-  ActorFuture<SnapshotChunk> getLatestSnapshot(int partition, UUID transferId);
+  ActorFuture<SnapshotChunk> getLatestSnapshot(
+      int partition, long lastProcessedPosition, UUID transferId);
 
   /**
    * Get the next chunk for the snapshot.
@@ -36,6 +40,15 @@ public interface SnapshotTransferService {
       int partition, String snapshotId, String previousChunkName, UUID transferId);
 
   interface TakeSnapshot {
-    ActorFuture<PersistedSnapshot> takeSnapshot(int partition);
+
+    /**
+     * Take a snapshot of a partition. The snapshot returned must have processed at least {@param
+     * lastProcessedPosition}
+     *
+     * @param partition the partition to take the snapshot for
+     * @param lastProcessedPosition the minimum value for lastProcessedPosition in the snapshot
+     * @return
+     */
+    ActorFuture<PersistedSnapshot> takeSnapshot(int partition, long lastProcessedPosition);
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.snapshots.transfer;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
 import java.util.UUID;
 
@@ -33,4 +34,8 @@ public interface SnapshotTransferService {
    */
   ActorFuture<SnapshotChunk> getNextChunk(
       int partition, String snapshotId, String previousChunkName, UUID transferId);
+
+  interface TakeSnapshot {
+    ActorFuture<PersistedSnapshot> takeSnapshot(int partition);
+  }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferServiceImpl.java
@@ -31,16 +31,19 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
 
   private final BootstrapSnapshotStore snapshotStore;
   private final Map<UUID, PendingTransfer> pendingTransfers = new HashMap<>();
+  private final TakeSnapshot takeSnapshot;
   private final int partitionId;
   private final BiConsumer<Path, Path> copyForBootstrap;
   private final ConcurrencyControl concurrency;
 
   public SnapshotTransferServiceImpl(
       final BootstrapSnapshotStore snapshotStore,
+      final TakeSnapshot takeSnapshot,
       final int partitionId,
       final BiConsumer<Path, Path> copyForBootstrap,
       final ConcurrencyControl concurrency) {
     this.snapshotStore = snapshotStore;
+    this.takeSnapshot = takeSnapshot;
     this.partitionId = partitionId;
     this.copyForBootstrap = copyForBootstrap;
     this.concurrency = concurrency;
@@ -113,41 +116,46 @@ public class SnapshotTransferServiceImpl implements SnapshotTransferService {
 
     final var lastSnapshot = snapshotStore.getBootstrapSnapshot();
     if (lastSnapshot.isEmpty()) {
-      createSnapshotForBootstrap(transferId).onComplete(lastSnapshotFuture, concurrency);
+      createSnapshotForBootstrap(partitionId, transferId)
+          .onComplete(lastSnapshotFuture, concurrency);
     } else {
       lastSnapshotFuture.complete(lastSnapshot.get());
     }
     return lastSnapshotFuture;
   }
 
-  private ActorFuture<PersistedSnapshot> createSnapshotForBootstrap(final UUID transferId) {
+  private ActorFuture<PersistedSnapshot> createSnapshotForBootstrap(
+      final int partitionId, final UUID transferId) {
     final var lastPersistedSnapshot = snapshotStore.getLatestSnapshot();
-    if (lastPersistedSnapshot.isEmpty()) {
-      return CompletableActorFuture.completedExceptionally(
-          new IllegalArgumentException(String.format("[%s] No snapshot found", transferId)));
-    } else {
-      final var persistedSnapshot = lastPersistedSnapshot.get();
+    final ActorFuture<PersistedSnapshot> lastSnapshot =
+        lastPersistedSnapshot.isEmpty()
+            ?
+            // TODO Add retries later and check if required idx is present in snapshot
+            takeSnapshot.takeSnapshot(partitionId)
+            : CompletableActorFuture.completed(lastPersistedSnapshot.get());
 
-      return withReservation(
-          persistedSnapshot,
-          () ->
-              snapshotStore
-                  .copyForBootstrap(persistedSnapshot, copyForBootstrap)
-                  .andThen(
-                      (snapshot, error) -> {
-                        if (error != null) {
-                          if (error instanceof SnapshotAlreadyExistsException) {
-                            return CompletableActorFuture.completed(
-                                snapshotStore.getBootstrapSnapshot().orElse(null));
-                          } else {
-                            return CompletableActorFuture.completedExceptionally(error);
-                          }
-                        } else {
-                          return CompletableActorFuture.completed(snapshot);
-                        }
-                      },
-                      concurrency));
-    }
+    return lastSnapshot.andThen(
+        persistedSnapshot ->
+            withReservation(
+                persistedSnapshot,
+                () ->
+                    snapshotStore
+                        .copyForBootstrap(persistedSnapshot, copyForBootstrap)
+                        .andThen(
+                            (snapshot, error) -> {
+                              if (error != null) {
+                                if (error instanceof SnapshotAlreadyExistsException) {
+                                  return CompletableActorFuture.completed(
+                                      snapshotStore.getBootstrapSnapshot().orElse(null));
+                                } else {
+                                  return CompletableActorFuture.completedExceptionally(error);
+                                }
+                              } else {
+                                return CompletableActorFuture.completed(snapshot);
+                              }
+                            },
+                            concurrency)),
+        concurrency);
   }
 
   /**

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -9,12 +9,16 @@ package io.camunda.zeebe.snapshots.transfer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.snapshots.SnapshotCopyUtil;
 import io.camunda.zeebe.snapshots.SnapshotTransferUtil;
@@ -113,11 +117,13 @@ public class SnapshotTransferTest {
   public void shouldTakeSnapshotIfNoneIsPresent() {
     // given
     final int partitionId = 1;
+    when(takeSnapshotMock.takeSnapshot(anyInt(), anyLong()))
+        .thenReturn(CompletableActorFuture.completed(null));
 
     // when
     final var persistedSnapshotFuture = snapshotTransfer.getLatestSnapshot(partitionId);
 
     // then
-    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(1));
+    verify(takeSnapshotMock, timeout(5000)).takeSnapshot(eq(1), eq(-1L));
   }
 }


### PR DESCRIPTION
## Description
This PR fixes the following problems:
- if a scale up is started but no  snapshot was taken, take a new snapshot
- require that the snapshot to be used for creating the snapshot for the new partition contains (via `processedPosition`) the event `SCALING_UP` that added the new partitions to the set of desired partitions 

An end to end test is not yet possible as it depends on other PRs

## Checklist
- [x] #33335 
## Related issues

relates #31755 
