### PR TITLE
Revert "deps: Update opensearchproject/opensearch Docker tag to v3 (main)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
       # Set up an OpenSearch service container
       # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
       opensearch:
-        image: opensearchproject/opensearch:3.0.0
+        image: opensearchproject/opensearch:2.19.2
         # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
         ports:
           - 9200:9200

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -3,7 +3,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     depends_on:
       - opensearch-init
     container_name: opensearch

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     environment:
       - cluster.name=opensearch

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     command: [ "sysctl", "-w", "vm.max_map_count=262144" ]
 
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     depends_on:
       - opensearch-init

--- a/qa/core-application-e2e-test-suite/config/docker-compose.yml
+++ b/qa/core-application-e2e-test-suite/config/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
 
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/zeebe/exporters/opensearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/opensearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.0.0
+    image: opensearchproject/opensearch:2.19.2
     container_name: opensearch
     environment:
       - "discovery.type=single-node"


### PR DESCRIPTION
Reverts camunda/camunda#33675

This was not meant to be autoupgraded as OS 3 is not supported yet (like https://github.com/camunda/camunda/pull/33667 for ES 9)
Will be later additionally fixed in a Renovate config update.