### PR TITLE
[Backport stable/optimize-8.7] ci: increase check-licenses.yml workflow timeout to 20 minutes

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -19,7 +19,7 @@ jobs:
         project:
         - name: optimize
           path: ./optimize
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
     # Import FOSSA_API_KEY secret from Vault


### PR DESCRIPTION
# Description
Backport of #33654 to `stable/optimize-8.7`.

relates to 