### PR TITLE
fix: Write `PI:ELEMENT_TERMINATED` event with `operationReference`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -81,7 +81,7 @@ public final class BpmnProcessors {
     final var keyGenerator = processingState.getKeyGenerator();
 
     addProcessInstanceCommandProcessor(
-        writers, typedRecordProcessors, processingState, authCheckBehavior);
+        writers, typedRecordProcessors, processingState, asyncRequestBehavior, authCheckBehavior);
 
     final var bpmnStreamProcessor =
         new BpmnStreamProcessor(
@@ -140,11 +140,13 @@ public final class BpmnProcessors {
       final Writers writers,
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
+      final AsyncRequestBehavior asyncRequestBehavior,
       final AuthorizationCheckBehavior authCheckBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
-        new ProcessInstanceCancelProcessor(processingState, writers, authCheckBehavior));
+        new ProcessInstanceCancelProcessor(
+            processingState, writers, asyncRequestBehavior, authCheckBehavior));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.processing.bpmn.task.ScriptTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UndefinedTaskProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.task.UserTaskProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.EnumMap;
 import java.util.Map;
@@ -45,6 +46,7 @@ public final class BpmnElementProcessors {
   public BpmnElementProcessors(
       final BpmnBehaviors bpmnBehaviors,
       final BpmnStateTransitionBehavior stateTransitionBehavior,
+      final AsyncRequestState asyncRequestState,
       final EngineConfiguration config) {
     // tasks
     processors.put(
@@ -86,7 +88,8 @@ public final class BpmnElementProcessors {
 
     // containers
     processors.put(
-        BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors, stateTransitionBehavior));
+        BpmnElementType.PROCESS,
+        new ProcessProcessor(bpmnBehaviors, stateTransitionBehavior, asyncRequestState));
     processors.put(
         BpmnElementType.SUB_PROCESS,
         new SubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -81,7 +81,9 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             processEngineMetrics,
             this::getContainerProcessor,
             writers);
-    processors = new BpmnElementProcessors(bpmnBehaviors, stateTransitionBehavior, config);
+    processors =
+        new BpmnElementProcessors(
+            bpmnBehaviors, stateTransitionBehavior, processingState.getAsyncRequestState(), config);
     stateBehavior = bpmnBehaviors.stateBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
     eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -135,6 +136,15 @@ public final class CancelProcessInstanceTest {
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ELEMENT_TERMINATED),
             tuple("PROCESS", ELEMENT_TERMINATED));
+
+    assertThat(
+            RecordingExporter.asyncRequestRecords()
+                .withRequestScopeKey(processInstanceKey)
+                .withRequestValueType(ValueType.PROCESS_INSTANCE)
+                .withRequestIntent(CANCEL)
+                .limit(2))
+        .extracting(Record::getIntent)
+        .containsExactly(AsyncRequestIntent.RECEIVED, AsyncRequestIntent.PROCESSED);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
@@ -649,12 +649,6 @@ public final class ProcessInstanceCommandRejectionTest {
             .withProcessInstanceKey(command.getValue().getProcessInstanceKey())
             .getFirst();
 
-    System.out.println(
-        "DMK: source record position: "
-            + rejection.getSourceRecordPosition()
-            + ", position: "
-            + rejection.getPosition());
-
     Assertions.assertThat(rejection)
         .hasIntent(command.getIntent())
         .hasSourceRecordPosition(command.getPosition())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
@@ -540,7 +540,7 @@ public final class ProcessInstanceCommandRejectionTest {
   }
 
   @Test
-  public void shouldRejectTerminateIfElementIsTerminating() {
+  public void shouldRejectCancelIfProcessInstanceIsAlreadyCanceling() {
     // given
     final var processInstanceKey =
         createProcessInstance(
@@ -560,20 +560,16 @@ public final class ProcessInstanceCommandRejectionTest {
 
     // then
     final var rejectedCommand =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.TERMINATE_ELEMENT)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.PROCESS)
-            .skip(1) // the process was already terminated once
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
+            .withRecordKey(processInstanceKey)
+            .skip(1) // the process was already canceled once
             .getFirst();
 
     assertThatCommandIsRejected(
         rejectedCommand,
         String.format(
-            "Expected element instance to be in state '%s' or one of '%s' but was '%s'.",
-            ProcessInstanceIntent.ELEMENT_ACTIVATING,
-            List.of(
-                ProcessInstanceIntent.ELEMENT_ACTIVATED, ProcessInstanceIntent.ELEMENT_COMPLETING),
-            ProcessInstanceIntent.ELEMENT_TERMINATING));
+            "Expected to cancel a process instance with key '%d', but a cancel request is already in progress",
+            processInstanceKey));
   }
 
   @Test
@@ -652,6 +648,12 @@ public final class ProcessInstanceCommandRejectionTest {
             .onlyCommandRejections()
             .withProcessInstanceKey(command.getValue().getProcessInstanceKey())
             .getFirst();
+
+    System.out.println(
+        "DMK: source record position: "
+            + rejection.getSourceRecordPosition()
+            + ", position: "
+            + rejection.getPosition());
 
     Assertions.assertThat(rejection)
         .hasIntent(command.getIntent())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -8,15 +8,22 @@
 package io.camunda.zeebe.it.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
@@ -140,5 +147,100 @@ public class OperationReferenceTest {
                 .getOperationReference())
         .describedAs("Should contain client operationReference")
         .isEqualTo(-1);
+  }
+
+  @Test
+  void shouldPreserveOperationReferenceOnVariableUpdatedEventAfterUpdatingUserTaskWithListeners() {
+    // Given
+    final var helper = new ZeebeResourcesHelper(client);
+    final var listenerType = "updating_listener";
+
+    final var userTaskKey =
+        helper.createSingleUserTask(t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
+
+    final var userTaskInstanceKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withRecordKey(userTaskKey)
+            .getFirst()
+            .getValue()
+            .getElementInstanceKey();
+
+    client
+        .newWorker()
+        .jobType(listenerType)
+        .handler((jobClient, job) -> jobClient.newCompleteCommand(job).withResult().send().join())
+        .open();
+
+    // When
+    final var updateVariablesFuture =
+        client
+            .newSetVariablesCommand(userTaskInstanceKey)
+            .variables(Map.of("approvalStatus", "APPROVED"))
+            .operationReference(OPERATION_REFERENCE)
+            .send();
+
+    assertThatCode(updateVariablesFuture::join).doesNotThrowAnyException();
+
+    // Then
+    Assertions.assertThat(
+            RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATED)
+                .withScopeKey(userTaskInstanceKey)
+                .getFirst())
+        .describedAs("VARIABLE_DOCUMENT:UPDATED should carry original 'operationReference'")
+        .hasOperationReference(OPERATION_REFERENCE);
+  }
+
+  @Test
+  void shouldPreserveOperationRefOnVariableUpdateDeniedEventAfterDenialByUpdatingTaskListener() {
+    // Given
+    final var helper = new ZeebeResourcesHelper(client);
+    final var listenerType = "updating_listener_with_denial";
+
+    final var userTaskKey =
+        helper.createSingleUserTask(t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
+
+    final var userTaskInstanceKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withRecordKey(userTaskKey)
+            .getFirst()
+            .getValue()
+            .getElementInstanceKey();
+
+    final var reason = "Denied by listener";
+    client
+        .newWorker()
+        .jobType(listenerType)
+        .handler(
+            (jobClient, job) ->
+                jobClient
+                    .newCompleteCommand(job)
+                    .withResult()
+                    .deny(true)
+                    .deniedReason(reason)
+                    .send()
+                    .join())
+        .open();
+
+    // When
+    final var updateVariablesFuture =
+        client
+            .newSetVariablesCommand(userTaskInstanceKey)
+            .useRest()
+            .variables(Map.of("approvalStatus", "APPROVED"))
+            .local(true)
+            .operationReference(OPERATION_REFERENCE)
+            .send();
+
+    // Then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(updateVariablesFuture::join)
+        .withMessageContaining(reason);
+
+    Assertions.assertThat(
+            RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATE_DENIED)
+                .withScopeKey(userTaskInstanceKey)
+                .getFirst())
+        .describedAs("VARIABLE_DOCUMENT:UPDATE_DENIED should carry original 'operationReference'")
+        .hasOperationReference(OPERATION_REFERENCE);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -59,14 +59,12 @@ public class OperationReferenceTest {
         .join();
 
     // Then
-    assertThat(
+    Assertions.assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
                 .withRecordKey(processInstanceKey)
-                .limit(1)
-                .getFirst()
-                .getOperationReference())
+                .getFirst())
         .describedAs("Should contain client operationReference")
-        .isEqualTo(OPERATION_REFERENCE);
+        .hasOperationReference(OPERATION_REFERENCE);
   }
 
   @Test
@@ -88,7 +86,6 @@ public class OperationReferenceTest {
     final var cancelCommand =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
             .withRecordKey(processInstanceKey)
-            .limit(1)
             .getFirst();
 
     final var followUpRecords =
@@ -102,7 +99,7 @@ public class OperationReferenceTest {
     assertThat(followUpRecords)
         .hasSizeGreaterThan(0)
         .describedAs("Should contain client operationReference")
-        .allMatch(r -> r.getOperationReference() == OPERATION_REFERENCE);
+        .allSatisfy(r -> Assertions.assertThat(r).hasOperationReference(OPERATION_REFERENCE));
   }
 
   @Test
@@ -117,14 +114,12 @@ public class OperationReferenceTest {
     client.newCancelInstanceCommand(processInstanceKey).send().join();
 
     // Then
-    assertThat(
+    Assertions.assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
                 .withRecordKey(processInstanceKey)
-                .limit(1)
-                .getFirst()
-                .getOperationReference())
+                .getFirst())
         .describedAs("Should contain -1 operationReference")
-        .isEqualTo(-1);
+        .hasOperationReference(-1);
   }
 
   @Test
@@ -139,14 +134,12 @@ public class OperationReferenceTest {
     client.newCancelInstanceCommand(processInstanceKey).operationReference(-1).send().join();
 
     // Then
-    assertThat(
+    Assertions.assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
                 .withRecordKey(processInstanceKey)
-                .limit(1)
-                .getFirst()
-                .getOperationReference())
+                .getFirst())
         .describedAs("Should contain client operationReference")
-        .isEqualTo(-1);
+        .hasOperationReference(-1);
   }
 
   @Test
