### PR TITLE
feat: increase toast notification time from 5s to 10s

### DIFF
--- a/identity/client/src/components/notifications/Notification.tsx
+++ b/identity/client/src/components/notifications/Notification.tsx
@@ -13,7 +13,7 @@ import { ToastNotification } from "@carbon/react";
 import { spacing03 } from "@carbon/elements";
 import { NotificationOptions } from "./NotificationContext";
 
-const NOTIFICATION_TIMEOUT = 5000;
+const NOTIFICATION_TIMEOUT = 10000;
 const TRANSITION_DURATION = 300;
 
 const StyledCSSTransition = styled(CSSTransition)`


### PR DESCRIPTION
## Description

Increases toast notification time on screen from 5s to 10s **only on Identity**. More details on this decision on the corresponding [issue](https://github.com/camunda/camunda/issues/33463#issuecomment-2963397790).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33463
