### PR TITLE
Add migration for clients permissions

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -8,7 +8,7 @@
 package io.camunda.migration.identity.config;
 
 import io.camunda.migration.identity.GroupMigrationHandler;
-import io.camunda.migration.identity.StaticConsoleRoleAuthorizationMigrationHandler;
+import io.camunda.migration.identity.StaticConsoleAuthorizationMigrationHandler;
 import io.camunda.migration.identity.StaticConsoleRoleMigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
@@ -39,8 +39,8 @@ public class MigrationHandlerConfig {
   }
 
   @Bean
-  public StaticConsoleRoleAuthorizationMigrationHandler authorizationMigrationHandler(
+  public StaticConsoleAuthorizationMigrationHandler authorizationMigrationHandler(
       final AuthorizationServices authorizationService, final Authentication authentication) {
-    return new StaticConsoleRoleAuthorizationMigrationHandler(authorizationService, authentication);
+    return new StaticConsoleAuthorizationMigrationHandler(authorizationService, authentication);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -22,8 +22,14 @@ public class StaticEntities {
   public static final String TASK_USER_ROLE_ID = "taskuser";
   public static final String VISITOR_ROLE_ID = "visitor";
 
+  public static final String ZEEBE_CLIENT_ID = "Zeebe";
+  public static final String OPERATE_CLIENT_ID = "Operate";
+  public static final String TASKLIST_CLIENT_ID = "Tasklist";
+
   public static final Set<String> ROLE_IDS =
       Set.of(DEVELOPER_ROLE_ID, OPERATIONS_ENGINEER_ROLE_ID, TASK_USER_ROLE_ID, VISITOR_ROLE_ID);
+  public static final Set<String> CLIENT_IDS =
+      Set.of(ZEEBE_CLIENT_ID, OPERATE_CLIENT_ID, TASKLIST_CLIENT_ID);
 
   public static final List<CreateRoleRequest> ROLES =
       List.of(
@@ -152,4 +158,113 @@ public class StaticEntities {
               Set.of(PermissionType.READ))
           // TODO: add document permissions once implemented
           );
+
+  public static final List<CreateAuthorizationRequest> CLIENT_PERMISSIONS =
+      List.of(
+          // ZEEBE
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.CREATE)),
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.SYSTEM,
+              AuthorizationResourceType.SYSTEM.getSupportedPermissionTypes()),
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.RESOURCE,
+              Set.of(
+                  PermissionType.CREATE,
+                  PermissionType.DELETE_FORM,
+                  PermissionType.DELETE_PROCESS,
+                  PermissionType.DELETE_DRD,
+                  PermissionType.DELETE_RESOURCE)),
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              Set.of(
+                  PermissionType.UPDATE_PROCESS_INSTANCE,
+                  PermissionType.UPDATE_USER_TASK,
+                  PermissionType.CREATE_PROCESS_INSTANCE,
+                  PermissionType.DELETE_PROCESS_INSTANCE)),
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.DECISION_DEFINITION,
+              Set.of(
+                  PermissionType.CREATE_DECISION_INSTANCE,
+                  PermissionType.DELETE_DECISION_INSTANCE)),
+          new CreateAuthorizationRequest(
+              ZEEBE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+              Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
+          // OPERATE
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.MESSAGE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.BATCH_OPERATION,
+              Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.RESOURCE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              Set.of(
+                  PermissionType.READ_PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_INSTANCE,
+                  PermissionType.DELETE_PROCESS_INSTANCE)),
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.DECISION_DEFINITION,
+              Set.of(
+                  PermissionType.READ_DECISION_DEFINITION, PermissionType.READ_DECISION_INSTANCE)),
+          new CreateAuthorizationRequest(
+              OPERATE_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+              Set.of(PermissionType.READ)),
+          // TASKLIST
+          new CreateAuthorizationRequest(
+              TASKLIST_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.RESOURCE,
+              Set.of(PermissionType.READ)),
+          new CreateAuthorizationRequest(
+              TASKLIST_CLIENT_ID,
+              AuthorizationOwnerType.CLIENT,
+              "*",
+              AuthorizationResourceType.PROCESS_DEFINITION,
+              Set.of(
+                  // TODO: add document permissions once implemented
+                  PermissionType.READ_PROCESS_DEFINITION,
+                  PermissionType.READ_USER_TASK,
+                  PermissionType.UPDATE_USER_TASK)));
 }

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleAuthorizationMigrationHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.config.saas.StaticEntities.CLIENT_PERMISSIONS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -16,6 +17,7 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -25,16 +27,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
+public class StaticConsoleAuthorizationMigrationHandlerTest {
 
   private final AuthorizationServices authorizationServices;
-  private final StaticConsoleRoleAuthorizationMigrationHandler migrationHandler;
+  private final StaticConsoleAuthorizationMigrationHandler migrationHandler;
 
-  public StaticConsoleRoleAuthorizationMigrationHandlerTest(
+  public StaticConsoleAuthorizationMigrationHandlerTest(
       @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices) {
     this.authorizationServices = authorizationServices;
     migrationHandler =
-        new StaticConsoleRoleAuthorizationMigrationHandler(
+        new StaticConsoleAuthorizationMigrationHandler(
             authorizationServices, Authentication.none());
   }
 
@@ -45,8 +47,10 @@ public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    Mockito.verify(authorizationServices, Mockito.times(16)).createAuthorization(results.capture());
+    Mockito.verify(authorizationServices, Mockito.times(30)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
-    assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
+    final var authorizations =
+        Stream.concat(ROLE_PERMISSIONS.stream(), CLIENT_PERMISSIONS.stream()).toList();
+    assertThat(requests).containsExactlyElementsOf(authorizations);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds the migration step to migrate clients permission. Those permissions are created statically by the migration app

## Related issues

closes #33738 
