### PR TITLE
feat: adding advanced filter for ProcessDefinition Search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -16,10 +16,7 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
-import io.camunda.client.api.search.filter.UserTaskFilter;
-import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.ParseUtil;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -47,8 +47,7 @@ public class ProcessDefinitionFilterImpl
 
   @Override
   public ProcessDefinitionFilter name(final String name) {
-    name(b -> b.eq(name));
-    return this;
+    return name(b -> b.eq(name));
   }
 
   @Override
@@ -71,8 +70,7 @@ public class ProcessDefinitionFilterImpl
 
   @Override
   public ProcessDefinitionFilter processDefinitionId(final String processDefinitionId) {
-    processDefinitionId(b -> b.eq(processDefinitionId));
-    return this;
+    return processDefinitionId(b -> b.eq(processDefinitionId));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessDefinitionFilterImpl.java
@@ -16,8 +16,14 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
+import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.filter.builder.IntegerProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.ParseUtil;
+import java.util.function.Consumer;
 
 public class ProcessDefinitionFilterImpl
     extends TypedSearchRequestPropertyProvider<
@@ -44,7 +50,7 @@ public class ProcessDefinitionFilterImpl
 
   @Override
   public ProcessDefinitionFilter name(final String name) {
-    filter.setName(name);
+    name(b -> b.eq(name));
     return this;
   }
 
@@ -68,13 +74,27 @@ public class ProcessDefinitionFilterImpl
 
   @Override
   public ProcessDefinitionFilter processDefinitionId(final String processDefinitionId) {
-    filter.setProcessDefinitionId(processDefinitionId);
+    processDefinitionId(b -> b.eq(processDefinitionId));
     return this;
   }
 
   @Override
   public ProcessDefinitionFilter tenantId(final String tenantId) {
     filter.setTenantId(tenantId);
+    return this;
+  }
+
+  public ProcessDefinitionFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  public ProcessDefinitionFilter processDefinitionId(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
@@ -105,11 +105,11 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
     final ProcessDefinitionFilter filter = request.getFilter();
     assertThat(filter).isNotNull();
     assertThat(filter.getProcessDefinitionKey()).isEqualTo("5");
-    assertThat(filter.getName()).isEqualTo("Order process");
+    assertThat(filter.getName().get$Eq()).isEqualTo("Order process");
     assertThat(filter.getResourceName()).isEqualTo("usertest/complex-process.bpmn");
     assertThat(filter.getVersion()).isEqualTo(2);
     assertThat(filter.getVersionTag()).isEqualTo("alpha");
-    assertThat(filter.getProcessDefinitionId()).isEqualTo("orderProcess");
+    assertThat(filter.getProcessDefinitionId().get$Eq()).isEqualTo("orderProcess");
     assertThat(filter.getTenantId()).isEqualTo("<default>");
   }
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -60,13 +60,13 @@
         close=")">#{value}
       </foreach>
     </if>
-    <if test="filter.processDefinitionIdsOperations != null and !filter.processDefinitionIdsOperations.isEmpty()">
-      <foreach collection="filter.processDefinitionIdsOperations" item="operation">
+    <if test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdOperations" item="operation">
         AND PROCESS_DEFINITION_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.namesOperations != null and !filter.namesOperations.isEmpty()">
-      <foreach collection="filter.namesOperations" item="operation">
+    <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+      <foreach collection="filter.nameOperations" item="operation">
         AND NAME <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -60,15 +60,14 @@
         close=")">#{value}
       </foreach>
     </if>
-    <if test="filter.processDefinitionIds != null and !filter.processDefinitionIds.isEmpty()">
-      AND PROCESS_DEFINITION_ID IN
-      <foreach collection="filter.processDefinitionIds" item="value" open="(" separator=", "
-        close=")">#{value}
+    <if test="filter.processDefinitionIdsOperations != null and !filter.processDefinitionIdsOperations.isEmpty()">
+      <foreach collection="filter.processDefinitionIdsOperations" item="operation">
+        AND PROCESS_DEFINITION_ID <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.names != null and !filter.names.isEmpty()">
-      AND name IN
-      <foreach collection="filter.names" item="value" open="(" separator=", " close=")">#{value}
+    <if test="filter.namesOperations != null and !filter.namesOperations.isEmpty()">
+      <foreach collection="filter.namesOperations" item="operation">
+        AND NAME <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
     <if test="filter.resourceNames != null and !filter.resourceNames.isEmpty()">

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -41,7 +41,8 @@ public class ProcessDefinitionFilterTransformer
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(longTerms(KEY, filter.processDefinitionKeys())).ifPresent(queries::add);
     ofNullable(getNamesQuery(filter.namesOperations())).ifPresent(queries::addAll);
-    ofNullable(getProcessDefinitionIdsQuery(filter.processDefinitionIdsOperations())).ifPresent(queries::addAll);
+    ofNullable(getProcessDefinitionIdsQuery(filter.processDefinitionIdsOperations()))
+        .ifPresent(queries::addAll);
     ofNullable(stringTerms(RESOURCE_NAME, filter.resourceNames())).ifPresent(queries::add);
     ofNullable(intTerms(VERSION, filter.versions())).ifPresent(queries::add);
     ofNullable(stringTerms(VERSION_TAG, filter.versionTags())).ifPresent(queries::add);
@@ -54,7 +55,8 @@ public class ProcessDefinitionFilterTransformer
     return stringOperations(NAME, names);
   }
 
