### PR TITLE
test: make http port dynamic

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderOidcWithSSLTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderOidcWithSSLTest.java
@@ -75,6 +75,7 @@ public class CredentialsProviderOidcWithSSLTest {
                   .keystorePassword("password")
                   .trustStorePath(VALID_TRUSTSTORE_PATH)
                   .trustStorePassword("password")
+                  .dynamicPort()
                   .dynamicHttpsPort())
           .build();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes a test setup where the test could not be executed if port 8080 was already in use on the test host.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
