### PR TITLE
Backup status endpoint returns INCOMPLETE while backup is still in progress

### DIFF
--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -122,8 +122,10 @@ public class BackupRestoreTest {
     snapshots = backupResponse.getScheduledSnapshots();
 
     RetryOperation.newBuilder()
-        .noOfRetry(10)
-        .delayInterval(2000, TimeUnit.MILLISECONDS)
+        .noOfRetry(100)
+        .delayInterval(
+            10,
+            TimeUnit.MILLISECONDS) // short delay to verify that INCOMPLETE state is not returned
         .retryPredicate(result -> !(boolean) result)
         .retryConsumer(
             () -> {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.backup;
 import io.camunda.operate.util.Either;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public interface BackupRepository {
@@ -25,14 +26,14 @@ public interface BackupRepository {
 
   void validateNoDuplicateBackupId(String repositoryName, Long backupId);
 
-  GetBackupStateResponseDto getBackupState(String repositoryName, Long backupId);
+  GetBackupStateResponseDto getBackupState(
+      String repositoryName, Long backupId, final Predicate<Long> isBackupInProgressPredicate);
 
   List<GetBackupStateResponseDto> getBackups(
-      String repositoryName, boolean verbose, final String pattern);
-
-  default List<GetBackupStateResponseDto> getBackups(final String repositoryName) {
-    return getBackups(repositoryName, true, null);
-  }
+      String repositoryName,
+      boolean verbose,
+      final String pattern,
+      Predicate<Long> isBackupInProgressPredicate);
 
   void executeSnapshotting(
       BackupService.SnapshotRequest snapshotRequest, Runnable onSuccess, Runnable onFailure);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
@@ -58,18 +58,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BackupManagerElasticsearchTest {
 
+  private static final String TASKLIST_VERSION = "8.6.1";
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
   private final long backupId = 2L;
   final Metadata metadata =
-      new Metadata().setBackupId(backupId).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+      new Metadata()
+          .setBackupId(backupId)
+          .setPartCount(3)
+          .setPartNo(1)
+          .setVersion(TASKLIST_VERSION);
 
   private final String repositoryName = "test-repo";
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private RestHighLevelClient searchClient;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS, strictness = Strictness.LENIENT)
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private TasklistProperties tasklistProperties;
 
   @InjectMocks private BackupManagerElasticSearch backupManager;
@@ -90,7 +94,6 @@ class BackupManagerElasticsearchTest {
         .thenAnswer(
             invocation -> MAPPER.convertValue(invocation.getArgument(0), new TypeReference<>() {}));
     when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
-    when(tasklistProperties.getVersion()).thenReturn("8.6.0");
   }
 
   @ParameterizedTest
@@ -232,6 +235,7 @@ class BackupManagerElasticsearchTest {
   @Test
   void shouldReturnInProgressStateWhenBackupIsStillRunning() throws IOException {
     // given
+    when(tasklistProperties.getVersion()).thenReturn(TASKLIST_VERSION);
     // run takeBackup in parallel to simulate an ongoing backup
     when(searchClient.snapshot().createAsync(any(), any(), any()))
         .thenAnswer(

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticsearchTest.java
@@ -22,9 +22,14 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.backup.Prio1Backup;
+import io.camunda.tasklist.schema.backup.Prio2Backup;
+import io.camunda.tasklist.schema.backup.Prio3Backup;
+import io.camunda.tasklist.schema.backup.Prio4Backup;
 import io.camunda.tasklist.webapp.es.backup.Metadata;
 import io.camunda.tasklist.webapp.es.backup.es.BackupManagerElasticSearch.CreateSnapshotListener;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
+import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
@@ -34,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.client.Cancellable;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
@@ -48,7 +54,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 @ExtendWith(MockitoExtension.class)
 class BackupManagerElasticsearchTest {
@@ -64,20 +69,28 @@ class BackupManagerElasticsearchTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private RestHighLevelClient searchClient;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS, strictness = Strictness.LENIENT)
   private TasklistProperties tasklistProperties;
 
   @InjectMocks private BackupManagerElasticSearch backupManager;
 
   @Mock(strictness = Strictness.LENIENT)
-  @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
+
+  @Mock private List<Prio1Backup> prio1BackupIndices;
+  @Mock private List<Prio2Backup> prio2BackupTemplates;
+  @Mock private List<Prio3Backup> prio3BackupTemplates;
+  @Mock private List<Prio4Backup> prio4BackupIndices;
 
   @BeforeEach
   public void setUp() {
     when(objectMapper.convertValue(any(), eq(Metadata.class)))
         .thenAnswer(invocation -> MAPPER.convertValue(invocation.getArgument(0), Metadata.class));
+    when(objectMapper.convertValue(any(Metadata.class), any(TypeReference.class)))
+        .thenAnswer(
+            invocation -> MAPPER.convertValue(invocation.getArgument(0), new TypeReference<>() {}));
     when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
+    when(tasklistProperties.getVersion()).thenReturn("8.6.0");
   }
 
   @ParameterizedTest
@@ -214,5 +227,40 @@ class BackupManagerElasticsearchTest {
               final var response = backupManager.getBackupState(backupId);
               assertThat(response.getState()).isEqualTo(BackupStateDto.COMPLETED);
             });
+  }
+
+  @Test
+  void shouldReturnInProgressStateWhenBackupIsStillRunning() throws IOException {
+    // given
+    // run takeBackup in parallel to simulate an ongoing backup
+    when(searchClient.snapshot().createAsync(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Thread.sleep(1000);
+              return mock(Cancellable.class);
+            });
+    when(searchClient.snapshot().get(any(), any())).thenReturn(mock(GetSnapshotsResponse.class));
+    backupManager.takeBackup(new TakeBackupRequestDto().setBackupId(backupId));
+
+    // return (partCount - 1) SUCCESS snapshots, one is remaining
+    final var snapshots = new ArrayList<SnapshotInfo>(metadata.getPartCount());
+    for (int i = 1; i <= metadata.getPartCount() - 1; i++) {
+      final var copy = new Metadata(metadata);
+      copy.setPartNo(i);
+      final var snapshotInfo = mock(SnapshotInfo.class, Answers.RETURNS_DEEP_STUBS);
+      snapshots.add(snapshotInfo);
+      when(snapshotInfo.snapshotId().getName()).thenReturn(copy.buildSnapshotName());
+      when(snapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    }
+
+    final var snapshotResponse = mock(GetSnapshotsResponse.class, Answers.RETURNS_DEEP_STUBS);
+    when(snapshotResponse.getSnapshots()).thenReturn(snapshots);
+    when(searchClient.snapshot().get(any(), any())).thenReturn(snapshotResponse);
+
+    // when
+    final var backupResponse = backupManager.getBackupState(backupId);
+
+    // then
+    assertThat(backupResponse.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
@@ -19,10 +19,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.backup.Prio1Backup;
+import io.camunda.tasklist.schema.backup.Prio2Backup;
+import io.camunda.tasklist.schema.backup.Prio3Backup;
+import io.camunda.tasklist.schema.backup.Prio4Backup;
 import io.camunda.tasklist.webapp.es.backup.Metadata;
 import io.camunda.tasklist.webapp.es.backup.os.GetCustomSnapshotResponse.Builder;
 import io.camunda.tasklist.webapp.es.backup.os.response.SnapshotState;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
+import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
@@ -56,7 +61,9 @@ import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class BackupManagerOpenSearchTest {
 
-  @Mock OpenSearchTransport openSearchTransport;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  OpenSearchTransport openSearchTransport;
+
   private final long backupId = 2L;
   final Metadata metadata =
       new Metadata().setBackupId(backupId).setPartCount(3).setPartNo(1).setVersion("8.6.1");
@@ -71,6 +78,11 @@ class BackupManagerOpenSearchTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private TasklistProperties tasklistProperties;
 
+  @Mock private List<Prio1Backup> prio1BackupIndices;
+  @Mock private List<Prio2Backup> prio2BackupTemplates;
+  @Mock private List<Prio3Backup> prio3BackupTemplates;
+  @Mock private List<Prio4Backup> prio4BackupIndices;
+
   @InjectMocks private BackupManagerOpenSearch backupManagerOpenSearch;
 
   @BeforeEach
@@ -78,6 +90,7 @@ class BackupManagerOpenSearchTest {
     when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
     when(openSearchClient._transport()).thenReturn(openSearchTransport);
     when(openSearchAsyncClient._transport()).thenReturn(openSearchTransport);
+    when(tasklistProperties.getVersion()).thenReturn("8.6.0");
   }
 
   @Test
@@ -252,5 +265,49 @@ class BackupManagerOpenSearchTest {
         .performRequest(any(), any(), any());
     final var response = backupManagerOpenSearch.getBackupState(backupId);
     assertThat(response.getState()).isEqualTo(BackupStateDto.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnInProgressStateWhenBackupIsStillRunning() throws IOException {
+    // given
+    // run takeBackup in parallel to simulate an ongoing backup
+    when(openSearchClient.snapshot().create(any(CreateSnapshotRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              Thread.sleep(1000);
+              return mock(CompletableFuture.class);
+            });
+    /*when(openSearchClient.snapshot().get(any(GetSnapshotRequest.class)))
+    .thenReturn(mock(GetSnapshotResponse.class));*/
+    when(openSearchTransport.performRequest(any(), any(), any()))
+        .thenReturn(mock(GetCustomSnapshotResponse.class));
+    backupManagerOpenSearch.takeBackup(new TakeBackupRequestDto().setBackupId(backupId));
+
+    final var metadata =
+        new Metadata().setBackupId(2L).setPartCount(3).setPartNo(1).setVersion("8.6.1");
+    final var snapshots = new ArrayList<SnapshotInfo>(metadata.getPartCount());
+    // return (partCount - 1) SUCCESS snapshots, one is remaining
+    for (int i = 1; i <= metadata.getPartCount() - 1; i++) {
+      final var copy = new Metadata(metadata);
+      copy.setPartNo(i);
+      snapshots.add(
+          SnapshotInfo.of(
+              sib ->
+                  sib.snapshot(copy.buildSnapshotName())
+                      .state("SUCCESS")
+                      .uuid(UUID.randomUUID().toString())
+                      .dataStreams(List.of())
+                      .indices(List.of())));
+    }
+
+    final var snapshotResponse = GetCustomSnapshotResponse.of(b -> b.snapshots(snapshots));
+    when(openSearchTransport.performRequest(any(), any(), any())).thenReturn(snapshotResponse);
+    when(tasklistProperties.getBackup().getRepositoryName()).thenReturn(repositoryName);
+
+    // when
+    final var backupResponse = backupManagerOpenSearch.getBackupState(backupId);
+
+    // then
+    assertThat(backupResponse.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The GET backup status endpoint sometimes returns an `INCOMPLETE` state, even though the backup is still actively progressing.

This happens when some of the snapshots of a backup were successfully completed, but the next ones have not yet been scheduled by ElasticSearch/OpenSearch.

The GET backup status endpoint will fetch from ES/OS for example 2 snapshots with SUCCESS status out of 6,  and no status about the remaining snapshots as they were not scheduled yet by ES/OS. So this is mistakenly considered as `INCOMPLETE` backup status for the backup.

I managed to reproduce the issue by running [BackupRestoreTest](https://github.com/camunda/camunda/blob/stable/8.6/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java#L126)  and reducing the retry delay to check the backup state to 10 milliseconds 

To solve this, the idea is to check the in-memory state to check if a given backup is still in progress, besides the snapshot states that we get from ES/OS. This has the limitation that it does not work in multi-mode deployment, if the GET backup status hits the node where the backup is not running. In this case, INCOMPLETE would be returned.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33717 
