### PR TITLE
ci: increase check-licenses.yml workflow timeout to 20 minutes

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -36,7 +36,7 @@ jobs:
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
     # Import FOSSA_API_KEY secret from Vault


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1749669463285589

For a few [pull requests](https://github.com/camunda/camunda/actions/workflows/check-licenses.yml?query=is%3Acancelled), FOSSA scanning and comparison against the base reference can take up to 15 minutes. It makes sense to increase the threshold to 20 minutes to avoid timeouts.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
