### PR TITLE
fix: mark document hash as required in rest api docs

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4309,7 +4309,7 @@ paths:
             type: string
         - name: contentHash
           in: query
-          required: false
+          required: true
           schema:
             type: string
           description: >
@@ -4394,7 +4394,7 @@ paths:
             type: string
         - name: contentHash
           in: query
-          required: false
+          required: true
           schema:
             type: string
           description: >


### PR DESCRIPTION
## Description

This PR will mark the document hash param as required in the REST API docs. It's confusing for users right now because if the hash is not provided, an error is always returned.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

