### PR TITLE
fix: include all state in OR filter

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.test.tsx
@@ -348,96 +348,94 @@ describe('DiagramPanel', () => {
     expect(screen.queryByTestId(/^state-overlay/)).not.toBeInTheDocument();
   });
 
-  describe('State filters', () => {
-    it('should display statistics when active and incidents are selected in the filter', async () => {
-      const queryString =
-        '?process=bigVarProcess&version=1&active=true&incidents=true';
+  it('should display statistics when active and incidents are selected in the filter', async () => {
+    const queryString =
+      '?process=bigVarProcess&version=1&active=true&incidents=true';
 
-      locationSpy.mockImplementation(() => ({
-        ...originalWindow.location,
-        search: queryString,
-      }));
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: queryString,
+    }));
 
-      mockFetchProcessInstancesStatistics().withSuccess(
-        mockMultipleStatesStatistics,
-      );
-      mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessInstancesStatistics().withSuccess(
+      mockMultipleStatesStatistics,
+    );
+    mockFetchProcessDefinitionXml().withSuccess('');
 
-      render(<DiagramPanel />, {
-        wrapper: getWrapper(`${Paths.processes()}${queryString}`),
-      });
-
-      expect(await screen.findByTestId('diagram')).toBeInTheDocument();
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-active'),
-      ).toHaveTextContent('1');
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-incidents'),
-      ).toHaveTextContent('3');
+    render(<DiagramPanel />, {
+      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
     });
 
-    it('should display statistics when completed and canceled are selected in the filter', async () => {
-      const queryString =
-        '?process=bigVarProcess&version=1&completed=true&canceled=true';
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-active'),
+    ).toHaveTextContent('1');
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-incidents'),
+    ).toHaveTextContent('3');
+  });
 
-      locationSpy.mockImplementation(() => ({
-        ...originalWindow.location,
-        search: queryString,
-      }));
+  it('should display statistics when completed and canceled are selected in the filter', async () => {
+    const queryString =
+      '?process=bigVarProcess&version=1&completed=true&canceled=true';
 
-      mockFetchProcessInstancesStatistics().withSuccess(
-        mockMultipleStatesStatistics,
-      );
-      mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: queryString,
+    }));
 
-      render(<DiagramPanel />, {
-        wrapper: getWrapper(`${Paths.processes()}${queryString}`),
-      });
+    mockFetchProcessInstancesStatistics().withSuccess(
+      mockMultipleStatesStatistics,
+    );
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
 
-      expect(await screen.findByTestId('diagram')).toBeInTheDocument();
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-canceled'),
-      ).toHaveTextContent('2');
-      expect(
-        await screen.findByTestId(
-          'state-overlay-EndEvent_042s0oc-completedEndEvents',
-        ),
-      ).toHaveTextContent('4');
+    render(<DiagramPanel />, {
+      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
     });
 
-    it('should display statistics when all states are selected', async () => {
-      const queryString =
-        '?process=bigVarProcess&version=1&active=true&incidents=true&completed=true&canceled=true';
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-canceled'),
+    ).toHaveTextContent('2');
+    expect(
+      await screen.findByTestId(
+        'state-overlay-EndEvent_042s0oc-completedEndEvents',
+      ),
+    ).toHaveTextContent('4');
+  });
 
-      locationSpy.mockImplementation(() => ({
-        ...originalWindow.location,
-        search: queryString,
-      }));
+  it('should display statistics when all states are selected', async () => {
+    const queryString =
+      '?process=bigVarProcess&version=1&active=true&incidents=true&completed=true&canceled=true';
 
-      mockFetchProcessInstancesStatistics().withSuccess(
-        mockMultipleStatesStatistics,
-      );
-      mockFetchProcessDefinitionXml().withSuccess('');
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: queryString,
+    }));
 
-      render(<DiagramPanel />, {
-        wrapper: getWrapper(`${Paths.processes()}${queryString}`),
-      });
+    mockFetchProcessInstancesStatistics().withSuccess(
+      mockMultipleStatesStatistics,
+    );
+    mockFetchProcessDefinitionXml().withSuccess('');
 
-      expect(await screen.findByTestId('diagram')).toBeInTheDocument();
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-active'),
-      ).toHaveTextContent('1');
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-canceled'),
-      ).toHaveTextContent('2');
-      expect(
-        await screen.findByTestId('state-overlay-EndEvent_042s0oc-incidents'),
-      ).toHaveTextContent('3');
-      expect(
-        await screen.findByTestId(
-          'state-overlay-EndEvent_042s0oc-completedEndEvents',
-        ),
-      ).toHaveTextContent('4');
+    render(<DiagramPanel />, {
+      wrapper: getWrapper(`${Paths.processes()}${queryString}`),
     });
+
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-active'),
+    ).toHaveTextContent('1');
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-canceled'),
+    ).toHaveTextContent('2');
+    expect(
+      await screen.findByTestId('state-overlay-EndEvent_042s0oc-incidents'),
+    ).toHaveTextContent('3');
+    expect(
+      await screen.findByTestId(
+        'state-overlay-EndEvent_042s0oc-completedEndEvents',
+      ),
+    ).toHaveTextContent('4');
   });
 });

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -69,7 +69,11 @@ describe('useProcessInstanceFilters', () => {
         $or: [
           {
             state: {
-              $eq: ProcessInstanceState.ACTIVE,
+              $in: [
+                ProcessInstanceState.ACTIVE,
+                ProcessInstanceState.COMPLETED,
+                ProcessInstanceState.TERMINATED,
+              ],
             },
           },
           {hasIncident: true},

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -108,11 +108,8 @@ function mapFiltersToRequest(
   if (canceled) state.push(ProcessInstanceState.TERMINATED);
 
   if (incidents) {
-    if (active) {
-      request.filter.$or = [
-        {state: {$eq: ProcessInstanceState.ACTIVE}},
-        {hasIncident: true},
-      ];
+    if (active || completed || canceled) {
+      request.filter.$or = [{state: {$in: state}}, {hasIncident: true}];
     } else {
       request.filter.hasIncident = true;
     }

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -386,6 +386,18 @@ export const mockProcessStatisticsV2 = {
   ],
 };
 
+export const mockMultipleStatesStatistics = {
+  items: [
+    {
+      elementId: 'EndEvent_042s0oc',
+      active: 1,
+      canceled: 2,
+      incidents: 3,
+      completed: 4,
+    },
+  ],
+};
+
 export const mockProcessXML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1771k9d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.5.0">
   <bpmn:process id="bigVarProcess" isExecutable="true" name="Big variable process">


### PR DESCRIPTION
## Description

The Operate process page does not show completed process instanced on the model if running instances are also selected to be filtered by. (See [screenshots](https://camunda.slack.com/archives/C08MRKHJ0CD/p1749718345299039))

We're missing COMPLETED and CANCELED states in our [OR filter here](https://github.com/camunda/camunda/blob/9f5ac19543da6cb862714ad96b67eb9882819460/operate/client/src/modules/hooks/useProcessInstancesFilters.ts#L113) which causes them to be excluded when ACTIVE and INCIDENTS are being used. I think it might have been a bug introduced when we migrated the process instance statistics overlay to v2 with the $OR filter introduction.

https://github.com/user-attachments/assets/d7faffdd-6ecc-4368-82b7-c0ac086252e5

## Related issues

closes #33700
