### PR TITLE
Redirect to `/identity/setup` page if no admin user exists or is configured

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
 import io.camunda.authentication.ConditionalOnProtectedApi;
 import io.camunda.authentication.ConditionalOnUnprotectedApi;
+import io.camunda.authentication.filters.AdminUserCheckFilter;
 import io.camunda.authentication.filters.WebApplicationAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.handler.CustomMethodSecurityExpressionHandler;
@@ -250,7 +251,8 @@ public class WebSecurityConfig {
     public SecurityFilterChain httpBasicWebappAuthSecurityFilterChain(
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
-        final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter)
+        final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter,
+        final SecurityConfiguration securityConfiguration)
         throws Exception {
       LOG.info("Web Applications Login/Logout is setup.");
       return httpSecurity
@@ -284,6 +286,8 @@ public class WebSecurityConfig {
                       .authenticationEntryPoint(authFailureHandler)
                       .accessDeniedHandler(authFailureHandler))
           .addFilterAfter(webApplicationAuthorizationCheckFilter, AuthorizationFilter.class)
+          .addFilterBefore(
+              new AdminUserCheckFilter(securityConfiguration), AuthorizationFilter.class)
           .build();
     }
   }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -252,7 +252,8 @@ public class WebSecurityConfig {
         final HttpSecurity httpSecurity,
         final AuthFailureHandler authFailureHandler,
         final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter,
-        final SecurityConfiguration securityConfiguration)
+        final SecurityConfiguration securityConfiguration,
+        final RoleServices roleServices)
         throws Exception {
       LOG.info("Web Applications Login/Logout is setup.");
       return httpSecurity
@@ -287,7 +288,8 @@ public class WebSecurityConfig {
                       .accessDeniedHandler(authFailureHandler))
           .addFilterAfter(webApplicationAuthorizationCheckFilter, AuthorizationFilter.class)
           .addFilterBefore(
-              new AdminUserCheckFilter(securityConfiguration), AuthorizationFilter.class)
+              new AdminUserCheckFilter(securityConfiguration, roleServices),
+              AuthorizationFilter.class)
           .build();
     }
   }

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.filters;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -46,7 +47,7 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
         !securityConfig
             .getInitialization()
             .getDefaultRoles()
-            .getOrDefault("admin", Map.of())
+            .getOrDefault(ADMIN_ROLE_ID, Map.of())
             .getOrDefault(USER_MEMBERS, Set.of())
             .isEmpty();
 
@@ -64,7 +65,9 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
                           builder ->
                               builder.filter(
                                   filter ->
-                                      filter.joinParentId("admin").memberType(EntityType.USER))))
+                                      filter
+                                          .joinParentId(ADMIN_ROLE_ID)
+                                          .memberType(EntityType.USER))))
                   .total()
               > 0;
 

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import io.camunda.security.configuration.SecurityConfiguration;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class AdminUserCheckFilter extends OncePerRequestFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(AdminUserCheckFilter.class);
+  public static final String USER_MEMBERS = "users";
+  private final SecurityConfiguration securityConfig;
+
+  public AdminUserCheckFilter(final SecurityConfiguration securityConfig) {
+    this.securityConfig = securityConfig;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+    final var hasConfiguredAdminUser =
+        !securityConfig
+            .getInitialization()
+            .getDefaultRoles()
+            .getOrDefault("admin", Map.of())
+            .getOrDefault(USER_MEMBERS, Set.of())
+            .isEmpty();
+
+    if (!hasConfiguredAdminUser) {
+      LOG.info("No admin user configured. Redirecting to identity setup page.");
+      response.sendRedirect(String.format("%s/identity/setup", request.getContextPath()));
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -52,7 +52,6 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
             .isEmpty();
 
     if (hasConfiguredAdminUser) {
-      LOG.debug("Admin user has been configured.");
       filterChain.doFilter(request, response);
       return;
     }

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.filters;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.RoleMemberEntity;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.RoleServices;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class AdminUserCheckFilterTest {
+
+  @Mock private final RoleServices roleServices = mock(RoleServices.class);
+  @Mock private final HttpServletRequest request = mock(HttpServletRequest.class);
+  @Mock private final HttpServletResponse response = mock(HttpServletResponse.class);
+  @Mock private final FilterChain filterChain = mock(FilterChain.class);
+
+  @Test
+  void shouldRedirectIfNoAdminUserExistsOrIsConfigured() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    when(roleServices.searchMembers(any())).thenReturn(SearchQueryResult.empty());
+    when(request.getContextPath()).thenReturn("localhost:8080");
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(response).sendRedirect("localhost:8080/identity/setup");
+  }
+
+  @Test
+  void shouldNotRedirectIfAdminUserIsConfigured() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    securityConfig
+        .getInitialization()
+        .getDefaultRoles()
+        .put("admin", Map.of("users", Set.of("adminUser")));
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldNotRedirectIfAdminUserExists() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    when(roleServices.searchMembers(any()))
+        .thenReturn(new SearchQueryResult.Builder<RoleMemberEntity>().total(1).build());
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
+++ b/security/security-protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DefaultRole.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum DefaultRole {
+  ADMIN("admin"),
+  RPA("rpa"),
+  CONNECTORS("connectors");
+
+  private final String id;
+
+  DefaultRole(final String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -139,7 +140,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   }
 
   private static void setupAdminRole(final IdentitySetupRecord setupRecord) {
-    final var adminRoleId = "admin";
+    final var adminRoleId = DefaultRole.ADMIN.getId();
     setupRecord.addRole(new RoleRecord().setRoleId(adminRoleId).setName("Admin"));
     for (final var resourceType : AuthorizationResourceType.values()) {
       if (resourceType == AuthorizationResourceType.UNSPECIFIED) {
@@ -163,7 +164,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   }
 
   private static void setupConnectorsRole(final IdentitySetupRecord setupRecord) {
-    final var connectorsRoleId = "connectors";
+    final var connectorsRoleId = DefaultRole.CONNECTORS.getId();
     setupRecord.addRole(new RoleRecord().setRoleId(connectorsRoleId).setName("Connectors"));
     setupRecord.addAuthorization(
         new AuthorizationRecord()
@@ -190,7 +191,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   }
 
   private static void setupRpaRole(final IdentitySetupRecord setupRecord) {
-    final var rpaRoleId = "rpa";
+    final var rpaRoleId = DefaultRole.RPA.getId();
     setupRecord
         .addRole(new RoleRecord().setRoleId(rpaRoleId).setName("RPA"))
         .addAuthorization(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a filter that checks if an admin user exists, or is configured. If this is **not** the case we will redirect to the `/identity/setup` page. This page will allow the user to fill out a form with a username, password, etc.., allowing them to create an admin user through the UI. The scope of this PR is limited to the redirect.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33533
