### PR TITLE
Prevent NPE on `ProcessInstanceBatch ACTIVATE` if parent is terminated

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
@@ -12,11 +12,14 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMul
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -25,11 +28,15 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 @ExcludeAuthorizationCheck
 public final class ProcessInstanceBatchActivateProcessor
     implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
+
+  public static final String PARENT_NOT_FOUND_ERROR_MESSAGE =
+      "Expected to activate child for batch element instance, but no parent element instance found for key '%s'. The parent was likely terminated before processing this batch activation.";
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final KeyGenerator keyGenerator;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
+  private final TypedRejectionWriter rejectionWriter;
 
   public ProcessInstanceBatchActivateProcessor(
       final Writers writers,
@@ -41,6 +48,7 @@ public final class ProcessInstanceBatchActivateProcessor
     this.keyGenerator = keyGenerator;
     this.elementInstanceState = elementInstanceState;
     this.processState = processState;
+    rejectionWriter = writers.rejection();
   }
 
   @Override
@@ -48,15 +56,26 @@ public final class ProcessInstanceBatchActivateProcessor
     final var recordValue = record.getValue();
     final var remainingChildrenToActivate = recordValue.getIndex();
 
+    final var batchElementInstanceKey = record.getValue().getBatchElementInstanceKey();
+    final var parentElementInstance = elementInstanceState.getInstance(batchElementInstanceKey);
+    if (parentElementInstance == null) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.INVALID_STATE,
+          PARENT_NOT_FOUND_ERROR_MESSAGE.formatted(batchElementInstanceKey));
+      return;
+    }
+
     if (remainingChildrenToActivate > 0) {
-      writeActivateChildCommand(recordValue);
+      writeActivateChildCommand(parentElementInstance);
     }
 
     writeNextBatchCommand(remainingChildrenToActivate - 1, record);
   }
 
