### PR TITLE
[POC} Harmonised indices basic mermaid diagrams

### DIFF
--- a/webapps-schema/src/main/resources/schema/mermaid_create.py
+++ b/webapps-schema/src/main/resources/schema/mermaid_create.py
@@ -2,6 +2,23 @@ import json
 import sys
 import os
 
+
+styling = """
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "primaryColor": "#1f77b4",
+    "secondaryColor": "#ff7f0e",
+    "tertiaryColor": "#2ca02c",
+    "background": "#ffffff",
+    "nodeBorder": "2px",
+    "primaryBorderColor": "#1f77b4",
+    "edgeLabelBackground": "#f0f0f0",
+    "fontSize": "14px"
+  }
+}}%%
+"""
+
 def json_mapping_to_mermaid(mapping_json, class_name):
   properties = mapping_json.get("mappings", {}).get("properties", {})
 
@@ -38,22 +55,17 @@ if __name__ == "__main__":
 
   prefix = sys.argv[1]
 
-  files = find_files_with_prefix("elasticsearch",  prefix)
-
-  index_diagram = []
-  index_diagram.append("classDiagram")
-  for file in files:
+  diagram_for_indices_with_prefix = [styling,"classDiagram"]
+  for file in find_files_with_prefix("elasticsearch", prefix):
     with open(file) as f:
-      mapping_json = json.load(f)
       class_name = os.path.splitext(os.path.basename(file))[0]
-      diagram_code = json_mapping_to_mermaid(mapping_json, class_name)
-      index_diagram.append(diagram_code)
+      diagram_for_file = json_mapping_to_mermaid(json.load(f), class_name)
+      diagram_for_indices_with_prefix.append(diagram_for_file)
 
 
-  print("\n".join(index_diagram))
-  output_filename = "index_diagram.mmd"
+  output_filename = f"{prefix}-diagrams.mmd"
 
   with open(output_filename, "w") as f:
-    f.write("\n".join(index_diagram))
+    f.write("\n".join(diagram_for_indices_with_prefix))
 
-  print(f"Mermaid diagram generated and saved as '{output_filename}'")
+  print(f"Mermaid diagram for prefix '{prefix}' generated and saved as '{output_filename}'")

--- a/webapps-schema/src/main/resources/schema/mermaid_create.py
+++ b/webapps-schema/src/main/resources/schema/mermaid_create.py
@@ -1,0 +1,59 @@
+import json
+import sys
+import os
+
+def json_mapping_to_mermaid(mapping_json, class_name):
+  properties = mapping_json.get("mappings", {}).get("properties", {})
+
+  mermaid_lines = [
+    f"    class {class_name} {{"
+  ]
+
+  for field_name, field_info in properties.items():
+    field_type = field_info.get("type", "object")
+
+    if field_type == "join":
+      continue
+
+    mermaid_lines.append(f"        +{field_name} : {field_type}")
+
+  mermaid_lines.append("    }")
+  return "\n".join(mermaid_lines)
+
+def find_files_with_prefix(directory, prefix):
+  matched_files = []
+
+  for root, dirs, files in os.walk(directory):
+    for filename in files:
+      if filename.startswith(prefix):
+        full_path = os.path.join(root, filename)
+        matched_files.append(full_path)
+
+  return matched_files
+
+if __name__ == "__main__":
+  if len(sys.argv) != 2:
+    print("Usage: python mermaid_create.py <prefix>")
+    sys.exit(1)
+
+  prefix = sys.argv[1]
+
+  files = find_files_with_prefix("elasticsearch",  prefix)
+
+  index_diagram = []
+  index_diagram.append("classDiagram")
+  for file in files:
+    with open(file) as f:
+      mapping_json = json.load(f)
+      class_name = os.path.splitext(os.path.basename(file))[0]
+      diagram_code = json_mapping_to_mermaid(mapping_json, class_name)
+      index_diagram.append(diagram_code)
+
+
+  print("\n".join(index_diagram))
+  output_filename = "index_diagram.mmd"
+
+  with open(output_filename, "w") as f:
+    f.write("\n".join(index_diagram))
+
+  print(f"Mermaid diagram generated and saved as '{output_filename}'")


### PR DESCRIPTION
## Description

This is a basic first iteration that just contains a script that converts the mappings for the harmonised indices into class diagrams, the script works by specifying a prefix and all diagrams with that prefix are grouped together, for example `operate`, `tasklist`, `camunda`.

Once the resulting diagrams are of a satisfactory format then I can move to sync workflow implementation where it:
- automatically generating diagrams based on the current repo state.
- automatically creating PRs to update the diagrams on documentation files.

The script works as so:
- `python mermaid_create.py <prefix>` which generates a mmd file
- render the mmd file for example with `mmdc -i tasklist-diagrams.mmd -o output.svg`

The goal of this draft PR is just to get thoughts on the formatting of the diagrams, I have made the following decisions
- class diagram instead of entity diagram as there is not really a relationship between different indices to establish like in a relational database.
- joins are not encoded into the diagram information, they are intended to speed up specific queries and the information should not help the customer if they are trying to see what an index mappings looks like for debugging purposes.

![output](https://github.com/user-attachments/assets/3e53a929-ef88-4d23-a9c4-111a9eb00d81)
The styling is just to show styling is possible, the full mermaid style documentation is here https://mermaid.js.org/config/theming.html
## Related issues

closes https://github.com/camunda/camunda-docs/issues/4870
