### PR TITLE
Add observability for bootstrap snapshots

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -23828,7 +23828,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=\"1\", bootstrap=\"true\"}",
               "legendFormat": "{{pod}} p{{partition}}",
               "range": true,
               "refId": "A"
@@ -23911,7 +23911,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"1\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -5141,7 +5141,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}[$__rate_interval])",
+              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{pod}} p{{partition}}",
               "refId": "A"
@@ -5224,7 +5224,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5236,7 +5236,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5334,7 +5334,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}",
               "legendFormat": "{{pod}} p{{partition}}",
               "refId": "A"
             }
@@ -5414,7 +5414,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "{{le}}",
               "refId": "A"
@@ -5510,7 +5510,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", bootstrap=~\"false\"}",
               "interval": "",
               "legendFormat": "{{pod}} {{partition}}",
               "refId": "A"
@@ -23629,6 +23629,409 @@
       ],
       "title": "Cluster",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 665,
+      "title": "Dynamic scaling",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Total number of committed snapshots on disk",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 669,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])",
+              "interval": "",
+              "legendFormat": "{{pod}} p{{partition}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Snapshot Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Size in bytes of snapshots for bootstrap on disk",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 666,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.4.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}",
+              "legendFormat": "{{pod}} p{{partition}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Snapshot for Bootstrap Size",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Approximate duration of taking a single snapshot from the processor point-of-view (without replication or committing).",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 668,
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#b4ff00",
+              "mode": "opacity",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "10.4.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_snapshot_transfer_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Snapshot for Bootstrap Transfer Duration",
+          "type": "heatmap"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$DS_PROMETHEUS"
+          },
+          "description": "Approximate duration of creating a new snapshot for bootstrap from a previously persisted snapshot.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 670,
+          "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+              "exponent": 0.5,
+              "fill": "#b4ff00",
+              "mode": "opacity",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 128
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": false
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "showColorScale": false,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "dtdurations"
+            }
+          },
+          "pluginVersion": "10.4.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=\"true\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Snapshot for Bootstrap Creation Duration",
+          "type": "heatmap"
+        }
+      ]
     },
     {
       "collapsed": true,

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -5141,7 +5141,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])",
+              "expr": "rate(zeebe_snapshot_count_total{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])",
               "interval": "",
               "legendFormat": "{{pod}} p{{partition}}",
               "refId": "A"
@@ -5224,7 +5224,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5236,7 +5236,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "legendFormat": "{{le}}",
@@ -5334,7 +5334,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}",
+              "expr": "zeebe_snapshot_size_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap!=\"true\"}",
               "legendFormat": "{{pod}} p{{partition}}",
               "refId": "A"
             }
@@ -5414,7 +5414,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap=~\"false\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_snapshot_file_size_megabytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\", bootstrap!=\"true\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "legendFormat": "{{le}}",
               "refId": "A"
@@ -5510,7 +5510,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", bootstrap=~\"false\"}",
+              "expr": "zeebe_snapshot_chunks_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", bootstrap!=\"true\"}",
               "interval": "",
               "legendFormat": "{{pod}} {{partition}}",
               "refId": "A"

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -54,6 +54,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                     final var snapshotTransfer =
                         new SnapshotTransferImpl(
                             actor -> new SnapshotTransferServiceClient(context.brokerClient()),
+                            snapshotStore.getSnapshotMetrics(),
                             snapshotStore);
                     return context
                         .schedulingService()

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -165,6 +165,10 @@ public final class FileBasedSnapshotStore extends Actor
     return snapshotStore.restore(snapshot);
   }
 
