### PR TITLE
[Backport stable/optimize-8.6] fix: parse none nested string date correctly

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -137,7 +137,6 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
 
-    // when
     waitUntilNumberOfDefinitionsExported(1);
     waitUntilMinimumProcessInstanceEventsExportedCount(4);
     waitUntilMinimumVariableDocumentsExportedCount(1);
@@ -146,6 +145,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     // when
     final ProcessInstanceDto importedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
+
+    // then
     assertThat(importedProcessInstance.getVariables())
         .singleElement()
         .satisfies(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -126,6 +126,37 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   }
 
   @Test
+  public void variableImportWorksForDateStrings() {
+    // given
+    final Process deployedProcess = zeebeExtension.deployProcess(createStartEndProcess(PROCESS_ID));
+    final String variableName = "date";
+    final String variableValue = "2025-10-10";
+    final String parsedDateValue = "2025-10-10T00:00:00.000+0000";
+    final Map<String, Object> variables = Map.of(variableName, variableValue);
+    final Long processInstanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            deployedProcess.getBpmnProcessId(), variables);
+
+    // when
+    waitUntilNumberOfDefinitionsExported(1);
+    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumVariableDocumentsExportedCount(1);
+    importAllZeebeEntitiesFromScratch();
+
+    // when
+    final ProcessInstanceDto importedProcessInstance =
+        getProcessInstanceForId(String.valueOf(processInstanceKey));
+    assertThat(importedProcessInstance.getVariables())
+        .singleElement()
+        .satisfies(
+            variable -> {
+              assertThat(variable.getName()).isEqualTo(variableName);
+              assertThat(variable.getType()).isEqualTo(DATE.getId());
+              assertThat(variable.getValue().getFirst()).isEqualTo(parsedDateValue);
+            });
+  }
+
+  @Test
   public void zeebeVariableImport_variablesAddedAfterProcessStarted() {
     // given
     final ProcessInstanceEvent processInstanceEvent = deployProcessAndStartProcessInstance();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/ObjectVariableService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/ObjectVariableService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.service.importing.engine.service;
 
+import static io.camunda.optimize.dto.optimize.ReportConstants.STRING_TYPE;
 import static io.camunda.optimize.dto.optimize.query.variable.VariableType.BOOLEAN;
 import static io.camunda.optimize.dto.optimize.query.variable.VariableType.DATE;
 import static io.camunda.optimize.dto.optimize.query.variable.VariableType.DOUBLE;
@@ -73,8 +74,15 @@ public class ObjectVariableService {
         final ProcessVariableDto processVariableDto = createSkeletonVariableDto(variableUpdateDto);
         processVariableDto.setId(variableUpdateDto.getId());
         processVariableDto.setName(variableUpdateDto.getName());
-        processVariableDto.setType(variableUpdateDto.getType());
-        processVariableDto.setValue(Collections.singletonList(variableUpdateDto.getValue()));
+        if (variableUpdateDto.getType().equals(STRING_TYPE)) {
+          parseStringOrDateVariableAndSet(
+              variableUpdateDto.getValue(),
+              Collections.singletonList(variableUpdateDto.getValue()),
+              processVariableDto);
+        } else {
+          processVariableDto.setType(variableUpdateDto.getType());
+          processVariableDto.setValue(Collections.singletonList(variableUpdateDto.getValue()));
+        }
         resultList.add(processVariableDto);
       }
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/ObjectVariableService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/ObjectVariableService.java
@@ -71,19 +71,7 @@ public class ObjectVariableService {
           formatJsonObjectVariableAndAddToResult(variableUpdateDto, resultList);
         }
       } else {
-        final ProcessVariableDto processVariableDto = createSkeletonVariableDto(variableUpdateDto);
-        processVariableDto.setId(variableUpdateDto.getId());
-        processVariableDto.setName(variableUpdateDto.getName());
-        if (variableUpdateDto.getType().equals(STRING_TYPE)) {
-          parseStringOrDateVariableAndSet(
-              variableUpdateDto.getValue(),
-              Collections.singletonList(variableUpdateDto.getValue()),
-              processVariableDto);
-        } else {
-          processVariableDto.setType(variableUpdateDto.getType());
-          processVariableDto.setValue(Collections.singletonList(variableUpdateDto.getValue()));
-        }
-        resultList.add(processVariableDto);
+        formatNativeVariableAndAddToResult(variableUpdateDto, resultList);
       }
     }
     return resultList;
@@ -129,6 +117,23 @@ public class ObjectVariableService {
           variableUpdate.getName(),
           e);
     }
+  }
+
+  private void formatNativeVariableAndAddToResult(
+      final ProcessVariableUpdateDto variableUpdateDto, final List<ProcessVariableDto> resultList) {
+    final ProcessVariableDto processVariableDto = createSkeletonVariableDto(variableUpdateDto);
+    processVariableDto.setId(variableUpdateDto.getId());
+    processVariableDto.setName(variableUpdateDto.getName());
+    if (variableUpdateDto.getType().equals(STRING_TYPE)) {
+      parseStringOrDateVariableAndSet(
+          variableUpdateDto.getValue(),
+          Collections.singletonList(variableUpdateDto.getValue()),
+          processVariableDto);
+    } else {
+      processVariableDto.setType(variableUpdateDto.getType());
+      processVariableDto.setValue(Collections.singletonList(variableUpdateDto.getValue()));
+    }
+    resultList.add(processVariableDto);
   }
 
   @SuppressWarnings(UNCHECKED_CAST)


### PR DESCRIPTION
# Description
Backport of #33131 to `stable/optimize-8.6`.

relates to #32714