-  private List<SearchQuery> getProcessDefinitionIdsQuery(final List<Operation<String>> processDefinitionIds) {
+  private List<SearchQuery> getProcessDefinitionIdsQuery(
+      final List<Operation<String>> processDefinitionIds) {
     return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessDefinitionFilterTransformer.java
@@ -40,8 +40,8 @@ public class ProcessDefinitionFilterTransformer
   public SearchQuery toSearchQuery(final ProcessDefinitionFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(longTerms(KEY, filter.processDefinitionKeys())).ifPresent(queries::add);
-    ofNullable(getNamesQuery(filter.namesOperations())).ifPresent(queries::addAll);
-    ofNullable(getProcessDefinitionIdsQuery(filter.processDefinitionIdsOperations()))
+    ofNullable(getNamesQuery(filter.nameOperations())).ifPresent(queries::addAll);
+    ofNullable(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()))
         .ifPresent(queries::addAll);
     ofNullable(stringTerms(RESOURCE_NAME, filter.resourceNames())).ifPresent(queries::add);
     ofNullable(intTerms(VERSION, filter.versions())).ifPresent(queries::add);

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
@@ -19,8 +19,8 @@ import java.util.Objects;
 public record ProcessDefinitionFilter(
     Boolean isLatestVersion,
     List<Long> processDefinitionKeys,
-    List<Operation<String>> namesOperations,
-    List<Operation<String>> processDefinitionIdsOperations,
+    List<Operation<String>> nameOperations,
+    List<Operation<String>> processDefinitionIdOperations,
     List<String> resourceNames,
     List<Integer> versions,
     List<String> versionTags,
@@ -32,8 +32,8 @@ public record ProcessDefinitionFilter(
     private Boolean isLatestVersion;
     private List<String> tenantIds;
     private List<Long> processDefinitionKeys;
-    private List<Operation<String>> namesOperations;
-    private List<Operation<String>> processDefinitionIdsOperations;
+    private List<Operation<String>> nameOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
     private List<String> resourceNames;
     private List<Integer> versions;
     private List<String> versionTags;
@@ -47,34 +47,34 @@ public record ProcessDefinitionFilter(
       return processDefinitionKeys(collectValues(value, values));
     }
 
-    public Builder namesOperations(final List<Operation<String>> operations) {
-      namesOperations = addValuesToList(namesOperations, operations);
+    public Builder nameOperations(final List<Operation<String>> operations) {
+      nameOperations = addValuesToList(nameOperations, operations);
       return this;
     }
 
     @SafeVarargs
-    public final Builder namesOperations(
+    public final Builder nameOperations(
         final Operation<String> operation, final Operation<String>... operations) {
-      return namesOperations(collectValues(operation, operations));
+      return nameOperations(collectValues(operation, operations));
     }
 
     public Builder names(final String value, final String... values) {
-      return namesOperations(FilterUtil.mapDefaultToOperation(value, values));
+      return nameOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     @SafeVarargs
-    public final Builder processDefinitionIdsOperations(
+    public final Builder processDefinitionIdOperations(
         final Operation<String> operation, final Operation<String>... operations) {
-      return processDefinitionIdsOperations(collectValues(operation, operations));
+      return processDefinitionIdOperations(collectValues(operation, operations));
     }
 
-    public Builder processDefinitionIdsOperations(final List<Operation<String>> operations) {
-      processDefinitionIdsOperations = addValuesToList(processDefinitionIdsOperations, operations);
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
       return this;
     }
 
     public Builder processDefinitionIds(final String value, final String... values) {
-      processDefinitionIdsOperations(FilterUtil.mapDefaultToOperation(value, values));
+      processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
       return this;
     }
 
@@ -124,8 +124,8 @@ public record ProcessDefinitionFilter(
       return new ProcessDefinitionFilter(
           Objects.requireNonNullElse(isLatestVersion, false),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(namesOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionIdsOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(nameOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(resourceNames, Collections.emptyList()),
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(versionTags, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessDefinitionFilter.java
@@ -10,6 +10,7 @@ package io.camunda.search.filter;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
+import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
 import java.util.List;
@@ -18,8 +19,8 @@ import java.util.Objects;
 public record ProcessDefinitionFilter(
     Boolean isLatestVersion,
     List<Long> processDefinitionKeys,
-    List<String> names,
-    List<String> processDefinitionIds,
+    List<Operation<String>> namesOperations,
+    List<Operation<String>> processDefinitionIdsOperations,
     List<String> resourceNames,
     List<Integer> versions,
     List<String> versionTags,
@@ -31,8 +32,8 @@ public record ProcessDefinitionFilter(
     private Boolean isLatestVersion;
     private List<String> tenantIds;
     private List<Long> processDefinitionKeys;
-    private List<String> names;
-    private List<String> processDefinitionIds;
+    private List<Operation<String>> namesOperations;
+    private List<Operation<String>> processDefinitionIdsOperations;
     private List<String> resourceNames;
     private List<Integer> versions;
     private List<String> versionTags;
@@ -46,22 +47,35 @@ public record ProcessDefinitionFilter(
       return processDefinitionKeys(collectValues(value, values));
     }
 
-    public Builder names(final List<String> values) {
-      names = addValuesToList(names, values);
+    public Builder namesOperations(final List<Operation<String>> operations) {
+      namesOperations = addValuesToList(namesOperations, operations);
       return this;
     }
 
-    public Builder names(final String value, final String... values) {
-      return names(collectValues(value, values));
+    @SafeVarargs
+    public final Builder namesOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return namesOperations(collectValues(operation, operations));
     }
 
-    public Builder processDefinitionIds(final List<String> values) {
-      processDefinitionIds = addValuesToList(processDefinitionIds, values);
+    public Builder names(final String value, final String... values) {
+      return namesOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdsOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdsOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIdsOperations(final List<Operation<String>> operations) {
+      processDefinitionIdsOperations = addValuesToList(processDefinitionIdsOperations, operations);
       return this;
     }
 
     public Builder processDefinitionIds(final String value, final String... values) {
-      return processDefinitionIds(collectValues(value, values));
+      processDefinitionIdsOperations(FilterUtil.mapDefaultToOperation(value, values));
+      return this;
     }
 
     public Builder resourceNames(final List<String> values) {
@@ -110,8 +124,8 @@ public record ProcessDefinitionFilter(
       return new ProcessDefinitionFilter(
           Objects.requireNonNullElse(isLatestVersion, false),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(names, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionIds, Collections.emptyList()),
+          Objects.requireNonNullElse(namesOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdsOperations, Collections.emptyList()),
           Objects.requireNonNullElse(resourceNames, Collections.emptyList()),
           Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(versionTags, Collections.emptyList()),

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6025,9 +6025,6 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
-        formKey:
-          type: string
-          description: The identifier of the form used to start the process, applicable when the process is initiated via a form.
     ProcessInstanceSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5962,7 +5962,8 @@ components:
       properties:
         name:
           description: Name of this process definition.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         isLatestVersion:
           description: >
             Whether to only return the latest version of each process definition.
@@ -5981,7 +5982,8 @@ components:
           type: string
         processDefinitionId:
           description: Process definition ID of this process definition.
-          type: string
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
         tenantId:
           description: Tenant ID of this process definition.
           type: string
@@ -6023,6 +6025,9 @@ components:
         processDefinitionKey:
           description: The key for this process definition.
           type: string
+        formKey:
+          type: string
+          description: The identifier of the form used to start the process, applicable when the process is initiated via a form.
     ProcessInstanceSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -920,13 +920,13 @@ public final class SearchQueryRequestMapper {
                   .ifPresent(builder::processDefinitionKeys);
               Optional.ofNullable(f.getName())
                   .map(mapToOperations(String.class))
-                  .ifPresent(builder::namesOperations);
+                  .ifPresent(builder::nameOperations);
               Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
               Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
               Optional.ofNullable(f.getVersionTag()).ifPresent(builder::versionTags);
               Optional.ofNullable(f.getProcessDefinitionId())
                   .map(mapToOperations(String.class))
-                  .ifPresent(builder::processDefinitionIdsOperations);
+                  .ifPresent(builder::processDefinitionIdOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
             });
     return builder.build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -918,13 +918,13 @@ public final class SearchQueryRequestMapper {
               Optional.ofNullable(f.getProcessDefinitionKey())
                   .map(KeyUtil::keyToLong)
                   .ifPresent(builder::processDefinitionKeys);
-              Optional.ofNullable(filter.getName())
+              Optional.ofNullable(f.getName())
                   .map(mapToOperations(String.class))
                   .ifPresent(builder::namesOperations);
               Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
               Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
               Optional.ofNullable(f.getVersionTag()).ifPresent(builder::versionTags);
-              Optional.ofNullable(filter.getProcessDefinitionId())
+              Optional.ofNullable(f.getProcessDefinitionId())
                   .map(mapToOperations(String.class))
                   .ifPresent(builder::processDefinitionIdsOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -918,12 +918,15 @@ public final class SearchQueryRequestMapper {
               Optional.ofNullable(f.getProcessDefinitionKey())
                   .map(KeyUtil::keyToLong)
                   .ifPresent(builder::processDefinitionKeys);
-              Optional.ofNullable(f.getName()).ifPresent(builder::names);
+              Optional.ofNullable(filter.getName())
+                  .map(mapToOperations(String.class))
+                  .ifPresent(builder::namesOperations);
               Optional.ofNullable(f.getResourceName()).ifPresent(builder::resourceNames);
               Optional.ofNullable(f.getVersion()).ifPresent(builder::versions);
               Optional.ofNullable(f.getVersionTag()).ifPresent(builder::versionTags);
-              Optional.ofNullable(f.getProcessDefinitionId())
-                  .ifPresent(builder::processDefinitionIds);
+              Optional.ofNullable(filter.getProcessDefinitionId())
+                  .map(mapToOperations(String.class))
+                  .ifPresent(builder::processDefinitionIdsOperations);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
             });
     return builder.build();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -483,7 +483,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @MethodSource("provideAdvancedSearchParameters")
-  void shouldSearchTasksWithAdvancedFilter(final String filterString, final ProcessDefinitionFilter filter) {
+  void shouldSearchTasksWithAdvancedFilter(
+      final String filterString, final ProcessDefinitionFilter filter) {
     // given
     final var request =
         """
@@ -492,7 +493,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
             }"""
             .formatted(filterString);
     System.out.println("request = " + request);
-    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
 
     // when / then
     webClient
@@ -509,6 +511,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE);
 
-    verify(processDefinitionServices).search(new ProcessDefinitionQuery.Builder().filter(filter).build());
+    verify(processDefinitionServices)
+        .search(new ProcessDefinitionQuery.Builder().filter(filter).build());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -471,12 +471,12 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     stringOperationTestCases(
         streamBuilder,
         "name",
-        ops -> new ProcessDefinitionFilter.Builder().namesOperations(ops).build());
+        ops -> new ProcessDefinitionFilter.Builder().nameOperations(ops).build());
 
     stringOperationTestCases(
         streamBuilder,
         "processDefinitionId",
-        ops -> new ProcessDefinitionFilter.Builder().processDefinitionIdsOperations(ops).build());
+        ops -> new ProcessDefinitionFilter.Builder().processDefinitionIdOperations(ops).build());
 
     return streamBuilder.build();
   }
@@ -492,7 +492,6 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                 "filter": %s
             }"""
             .formatted(filterString);
-    System.out.println("request = " + request);
     when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
         .thenReturn(SEARCH_QUERY_RESULT);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I'm adding advanced filters for `name` and `processDefinitionId` on the `/v2/process-definitions/search`. This enables Tasklist to get Processes using those filters.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31831 