@@ -186,7 +179,7 @@ public class OperationReferenceTest {
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
                 .withRecordKey(processInstanceKey)
                 .getFirst())
-        .describedAs("PI:ELEMENT_TERMINATED should carry original 'operationReference'")
+        .describedAs("PI:ELEMENT_TERMINATED should carry client operationReference")
         .hasOperationReference(OPERATION_REFERENCE);
   }
 
@@ -227,7 +220,7 @@ public class OperationReferenceTest {
             RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATED)
                 .withScopeKey(userTaskInstanceKey)
                 .getFirst())
-        .describedAs("VARIABLE_DOCUMENT:UPDATED should carry original 'operationReference'")
+        .describedAs("VARIABLE_DOCUMENT:UPDATED should carry client operationReference")
         .hasOperationReference(OPERATION_REFERENCE);
   }
 
@@ -281,7 +274,7 @@ public class OperationReferenceTest {
             RecordingExporter.variableDocumentRecords(VariableDocumentIntent.UPDATE_DENIED)
                 .withScopeKey(userTaskInstanceKey)
                 .getFirst())
-        .describedAs("VARIABLE_DOCUMENT:UPDATE_DENIED should carry original 'operationReference'")
+        .describedAs("VARIABLE_DOCUMENT:UPDATE_DENIED should carry client operationReference")
         .hasOperationReference(OPERATION_REFERENCE);
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AsyncRequestRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AsyncRequestRecordStream.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
+import java.util.stream.Stream;
+
+public class AsyncRequestRecordStream
+    extends ExporterRecordStream<AsyncRequestRecordValue, AsyncRequestRecordStream> {
+
+  public AsyncRequestRecordStream(final Stream<Record<AsyncRequestRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected AsyncRequestRecordStream supply(
+      final Stream<Record<AsyncRequestRecordValue>> wrappedStream) {
+    return new AsyncRequestRecordStream(wrappedStream);
+  }
+
+  public AsyncRequestRecordStream withRequestScopeKey(final long scopeKey) {
+    return valueFilter(v -> v.getScopeKey() == scopeKey);
+  }
+
+  public AsyncRequestRecordStream withRequestValueType(final ValueType valueType) {
+    return valueFilter(v -> v.getValueType() == valueType);
+  }
+
+  public AsyncRequestRecordStream withRequestIntent(final Intent intent) {
+    return valueFilter(v -> v.getIntent() == intent);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -152,4 +152,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new AuthorizationRecordStream(
         filter(r -> r.getValueType() == ValueType.AUTHORIZATION).map(Record.class::cast));
   }
+
+  public AsyncRequestRecordStream asyncRequestRecords() {
+    return new AsyncRequestRecordStream(
+        filter(r -> r.getValueType() == ValueType.ASYNC_REQUEST).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -48,6 +48,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
@@ -600,6 +601,11 @@ public final class RecordingExporter implements Exporter {
         records(
             ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE,
             BatchOperationPartitionLifecycleRecordValue.class));
+  }
+
+  public static AsyncRequestRecordStream asyncRequestRecords() {
+    return new AsyncRequestRecordStream(
+        records(ValueType.ASYNC_REQUEST, AsyncRequestRecordValue.class));
   }
 
   public static BatchOperationPartitionLifecycleRecordStream


### PR DESCRIPTION
> [!TIP]
> For clarity, this PR was intentionally split into focused commits.
Reviewing it commit-by-commit (rather than as one diff) will make it easier to understand the purpose and motivation of each change.


## Description

This PR was build on the mechanisms introduced in #32687 and #30686 PRs to preserve and provide `operationReference` in `ProcessInstance:ELEMENT_TERMINATED` event.

### Problem

When canceling a process instance that includes a user task with a `canceling` listener, the final `ProcessInstance:ELEMENT_TERMINATED` event lacked the original `operationReference` passed via the `ProcessInstance:CANCEL` command.

As a result, Operate was unable to correlate the `ProcessInstance:ELEMENT_TERMINATED` event with the user-triggered operation. The cancel operation remained stuck in `"SENT"` state, leaving the UI in a perpetual loading state — despite the process being successfully terminated by the engine.

### Solution

This PR:

- Writes `AsyncRequest:RECEIVED` event on handling `ProcessInstance:CANCEL` command to capture the request metadata
- Leverages `FollowUpEventMetadata` to enrich `PI:ELEMENT_TERMINATED` events with the original `operationReference` from `AsyncRequestMetadata`
- Writes `AsyncRequest:PROCESSED` event after `PI:ELEMENT_TERMINATED` to make clean metadata of `PI:CANCEL` request
- Ensures only one cancel request per process instance is allowed by rejecting duplicate `PI:CANCEL` commands
- Refactors `ProcessProcessor` and `BpmnStateTransitionBehavior` to support request metadata-aware flow

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31701 
