### PR TITLE
release: allow "alphaX.Y" releases to be detected as prerelease

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -324,7 +324,7 @@ jobs:
         run: |
           shopt -s nocasematch # set matching to case insensitive
           PRE_RELEASE=false
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT).*$ ]]; then
             PRE_RELEASE=true
           fi
           shopt -u nocasematch # reset it


### PR DESCRIPTION
## Description

Align the monorepo behavior [with ZPT](https://github.com/camunda/zeebe-process-test/blob/3c8d707125caf10ae62d23f50b59ef4004a4cfa3/.github/workflows/create-release.yml#L124C11-L124C76) in order to allow extraordinary "alphaX.Y" releases and detect those correctly as "prerelease".

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - not needed since alpha releases only apply to `main`

## Related issues

None
