### PR TITLE
feat: use operations for incident search

### DIFF
--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -44,58 +44,80 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <!-- basic filters -->
-    <if test="filter.incidentKeys != null and !filter.incidentKeys.isEmpty()">
-      AND INCIDENT_KEY IN
-      <foreach collection="filter.incidentKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.incidentKeyOperations != null and !filter.incidentKeyOperations.isEmpty()">
+      <foreach collection="filter.incidentKeyOperations" item="operation">
+        AND INCIDENT_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.processDefinitionKeys != null and !filter.processDefinitionKeys.isEmpty()">
-      AND PROCESS_DEFINITION_KEY IN
-      <foreach collection="filter.processDefinitionKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+        AND PROCESS_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.processDefinitionIds != null and !filter.processDefinitionIds.isEmpty()">
-      AND PROCESS_DEFINITION_ID IN
-      <foreach collection="filter.processDefinitionIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdOperations" item="operation">
+        AND PROCESS_DEFINITION_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.processInstanceKeys != null and !filter.processInstanceKeys.isEmpty()">
-      AND PROCESS_INSTANCE_KEY IN
-      <foreach collection="filter.processInstanceKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.processInstanceKeyOperations" item="operation">
+        AND PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.errorTypes != null and !filter.errorTypes.isEmpty()">
-      AND ERROR_TYPE IN
-      <foreach collection="filter.errorTypes" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.errorTypeOperations != null and !filter.errorTypeOperations.isEmpty()">
+      <foreach collection="filter.errorTypeOperations" item="operation">
+        AND ERROR_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.errorMessages != null and !filter.errorMessages.isEmpty()">
-      AND ERROR_MESSAGE IN
-      <foreach collection="filter.errorMessages" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
+      <foreach collection="filter.errorMessageOperations" item="operation">
+        AND ERROR_MESSAGE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.flowNodeIds != null and !filter.flowNodeIds.isEmpty()">
-      AND FLOW_NODE_ID IN
-      <foreach collection="filter.flowNodeIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.flowNodeIdOperations != null and !filter.flowNodeIdOperations.isEmpty()">
+      <foreach collection="filter.flowNodeIdOperations" item="operation">
+        AND FLOW_NODE_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.flowNodeInstanceKeys != null and !filter.flowNodeInstanceKeys.isEmpty()">
-      AND FLOW_NODE_INSTANCE_KEY IN
-      <foreach collection="filter.flowNodeInstanceKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.flowNodeInstanceKeyOperations != null and !filter.flowNodeInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.flowNodeInstanceKeyOperations" item="operation">
+        AND FLOW_NODE_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
 
-    <if test="filter.states != null and !filter.states.isEmpty()">
-      AND STATE IN
-      <foreach collection="filter.states" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.stateOperations != null and !filter.stateOperations.isEmpty()">
+      <foreach collection="filter.stateOperations" item="operation">
+        AND STATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.jobKeys != null and !filter.jobKeys.isEmpty()">
-      AND JOB_KEY IN
-      <foreach collection="filter.jobKeys" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.jobKeyOperations != null and !filter.jobKeyOperations.isEmpty()">
+      <foreach collection="filter.jobKeyOperations" item="operation">
+        AND JOB_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
-      AND TENANT_ID IN
-      <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">
+      <foreach collection="filter.tenantIdOperations" item="operation">
+        AND TENANT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
 
     <!-- date filters -->
-    <if test="filter.creationTime != null and !filter.creationTime.after != null">
-        AND CREATION_DATE &gt; #{filter.creationTime.after}
-    </if>
-    <if test="filter.creationTime != null and !filter.creationTime.before != null">
-        AND CREATION_DATE &lt; #{filter.creationTime.before}
+    <if test="filter.creationTimeOperations != null and !filter.creationTimeOperations.isEmpty()">
+      <foreach collection="filter.creationTimeOperations" item="operation">
+        AND CREATION_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
   </sql>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -21,7 +21,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.filter.DateValueFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.sort.IncidentSort;
 import java.time.OffsetDateTime;
