### PR TITLE
fix: use correct meter name/description for recovery time

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -76,7 +76,7 @@ public final class StreamProcessorMetrics {
   }
 
   private void registerStartupRecoveryTime() {
-    final var meterDoc = StreamMetricsDoc.PROCESSOR_STATE;
+    final var meterDoc = StreamMetricsDoc.STARTUP_RECOVERY_TIME;
     TimeGauge.builder(
             meterDoc.getName(), startupRecoveryTime, TimeUnit.MILLISECONDS, AtomicLong::longValue)
         .description(meterDoc.getDescription())


### PR DESCRIPTION
## Description

Fixes an issue with the processor state where we were registering two different metrics with the same name :see_no_evil: 