-  private void writeActivateChildCommand(final ProcessInstanceBatchRecord record) {
-    final ProcessInstanceRecord childInstanceRecord = createChildInstanceRecord(record);
+  private void writeActivateChildCommand(final ElementInstance parentElementInstance) {
+    final ProcessInstanceRecord childInstanceRecord =
+        createChildInstanceRecord(parentElementInstance);
 
     commandWriter.appendFollowUpCommand(
         keyGenerator.nextKey(), ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);
@@ -89,9 +108,7 @@ public final class ProcessInstanceBatchActivateProcessor
   }
 
   private ProcessInstanceRecord createChildInstanceRecord(
-      final ProcessInstanceBatchRecord recordValue) {
-    final var parentElementInstance =
-        elementInstanceState.getInstance(recordValue.getBatchElementInstanceKey());
+      final ElementInstance parentElementInstance) {
     final var processDefinition =
         processState
             .getProcessByKeyAndTenant(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceConcurrencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceConcurrencyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.multiinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.engine.util.Records;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultiInstanceConcurrencyTest {
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().maxCommandsInBatch(1);
+
+  private static final String PROCESS_ID = "processId";
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldRejectPiBatchActivateWhenBodyIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("serviceTask1", t -> t.zeebeJobType("jobType1"))
+                .sequenceFlowId("task1-to-task2")
+                .serviceTask("serviceTask2", t -> t.zeebeJobType("jobType2"))
+                .multiInstance(
+                    mi ->
+                        mi.zeebeInputCollectionExpression("[1,2,3]")
+                            .zeebeInputElement("item")
+                            .parallel())
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTask =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final var task1Job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    final var procDefKey = serviceTask.getValue().getProcessDefinitionKey();
+    final ProcessInstanceRecord sequenceFlow =
+        Records.processInstance(processInstanceKey, PROCESS_ID)
+            .setBpmnElementType(BpmnElementType.SEQUENCE_FLOW)
+            .setElementId("task1-to-task2")
+            .setFlowScopeKey(processInstanceKey)
+            .setProcessDefinitionKey(procDefKey);
+    final var multiInstance =
+        Records.processInstance(processInstanceKey, PROCESS_ID)
+            .setBpmnElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .setElementId("serviceTask2")
+            .setFlowScopeKey(processInstanceKey)
+            .setProcessDefinitionKey(procDefKey);
+
+    // when
+    ENGINE.stop();
+    RecordingExporter.reset();
+    final var multiInstanceKey = task1Job.getKey() + 10000;
+    final var batchActivateKey = multiInstanceKey + 1;
+    // We need to ensure that the multi-instance body is terminated before we try to activate the
+    // first batch. In order to achieve we have to write our events and commands manually. If we
+    // don't do this the test won't be deterministic.
+    ENGINE.writeRecords(
+        RecordToWrite.event().key(task1Job.getKey()).job(JobIntent.COMPLETED, task1Job.getValue()),
+        RecordToWrite.event()
+            .key(serviceTask.getKey())
+            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETING, serviceTask.getValue()),
+        RecordToWrite.event()
+            .key(serviceTask.getKey())
+            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETED, serviceTask.getValue()),
+        RecordToWrite.event()
+            .key(-1L)
+            .processInstance(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, sequenceFlow),
+        RecordToWrite.event()
+            .key(multiInstanceKey)
+            .processInstance(ProcessInstanceIntent.ELEMENT_ACTIVATING, multiInstance),
+        RecordToWrite.event()
+            .key(multiInstanceKey)
+            .processInstance(ProcessInstanceIntent.ELEMENT_ACTIVATED, multiInstance),
+        RecordToWrite.command()
+            .key(multiInstanceKey)
+            .processInstance(ProcessInstanceIntent.TERMINATE_ELEMENT, multiInstance),
+        RecordToWrite.command()
+            .key(batchActivateKey)
+            .processInstanceBatch(
+                ProcessInstanceBatchIntent.ACTIVATE,
+                Records.processInstanceBatch(processInstanceKey, multiInstanceKey)));
+    ENGINE.start();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceBatchRecords(ProcessInstanceBatchIntent.ACTIVATE)
+                .onlyCommandRejections()
+                .withProcessInstanceKey(processInstanceKey)
+                .withRecordKey(batchActivateKey)
+                .getFirst()
+                .getRejectionReason())
+        .isEqualTo(
+            "Expected to activate child for batch element instance, but no parent element instance found for key '%s'. The parent was likely terminated before processing this batch activation."
+                .formatted(multiInstanceKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceConcurrencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceConcurrencyTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.multiinstance;
 
+import static io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor.PARENT_NOT_FOUND_ERROR_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -117,8 +118,6 @@ public class MultiInstanceConcurrencyTest {
                 .withRecordKey(batchActivateKey)
                 .getFirst()
                 .getRejectionReason())
-        .isEqualTo(
-            "Expected to activate child for batch element instance, but no parent element instance found for key '%s'. The parent was likely terminated before processing this batch activation."
-                .formatted(multiInstanceKey));
+        .isEqualTo(PARENT_NOT_FOUND_ERROR_MESSAGE.formatted(multiInstanceKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -42,6 +44,7 @@ import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationR
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
@@ -138,6 +141,13 @@ public final class RecordToWrite implements LogAppendEntry {
       final ProcessInstanceCreationIntent intent, final ProcessInstanceCreationRecordValue value) {
     recordMetadata.valueType(ValueType.PROCESS_INSTANCE_CREATION).intent(intent);
     unifiedRecordValue = (ProcessInstanceCreationRecord) value;
+    return this;
+  }
+
+  public RecordToWrite processInstanceBatch(
+      final ProcessInstanceBatchIntent intent, final ProcessInstanceBatchRecordValue value) {
+    recordMetadata.valueType(ValueType.PROCESS_INSTANCE_BATCH).intent(intent);
+    unifiedRecordValue = (ProcessInstanceBatchRecord) value;
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/Records.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/Records.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -176,6 +177,14 @@ public final class Records {
     record.setProcessInstanceKey(instanceKey);
     record.setBpmnProcessId(processId);
     return record;
+  }
+
+  public static ProcessInstanceBatchRecord processInstanceBatch(
+      final long processInstanceKey, final long batchElementInstanceKey) {
+    return new ProcessInstanceBatchRecord()
+        .setProcessInstanceKey(processInstanceKey)
+        .setBatchElementInstanceKey(batchElementInstanceKey)
+        .setIndex(3);
   }
 
   public static ErrorRecord error(final int instanceKey, final long pos) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -331,6 +332,11 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceBatchRecordStream processInstanceBatchRecords() {
     return new ProcessInstanceBatchRecordStream(
         records(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecordValue.class));
+  }
+
+  public static ProcessInstanceBatchRecordStream processInstanceBatchRecords(
+      final ProcessInstanceBatchIntent intent) {
+    return processInstanceBatchRecords().withIntent(intent);
   }
 
   public static TimerRecordStream timerRecords() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

If the parent is terminated the PI batch would result in an NPE. This results in a banned process instance. Obviously
that's not desirable and we should be able to handle this case gracefully.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31511