@@ -150,18 +150,17 @@ public class IncidentIT {
                                     .processInstanceKeys(original.processInstanceKey())
                                     .processDefinitionIds(original.processDefinitionId())
                                     .processDefinitionKeys(original.processDefinitionKey())
-                                    .states(original.state())
-                                    .errorTypes(original.errorType())
+                                    .states(original.state().name())
+                                    .errorTypes(original.errorType().name())
                                     .errorMessages(original.errorMessage())
                                     .errorMessageHashes(original.errorMessageHash())
                                     .flowNodeInstanceKeys(original.flowNodeInstanceKey())
                                     .flowNodeIds(original.flowNodeId())
                                     .jobKeys(original.jobKey())
                                     .tenantIds(original.tenantId())
-                                    .creationTime(
-                                        new DateValueFilter(
-                                            original.creationDate().minusSeconds(1),
-                                            original.creationDate().plusSeconds(1))))
+                                    .creationTimeOperations(
+                                        Operation.gt(original.creationDate().minusSeconds(1)),
+                                        Operation.lt(original.creationDate().plusSeconds(1))))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(5))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
@@ -21,8 +21,8 @@ import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
-import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.sort.IncidentSort;
@@ -96,14 +96,14 @@ public class IncidentSpecificFilterIT {
         new IncidentFilter.Builder().processInstanceKeys(3000L).build(),
         new IncidentFilter.Builder().flowNodeIds("sorting-flow-node").build(),
         new IncidentFilter.Builder().flowNodeInstanceKeys(4000L).build(),
-        new IncidentFilter.Builder().errorTypes(ErrorType.JOB_NO_RETRIES).build(),
+        new IncidentFilter.Builder().errorTypes(ErrorType.JOB_NO_RETRIES.name()).build(),
         new IncidentFilter.Builder().errorMessages("error-message-5000").build(),
-        new IncidentFilter.Builder().states(IncidentState.ACTIVE).build(),
+        new IncidentFilter.Builder().states(IncidentState.ACTIVE.name()).build(),
         new IncidentFilter.Builder().jobKeys(6000L).build(),
         new IncidentFilter.Builder()
-            .creationTime(
-                new DateValueFilter(
-                    NOW.minus(1, ChronoUnit.MILLIS), NOW.plus(1, ChronoUnit.MILLIS)))
+            .creationTimeOperations(
+                Operation.gt(NOW.minus(1, ChronoUnit.MILLIS)),
+                Operation.lt(NOW.plus(1, ChronoUnit.MILLIS)))
             .build(),
         new IncidentFilter.Builder().tenantIds("sorting-tenant1").build());
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -71,6 +71,7 @@ import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.util.FilterUtil;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -285,7 +286,10 @@ public class DocumentBasedSearchClients implements SearchClientsProxy, Closeable
     // Search for active incidents that match the given error message hash codes
     final var incidentFilter =
         FilterBuilders.incident(
-            f -> f.errorMessageHashes(incidentErrorHashCodes).states(IncidentState.ACTIVE));
+            f ->
+                f.errorMessageHashOperations(
+                        FilterUtil.mapDefaultToOperation(incidentErrorHashCodes))
+                    .states(IncidentState.ACTIVE.name()));
 
     final var incidentResult = searchIncidents(IncidentQuery.of(f -> f.filter(incidentFilter)));
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -21,6 +21,7 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -79,6 +80,11 @@ public final class SearchQueryBuilders {
 
   public static SearchQuery and(final List<SearchQuery> queries) {
     return map(queries, SearchQueryBuilders::must);
+  }
+
+  @SafeVarargs
+  public static SearchQuery and(final List<SearchQuery>... queries) {
+    return map(Arrays.stream(queries).flatMap(List::stream).toList(), SearchQueryBuilders::must);
   }
 
   public static SearchQuery not(final SearchQuery query, final SearchQuery... queries) {
@@ -336,7 +342,7 @@ public final class SearchQueryBuilders {
   public static <C extends List<Operation<Integer>>> List<SearchQuery> intOperations(
       final String field, final C operations) {
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     } else {
       final var queries = new ArrayList<SearchQuery>();
       SearchRangeQuery.Builder rangeQueryBuilder = null;
@@ -373,7 +379,7 @@ public final class SearchQueryBuilders {
   public static <C extends List<Operation<Long>>> List<SearchQuery> longOperations(
       final String field, final C operations) {
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     } else {
       final var queries = new ArrayList<SearchQuery>();
       SearchRangeQuery.Builder rangeQueryBuilder = null;
@@ -410,7 +416,7 @@ public final class SearchQueryBuilders {
   public static <C extends List<Operation<String>>> List<SearchQuery> stringOperations(
       final String field, final C operations) {
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     } else {
       final var searchQueries = new ArrayList<SearchQuery>();
       operations.forEach(
@@ -439,7 +445,7 @@ public final class SearchQueryBuilders {
           final SearchMatchQueryOperator matchQueryOperator) {
 
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     }
 
     return operations.stream()
@@ -504,7 +510,7 @@ public final class SearchQueryBuilders {
   public static <C extends List<Operation<OffsetDateTime>>> List<SearchQuery> dateTimeOperations(
       final String field, final C operations) {
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     } else {
       final var queries = new ArrayList<SearchQuery>();
       SearchRangeQuery.Builder rangeQueryBuilder = null;
@@ -592,7 +598,7 @@ public final class SearchQueryBuilders {
   public static <C extends List<UntypedOperation>> List<SearchQuery> variableOperations(
       final String field, final C operations) {
     if (operations == null || operations.isEmpty()) {
-      return null;
+      return List.of();
     } else {
       return operations.stream()
           .map(op -> variableOperation(field, op))

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -386,7 +386,7 @@ public final class ServiceTransformers {
         GroupFilter.class, new GroupFilterTransformer(indexDescriptors.get(GroupIndex.class)));
     mappers.put(
         IncidentFilter.class,
-        new IncidentFilterTransformer(mappers, indexDescriptors.get(IncidentTemplate.class)));
+        new IncidentFilterTransformer(indexDescriptors.get(IncidentTemplate.class)));
     mappers.put(FormFilter.class, new FormFilterTransformer(indexDescriptors.get(FormIndex.class)));
     mappers.put(
         ProcessDefinitionFilter.class,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationFilterTransformer.java
@@ -9,12 +9,10 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.*;
 import static io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate.*;
-import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.ArrayList;
 
 public final class BatchOperationFilterTransformer
     extends IndexFilterTransformer<BatchOperationFilter> {
@@ -25,13 +23,9 @@ public final class BatchOperationFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final BatchOperationFilter filter) {
-    final var queries = new ArrayList<SearchQuery>();
-
-    ofNullable(stringOperations(ID, filter.batchOperationIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(TYPE, filter.operationTypeOperations())).ifPresent(queries::addAll);
-
-    return and(queries);
+    return and(
+        stringOperations(ID, filter.batchOperationIdOperations()),
+        stringOperations(STATE, filter.stateOperations()),
+        stringOperations(TYPE, filter.operationTypeOperations()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/BatchOperationItemFilterTransformer.java
@@ -14,9 +14,7 @@ import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.BatchOperationItemFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public final class BatchOperationItemFilterTransformer
     extends IndexFilterTransformer<BatchOperationItemFilter> {
@@ -27,18 +25,11 @@ public final class BatchOperationItemFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final BatchOperationItemFilter filter) {
-    final var queries = new ArrayList<SearchQuery>();
-
-    Optional.ofNullable(stringOperations(BATCH_OPERATION_ID, filter.batchOperationIdOperations()))
-        .ifPresent(queries::addAll);
-    Optional.ofNullable(stringOperations(STATE, mapStateOperations(filter.stateOperations())))
-        .ifPresent(queries::addAll);
-    Optional.ofNullable(longOperations(ITEM_KEY, filter.itemKeyOperations()))
-        .ifPresent(queries::addAll);
-    Optional.ofNullable(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-
-    return and(queries);
+    return and(
+        stringOperations(BATCH_OPERATION_ID, filter.batchOperationIdOperations()),
+        stringOperations(STATE, mapStateOperations(filter.stateOperations())),
+        longOperations(ITEM_KEY, filter.itemKeyOperations()),
+        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
   }
 
   private List<Operation<String>> mapStateOperations(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionDefinitionFilterTransformer.java
@@ -16,12 +16,12 @@ import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.DECISION_REQUIREMENTS_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.DecisionIndex.VERSION;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.List;
 
 public final class DecisionDefinitionFilterTransformer
     extends IndexFilterTransformer<DecisionDefinitionFilter> {
@@ -32,53 +32,13 @@ public final class DecisionDefinitionFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final DecisionDefinitionFilter filter) {
-    final var decisionDefinitionKeysQuery =
-        getDecisionDefinitionKeysQuery(filter.decisionDefinitionKeys());
-    final var decisionDefinitionIdsQuery =
-        getDecisionDefinitionIdsQuery(filter.decisionDefinitionIds());
-    final var namesQuery = getNamesQuery(filter.names());
-    final var versionsQuery = getVersionsQuery(filter.versions());
-    final var decisionRequirementsIdsQuery =
-        getDecisionRequirementsIdsQuery(filter.decisionRequirementsIds());
-    final var decisionRequirementsKeysQuery =
-        getDecisionRequirementsKeysQuery(filter.decisionRequirementsKeys());
-    final var tenantIdsQuery = getTenantIdsQuery(filter.tenantIds());
-
     return and(
-        decisionDefinitionKeysQuery,
-        decisionDefinitionIdsQuery,
-        namesQuery,
-        versionsQuery,
-        decisionRequirementsIdsQuery,
-        decisionRequirementsKeysQuery,
-        tenantIdsQuery);
-  }
-
-  private SearchQuery getDecisionDefinitionKeysQuery(final List<Long> keys) {
-    return longTerms(KEY, keys);
-  }
-
-  private SearchQuery getDecisionDefinitionIdsQuery(final List<String> decisionDefinitionIds) {
-    return stringTerms(DECISION_ID, decisionDefinitionIds);
-  }
-
-  private SearchQuery getNamesQuery(final List<String> names) {
-    return stringTerms("name", names);
-  }
-
-  private SearchQuery getVersionsQuery(final List<Integer> versions) {
-    return intTerms(VERSION, versions);
-  }
-
-  private SearchQuery getDecisionRequirementsIdsQuery(final List<String> decisionRequirementsIds) {
-    return stringTerms(DECISION_REQUIREMENTS_ID, decisionRequirementsIds);
-  }
-
-  private SearchQuery getDecisionRequirementsKeysQuery(final List<Long> decisionRequirementsKeys) {
-    return longTerms(DECISION_REQUIREMENTS_KEY, decisionRequirementsKeys);
-  }
-
-  private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {
-    return stringTerms(TENANT_ID, tenantIds);
+        longTerms(KEY, filter.decisionDefinitionKeys()),
+        stringTerms(DECISION_ID, filter.decisionDefinitionIds()),
+        stringTerms(NAME, filter.names()),
+        intTerms(VERSION, filter.versions()),
+        stringTerms(DECISION_REQUIREMENTS_ID, filter.decisionRequirementsIds()),
+        longTerms(DECISION_REQUIREMENTS_KEY, filter.decisionRequirementsKeys()),
+        stringTerms(TENANT_ID, filter.tenantIds()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -53,14 +53,12 @@ public final class DecisionInstanceFilterTransformer
     ofNullable(getKeysQuery(filter.decisionInstanceKeys())).ifPresent(queries::add);
     ofNullable(getIdsQuery(filter.decisionInstanceIds())).ifPresent(queries::add);
     ofNullable(getStatesQuery(filter.states())).ifPresent(queries::add);
-    ofNullable(getEvaluationDateQuery(filter.evaluationDateOperations()))
-        .ifPresent(queries::addAll);
+    queries.addAll(getEvaluationDateQuery(filter.evaluationDateOperations()));
     ofNullable(getEvaluationFailuresQuery(filter.evaluationFailures())).ifPresent(queries::add);
     ofNullable(getProcessDefinitionKeysQuery(filter.processDefinitionKeys()))
         .ifPresent(queries::add);
     ofNullable(getProcessInstanceKeysQuery(filter.processInstanceKeys())).ifPresent(queries::add);
-    ofNullable(getDecisionDefinitionKeysQuery(filter.decisionDefinitionKeyOperations()))
-        .ifPresent(queries::addAll);
+    queries.addAll(getDecisionDefinitionKeysQuery(filter.decisionDefinitionKeyOperations()));
     ofNullable(getDecisionDefinitionIdsQuery(filter.decisionDefinitionIds()))
         .ifPresent(queries::add);
     ofNullable(getDecisionDefinitionNamesQuery(filter.decisionDefinitionNames()))

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionRequirementsFilterTransformer.java
@@ -21,7 +21,6 @@ import static io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIn
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.List;
 
 public final class DecisionRequirementsFilterTransformer
     extends IndexFilterTransformer<DecisionRequirementsFilter> {
@@ -32,44 +31,12 @@ public final class DecisionRequirementsFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final DecisionRequirementsFilter filter) {
-    final var keysQuery = getKeysQuery(filter.decisionRequirementsKeys());
-    final var namesQuery = getNamesQuery(filter.names());
-    final var versionsQuery = getVersionsQuery(filter.versions());
-    final var decisionRequirementsIdsQuery =
-        getDecisionRequirementsIdsQuery(filter.decisionRequirementsIds());
-    final var tenantIdsQuery = getTenantIdsQuery(filter.tenantIds());
-    final var resourceNamesQuery = getResourceNamesQuery(filter.resourceNames());
-
     return and(
-        keysQuery,
-        namesQuery,
-        versionsQuery,
-        decisionRequirementsIdsQuery,
-        tenantIdsQuery,
-        resourceNamesQuery);
-  }
-
-  private SearchQuery getKeysQuery(final List<Long> keys) {
-    return longTerms(KEY, keys);
-  }
-
-  private SearchQuery getNamesQuery(final List<String> names) {
-    return stringTerms(NAME, names);
-  }
-
-  private SearchQuery getVersionsQuery(final List<Integer> versions) {
-    return intTerms(VERSION, versions);
-  }
-
-  private SearchQuery getDecisionRequirementsIdsQuery(final List<String> decisionRequirementsIds) {
-    return stringTerms(DECISION_REQUIREMENTS_ID, decisionRequirementsIds);
-  }
-
-  private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {
-    return stringTerms(TENANT_ID, tenantIds);
-  }
-
-  private SearchQuery getResourceNamesQuery(final List<String> resourceNames) {
-    return stringTerms(RESOURCE_NAME, resourceNames);
+        longTerms(KEY, filter.decisionRequirementsKeys()),
+        stringTerms(NAME, filter.names()),
+        intTerms(VERSION, filter.versions()),
+        stringTerms(DECISION_REQUIREMENTS_ID, filter.decisionRequirementsIds()),
+        stringTerms(TENANT_ID, filter.tenantIds()),
+        stringTerms(RESOURCE_NAME, filter.resourceNames()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -40,7 +40,7 @@ public class FlownodeInstanceFilterTransformer
         .ifPresent(queries::add);
     ofNullable(stringTerms(BPMN_PROCESS_ID, filter.processDefinitionIds())).ifPresent(queries::add);
     ofNullable(getTypeQuery(filter.types())).ifPresent(queries::add);
-    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
+    queries.addAll(stringOperations(STATE, filter.stateOperations()));
     ofNullable(stringTerms(FLOW_NODE_ID, filter.flowNodeIds())).ifPresent(queries::add);
     ofNullable(stringTerms(FLOW_NODE_NAME, filter.flowNodeNames())).ifPresent(queries::add);
     ofNullable(longTerms(INCIDENT_KEY, filter.incidentKeys())).ifPresent(queries::add);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/IncidentFilterTransformer.java
@@ -26,12 +26,10 @@ import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.PR
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.STATE;
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.TREE_PATH;
-import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import java.util.ArrayList;
 
 public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFilter> {
 
@@ -41,31 +39,20 @@ public class IncidentFilterTransformer extends IndexFilterTransformer<IncidentFi
 
   @Override
   public SearchQuery toSearchQuery(final IncidentFilter filter) {
-    final var queries = new ArrayList<SearchQuery>();
-    ofNullable(longOperations(KEY, filter.incidentKeyOperations())).ifPresent(queries::addAll);
-    ofNullable(longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(ERROR_TYPE, filter.errorTypeOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(ERROR_MSG, filter.errorMessageOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(FLOW_NODE_ID, filter.flowNodeIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(longOperations(FLOW_NODE_INSTANCE_KEY, filter.flowNodeInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(dateTimeOperations(CREATION_TIME, filter.creationTimeOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(TREE_PATH, filter.treePathOperations())).ifPresent(queries::addAll);
-    ofNullable(longOperations(JOB_KEY, filter.jobKeyOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
-    ofNullable(intOperations(ERROR_MSG_HASH, filter.errorMessageHashOperations()))
-        .ifPresent(queries::addAll);
-
-    return and(queries);
+    return and(
+        longOperations(KEY, filter.incidentKeyOperations()),
+        longOperations(PROCESS_DEFINITION_KEY, filter.processDefinitionKeyOperations()),
+        stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()),
+        longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()),
+        stringOperations(ERROR_TYPE, filter.errorTypeOperations()),
+        stringOperations(ERROR_MSG, filter.errorMessageOperations()),
+        stringOperations(FLOW_NODE_ID, filter.flowNodeIdOperations()),
+        longOperations(FLOW_NODE_INSTANCE_KEY, filter.flowNodeInstanceKeyOperations()),
+        dateTimeOperations(CREATION_TIME, filter.creationTimeOperations()),
+        stringOperations(STATE, filter.stateOperations()),
+        stringOperations(TREE_PATH, filter.treePathOperations()),
+        longOperations(JOB_KEY, filter.jobKeyOperations()),
+        stringOperations(TENANT_ID, filter.tenantIdOperations()),
+        intOperations(ERROR_MSG_HASH, filter.errorMessageHashOperations()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionStatisticsFilterTransformer.java
@@ -93,10 +93,8 @@ public class ProcessDefinitionStatisticsFilterTransformer
       final ProcessDefinitionStatisticsFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
 
-    ofNullable(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()))
-        .ifPresent(queries::addAll);
+    queries.addAll((stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations())));
+    queries.addAll(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()));
     ofNullable(filter.hasFlowNodeInstanceIncident())
         .ifPresent(value -> queries.add(term(INCIDENT, value)));
 
@@ -107,32 +105,25 @@ public class ProcessDefinitionStatisticsFilterTransformer
       final ProcessDefinitionStatisticsFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
 
-    ofNullable(longOperations(KEY, filter.processInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(
-            longOperations(
-                PARENT_PROCESS_INSTANCE_KEY, filter.parentProcessInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(
-            longOperations(
-                PARENT_FLOW_NODE_INSTANCE_KEY, filter.parentFlowNodeInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(dateTimeOperations(START_DATE, filter.startDateOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(dateTimeOperations(END_DATE, filter.endDateOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
+    queries.addAll(longOperations(KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(
+        longOperations(PARENT_PROCESS_INSTANCE_KEY, filter.parentProcessInstanceKeyOperations()));
+    queries.addAll(
+        longOperations(
+            PARENT_FLOW_NODE_INSTANCE_KEY, filter.parentFlowNodeInstanceKeyOperations()));
+    queries.addAll(dateTimeOperations(START_DATE, filter.startDateOperations()));
+    queries.addAll(dateTimeOperations(END_DATE, filter.endDateOperations()));
+    queries.addAll(stringOperations(STATE, filter.stateOperations()));
     ofNullable(filter.hasIncident()).ifPresent(value -> queries.add(term(INCIDENT, value)));
-    ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
+    queries.addAll(stringOperations(TENANT_ID, filter.tenantIdOperations()));
     ofNullable(getProcessVariablesQuery(filter.variableFilters())).ifPresent(queries::add);
-    ofNullable(
-            stringMatchWithHasChildOperations(
-                ERROR_MSG,
-                filter.errorMessageOperations(),
-                ACTIVITIES_JOIN_RELATION,
-                SearchMatchQueryOperator.AND))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()))
-        .ifPresent(queries::addAll);
+    queries.addAll(
+        stringMatchWithHasChildOperations(
+            ERROR_MSG,
+            filter.errorMessageOperations(),
+            ACTIVITIES_JOIN_RELATION,
+            SearchMatchQueryOperator.AND));
+    queries.addAll(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()));
     ofNullable(filter.hasRetriesLeft()).ifPresent(value -> queries.add(hasRetriesLeftQuery(value)));
 
     return ofNullable(queries.isEmpty() ? null : queries);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -55,33 +55,23 @@ public final class ProcessInstanceFilterTransformer
 
   public ArrayList<SearchQuery> toSearchQueryFields(final ProcessInstanceFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
-    ofNullable(longOperations(KEY, filter.processInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(stringOperations(PROCESS_NAME, filter.processDefinitionNameOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(intOperations(PROCESS_VERSION, filter.processDefinitionVersionOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(
-            stringOperations(PROCESS_VERSION_TAG, filter.processDefinitionVersionTagOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(longOperations(PROCESS_KEY, filter.processDefinitionKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(
-            longOperations(
-                PARENT_PROCESS_INSTANCE_KEY, filter.parentProcessInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(
-            longOperations(
-                PARENT_FLOW_NODE_INSTANCE_KEY, filter.parentFlowNodeInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(dateTimeOperations(START_DATE, filter.startDateOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(dateTimeOperations(END_DATE, filter.endDateOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
+    queries.addAll(longOperations(KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(stringOperations(BPMN_PROCESS_ID, filter.processDefinitionIdOperations()));
+    queries.addAll(stringOperations(PROCESS_NAME, filter.processDefinitionNameOperations()));
+    queries.addAll(intOperations(PROCESS_VERSION, filter.processDefinitionVersionOperations()));
+    queries.addAll(
+        stringOperations(PROCESS_VERSION_TAG, filter.processDefinitionVersionTagOperations()));
+    queries.addAll(longOperations(PROCESS_KEY, filter.processDefinitionKeyOperations()));
+    queries.addAll(
+        longOperations(PARENT_PROCESS_INSTANCE_KEY, filter.parentProcessInstanceKeyOperations()));
+    queries.addAll(
+        longOperations(
+            PARENT_FLOW_NODE_INSTANCE_KEY, filter.parentFlowNodeInstanceKeyOperations()));
+    queries.addAll(dateTimeOperations(START_DATE, filter.startDateOperations()));
+    queries.addAll(dateTimeOperations(END_DATE, filter.endDateOperations()));
+    queries.addAll(stringOperations(STATE, filter.stateOperations()));
     ofNullable(getIncidentQuery(filter.hasIncident())).ifPresent(queries::add);
-    ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
+    queries.addAll(stringOperations(TENANT_ID, filter.tenantIdOperations()));
 
     if (filter.variableFilters() != null && !filter.variableFilters().isEmpty()) {
       final var processVariableQuery = getProcessVariablesQuery(filter.variableFilters());
@@ -89,17 +79,15 @@ public final class ProcessInstanceFilterTransformer
     }
 
     if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
-      ofNullable(
-              stringMatchWithHasChildOperations(
-                  ERROR_MSG,
-                  filter.errorMessageOperations(),
-                  ACTIVITIES_JOIN_RELATION,
-                  SearchMatchQueryOperator.AND))
-          .ifPresent(queries::addAll);
+      queries.addAll(
+          stringMatchWithHasChildOperations(
+              ERROR_MSG,
+              filter.errorMessageOperations(),
+              ACTIVITIES_JOIN_RELATION,
+              SearchMatchQueryOperator.AND));
     }
 
-    ofNullable(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()))
-        .ifPresent(queries::addAll);
+    queries.addAll(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()));
 
     ofNullable(getHasRetriesLeftQuery(filter.hasRetriesLeft())).ifPresent(queries::add);
 
@@ -133,10 +121,9 @@ public final class ProcessInstanceFilterTransformer
   private static SearchQuery getFlowNodeInstanceQuery(final ProcessInstanceFilter filter) {
     final var flowNodeInstanceQueries = new ArrayList<SearchQuery>();
 
-    ofNullable(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()))
-        .ifPresent(flowNodeInstanceQueries::addAll);
-    ofNullable(stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()))
-        .ifPresent(flowNodeInstanceQueries::addAll);
+    flowNodeInstanceQueries.addAll(stringOperations(ACTIVITY_ID, filter.flowNodeIdOperations()));
+    flowNodeInstanceQueries.addAll(
+        stringOperations(ACTIVITY_STATE, filter.flowNodeInstanceStateOperations()));
     ofNullable(filter.hasFlowNodeInstanceIncident())
         .ifPresent(incident -> flowNodeInstanceQueries.add((term(INCIDENT, incident))));
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -14,7 +14,6 @@ import static io.camunda.webapps.schema.descriptors.index.UserIndex.EMAIL;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.NAME;
 import static io.camunda.webapps.schema.descriptors.index.UserIndex.USERNAME;
-import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.UserFilter;
@@ -33,9 +32,9 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
     if (filter.key() != null) {
       queries.add(term(KEY, filter.key()));
     }
-    ofNullable(stringOperations(USERNAME, filter.usernameOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(NAME, filter.nameOperations())).ifPresent(queries::addAll);
-    ofNullable(stringOperations(EMAIL, filter.emailOperations())).ifPresent(queries::addAll);
+    queries.addAll(stringOperations(USERNAME, filter.usernameOperations()));
+    queries.addAll(stringOperations(NAME, filter.nameOperations()));
+    queries.addAll(stringOperations(EMAIL, filter.emailOperations()));
     return and(queries);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -67,19 +67,17 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
         .ifPresent(queries::add);
     ofNullable(getBpmnProcessIdQuery(filter.bpmnProcessIds())).ifPresent(queries::add);
     ofNullable(getElementIdQuery(filter.elementIds())).ifPresent(queries::add);
-    ofNullable(getCandidateUsersQuery(filter.candidateUserOperations())).ifPresent(queries::addAll);
-    ofNullable(getCandidateGroupsQuery(filter.candidateGroupOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(getAssigneesQuery(filter.assigneeOperations())).ifPresent(queries::addAll);
-    ofNullable(getPrioritiesQuery(filter.priorityOperations())).ifPresent(queries::addAll);
+    queries.addAll(getCandidateUsersQuery(filter.candidateUserOperations()));
+    queries.addAll(getCandidateGroupsQuery(filter.candidateGroupOperations()));
+    queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
+    queries.addAll(getPrioritiesQuery(filter.priorityOperations()));
     ofNullable(getStateQuery(filter.states())).ifPresent(queries::add);
     ofNullable(getTenantQuery(filter.tenantIds())).ifPresent(queries::add);
     ofNullable(getElementInstanceKeyQuery(filter.elementInstanceKeys())).ifPresent(queries::add);
-    ofNullable(getCreationTimeQuery(filter.creationDateOperations())).ifPresent(queries::addAll);
-    ofNullable(getCompletionTimeQuery(filter.completionDateOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(getFollowUpDateQuery(filter.followUpDateOperations())).ifPresent(queries::addAll);
-    ofNullable(getDueDateQuery(filter.dueDateOperations())).ifPresent(queries::addAll);
+    queries.addAll(getCreationTimeQuery(filter.creationDateOperations()));
+    queries.addAll(getCompletionTimeQuery(filter.completionDateOperations()));
+    queries.addAll(getFollowUpDateQuery(filter.followUpDateOperations()));
+    queries.addAll(getDueDateQuery(filter.dueDateOperations()));
 
     // Process Instance Variable Query: Check if processVariable  with specified varName and
     // varValue exists

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
@@ -39,12 +39,11 @@ public class VariableFilterTransformer extends IndexFilterTransformer<VariableFi
   @Override
   public SearchQuery toSearchQuery(final VariableFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
-    ofNullable(stringOperations(NAME, filter.nameOperations())).ifPresent(queries::addAll);
-    ofNullable(getVariablesQuery(filter.valueOperations())).ifPresent(queries::addAll);
-    ofNullable(getScopeKeyQuery(filter.scopeKeyOperations())).ifPresent(queries::addAll);
-    ofNullable(getProcessInstanceKeyQuery(filter.processInstanceKeyOperations()))
-        .ifPresent(queries::addAll);
-    ofNullable(getVariableKeyQuery(filter.variableKeyOperations())).ifPresent(queries::addAll);
+    queries.addAll(stringOperations(NAME, filter.nameOperations()));
+    queries.addAll(getVariablesQuery(filter.valueOperations()));
+    queries.addAll(getScopeKeyQuery(filter.scopeKeyOperations()));
+    queries.addAll(getProcessInstanceKeyQuery(filter.processInstanceKeyOperations()));
+    queries.addAll(getVariableKeyQuery(filter.variableKeyOperations()));
     ofNullable(getTenantIdQuery(filter.tenantIds())).ifPresent(queries::add);
     ofNullable(getIsTruncatedQuery(filter.isTruncated())).ifPresent(queries::add);
     return and(queries);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableValueFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableValueFilterTransformer.java
@@ -14,11 +14,8 @@ import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NA
 import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.VALUE;
 
 import io.camunda.search.clients.query.SearchQuery;
-import io.camunda.search.clients.query.SearchQueryBuilders;
-import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.filter.VariableValueFilter;
 import java.util.ArrayList;
-import java.util.Collections;
 
 public final class VariableValueFilterTransformer
     implements FilterTransformer<VariableValueFilter> {
@@ -35,14 +32,9 @@ public final class VariableValueFilterTransformer
       return variableNameQuery;
     }
 
-    final var valueQueries = variableOperations(varValue, value.valueOperations());
-    final var queries = new ArrayList<>(Collections.singletonList(variableNameQuery));
-    queries.addAll(valueQueries);
+    final var queries = new ArrayList<SearchQuery>();
+    queries.add(variableNameQuery);
+    queries.addAll(variableOperations(varValue, value.valueOperations()));
     return and(queries);
-  }
-
-  private SearchQuery of(final Object value, final String field) {
-    final var typedValue = TypedValue.toTypedValue(value);
-    return SearchQueryBuilders.term().field(field).value(typedValue).build().toSearchQuery();
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/IncidentQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/IncidentQueryTransformerTest.java
@@ -9,11 +9,9 @@ package io.camunda.search.clients.transformers.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
-import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.FilterBuilders;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -97,7 +95,7 @@ public final class IncidentQueryTransformerTest extends AbstractTransformerTest 
 
   @Test
   public void shouldQueryByErrorType() {
-    final var filter = FilterBuilders.incident(f -> f.errorTypes(ErrorType.JOB_NO_RETRIES));
+    final var filter = FilterBuilders.incident(f -> f.errorTypes(ErrorType.JOB_NO_RETRIES.name()));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -115,7 +113,8 @@ public final class IncidentQueryTransformerTest extends AbstractTransformerTest 
 
   @Test
   public void shouldQueryByResourceNotFoundErrorType() {
-    final var filter = FilterBuilders.incident(f -> f.errorTypes(ErrorType.RESOURCE_NOT_FOUND));
+    final var filter =
+        FilterBuilders.incident(f -> f.errorTypes(ErrorType.RESOURCE_NOT_FOUND.name()));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -189,8 +188,7 @@ public final class IncidentQueryTransformerTest extends AbstractTransformerTest 
   public void shouldQueryByCreationTime() {
     final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     final var date = OffsetDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
-    final var dateFilter = new DateValueFilter.Builder().before(date).after(date).build();
-    final var filter = FilterBuilders.incident(f -> f.creationTime(dateFilter));
+    final var filter = FilterBuilders.incident(f -> f.creationTime(date));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -199,16 +197,16 @@ public final class IncidentQueryTransformerTest extends AbstractTransformerTest 
     final var queryVariant = searchRequest.queryOption();
     assertThat(queryVariant)
         .isInstanceOfSatisfying(
-            SearchRangeQuery.class,
+            SearchTermQuery.class,
             t -> {
               assertThat(t.field()).isEqualTo("creationTime");
-              assertThat(t.gte().toString()).isEqualTo(date.format(formatter));
+              assertThat(t.value().stringValue()).isEqualTo(date.format(formatter));
             });
   }
 
   @Test
   public void shouldQueryByState() {
-    final var filter = FilterBuilders.incident(f -> f.states(IncidentState.ACTIVE));
+    final var filter = FilterBuilders.incident(f -> f.states(IncidentState.ACTIVE.name()));
 
     // when
     final var searchRequest = transformQuery(filter);

--- a/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/IncidentFilter.java
@@ -10,182 +10,274 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
-import io.camunda.search.entities.IncidentEntity.ErrorType;
-import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public record IncidentFilter(
-    List<Long> incidentKeys,
-    List<Long> processDefinitionKeys,
-    List<String> processDefinitionIds,
-    List<Long> processInstanceKeys,
-    List<ErrorType> errorTypes,
-    List<String> errorMessages,
-    List<Integer> errorMessageHashes,
-    List<String> flowNodeIds,
-    List<Long> flowNodeInstanceKeys,
-    DateValueFilter creationTime,
-    List<IncidentState> states,
-    String treePath,
-    List<Long> jobKeys,
-    List<String> tenantIds)
+    List<Operation<Long>> incidentKeyOperations,
+    List<Operation<Long>> processDefinitionKeyOperations,
+    List<Operation<String>> processDefinitionIdOperations,
+    List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<String>> errorTypeOperations,
+    List<Operation<String>> errorMessageOperations,
+    List<Operation<Integer>> errorMessageHashOperations,
+    List<Operation<String>> flowNodeIdOperations,
+    List<Operation<Long>> flowNodeInstanceKeyOperations,
+    List<Operation<OffsetDateTime>> creationTimeOperations,
+    List<Operation<String>> stateOperations,
+    List<Operation<String>> treePathOperations,
+    List<Operation<Long>> jobKeyOperations,
+    List<Operation<String>> tenantIdOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<IncidentFilter> {
 
-    private List<Long> incidentKeys;
-    private List<Long> processDefinitionKeys;
-    private List<String> processDefinitionIds;
-    private List<Long> processInstanceKeys;
-    private List<ErrorType> errorTypes;
-    private List<String> errorMessages;
-    private List<Integer> errorMessageHashes;
-    private List<String> flowNodeIds;
-    private List<Long> flowNodeInstanceKeys;
-    private DateValueFilter creationTimeFilter;
-    private List<IncidentState> states;
-    private String treePath;
-    private List<Long> jobKeys;
-    private List<String> tenantIds;
+    private List<Operation<Long>> incidentKeyOperations;
+    private List<Operation<Long>> processDefinitionKeyOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
+    private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<String>> errorTypeOperations;
+    private List<Operation<String>> errorMessageOperations;
+    private List<Operation<Integer>> errorMessageHashOperations;
+    private List<Operation<String>> flowNodeIdOperations;
+    private List<Operation<Long>> flowNodeInstanceKeyOperations;
+    private List<Operation<OffsetDateTime>> creationTimeOperations;
+    private List<Operation<String>> stateOperations;
+    private List<Operation<String>> treePathOperations;
+    private List<Operation<Long>> jobKeyOperations;
+    private List<Operation<String>> tenantIdOperations;
 
     public Builder incidentKeys(final Long value, final Long... values) {
-      return incidentKeys(collectValues(value, values));
+      return incidentKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder incidentKeys(final List<Long> values) {
-      incidentKeys = addValuesToList(incidentKeys, values);
+    public Builder incidentKeyOperations(final List<Operation<Long>> operations) {
+      incidentKeyOperations = addValuesToList(incidentKeyOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder incidentKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return incidentKeyOperations(collectValues(operation, operations));
     }
 
     public Builder processDefinitionKeys(final Long value, final Long... values) {
-      return processDefinitionKeys(collectValues(value, values));
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder processDefinitionKeys(final List<Long> values) {
-      processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = addValuesToList(processDefinitionKeyOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
     }
 
     public Builder processDefinitionIds(final String value, final String... values) {
-      return processDefinitionIds(collectValues(value, values));
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder processDefinitionIds(final List<String> values) {
-      processDefinitionIds = addValuesToList(processDefinitionIds, values);
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
     }
 
     public Builder processInstanceKeys(final Long value, final Long... values) {
-      return processInstanceKeys(collectValues(value, values));
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder processInstanceKeys(final List<Long> values) {
-      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
       return this;
     }
 
-    public Builder errorTypes(final ErrorType value, final ErrorType... values) {
-      return errorTypes(collectValues(value, values));
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder errorTypes(final List<ErrorType> values) {
-      errorTypes = addValuesToList(errorTypes, values);
+    public Builder errorTypes(final String value, final String... values) {
+      return errorTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder errorTypeOperations(final List<Operation<String>> operations) {
+      errorTypeOperations = addValuesToList(errorTypeOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorTypeOperations(collectValues(operation, operations));
     }
 
     public Builder errorMessages(final String value, final String... values) {
-      return errorMessages(collectValues(value, values));
+      return errorMessageOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder errorMessages(final List<String> values) {
-      errorMessages = addValuesToList(errorMessages, values);
+    public Builder errorMessageOperations(final List<Operation<String>> values) {
+      errorMessageOperations = addValuesToList(errorMessageOperations, values);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder errorMessageOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorMessageOperations(collectValues(operation, operations));
     }
 
     public Builder errorMessageHashes(final Integer value, final Integer... values) {
-      return errorMessageHashes(collectValues(value, values));
+      return errorMessageHashOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder errorMessageHashes(final List<Integer> values) {
-      errorMessageHashes = addValuesToList(errorMessageHashes, values);
+    public Builder errorMessageHashOperations(final List<Operation<Integer>> operations) {
+      errorMessageHashOperations = addValuesToList(errorMessageHashOperations, operations);
       return this;
     }
 
-    public Builder creationTime(final DateValueFilter value) {
-      creationTimeFilter = value;
+    @SafeVarargs
+    public final Builder errorMessageHashOperations(
+        final Operation<Integer> operation, final Operation<Integer>... operations) {
+      return errorMessageHashOperations(collectValues(operation, operations));
+    }
+
+    public Builder creationTime(final OffsetDateTime value) {
+      return creationTimeOperations(FilterUtil.mapDefaultToOperation(value));
+    }
+
+    public Builder creationTimeOperations(final List<Operation<OffsetDateTime>> operations) {
+      creationTimeOperations = addValuesToList(creationTimeOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder creationTimeOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return creationTimeOperations(collectValues(operation, operations));
     }
 
     public Builder flowNodeIds(final String value, final String... values) {
-      return flowNodeIds(collectValues(value, values));
+      return flowNodeIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder flowNodeIds(final List<String> values) {
-      flowNodeIds = addValuesToList(flowNodeIds, values);
+    public Builder flowNodeIdOperations(final List<Operation<String>> operations) {
+      flowNodeIdOperations = addValuesToList(flowNodeIdOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder flowNodeIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return flowNodeIdOperations(collectValues(operation, operations));
     }
 
     public Builder flowNodeInstanceKeys(final Long value, final Long... values) {
-      return flowNodeInstanceKeys(collectValues(value, values));
+      return flowNodeInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder flowNodeInstanceKeys(final List<Long> values) {
-      flowNodeInstanceKeys = addValuesToList(flowNodeInstanceKeys, values);
+    public Builder flowNodeInstanceKeyOperations(final List<Operation<Long>> operations) {
+      flowNodeInstanceKeyOperations = addValuesToList(flowNodeInstanceKeyOperations, operations);
       return this;
     }
 
-    public Builder states(final IncidentState value, final IncidentState... values) {
-      return states(collectValues(value, values));
+    @SafeVarargs
+    public final Builder flowNodeInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return flowNodeInstanceKeyOperations(collectValues(operation, operations));
     }
 
-    public Builder states(final List<IncidentState> values) {
-      states = addValuesToList(states, values);
+    public Builder states(final String value, final String... values) {
+      return stateOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder stateOperations(final List<Operation<String>> values) {
+      stateOperations = addValuesToList(stateOperations, values);
       return this;
     }
 
-    public Builder treePath(final String value) {
-      treePath = value;
+    @SafeVarargs
+    public final Builder stateOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return stateOperations(collectValues(operation, operations));
+    }
+
+    public Builder treePaths(final String value, final String... values) {
+      return treePathOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder treePathOperations(final List<Operation<String>> operations) {
+      treePathOperations = addValuesToList(treePathOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder treePathOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return treePathOperations(collectValues(operation, operations));
     }
 
     public Builder jobKeys(final Long value, final Long... values) {
-      return jobKeys(collectValues(value, values));
+      return jobKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder jobKeys(final List<Long> values) {
-      jobKeys = addValuesToList(jobKeys, values);
+    public Builder jobKeyOperations(final List<Operation<Long>> operations) {
+      jobKeyOperations = addValuesToList(jobKeyOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder jobKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return jobKeyOperations(collectValues(operation, operations));
     }
 
     public Builder tenantIds(final String value, final String... values) {
-      return tenantIds(collectValues(value, values));
+      return tenantIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder tenantIds(final List<String> values) {
-      tenantIds = addValuesToList(tenantIds, values);
+    public Builder tenantIdOperations(final List<Operation<String>> operations) {
+      tenantIdOperations = addValuesToList(tenantIdOperations, operations);
       return this;
+    }
+
+    @SafeVarargs
+    public final Builder tenantIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return tenantIdOperations(collectValues(operation, operations));
     }
 
     @Override
     public IncidentFilter build() {
       return new IncidentFilter(
-          Objects.requireNonNullElse(incidentKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionIds, Collections.emptyList()),
-          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(errorTypes, Collections.emptyList()),
-          Objects.requireNonNullElse(errorMessages, Collections.emptyList()),
-          Objects.requireNonNullElse(errorMessageHashes, Collections.emptyList()),
-          Objects.requireNonNullElse(flowNodeIds, Collections.emptyList()),
-          Objects.requireNonNullElse(flowNodeInstanceKeys, Collections.emptyList()),
-          creationTimeFilter,
-          Objects.requireNonNullElse(states, Collections.emptyList()),
-          treePath,
-          Objects.requireNonNullElse(jobKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(incidentKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorTypeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorMessageHashOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeInstanceKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(creationTimeOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(treePathOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(jobKeyOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()));
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -17,7 +17,6 @@ import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
-import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
@@ -311,11 +310,11 @@ public final class ProcessInstanceServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .searchIncidents(
-            new IncidentQuery.Builder()
-                .filter(new IncidentFilter.Builder().treePath(treePath).build())
-                .page(query.page())
-                .sort(query.sort())
-                .build());
+            IncidentQuery.of(
+                b ->
+                    b.filter(f -> f.treePathOperations(Operation.like("*" + treePath + "*")))
+                        .page(query.page())
+                        .sort(query.sort())));
   }
 
   public record ProcessInstanceCreateRequest(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -450,7 +450,8 @@ public final class ProcessInstanceServiceTest {
     final var incidentQueryCaptor = ArgumentCaptor.forClass(IncidentQuery.class);
     verify(incidentSearchClient).searchIncidents(incidentQueryCaptor.capture());
     final var incidentQuery = incidentQueryCaptor.getValue();
-    assertThat(incidentQuery.filter().treePath()).isEqualTo(processInstance.treePath());
+    assertThat(incidentQuery.filter().treePathOperations())
+        .containsExactly(Operation.like("*" + processInstance.treePath() + "*"));
     assertThat(incidentQuery.page()).isEqualTo(query.page());
     assertThat(incidentQuery.sort()).isEqualTo(query.sort());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationItemProvider.java
@@ -19,6 +19,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.util.FilterUtil;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -174,7 +175,10 @@ public class BatchOperationItemProvider {
         return Set.of();
       }
       final var filter =
-          new IncidentFilter.Builder().processInstanceKeys(processInstanceKeysBatch).build();
+          new IncidentFilter.Builder()
+              .processInstanceKeyOperations(
+                  FilterUtil.mapDefaultToOperation(processInstanceKeysBatch))
+              .build();
       incidents.addAll(fetchIncidentItems(filter, authentication, shouldAbort));
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -17,8 +17,6 @@ import static java.util.Optional.ofNullable;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
-import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.filter.*;
 import io.camunda.search.filter.AuthorizationFilter;
@@ -1123,17 +1121,15 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getProcessInstanceKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::processInstanceKeys);
-      ofNullable(filter.getErrorType())
-          .ifPresent(t -> builder.errorTypes(IncidentEntity.ErrorType.valueOf(t.getValue())));
+      ofNullable(filter.getErrorType()).ifPresent(t -> builder.errorTypes(t.getValue()));
       ofNullable(filter.getErrorMessage()).ifPresent(builder::errorMessages);
       ofNullable(filter.getElementId()).ifPresent(builder::flowNodeIds);
       ofNullable(filter.getElementInstanceKey())
           .map(KeyUtil::keyToLong)
           .ifPresent(builder::flowNodeInstanceKeys);
       ofNullable(filter.getCreationTime())
-          .ifPresent(t -> builder.creationTime(toDateValueFilter(t)));
-      ofNullable(filter.getState())
-          .ifPresent(s -> builder.states(IncidentState.valueOf(s.getValue())));
+          .ifPresent(t -> builder.creationTime(toOffsetDateTime(t)));
+      ofNullable(filter.getState()).ifPresent(s -> builder.states(s.getValue()));
       ofNullable(filter.getJobKey()).map(KeyUtil::keyToLong).ifPresent(builder::jobKeys);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
@@ -1638,27 +1634,6 @@ public final class SearchQueryRequestMapper {
     } else {
       return values.toArray();
     }
-  }
-
-  private static DateValueFilter toDateValueFilter(final String text) {
-    if (StringUtils.isEmpty(text)) {
-      return null;
-    }
-    final var date = OffsetDateTime.parse(text);
-    return new DateValueFilter.Builder().before(date).after(date).build();
-  }
-
-  private static DateValueFilter toDateValueFilter(final String after, final String before) {
-    final Optional<OffsetDateTime> beforeDateTime = ofNullable(before).map(OffsetDateTime::parse);
-    final Optional<OffsetDateTime> afterDateTime =
-        Optional.ofNullable(after).map(OffsetDateTime::parse);
-    if (beforeDateTime.isEmpty() && afterDateTime.isEmpty()) {
-      return null;
-    }
-    return new DateValueFilter.Builder()
-        .before(beforeDateTime.orElse(null))
-        .after(afterDateTime.orElse(null))
-        .build();
   }
 
   public static Either<ProblemDetail, AuthorizationQuery> toAuthorizationQuery(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -15,7 +15,6 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.filter.DateValueFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -222,16 +221,12 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                         .processDefinitionKeys(23L)
                         .processDefinitionIds("complexProcess")
                         .processInstanceKeys(42L)
-                        .errorTypes(ErrorType.JOB_NO_RETRIES)
+                        .errorTypes(ErrorType.JOB_NO_RETRIES.name())
                         .errorMessages("No retries left.")
                         .flowNodeIds("elementId")
                         .flowNodeInstanceKeys(17L)
-                        .creationTime(
-                            new DateValueFilter.Builder()
-                                .before(creationTime)
-                                .after(creationTime)
-                                .build())
-                        .states(IncidentState.ACTIVE)
+                        .creationTime(creationTime)
+                        .states(IncidentState.ACTIVE.name())
                         .jobKeys(101L)
                         .tenantIds("tenantId")
                         .build())


### PR DESCRIPTION
## Description

Uses operations in incident filters in the search layer. This allows defining specific operations instead of equality only. With this, for process instance incident search, the tree path matching can be defined for all data layers at once.

Note: this is a nice preparation for adding advanced search to this endpoint later as well since all fields support operations then already.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33060 
