### PR TITLE
The identity migration fails fast on unhandled errors

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.application;
 
-import io.camunda.application.commons.migration.MigrationsRunner;
+import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
@@ -32,7 +32,7 @@ public class StandaloneProcessMigration {
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.SERVLET)
-            .sources(MigrationsRunner.class)
+            .sources(AsyncMigrationsRunner.class)
             .profiles(Profile.PROCESS_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);

--- a/dist/src/main/java/io/camunda/application/commons/migration/AsyncMigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/AsyncMigrationsRunner.java
@@ -21,14 +21,14 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("identity-migration | process-migration")
+@Profile("process-migration")
 @ComponentScan(basePackages = "io.camunda.application.commons.migration")
-public class MigrationsRunner implements ApplicationRunner {
+public class AsyncMigrationsRunner implements ApplicationRunner {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MigrationsRunner.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncMigrationsRunner.class);
   private final List<Migrator> migrators;
 
-  public MigrationsRunner(final List<Migrator> migrators) {
+  public AsyncMigrationsRunner(final List<Migrator> migrators) {
     this.migrators = migrators;
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.migration;
 
 import io.camunda.migration.api.Migrator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
@@ -29,13 +30,16 @@ public class BlockingMigrationsRunner implements Runnable {
 
   @Override
   public void run() {
-    LOG.info("Starting {} migrations: {}", migrators.size(), migrators);
+    LOG.info(
+        "Starting {} migrations: {}",
+        migrators.size(),
+        migrators.stream().map(Migrator::getName).collect(Collectors.joining(", ")));
 
     for (final Migrator migrator : migrators) {
       try {
         migrator.call();
       } catch (final Exception e) {
-        LOG.error("Migrator {} failed with: {}", migrator.getName(), e.getMessage());
+        LOG.error("{} failed with: {}", migrator.getName(), e.getMessage());
         LOG.error(
             "The cause for the failed migration was: {}", e.getCause().getMessage(), e.getCause());
         LOG.info(

--- a/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
@@ -41,7 +41,7 @@ public class BlockingMigrationsRunner implements Runnable {
       } catch (final Exception e) {
         LOG.error("{} failed with: {}", migrator.getName(), e.getMessage());
         LOG.error(
-            "The cause for the failed migration was: {}", e.getCause().getMessage(), e.getCause());
+            "The cause of the failed migration was: {}", e.getCause().getMessage(), e.getCause());
         LOG.info(
             "Please assess the cause, take potential corrective action and rerun the migration.");
         throw new RuntimeException(e);

--- a/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/BlockingMigrationsRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.migration;
+
+import io.camunda.migration.api.Migrator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("identity-migration")
+@ComponentScan(basePackages = "io.camunda.application.commons.migration")
+public class BlockingMigrationsRunner implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlockingMigrationsRunner.class);
+  private final List<Migrator> migrators;
+
+  public BlockingMigrationsRunner(final List<Migrator> migrators) {
+    this.migrators = migrators;
+  }
+
+  @Override
+  public void run() {
+    LOG.info("Starting {} migrations: {}", migrators.size(), migrators);
+
+    for (final Migrator migrator : migrators) {
+      try {
+        migrator.call();
+      } catch (final Exception e) {
+        LOG.error("Migrator {} failed with: {}", migrator.getName(), e.getMessage());
+        LOG.error(
+            "The cause for the failed migration was: {}", e.getCause().getMessage(), e.getCause());
+        LOG.info(
+            "Please assess the cause, take potential corrective action and rerun the migration.");
+        throw new RuntimeException(e);
+      }
+    }
+
+    LOG.info("All migrations completed successfully.");
+  }
+}

--- a/migration/identity-migration/pom.xml
+++ b/migration/identity-migration/pom.xml
@@ -77,10 +77,6 @@
       <artifactId>migration-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.identity;
 
+import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.security.auth.Authentication;
@@ -45,7 +46,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
             assignUsersToGroup(group.id(), normalizedGroupId);
           } catch (final Exception e) {
             if (!isConflictError(e)) {
-              throw new RuntimeException("Failed to migrate group with ID: " + group.id(), e);
+              throw new MigrationException("Failed to migrate group with ID: " + group.id(), e);
             }
           }
         });
@@ -79,7 +80,7 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
             groupServices.assignMember(groupMember).join();
           } catch (final Exception e) {
             if (!isConflictError(e)) {
-              throw new RuntimeException(
+              throw new MigrationException(
                   String.format(
                       "Failed to assign user with ID '%s' to group with ID '%s'",
                       user.getEmail(), targetGroupId),

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
@@ -9,22 +9,35 @@ package io.camunda.migration.identity;
 
 import io.camunda.migration.api.Migrator;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.migration.identity.config.cluster.ClusterProperties;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @EnableConfigurationProperties(IdentityMigrationProperties.class)
 @Component("identity-migrator")
 public class IdentityMigrator implements Migrator {
+  private static final Logger LOG = LoggerFactory.getLogger(IdentityMigrator.class);
 
   private final List<MigrationHandler<?>> handlers;
+  private final BrokerTopologyManager brokerTopologyManager;
+  private final IdentityMigrationProperties identityMigrationProperties;
 
-  public IdentityMigrator(final List<MigrationHandler<?>> handlers) {
+  public IdentityMigrator(
+      final List<MigrationHandler<?>> handlers,
+      final BrokerTopologyManager brokerTopologyManager,
+      final IdentityMigrationProperties identityMigrationProperties) {
     this.handlers = handlers;
+    this.brokerTopologyManager = brokerTopologyManager;
+    this.identityMigrationProperties = identityMigrationProperties;
   }
 
   @Override
   public Void call() {
+    awaitClusterJoin();
     migrate();
     return null;
   }
@@ -32,6 +45,35 @@ public class IdentityMigrator implements Migrator {
   private void migrate() {
     for (final MigrationHandler<?> handler : handlers) {
       handler.migrate();
+    }
+  }
+
+  private void awaitClusterJoin() {
+    final ClusterProperties clusterConfig = identityMigrationProperties.getCluster();
+    int remainingClusterStateAttempts = clusterConfig.getAwaitClusterJoinMaxAttempts();
+    boolean joinedCluster = false;
+    do {
+      joinedCluster = brokerTopologyManager.getTopology().isInitialized();
+      LOG.info("Waiting for Orchestration Cluster Broker availability...");
+      try {
+        Thread.sleep(clusterConfig.getAwaitClusterJoinRetryInterval().toMillis());
+      } catch (final InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      remainingClusterStateAttempts--;
+    } while (!joinedCluster && remainingClusterStateAttempts > 0);
+
+    if (joinedCluster) {
+      LOG.info("Successfully connected to Orchestration Cluster, starting migration.");
+    } else {
+      final String message =
+          "Failed to connect to Orchestration Cluster within %s."
+              .formatted(
+                  clusterConfig
+                      .getAwaitClusterJoinRetryInterval()
+                      .multipliedBy(clusterConfig.getAwaitClusterJoinMaxAttempts()));
+      LOG.error(message);
+      throw new RuntimeException(message);
     }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
@@ -15,11 +15,11 @@ import org.springframework.stereotype.Component;
 
 @EnableConfigurationProperties(IdentityMigrationProperties.class)
 @Component("identity-migrator")
-public class MigrationRunner implements Migrator {
+public class IdentityMigrator implements Migrator {
 
   private final List<MigrationHandler<?>> handlers;
 
-  public MigrationRunner(final List<MigrationHandler<?>> handlers) {
+  public IdentityMigrator(final List<MigrationHandler<?>> handlers) {
     this.handlers = handlers;
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/IdentityMigrator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.identity;
 
+import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.api.Migrator;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.config.cluster.ClusterProperties;
@@ -44,7 +45,13 @@ public class IdentityMigrator implements Migrator {
 
   private void migrate() {
     for (final MigrationHandler<?> handler : handlers) {
-      handler.migrate();
+      LOG.info("Starting {}", handler.getName());
+      try {
+        handler.migrate();
+      } catch (final Exception e) {
+        throw new MigrationException("Execution of %s failed".formatted(handler.getName()), e);
+      }
+      LOG.info("Completed {}", handler.getName());
     }
   }
 
@@ -73,7 +80,7 @@ public class IdentityMigrator implements Migrator {
                       .getAwaitClusterJoinRetryInterval()
                       .multipliedBy(clusterConfig.getAwaitClusterJoinMaxAttempts()));
       LOG.error(message);
-      throw new RuntimeException(message);
+      throw new MigrationException(message);
     }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationHandler.java
@@ -29,7 +29,6 @@ public abstract class MigrationHandler<T> {
   }
 
   public void migrate() {
-    logger.info("Migrating started.");
     List<T> batch;
     int page = 0;
     do {
@@ -37,7 +36,10 @@ public abstract class MigrationHandler<T> {
       process(batch);
       page++;
     } while (!batch.isEmpty());
-    logger.info("Migrating finished.");
+  }
+
+  public String getName() {
+    return getClass().getSimpleName();
   }
 
   protected abstract List<T> fetchBatch(int page);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
@@ -7,22 +7,15 @@
  */
 package io.camunda.migration.identity;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import io.camunda.migration.api.Migrator;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.NotImplementedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @EnableConfigurationProperties(IdentityMigrationProperties.class)
 @Component("identity-migrator")
 public class MigrationRunner implements Migrator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MigrationRunner.class);
 
   private final List<MigrationHandler<?>> handlers;
 
@@ -37,19 +30,8 @@ public class MigrationRunner implements Migrator {
   }
 
   private void migrate() {
-    while (true) {
-      try {
-        for (final MigrationHandler<?> handler : handlers) {
-          handler.migrate();
-        }
-        break;
-      } catch (final NotImplementedException e) {
-        LOGGER.error("Identity endpoint is not implemented {}", e.getCode());
-        throw e;
-      } catch (final Exception e) {
-        LOGGER.warn("Migration failed, let's retry!", e);
-        Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
-      }
+    for (final MigrationHandler<?> handler : handlers) {
+      handler.migrate();
     }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/ClusterProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/cluster/ClusterProperties.java
@@ -29,8 +29,10 @@ public class ClusterProperties {
   public static final String DEFAULT_CLUSTER_HOST = "0.0.0.0";
   public static final int DEFAULT_CLUSTER_PORT = 26502;
 
-  private static final String DEFAULT_ADVERTISED_HOST =
+  public static final String DEFAULT_ADVERTISED_HOST =
       Address.defaultAdvertisedHost().getHostAddress();
+  public static final Duration DEFAULT_AWAIT_CLUSTER_JOIN_RETRY_INTERVAL = Duration.ofSeconds(1);
+  public static final int DEFAULT_AWAIT_CLUSTER_JOIN_MAX_ATTEMPTS = 30;
   private List<String> initialContactPoints =
       Collections.singletonList(DEFAULT_CONTACT_POINT_HOST + ":" + DEFAULT_CONTACT_POINT_PORT);
   private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
@@ -45,6 +47,8 @@ public class ClusterProperties {
   private SecurityConfig security = new SecurityConfig();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
   private ConfigManagerConfig configManager = ConfigManagerConfig.defaultConfig();
+  private Duration awaitClusterJoinRetryInterval = DEFAULT_AWAIT_CLUSTER_JOIN_RETRY_INTERVAL;
+  private int awaitClusterJoinMaxAttempts = DEFAULT_AWAIT_CLUSTER_JOIN_MAX_ATTEMPTS;
 
   public String getMemberId() {
     return memberId;
@@ -223,5 +227,21 @@ public class ClusterProperties {
         + ", configManagerCfg="
         + configManager
         + '}';
+  }
+
+  public Duration getAwaitClusterJoinRetryInterval() {
+    return awaitClusterJoinRetryInterval;
+  }
+
+  public void setAwaitClusterJoinRetryInterval(final Duration awaitClusterJoinRetryInterval) {
+    this.awaitClusterJoinRetryInterval = awaitClusterJoinRetryInterval;
+  }
+
+  public int getAwaitClusterJoinMaxAttempts() {
+    return awaitClusterJoinMaxAttempts;
+  }
+
+  public void setAwaitClusterJoinMaxAttempts(final int awaitClusterJoinMaxAttempts) {
+    this.awaitClusterJoinMaxAttempts = awaitClusterJoinMaxAttempts;
   }
 }

--- a/migration/migration-api/src/main/java/io/camunda/migration/api/Migrator.java
+++ b/migration/migration-api/src/main/java/io/camunda/migration/api/Migrator.java
@@ -10,4 +10,8 @@ package io.camunda.migration.api;
 import java.util.concurrent.Callable;
 
 /** Scanned interface for migration tasks. */
-public interface Migrator extends Callable<Void> {}
+public interface Migrator extends Callable<Void> {
+  default String getName() {
+    return getClass().getSimpleName();
+  }
+}

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/ProcessMigrator.java
@@ -36,9 +36,9 @@ import org.springframework.stereotype.Component;
 
 @Component("process-migrator")
 @EnableConfigurationProperties(ProcessMigrationProperties.class)
-public class MigrationRunner implements Migrator {
+public class ProcessMigrator implements Migrator {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MigrationRunner.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessMigrator.class);
 
   private final Adapter adapter;
   private final ProcessMigrationProperties properties;
@@ -46,7 +46,7 @@ public class MigrationRunner implements Migrator {
   private final ScheduledExecutorService scheduler;
   private final MetricRegistry metricRegistry;
 
-  public MigrationRunner(
+  public ProcessMigrator(
       final ProcessMigrationProperties properties,
       final ConnectConfiguration connect,
       final MeterRegistry meterRegistry) {

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
@@ -21,7 +21,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.migration.process.MigrationRunner;
+import io.camunda.migration.process.ProcessMigrator;
 import io.camunda.migration.process.TestData;
 import io.camunda.migration.process.adapter.MigrationRepositoryIndex;
 import io.camunda.migration.process.adapter.ProcessorStep;
@@ -66,8 +66,8 @@ public abstract class AdapterTest {
   protected static OpenSearchClient osClient;
   protected static final ConnectConfiguration ES_CONFIGURATION = new ConnectConfiguration();
   protected static final ConnectConfiguration OS_CONFIGURATION = new ConnectConfiguration();
-  protected static MigrationRunner osMigrator;
-  protected static MigrationRunner esMigrator;
+  protected static ProcessMigrator osMigrator;
+  protected static ProcessMigrator esMigrator;
 
   protected static MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
@@ -100,8 +100,8 @@ public abstract class AdapterTest {
     final var osConnector = new OpensearchConnector(OS_CONFIGURATION);
     osObjectMapper = osConnector.objectMapper();
     osClient = osConnector.createClient();
-    esMigrator = new MigrationRunner(properties, ES_CONFIGURATION, meterRegistry);
-    osMigrator = new MigrationRunner(properties, OS_CONFIGURATION, meterRegistry);
+    esMigrator = new ProcessMigrator(properties, ES_CONFIGURATION, meterRegistry);
+    osMigrator = new ProcessMigrator(properties, OS_CONFIGURATION, meterRegistry);
     createIndices();
   }
 
@@ -134,7 +134,7 @@ public abstract class AdapterTest {
   public void cleanUp() throws IOException {
     properties.setBatchSize(5);
     if (isElasticsearch) {
-      esMigrator = new MigrationRunner(properties, ES_CONFIGURATION, meterRegistry);
+      esMigrator = new ProcessMigrator(properties, ES_CONFIGURATION, meterRegistry);
       esClient.deleteByQuery(
           DeleteByQueryRequest.of(
               d ->
@@ -148,7 +148,7 @@ public abstract class AdapterTest {
       esClient.indices().refresh();
 
     } else {
-      osMigrator = new MigrationRunner(properties, OS_CONFIGURATION, meterRegistry);
+      osMigrator = new ProcessMigrator(properties, OS_CONFIGURATION, meterRegistry);
       osClient.deleteByQuery(
           org.opensearch.client.opensearch.core.DeleteByQueryRequest.of(
               d ->

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/ProcessMigratorIT.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.camunda.migration.api.MigrationException;
-import io.camunda.migration.process.MigrationRunner;
+import io.camunda.migration.process.ProcessMigrator;
 import io.camunda.migration.process.TestData;
 import io.camunda.migration.process.adapter.Adapter;
 import io.camunda.migration.process.adapter.ProcessorStep;
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(Lifecycle.PER_CLASS)
-public class MigrationRunnerIT extends AdapterTest {
+public class ProcessMigratorIT extends AdapterTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -382,7 +382,7 @@ public class MigrationRunnerIT extends AdapterTest {
     }
     // invalid URL
     connectConfiguration.setUrl("http://localhost:3333");
-    final var migrator = new MigrationRunner(properties, connectConfiguration, meterRegistry);
+    final var migrator = new ProcessMigrator(properties, connectConfiguration, meterRegistry);
     properties.getRetry().setMaxRetries(2);
     properties.getRetry().setMinRetryDelay(Duration.ofSeconds(1));
 

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -115,6 +115,12 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationFailureIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.migration;
+
+import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.camunda.application.commons.migration.BlockingMigrationsRunner;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneIdentityMigration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.boot.context.logging.LoggingApplicationListener;
+import org.springframework.context.ApplicationListener;
+
+@ZeebeIntegration
+public class IdentityMigrationFailureIT {
+
+  @TestZeebe
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled().withRdbmsExporter();
+
+  private final LogCapturer logCapturer = new LogCapturer();
+
+  @BeforeEach
+  void resetCapturer() {
+    logCapturer.stop();
+    logCapturer.list.clear();
+  }
+
+  @Test
+  void failIfCannotJoinCluster() {
+    // given
+    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
+    // no contact points for cluster configured
+    migrationProperties.getCluster().setAwaitClusterJoinMaxAttempts(1);
+
+    final TestStandaloneIdentityMigration testIdentityMigration =
+        new TestStandaloneIdentityMigration(migrationProperties);
+    setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
+
+    // when
+    testIdentityMigration.start();
+
+    // then
+    assertThat(testIdentityMigration.getExitCode()).isEqualTo(1);
+    assertThat(
+            logCapturer.contains(
+                "IdentityMigrator failed with: Failed to connect to Orchestration Cluster within PT1S.",
+                Level.ERROR))
+        .isTrue();
+  }
+
+  @Test
+  void failOnMissingConfiguration() {
+    // given
+    final IdentityMigrationProperties migrationProperties = new IdentityMigrationProperties();
+    // connection to broker is set
+    migrationProperties
+        .getCluster()
+        .setInitialContactPoints(List.of("localhost:" + BROKER.mappedPort(CLUSTER)));
+    // but no other config, e.g. for management identity connection
+
+    final TestStandaloneIdentityMigration testIdentityMigration =
+        new TestStandaloneIdentityMigration(migrationProperties);
+    setupLogCapturing(testIdentityMigration, BlockingMigrationsRunner.class);
+
+    // when
+    testIdentityMigration.start();
+
+    // then
+    assertThat(testIdentityMigration.getExitCode()).isEqualTo(1);
+    assertThat(
+            logCapturer.contains(
+                "IdentityMigrator failed with: Execution of GroupMigrationHandler failed",
+                Level.ERROR))
+        .isTrue();
+  }
+
+  /**
+   * This utility method is needed to set up the log capturing after spring initialized the app
+   * context, if we do it before Spring resets everything during app startup via {@link
+   * LoggingApplicationListener }.
+   *
+   * @param testIdentityMigration test migration app instance
+   * @param loggerClass clazz to capture logs from
+   */
+  private void setupLogCapturing(
+      final TestStandaloneIdentityMigration testIdentityMigration, final Class<?> loggerClass) {
+    testIdentityMigration.withAdditionalInitializer(
+        applicationContext ->
+            applicationContext.addApplicationListener(
+                (ApplicationListener<ApplicationStartedEvent>)
+                    event -> {
+                      final Logger logger = (Logger) LoggerFactory.getLogger(loggerClass);
+                      logCapturer.setContext(logger.getLoggerContext());
+                      logCapturer.start();
+                      logger.addAppender(logCapturer);
+                    }));
+  }
+
+  static class LogCapturer extends ListAppender<ILoggingEvent> {
+
+    public boolean contains(final String string, final Level level) {
+      return list.stream()
+          .anyMatch(event -> event.toString().contains(string) && event.getLevel().equals(level));
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationIT.java
@@ -70,7 +70,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @WireMockTest
 @ZeebeIntegration
 @Testcontainers(parallel = true)
-public class IdentityDefaultEntitiesIT {
+public class IdentityMigrationIT {
 
   @TestZeebe(autoStart = false)
   static final TestStandaloneBroker BROKER =
@@ -115,7 +115,7 @@ public class IdentityDefaultEntitiesIT {
   @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-  private TestStandaloneIdentityMigration standaloneIdentityMigration;
+  private TestStandaloneIdentityMigration migration;
   private CamundaClient client;
 
   @BeforeAll
@@ -149,7 +149,7 @@ public class IdentityDefaultEntitiesIT {
     migrationProperties.getConsole().setClusterId("cluster123");
     migrationProperties.getConsole().setInternalClientId("client123");
 
-    standaloneIdentityMigration =
+    migration =
         new TestStandaloneIdentityMigration(migrationProperties)
             .withAppConfig(
                 config -> {
@@ -164,7 +164,7 @@ public class IdentityDefaultEntitiesIT {
   @Test
   void canMigrateGroups() {
     // when
-    standaloneIdentityMigration.start();
+    migration.start();
 
     Awaitility.await()
         .atMost(Duration.ofSeconds(5))
@@ -176,6 +176,8 @@ public class IdentityDefaultEntitiesIT {
             });
 
     // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
     final var groups = client.newGroupsSearchRequest().send().join();
     assertThat(groups.items().size()).isEqualTo(3);
     assertThat(groups.items())
@@ -196,7 +198,7 @@ public class IdentityDefaultEntitiesIT {
   @Test
   public void canMigrateRoles() {
     // when
-    standaloneIdentityMigration.start();
+    migration.start();
 
     Awaitility.await()
         .atMost(Duration.ofSeconds(5))
@@ -214,6 +216,8 @@ public class IdentityDefaultEntitiesIT {
             });
 
     // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
     final var roles = client.newRolesSearchRequest().send().join();
     assertThat(roles.items())
         .map(
@@ -235,7 +239,7 @@ public class IdentityDefaultEntitiesIT {
   public void canMigrateRolePermissions()
       throws URISyntaxException, IOException, InterruptedException {
     // when
-    standaloneIdentityMigration.start();
+    migration.start();
     final var restAddress = client.getConfiguration().getRestAddress().toString();
 
     Awaitility.await()
@@ -253,6 +257,8 @@ public class IdentityDefaultEntitiesIT {
             });
 
     // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
     final var authorizations = searchAuthorizations(restAddress);
     assertThat(authorizations.items())
         .extracting(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/util/MigrationITExtension.java
@@ -17,7 +17,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import io.camunda.client.CamundaClient;
-import io.camunda.migration.process.MigrationRunner;
+import io.camunda.migration.process.ProcessMigrator;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.search.clients.DocumentBasedSearchClient;
@@ -196,7 +196,7 @@ public class MigrationITExtension
   }
 
   private void awaitProcessMigrationFinished() {
-    final var logger = (Logger) LoggerFactory.getLogger(MigrationRunner.class);
+    final var logger = (Logger) LoggerFactory.getLogger(ProcessMigrator.class);
     final var appender = new LogAppender();
     appender.setContext(logger.getLoggerContext());
     appender.start();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -38,14 +38,14 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TestSpringApplication.class);
 
+  protected ConfigurableApplicationContext springContext;
+
   private final Class<?>[] springApplications;
   private final Map<String, Bean<?>> beans;
   private final Map<String, Object> propertyOverrides;
   private final Collection<String> additionalProfiles;
   private final Collection<ApplicationContextInitializer> additionalInitializers;
   private final ReactorResourceFactory reactorResourceFactory = new ReactorResourceFactory();
-
-  private ConfigurableApplicationContext springContext;
 
   public TestSpringApplication(final Class<?>... springApplications) {
     this(new HashMap<>(), new HashMap<>(), new ArrayList<>(), springApplications);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
@@ -9,7 +9,8 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
-import io.camunda.application.commons.migration.MigrationsRunner;
+import io.camunda.application.StandaloneIdentityMigration;
+import io.camunda.application.commons.migration.BlockingMigrationsRunner;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
@@ -17,7 +18,9 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Encapsulates an instance of the {@link MigrationsRunner} for identity Spring application. */
+/**
+ * Encapsulates an instance of the {@link BlockingMigrationsRunner} for identity Spring application.
+ */
 public final class TestStandaloneIdentityMigration
     extends TestSpringApplication<TestStandaloneIdentityMigration> {
   private static final Logger LOGGER =
@@ -26,7 +29,7 @@ public final class TestStandaloneIdentityMigration
   private final IdentityMigrationProperties config;
 
   public TestStandaloneIdentityMigration(final IdentityMigrationProperties migrationProperties) {
-    super(MigrationsRunner.class);
+    super(StandaloneIdentityMigration.class, BlockingMigrationsRunner.class);
     config = migrationProperties;
 
     migrationProperties.getCluster().setPort(SocketUtil.getNextAddress().getPort());

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneIdentityMigration.java
@@ -79,4 +79,8 @@ public final class TestStandaloneIdentityMigration
       default -> super.mappedPort(port);
     };
   }
+
+  public int getExitCode() {
+    return springContext.getBean(StandaloneIdentityMigration.class).getExitCode();
+  }
 }


### PR DESCRIPTION
## Description

This change primarily converts the identity migration app to a CommandLineRunner implementation that runs the migration synchronously and converts any exception thrown to an exit code = 1. Endless retry loops from the Identity migration were removed.

In the course of improving the log messages former MigrationRunner classes for the process and identity migration got renamed to be unique and the migrator interface extended to provide a name for the migrator. (Just used the classname now)

The identity migration app is extended with additional log messages on the cause.

As the identity migration depends on having joined the cluster successfully the application now busily awaits an initialized topology state, the interval and max attempts of that are configurable throug the `camunda.migration.identity.cluster.*` property path and default to a 1s interval with at max 30 attempts. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33068