+  public SnapshotMetrics getSnapshotMetrics() {
+    return snapshotStore.getSnapshotMetrics();
+  }
+
   @Override
   public String toString() {
     return "FileBasedSnapshotStore{"

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -75,7 +75,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private void takeInternal(final Consumer<Path> takeSnapshot) {
     final var snapshotMetrics = snapshotStore.getSnapshotMetrics();
 
-    try (final var ignored = snapshotMetrics.startTimer()) {
+    try (final var ignored = snapshotMetrics.startTimer(isBootstrap)) {
       try {
         takeSnapshot.accept(getPath());
         if (!directory.toFile().exists() || directory.toFile().listFiles().length == 0) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
@@ -44,8 +44,8 @@ public final class SnapshotMetrics {
   public SnapshotMetrics(final MeterRegistry registry) {
     clock = registry.config().clock();
 
-    for (final var bool : List.of(true, false)) {
-      final var index = encodeBoolean(bool);
+    for (final var isBootstrap : List.of(true, false)) {
+      final var index = encodeBoolean(isBootstrap);
       // init the AtomicLongs
       snapshotChunkCountArray.put(new AtomicLong(), index);
       snapshotSizeArray.put(new AtomicLong(), index);
@@ -53,29 +53,29 @@ public final class SnapshotMetrics {
       // INIT non gauges
       snapshotDuration.put(
           MicrometerUtil.buildTimer(SNAPSHOT_DURATION)
-              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
               .register(registry),
           index);
       snapshotPersistDuration.put(
           MicrometerUtil.buildTimer(SNAPSHOT_PERSIST_DURATION)
-              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
               .register(registry),
           index);
       snapshotTransferDuration.put(
           MicrometerUtil.buildTimer(SNAPSHOT_TRANSFER_DURATION)
-              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
               .register(registry),
           index);
       snapshotFileSize.put(
           MicrometerUtil.buildSummary(SNAPSHOT_FILE_SIZE)
-              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
               .register(registry),
           index);
 
       snapshotCount.put(
           Counter.builder(SNAPSHOT_COUNT.getName())
               .description(SNAPSHOT_COUNT.getDescription())
-              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
               .register(registry),
           index);
 
@@ -83,11 +83,11 @@ public final class SnapshotMetrics {
       Gauge.builder(
               SNAPSHOT_CHUNK_COUNT.getName(), snapshotChunkCountArray.get(index), Number::longValue)
           .description(SNAPSHOT_CHUNK_COUNT.getDescription())
-          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
           .register(registry);
       Gauge.builder(SNAPSHOT_SIZE.getName(), snapshotSizeArray.get(index), Number::longValue)
           .description(SNAPSHOT_SIZE.getDescription())
-          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(isBootstrap))
           .register(registry);
     }
   }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.snapshots.impl.SnapshotMetricsDoc.SNAPSHOT_PERSIS
 import static io.camunda.zeebe.snapshots.impl.SnapshotMetricsDoc.SNAPSHOT_SIZE;
 
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.collection.MArray;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
@@ -22,60 +23,106 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class SnapshotMetrics {
 
-  private final AtomicLong snapshotChunkCount = new AtomicLong();
-  private final AtomicLong snapshotSize = new AtomicLong();
+  private final MArray<AtomicLong> snapshotChunkCountArray = MArray.of(AtomicLong[]::new, 2);
+  private final MArray<AtomicLong> snapshotSizeArray = MArray.of(AtomicLong[]::new, 2);
 
   private final Clock clock;
-  private final Timer snapshotPersistDuration;
-  private final DistributionSummary snapshotFileSize;
-  private final Timer snapshotDuration;
-  private final Counter snapshotCount;
+  private final MArray<Timer> snapshotPersistDuration;
+  private final MArray<DistributionSummary> snapshotFileSize;
+  private final MArray<Timer> snapshotDuration;
+  private final MArray<Counter> snapshotCount;
 
   public SnapshotMetrics(final MeterRegistry registry) {
     clock = registry.config().clock();
 
-    snapshotDuration = MicrometerUtil.buildTimer(SNAPSHOT_DURATION).register(registry);
-    snapshotPersistDuration =
-        MicrometerUtil.buildTimer(SNAPSHOT_PERSIST_DURATION).register(registry);
-    snapshotFileSize = MicrometerUtil.buildSummary(SNAPSHOT_FILE_SIZE).register(registry);
-    snapshotCount =
-        Counter.builder(SNAPSHOT_COUNT.getName())
-            .description(SNAPSHOT_COUNT.getDescription())
-            .register(registry);
+    snapshotDuration = MArray.of(Timer[]::new, 2);
+    snapshotPersistDuration = MArray.of(Timer[]::new, 2);
+    snapshotFileSize = MArray.of(DistributionSummary[]::new, 2);
+    snapshotCount = MArray.of(Counter[]::new, 2);
 
-    Gauge.builder(SNAPSHOT_CHUNK_COUNT.getName(), snapshotChunkCount, Number::longValue)
-        .description(SNAPSHOT_CHUNK_COUNT.getDescription())
-        .register(registry);
-    Gauge.builder(SNAPSHOT_SIZE.getName(), snapshotSize, Number::longValue)
-        .description(SNAPSHOT_SIZE.getDescription())
-        .register(registry);
+    for (final var bool : List.of(true, false)) {
+      // init the AtomicLongs
+      snapshotChunkCountArray.put(new AtomicLong(), encodeBoolean(bool));
+      snapshotSizeArray.put(new AtomicLong(), encodeBoolean(bool));
+
+      // INIT non gauges
+      snapshotDuration.put(
+          MicrometerUtil.buildTimer(SNAPSHOT_DURATION)
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .register(registry),
+          encodeBoolean(bool));
+      snapshotPersistDuration.put(
+          MicrometerUtil.buildTimer(SNAPSHOT_PERSIST_DURATION)
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .register(registry),
+          encodeBoolean(bool));
+      snapshotFileSize.put(
+          MicrometerUtil.buildSummary(SNAPSHOT_FILE_SIZE)
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .register(registry),
+          encodeBoolean(bool));
+
+      snapshotCount.put(
+          Counter.builder(SNAPSHOT_COUNT.getName())
+              .description(SNAPSHOT_COUNT.getDescription())
+              .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+              .register(registry),
+          encodeBoolean(bool));
+
+      // init gauges
+      Gauge.builder(
+              SNAPSHOT_CHUNK_COUNT.getName(),
+              snapshotChunkCountArray.get(encodeBoolean(bool)),
+              Number::longValue)
+          .description(SNAPSHOT_CHUNK_COUNT.getDescription())
+          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+          .register(registry);
+      Gauge.builder(
+              SNAPSHOT_SIZE.getName(),
+              snapshotSizeArray.get(encodeBoolean(bool)),
+              Number::longValue)
+          .description(SNAPSHOT_SIZE.getDescription())
+          .tags(SnapshotMetricsDoc.BootstrapKeyNames.tags(bool))
+          .register(registry);
+    }
   }
 
-  void incrementSnapshotCount() {
-    snapshotCount.increment();
+  void incrementSnapshotCount(final boolean isBootstrap) {
+    snapshotCount.get(encodeBoolean(isBootstrap)).increment();
   }
 
-  void observeSnapshotSize(final long sizeInBytes) {
-    snapshotSize.set(sizeInBytes);
+  void observeSnapshotSize(final long sizeInBytes, final boolean isBootstrap) {
+    snapshotSizeArray.get(encodeBoolean(isBootstrap)).set(sizeInBytes);
   }
 
-  void observeSnapshotChunkCount(final long count) {
-    snapshotChunkCount.set(count);
+  void observeSnapshotChunkCount(final long count, final boolean isBootstrap) {
+    snapshotChunkCountArray.get(encodeBoolean(isBootstrap)).set(count);
   }
 
-  void observeSnapshotFileSize(final long sizeInBytes) {
-    snapshotFileSize.record(sizeInBytes / 1_000_000f);
+  void observeSnapshotFileSize(final long sizeInBytes, final boolean isBootstrap) {
+    snapshotFileSize.get(encodeBoolean(isBootstrap)).record(sizeInBytes / 1_000_000f);
   }
 
-  CloseableSilently startTimer() {
-    return MicrometerUtil.timer(snapshotDuration, Timer.start(clock));
+  CloseableSilently startTimer(final boolean isBootstrap) {
+    return MicrometerUtil.timer(
+        snapshotDuration.get(encodeBoolean(isBootstrap)), Timer.start(clock));
   }
 
-  CloseableSilently startPersistTimer() {
-    return MicrometerUtil.timer(snapshotPersistDuration, Timer.start(clock));
+  CloseableSilently startPersistTimer(final boolean isBootstrap) {
+    return MicrometerUtil.timer(
+        snapshotPersistDuration.get(encodeBoolean(isBootstrap)), Timer.start(clock));
+  }
+
+  private static boolean decodeBoolean(final int i) {
+    return i == 1;
+  }
+
+  private static int encodeBoolean(final boolean b) {
+    return b ? 1 : 0;
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.Tags;
 
 @SuppressWarnings("NullableProblems")
 public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
@@ -33,7 +34,7 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
     }
   },
 
@@ -56,7 +57,7 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
     }
   },
 
@@ -79,7 +80,7 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
     }
   },
 
@@ -102,7 +103,7 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
     }
   },
 
@@ -125,7 +126,29 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
+    }
+  },
+  /** Approximate duration of snapshot transfer between two nodes */
+  SNAPSHOT_TRANSFER_DURATION {
+    @Override
+    public String getDescription() {
+      return "Total transfer duration of a snapshot between two nodes";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.transfer.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return getPartitionBootstrapKeyNames();
     }
   },
   /** Approximate size of snapshot files */
@@ -154,12 +177,31 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return getPartitionBootstrapKeyNames();
     }
 
     @Override
     public double[] getDistributionSLOs() {
       return BUCKETS;
+    }
+  };
+
+  private static KeyName[] getPartitionBootstrapKeyNames() {
+    return KeyName.merge(PartitionKeyNames.values(), BootstrapKeyNames.values());
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public enum BootstrapKeyNames implements KeyName {
+    /** Whether the metric is recorded during bootstrap phase */
+    BOOTSTRAP {
+      @Override
+      public String asString() {
+        return "bootstrap";
+      }
+    };
+
+    public static Tags tags(final boolean bootstrap) {
+      return Tags.of(BOOTSTRAP.asString(), String.valueOf(bootstrap));
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.Tags;
+import java.time.Duration;
 
 @SuppressWarnings("NullableProblems")
 public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
@@ -144,6 +145,24 @@ public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.TIMER;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return new Duration[] {
+        Duration.ofMillis(50),
+        Duration.ofMillis(250),
+        Duration.ofMillis(500),
+        Duration.ofSeconds(1),
+        Duration.ofSeconds(5),
+        Duration.ofSeconds(15),
+        Duration.ofMinutes(30)
+      };
     }
 
     @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
@@ -15,9 +15,13 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
+import io.camunda.zeebe.snapshots.impl.SnapshotMetrics;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.collection.Tuple;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
@@ -25,9 +29,14 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
   private final SnapshotTransferService service;
   private final ReceivableSnapshotStore snapshotStore;
 
+  private final SnapshotMetrics snapshotMetrics;
+  private final ConcurrentHashMap<UUID, CloseableSilently> timers = new ConcurrentHashMap<>();
+
   public SnapshotTransferImpl(
       final Function<ConcurrencyControl, SnapshotTransferService> service,
+      final SnapshotMetrics snapshotMetrics,
       final ReceivableSnapshotStore snapshotStore) {
+    this.snapshotMetrics = snapshotMetrics;
     this.snapshotStore = snapshotStore;
     this.service = service.apply(this);
   }
@@ -35,34 +44,41 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
   @Override
   public ActorFuture<PersistedSnapshot> getLatestSnapshot(final int partitionId) {
     final var transferId = UUID.randomUUID();
-    return service
-        // no requirements on last processing position
-        .getLatestSnapshot(partitionId, -1, transferId)
-        .andThen(
-            snapshot -> {
-              if (snapshot == null) {
-                return CompletableActorFuture.completed(null);
-              }
-              return snapshotStore
-                  .newReceivedSnapshot(snapshot.getSnapshotId())
-                  .thenApply(
-                      fbsnapshot -> {
-                        fbsnapshot.apply(snapshot);
-                        return new Tuple<>(snapshot, fbsnapshot);
-                      });
-            },
-            actor)
-        .andThen(
-            tuple -> {
-              if (tuple == null) {
-                return CompletableActorFuture.completed(null);
-              }
-              final var future =
-                  receiveAllChunks(partitionId, tuple.getLeft(), tuple.getRight(), transferId);
-              future.onError(error -> tuple.getRight().abort());
-              return future;
-            },
-            actor);
+    timers.put(transferId, snapshotMetrics.startTransferTimer(true));
+    final var result =
+        service
+            // no requirements on last processing position
+            .getLatestSnapshot(partitionId, -1, transferId)
+            .andThen(
+                snapshot -> {
+                  if (snapshot == null) {
+                    return CompletableActorFuture.completed(null);
+                  }
+                  return snapshotStore
+                      .newReceivedSnapshot(snapshot.getSnapshotId())
+                      .thenApply(
+                          fbsnapshot -> {
+                            fbsnapshot.apply(snapshot);
+                            return new Tuple<>(snapshot, fbsnapshot);
+                          });
+                },
+                actor)
+            .andThen(
+                tuple -> {
+                  if (tuple == null) {
+                    return CompletableActorFuture.completed(null);
+                  }
+                  final var future =
+                      receiveAllChunks(partitionId, tuple.getLeft(), tuple.getRight(), transferId);
+                  future.onError(error -> tuple.getRight().abort());
+                  return future;
+                },
+                actor);
+    result.onComplete(
+        (ignored, error) ->
+            Optional.ofNullable(timers.remove(transferId)).ifPresent(CloseableSilently::close));
+
+    return result;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## Description
- All snapshot metrics are now tagged with `bootstrap=true|false`. 
- A new metric `"zeebe.snapshot.transfer.duration` has been added to measure the transfer time of a snapshot between two nodes. 
- Pattern `bootstrap!="true"` is used for backwards compatibility instead of `bootstrap="false"`

Adding transfer time metric to raft snapshot replication is left as a follow up PR as a nice to have. 
Further metrics/dashboard changes can be added later on.

## Checklist
- [x] Grafana changes


## Related issues

relates #32590 
