### PR TITLE
[Backport stable/8.6] ci: increase check-licenses.yml workflow timeout to 20 minutes

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -27,7 +27,7 @@ jobs:
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
     # Import FOSSA_API_KEY secret from Vault


### PR DESCRIPTION
# Description
Backport of #33654 to `stable/8.6`.

relates to 