### PR TITLE
fix: add missing ASYNC_REQUEST config for exporter tests

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -70,6 +70,7 @@ public final class TestSupport {
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
+      case ASYNC_REQUEST -> config.asyncRequest = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -123,6 +124,7 @@ public final class TestSupport {
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
+      case ASYNC_REQUEST -> config.asyncRequest = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -71,6 +71,7 @@ public final class TestSupport {
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
+      case ASYNC_REQUEST -> config.asyncRequest = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -126,6 +127,7 @@ public final class TestSupport {
       case BATCH_OPERATION_PARTITION_LIFECYCLE -> config.batchOperationPartitionLifecycle = value;
       case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
           config.adHocSubProcessActivityActivation = value;
+      case ASYNC_REQUEST -> config.asyncRequest = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);


### PR DESCRIPTION
## Description

This PR adds missing support for the `ASYNC_REQUEST` value type in the exporter test configurations used by Operate and Tasklist.

The lack of this configuration caused integration test failures when `ASYNC_REQUEST` records were present 
(e.g. `ElasticsearchFinishedImportingIT`), due to `IllegalArgumentException` on unknown value type.

### Changes
- Extended `TestSupport` configurations to support `ASYNC_REQUEST`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32660
