### PR TITLE
fix: unnecessary logging of complete chunk records in batch operation execution

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCancelProcessor.java
@@ -86,10 +86,7 @@ public final class BatchOperationCancelProcessor
     final var recordValue = command.getValue();
     final var batchOperationKey = recordValue.getBatchOperationKey();
     final var cancelKey = keyGenerator.nextKey();
-    LOGGER.debug(
-        "Processing new command to cancel a batch operation with key '{}': {}",
-        batchOperationKey,
-        recordValue);
+    LOGGER.debug("Cancelling batch operation with key {}", batchOperationKey);
 
     final var batchOperation = batchOperationState.get(batchOperationKey);
     if (batchOperation.isPresent() && batchOperation.get().canCancel()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
@@ -34,8 +34,7 @@ public final class BatchOperationCreateChunkProcessor
   public void processRecord(final TypedRecord<BatchOperationChunkRecord> command) {
     final var recordValue = command.getValue();
     LOGGER.debug(
-        "Processing new command with key '{}' for batch operation {} to create chunk with {} items",
-        command.getKey(),
+        "Creating a new chunk with {} items for batch operation {}",
         recordValue.getBatchOperationKey(),
         recordValue.getItems().size());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
@@ -33,7 +33,11 @@ public final class BatchOperationCreateChunkProcessor
   @Override
   public void processRecord(final TypedRecord<BatchOperationChunkRecord> command) {
     final var recordValue = command.getValue();
-    LOGGER.debug("Processing new command with key '{}': {}", command.getKey(), recordValue);
+    LOGGER.debug(
+        "Processing new command with key '{}' for batch operation {} to create chunk with {} items",
+        command.getKey(),
+        recordValue.getBatchOperationKey(),
+        recordValue.getItems().size());
 
     stateWriter.appendFollowUpEvent(
         command.getKey(), BatchOperationChunkIntent.CREATED, recordValue);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -85,7 +85,7 @@ public final class BatchOperationCreateProcessor
 
     final long key = keyGenerator.nextKey();
     final var recordValue = command.getValue();
-    LOGGER.debug("Processing new command with key '{}': {}", key, recordValue);
+    LOGGER.debug("Creating new batch operation with key '{}': {}", key, recordValue);
     metrics.startTotalLatencyMeasure(key, recordValue.getBatchOperationType());
 
     final var recordWithKey = new BatchOperationCreationRecord();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -44,6 +44,7 @@ public final class BatchOperationExecuteProcessor
       LoggerFactory.getLogger(BatchOperationExecuteProcessor.class);
 
   private static final int BATCH_SIZE = 10;
+  private static final int HEARTBEAT_INTERVAL = 1000;
 
   private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
@@ -77,7 +78,7 @@ public final class BatchOperationExecuteProcessor
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   public void processRecord(final TypedRecord<BatchOperationExecutionRecord> command) {
     final var executionRecord = command.getValue();
-    LOGGER.debug(
+    LOGGER.trace(
         "Processing new command with key '{}' on partition{} : {}",
         command.getKey(),
         partitionId,
@@ -104,7 +105,7 @@ public final class BatchOperationExecuteProcessor
       LOGGER.debug(
           "No items to process for BatchOperation {} on partition {}", batchKey, partitionId);
 
-      appendBatchOperationExecutionExecutedEvent(command.getValue(), Collections.emptySet());
+      appendBatchOperationExecutionExecutedEvent(batchOperation, Collections.emptySet());
       appendBatchOperationExecutionCompletedEvent(command.getValue());
 
       metrics.stopTotalExecutionLatencyMeasure(batchKey);
@@ -119,14 +120,10 @@ public final class BatchOperationExecuteProcessor
     final var handler = handlers.get(batchOperation.getBatchOperationType());
     entityKeys.forEach(entityKey -> handler.execute(entityKey, batchOperation));
 
-    appendBatchOperationExecutionExecutedEvent(command.getValue(), Set.copyOf(entityKeys));
+    appendBatchOperationExecutionExecutedEvent(batchOperation, Set.copyOf(entityKeys));
     appendBatchOperationExecuteCommand(command, batchKey, batchOperation);
 
     metrics.startExecuteCycleLatencyMeasure(batchKey, batchOperation.getBatchOperationType());
-  }
-
-  private PersistedBatchOperation getBatchOperation(final long batchOperationKey) {
-    return batchOperationState.get(batchOperationKey).orElse(null);
   }
 
   @Override
@@ -134,11 +131,15 @@ public final class BatchOperationExecuteProcessor
     return true;
   }
 
+  private PersistedBatchOperation getBatchOperation(final long batchOperationKey) {
+    return batchOperationState.get(batchOperationKey).orElse(null);
+  }
+
   private void appendBatchOperationExecuteCommand(
       final TypedRecord<BatchOperationExecutionRecord> command,
       final long batchKey,
       final PersistedBatchOperation batchOperation) {
-    LOGGER.debug(
+    LOGGER.trace(
         "Scheduling next batch for BatchOperation {} on partition {}", batchKey, partitionId);
     final var followupCommand = new BatchOperationExecutionRecord();
     followupCommand.setBatchOperationKey(batchKey);
@@ -165,16 +166,27 @@ public final class BatchOperationExecuteProcessor
   }
 
   private void appendBatchOperationExecutionExecutedEvent(
-      final BatchOperationExecutionRecord executionRecord, final Set<Long> keys) {
+      final PersistedBatchOperation batchOperation, final Set<Long> keys) {
     final var batchExecute = new BatchOperationExecutionRecord();
-    batchExecute.setBatchOperationKey(executionRecord.getBatchOperationKey());
+
+    // Occasionally log a heartbeat
+    // This modulo only works good if batch size is a divider of HEARTBEAT_INTERVAL
+    if (batchOperation.getNumExecutedItems() % HEARTBEAT_INTERVAL == 0) {
+      LOGGER.debug(
+          "Batch operation {} on partition {} has executed {} of {} items.",
+          batchOperation.getKey(),
+          partitionId,
+          batchOperation.getNumExecutedItems(),
+          batchOperation.getNumTotalItems());
+    }
+
+    batchExecute.setBatchOperationKey(batchOperation.getKey());
     batchExecute.setItemKeys(keys);
     stateWriter.appendFollowUpEvent(
-        executionRecord.getBatchOperationKey(),
+        batchOperation.getKey(),
         BatchOperationExecutionIntent.EXECUTED,
         batchExecute,
-        FollowUpEventMetadata.of(
-            b -> b.batchOperationReference(executionRecord.getBatchOperationKey())));
+        FollowUpEventMetadata.of(b -> b.batchOperationReference(batchOperation.getKey())));
   }
 
   private void appendBatchOperationExecutionCompletedEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecuteProcessor.java
@@ -78,12 +78,9 @@ public final class BatchOperationExecuteProcessor
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   public void processRecord(final TypedRecord<BatchOperationExecutionRecord> command) {
     final var executionRecord = command.getValue();
-    LOGGER.trace(
-        "Processing new command with key '{}' on partition{} : {}",
-        command.getKey(),
-        partitionId,
-        executionRecord);
     final long batchKey = executionRecord.getBatchOperationKey();
+    LOGGER.trace(
+        "Executing next items of batch operation {} on partition {}", batchKey, partitionId);
 
     // Stop the measure for the batch operation execute cycle latency which was started the last
     // time

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationFailProcessor.java
@@ -57,7 +57,10 @@ public final class BatchOperationFailProcessor
   @Override
   public void processRecord(final TypedRecord<BatchOperationCreationRecord> command) {
     final var recordValue = command.getValue();
-    LOGGER.debug("Processing new command with key '{}': {}", command.getKey(), recordValue);
+    LOGGER.debug(
+        "Marking batch operation {} as failed on partition {}",
+        command.getValue().getBatchOperationKey(),
+        partitionId);
 
     final int originPartitionId = Protocol.decodePartitionId(recordValue.getBatchOperationKey());
     final var batchInternalFail =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -97,10 +97,7 @@ public final class BatchOperationResumeProcessor
     final var recordValue = command.getValue();
     final var batchOperationKey = command.getValue().getBatchOperationKey();
     final var resumeKey = keyGenerator.nextKey();
-    LOGGER.debug(
-        "Processing new command to resume a batch operation with key '{}': {}",
-        command.getKey(),
-        recordValue);
+    LOGGER.debug("Resuming batch operation with key {}", command.getValue().getBatchOperationKey());
 
     // validation
     final var batchOperation = batchOperationState.get(batchOperationKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationStartProcessor.java
@@ -35,7 +35,8 @@ public final class BatchOperationStartProcessor
   @Override
   public void processRecord(final TypedRecord<BatchOperationCreationRecord> command) {
     final var recordValue = command.getValue();
-    LOGGER.debug("Processing new command with key '{}': {}", command.getKey(), recordValue);
+    LOGGER.debug(
+        "Marking batch operation {} as started", command.getValue().getBatchOperationKey());
 
     stateWriter.appendFollowUpEvent(command.getKey(), BatchOperationIntent.STARTED, recordValue);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSuspendProcessor.java
@@ -90,9 +90,7 @@ public final class BatchOperationSuspendProcessor
     final var batchOperationKey = command.getValue().getBatchOperationKey();
     final var suspendKey = keyGenerator.nextKey();
     LOGGER.debug(
-        "Processing new command to suspend batch operation with key '{}': {}",
-        command.getKey(),
-        recordValue);
+        "Suspending batch operation with key {}", command.getValue().getBatchOperationKey());
 
     // validation
     final var batchOperation = batchOperationState.get(batchOperationKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -66,7 +66,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void create(final long batchOperationKey, final BatchOperationCreationRecord record) {
-    LOGGER.debug("Creating batch operation with key {}", record.getBatchOperationKey());
+    LOGGER.trace("Creating batch operation with key {}", record.getBatchOperationKey());
     batchKey.wrapLong(record.getBatchOperationKey());
     final var batchOperation = new PersistedBatchOperation();
     batchOperation.wrap(record).setStatus(BatchOperationStatus.CREATED);
@@ -76,7 +76,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void start(final long batchOperationKey) {
-    LOGGER.debug("Starting batch operation with key {}", batchOperationKey);
+    LOGGER.trace("Starting batch operation with key {}", batchOperationKey);
     batchKey.wrapLong(batchOperationKey);
     final var batchOperation = get(batchOperationKey);
     if (batchOperation.isPresent()) {
@@ -91,7 +91,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void fail(final long batchOperationKey) {
-    LOGGER.debug("Failing batch operation with key {}", batchOperationKey);
+    LOGGER.trace("Failing batch operation with key {}", batchOperationKey);
     batchKey.wrapLong(batchOperationKey);
     final var batchOperation = get(batchOperationKey);
     if (batchOperation.isPresent()) {
@@ -105,7 +105,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void appendItemKeys(final long batchOperationKey, final Set<Long> itemKeys) {
-    LOGGER.debug(
+    LOGGER.trace(
         "Appending {} item keys to batch operation with key {}",
         itemKeys.size(),
         batchOperationKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -105,7 +105,7 @@ public class DbBatchOperationState implements MutableBatchOperationState {
 
   @Override
   public void appendItemKeys(final long batchOperationKey, final Set<Long> itemKeys) {
-    LOGGER.trace(
+    LOGGER.debug(
         "Appending {} item keys to batch operation with key {}",
         itemKeys.size(),
         batchOperationKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -111,24 +111,29 @@ public class DbBatchOperationState implements MutableBatchOperationState {
         batchOperationKey);
 
     // First, get the batch operation
-    final var batch = get(batchOperationKey);
-    if (batch.isEmpty()) {
+    final var oBatch = get(batchOperationKey);
+    if (oBatch.isEmpty()) {
       LOGGER.error(
           "Batch operation with key {} not found, cannot append itemKeys to it.",
           batchOperationKey);
       return;
     }
 
+    final var batch = oBatch.get();
+
     // Second, get the chunk to append the keys to
-    var chunk = getOrCreateChunk(batch.get());
+    var chunk = getOrCreateChunk(batch);
 
     // Third, append the keys to the chunk, if the chunk is full, a new one is returned
     for (final long key : itemKeys) {
-      chunk = appendKeyToChunk(batch.get(), chunk, key);
+      chunk = appendKeyToChunk(batch, chunk, key);
     }
 
+    // Fourth, update the number of total items in the batch
+    batch.setNumTotalItems(batch.getNumTotalItems() + itemKeys.size());
+
     // Finally, update the batch and the chunk in the column family
-    updateChunkAndBatch(chunk, batch.get());
+    updateChunkAndBatch(chunk, batch);
   }
 
   @Override
@@ -139,8 +144,8 @@ public class DbBatchOperationState implements MutableBatchOperationState {
         batchOperationKey);
 
     // First, get the batch operation
-    final var batch = get(batchOperationKey);
-    if (batch.isEmpty()) {
+    final var batch = get(batchOperationKey).orElse(null);
+    if (batch == null) {
       LOGGER.error(
           "Batch operation with key {} not found, cannot remove itemKeys from it.",
           batchOperationKey);
@@ -148,11 +153,14 @@ public class DbBatchOperationState implements MutableBatchOperationState {
     }
 
     // Second, delete the keys from chunk
-    final var chunk = getMinChunk(batch.get());
+    final var chunk = getMinChunk(batch);
     chunk.removeItemKeys(itemKeys);
 
+    // Fourth, update the number of executed items in the batch
+    batch.setNumExecutedItems(batch.getNumExecutedItems() + itemKeys.size());
+
     // Finally, update the chunk and batch in the column family
-    updateBatchAndChunkAfterRemoval(batch.get(), chunk);
+    updateBatchAndChunkAfterRemoval(batch, chunk);
   }
 
   @Override
@@ -293,10 +301,10 @@ public class DbBatchOperationState implements MutableBatchOperationState {
     if (chunk.getItemKeys().isEmpty()) {
       batchOperationChunksColumnFamily.deleteExisting(fkBatchKeyAndChunkKey);
       batch.removeChunkKey(chunk.getKey());
-      batchOperationColumnFamily.update(batchKey, batch);
     } else {
       batchOperationChunksColumnFamily.update(fkBatchKeyAndChunkKey, chunk);
     }
+    batchOperationColumnFamily.update(batchKey, batch);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
@@ -44,6 +45,8 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final ObjectProperty<BatchOperationProcessInstanceModificationPlan> modificationPlanProp =
       new ObjectProperty<>("modificationPlan", new BatchOperationProcessInstanceModificationPlan());
   private final BooleanProperty initializedProp = new BooleanProperty("initialized", false);
+  private final IntegerProperty numTotalItemsProp = new IntegerProperty("numTotalItems", 0);
+  private final IntegerProperty numExecutedItemsProp = new IntegerProperty("numExecutedItems", 0);
   private final ArrayProperty<LongValue> chunkKeysProp =
       new ArrayProperty<>("chunkKeys", LongValue::new);
   // Authentication claims, needed for query + command auth
@@ -54,7 +57,7 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
       new ArrayProperty<>("finishedPartitions", IntegerValue::new);
 
   public PersistedBatchOperation() {
-    super(11);
+    super(13);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
@@ -65,7 +68,9 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .declareProperty(initializedProp)
         .declareProperty(authenticationProp)
         .declareProperty(partitionsProp)
-        .declareProperty(finishedPartitionsProp);
+        .declareProperty(finishedPartitionsProp)
+        .declareProperty(numTotalItemsProp)
+        .declareProperty(numExecutedItemsProp);
   }
 
   public PersistedBatchOperation wrap(final BatchOperationCreationRecord record) {
@@ -206,6 +211,24 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
 
   public List<Integer> getFinishedPartitions() {
     return finishedPartitionsProp.stream().map(IntegerValue::getValue).toList();
+  }
+
+  public int getNumTotalItems() {
+    return numTotalItemsProp.getValue();
+  }
+
+  public PersistedBatchOperation setNumTotalItems(final int numTotalItems) {
+    numTotalItemsProp.setValue(numTotalItems);
+    return this;
+  }
+
+  public int getNumExecutedItems() {
+    return numExecutedItemsProp.getValue();
+  }
+
+  public PersistedBatchOperation setNumExecutedItems(final int numExecutedItems) {
+    numExecutedItemsProp.setValue(numExecutedItems);
+    return this;
   }
 
   public long nextChunkKey() {


### PR DESCRIPTION
## Description

- fixed BatchOperationCreateChunkProcessor logging: Do not log the whole record since it could be **very** large
- refactor logging in BatchOperationExecutionProcessor: The previous logging on every execution was replaced by an occasional heartbeat every 1000 items.