### PR TITLE
ci: upgrade camunda-release-parent to 4.0.0 and switch to Central Portal deployment

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
+    <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath></relativePath>
   </parent>
@@ -37,7 +37,6 @@
     <!-- release parent settings -->
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
-    <nexus.sonatype.url>https://s01.oss.sonatype.org</nexus.sonatype.url>
 
     <!-- Camunda License v1.0 header -->
     <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
@@ -343,7 +342,7 @@
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <properties>
         <plugin.version.gpg>1.6</plugin.version.gpg>
       </properties>


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR upgrades the `camunda-release-parent `POM to version 4.0.0 and switches to the new `central-sonatype-publish` profile. This is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.

To ensure a smooth transition for the monorepo, I have surfaced changes in terms of plugin execution, and test deployment of an (empty) test submodule to a test namespace.

<details>
  <summary>TEST Submodule POM</summary>

```xml

<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

  <modelVersion>4.0.0</modelVersion>

  <parent>
    <groupId>io.camunda</groupId>
    <artifactId>zeebe-parent</artifactId>
    <version>8.8.0-SNAPSHOT</version>
    <relativePath>../parent/pom.xml</relativePath>
  </parent>

  <groupId>io.github.clementnero.maven-poc-833.camunda.camunda</groupId>
  <artifactId>infra-833-test</artifactId>
  <version>1.0.0-SNAPSHOT</version>
  <packaging>pom</packaging>

  <name>Infra 833 Test</name>

  <properties>
    <!-- Camund Nexus / Artifactory  -->
    <skip.camunda.release>false</skip.camunda.release>
    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-internal</nexus.release.repository>
    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-internal-snapshots</nexus.snapshot.repository>
    <!-- Maven Central -->
    <skip.central.release>false</skip.central.release>
    <deploymentName>https://github.com/camunda/camunda - Infra 833 Test</deploymentName>
  </properties>

</project>
```
</details>


### Plugins

To prevent any unexpected issue with plugin executions, I compared the effective <plugins> and <pluginManagement> sections using versions 3.9.1 and 4.0.0 of the parent POM to quickly surface any odd config changes that might affect behavior.

<details>
  <summary>Effective-plugins when using <strong>camunda-release-parent.3.9.1</strong> POM</summary>

```xml
mvnw help:effective-pom -Psonatype-oss-release
```
[effective-plugins.camunda-release-parent.3.9.1.xml.gz](https://github.com/user-attachments/files/20751501/effective-plugins.camunda-release-parent.3.9.1.xml.gz)

</details> 

<details>
  <summary>Effective-plugins when using <strong>camunda-release-parent.4.0.0</strong> POM</summary>

```xml
mvnw help:effective-pom -Pcentral-sonatype-publish
```
[effective-plugins.camunda-release-parent.4.0.0.xml.gz](https://github.com/user-attachments/files/20751510/effective-plugins.camunda-release-parent.4.0.0.xml.gz)

</details> 

Effective changes:

TL;DR ✅ 
- The `central-sonatype-publish` profile is now the default and is appended to the value of `arguments` property of the `maven-release-plugin` (actually not used by Connectors).
- The `nexus-staging-maven-plugin` has been updated to a newer patch version.
- A new `id:central-deploy` execution of the `central-publishing-maven-plugin` is configured, replacing the previous `id:central-deploy` execution from the `nexus-staging-maven-plugin`.
- The `nexusUrl` of the `id:default-deploy` execution from the `nexus-staging-maven-plugin` now points to the correct URL but is skipped because `skipStaging` is set to true.

```diff
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
 <build>
   <pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.5.1</version>
       </plugin>
       <plugin>
@@ -205,11 +210,11 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
           <mavenExecutorId>forked-path</mavenExecutorId>
           <useReleaseProfile>false</useReleaseProfile>
-          <arguments>${arguments} -Psonatype-oss-release</arguments>
+          <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
@@ -319,11 +324,11 @@
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.44.5</version>
@@ -349,10 +354,39 @@
         </configuration>
       </plugin>
     </plugins>
   </pluginManagement>
   <plugins>
+    <plugin>
+      <groupId>org.sonatype.central</groupId>
+      <artifactId>central-publishing-maven-plugin</artifactId>
+      <version>0.7.0</version>
+      <extensions>true</extensions>
+      <executions>
+        <execution>
+          <id>central-deploy</id>
+          <phase>deploy</phase>
+          <goals>
+            <goal>publish</goal>
+          </goals>
+          <configuration>
+            <autoPublish>false</autoPublish>
+            <deploymentName>https://github.com/camunda/camunda - Infra 833 Test</deploymentName>
+            <failOnBuildFailure>true</failOnBuildFailure>
+            <publishingServerId>central</publishingServerId>
+            <skipPublishing>false</skipPublishing>
+          </configuration>
+        </execution>
+      </executions>
+      <configuration>
+        <autoPublish>false</autoPublish>
+        <deploymentName>https://github.com/camunda/camunda - Infra 833 Test</deploymentName>
+        <failOnBuildFailure>true</failOnBuildFailure>
+        <publishingServerId>central</publishingServerId>
+        <skipPublishing>false</skipPublishing>
+      </configuration>
+    </plugin>
     <plugin>
       <artifactId>maven-clean-plugin</artifactId>
       <version>3.1.0</version>
       <executions>
         <execution>
@@ -540,11 +574,11 @@
       </executions>
     </plugin>
     <plugin>
       <groupId>org.sonatype.plugins</groupId>
       <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>1.6.8</version>
+      <version>1.6.13</version>
       <extensions>true</extensions>
       <executions>
         <execution>
           <id>default-deploy</id>
           <phase>deploy</phase>
@@ -552,30 +586,14 @@
             <goal>deploy</goal>
           </goals>
           <configuration>
             <detectBuildFailures>true</detectBuildFailures>
             <serverId>camunda-nexus</serverId>
-            <nexusUrl>https://app.camunda.com/nexus</nexusUrl>
+            <nexusUrl>https://artifacts.camunda.com/artifactory</nexusUrl>
             <skipStaging>true</skipStaging>
             <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
           </configuration>
         </execution>
-        <execution>
-          <id>central-deploy</id>
-          <phase>deploy</phase>
-          <goals>
-            <goal>deploy</goal>
-          </goals>
-          <configuration>
-            <detectBuildFailures>true</detectBuildFailures>
-            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-            <serverId>central</serverId>
-            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-            <skipStaging>false</skipStaging>
-            <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
-          </configuration>
-        </execution>
       </executions>
     </plugin>
   </plugins>
 </build>
```

### Deployment

To ensure artifact deployment continues to work, I performed one locally using `release:prepare` and `release:perform` plugin goals (maven-release-plugin).

For this, I used a minimal empty test submodulemodule inheriting the project’s (parent) POMs but changed the groupId to a test namespace (io.github.clementnero).

<details>
  <summary>Deployment logs</summary>

```log
mvn clean release:prepare release:perform --batch-mode -DreleaseVersion=1.0.1 -DlocalCheckout=true -DpushChanges=false -DremoteTagging=false -Darguments=-Dgpg.passphrase=*** -DignoreSnapshots=true

[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Not installing Nexus Staging features:
[INFO]  * Preexisting staging related goal bindings found in 1 modules.
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 15.5
[INFO] os.detected.version.major: 15
[INFO] os.detected.version.minor: 5
[INFO] os.detected.classifier: osx-aarch_64
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test >--
[INFO] Building Infra 833 Test 1.0.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- clean:3.1.0:clean (default-clean) @ infra-833-test ---
[INFO] Deleting /Users/clement.nero/camunda/camunda/infra-833-test/target
[INFO] 
[INFO] --- flatten:1.7.0:clean (flatten.clean) @ infra-833-test ---
[INFO] Deleting /Users/clement.nero/camunda/camunda/infra-833-test/.flattened-pom.xml
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test >--
[INFO] Building Infra 833 Test 1.0.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- release:2.5.3:prepare (default-cli) @ infra-833-test ---
[INFO] Verifying that there are no local modifications...
[INFO]   ignoring changes on: **/pom.xml.releaseBackup, **/pom.xml.next, **/pom.xml.tag, **/pom.xml.branch, **/release.properties, **/pom.xml.backup
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Ignoring SNAPSHOT depenedencies and plugins ...
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not generating release POMs
[INFO] Executing goals 'clean verify'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings12032071719082599300.xml clean verify --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] ------------------------------------------------------------------------
    [INFO] Detecting the operating system and CPU architecture
    [INFO] ------------------------------------------------------------------------
    [INFO] os.detected.name: osx
    [INFO] os.detected.arch: aarch_64
    [INFO] os.detected.bitness: 64
    [INFO] os.detected.version: 15.5
    [INFO] os.detected.version.major: 15
    [INFO] os.detected.version.minor: 5
    [INFO] os.detected.classifier: osx-aarch_64
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test >--
    [INFO] Building Infra 833 Test 1.0.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- clean:3.1.0:clean (default-clean) @ infra-833-test ---
    [INFO] 
    [INFO] --- flatten:1.7.0:clean (flatten.clean) @ infra-833-test ---
    [INFO] 
    [INFO] --- checkstyle:3.6.0:check (validate-java) @ infra-833-test ---
    [INFO] You have 0 Checkstyle violations.
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (enforce-dependency-convergence) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (enforce-unique-dependencies) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.BanDuplicatePomDependencyVersions passed
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (forbid-banned-dependencies) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
    [INFO] 
    [INFO] --- jacoco:0.8.13:prepare-agent (coverage-initialize) @ infra-833-test ---
    [INFO] argLine set to -javaagent:/Users/clement.nero/.m2/repository/org/jacoco/org.jacoco.agent/0.8.13/org.jacoco.agent-0.8.13-runtime.jar=destfile=/Users/clement.nero/camunda/camunda/infra-833-test/target/jacoco.exec
    [INFO] 
    [INFO] --- flatten:1.7.0:flatten (flatten) @ infra-833-test ---
    [INFO] Generating flattened POM of project io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test:pom:1.0.0...
    [INFO] 
    [INFO] --- source:3.2.1:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:3.2.1:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.11.2:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- jacoco:0.8.13:report (coverage-report) @ infra-833-test ---
    [INFO] Skipping JaCoCo execution due to missing execution data file.
    [INFO] 
    [INFO] --- dependency:3.8.1:analyze-only (analyze-dependencies) @ infra-833-test ---
    [INFO] Skipping pom project
    [INFO] 
    [INFO] --- gpg:1.6:sign (sign-artifacts) @ infra-833-test ---
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  2.429 s
    [INFO] Finished at: 2025-06-14T19:03:36+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-84232437.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Tagging release with the label infra-833-test-1.0.0...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git tag -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1743826242.commit infra-833-test-1.0.0
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not removing release POMs
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1406818617.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Release preparation complete.
[INFO] 
[INFO] --- release:2.5.3:perform (default-cli) @ infra-833-test ---
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/camunda/infra-833-test
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target && git clone --branch infra-833-test-1.0.0 file:///Users/clement.nero/camunda/camunda/infra-833-test /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test/target
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/camunda
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target && git clone --branch infra-833-test-1.0.0 file:///Users/clement.nero/camunda/camunda /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test/target
[INFO] Executing: /bin/sh -c cd /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/ && git ls-remote file:///Users/clement.nero/camunda/camunda
[INFO] Working directory: /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout && git fetch file:///Users/clement.nero/camunda/camunda
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout && git checkout infra-833-test-1.0.0
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout
[INFO] Invoking perform goals in directory /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test
[INFO] Executing goals 'deploy'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings10250399838474301838.xml deploy --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish -f pom.xml
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] ------------------------------------------------------------------------
    [INFO] Detecting the operating system and CPU architecture
    [INFO] ------------------------------------------------------------------------
    [INFO] os.detected.name: osx
    [INFO] os.detected.arch: aarch_64
    [INFO] os.detected.bitness: 64
    [INFO] os.detected.version: 15.5
    [INFO] os.detected.version.major: 15
    [INFO] os.detected.version.minor: 5
    [INFO] os.detected.classifier: osx-aarch_64
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test >--
    [INFO] Building Infra 833 Test 1.0.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- checkstyle:3.6.0:check (validate-java) @ infra-833-test ---
    [INFO] You have 0 Checkstyle violations.
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (enforce-dependency-convergence) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence passed
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (enforce-unique-dependencies) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.BanDuplicatePomDependencyVersions passed
    [INFO] 
    [INFO] --- enforcer:3.5.0:enforce (forbid-banned-dependencies) @ infra-833-test ---
    [INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
    [INFO] 
    [INFO] --- jacoco:0.8.13:prepare-agent (coverage-initialize) @ infra-833-test ---
    [INFO] argLine set to -javaagent:/Users/clement.nero/.m2/repository/org/jacoco/org.jacoco.agent/0.8.13/org.jacoco.agent-0.8.13-runtime.jar=destfile=/Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/jacoco.exec
    [INFO] 
    [INFO] --- flatten:1.7.0:flatten (flatten) @ infra-833-test ---
    [INFO] Generating flattened POM of project io.github.clementnero.maven-poc-833.camunda.camunda:infra-833-test:pom:1.0.0...
    [INFO] 
    [INFO] --- source:3.2.1:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:3.2.1:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.11.2:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- jacoco:0.8.13:report (coverage-report) @ infra-833-test ---
    [INFO] Skipping JaCoCo execution due to missing execution data file.
    [INFO] 
    [INFO] --- dependency:3.8.1:analyze-only (analyze-dependencies) @ infra-833-test ---
    [INFO] Skipping pom project
    [INFO] 
    [INFO] --- gpg:1.6:sign (sign-artifacts) @ infra-833-test ---
    [INFO] 
    [INFO] --- install:3.1.2:install (default-install) @ infra-833-test ---
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] 
    [INFO] --- deploy:2.8.2:deploy (default-deploy) @ infra-833-test ---
    [INFO] Skipping artifact deployment
    [INFO] 
    [INFO] --- nexus-staging:1.6.13:deploy (default-deploy) @ infra-833-test ---
    [INFO] Performing deferred deploys (gathering into "/Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred")...
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Deploying remotely...
    [INFO] Bulk deploying locally gathered artifacts from directory: 
    [INFO]  * Bulk deploying locally gathered snapshot artifacts
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc (659 B at 967 B/s)
    [INFO] Downloading from camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/maven-metadata.xml
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/maven-metadata.xml
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/maven-metadata.xml (345 B at 853 B/s)
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom (2.0 kB at 5.1 kB/s)
    [INFO]  * Bulk deploy of locally gathered snapshot artifacts finished.
    [INFO] Remote deploy finished with success.
    [INFO] 
    [INFO] --- central-publishing:0.7.0:publish (central-deploy) @ infra-833-test ---
    [INFO] Using Central baseUrl: https://central.sonatype.com
    [INFO] Using credentials from server id central in settings.xml
    [INFO] Using Usertoken auth, with namecode: g0xTmVDT
    [INFO] Staging 2 files
    [INFO] Staging /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/pom.xml
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom
    [INFO] Staging /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc
    [INFO] Installing /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-1.0.0.pom.asc to /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/infra-833-test-1.0.0.pom.asc
    [INFO] Pre Bundling - deleted /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/maven-metadata-central-staging.xml
    [INFO] Generate checksums for dir: io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0
    [INFO] Going to create /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip by bundling content at /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-staging
    [INFO] Created bundle successfully /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-staging/central-bundle.zip
    [INFO] Going to upload /Users/clement.nero/camunda/camunda/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip
    [INFO] Uploaded bundle successfully, deployment name: https://github.com/camunda/camunda - Infra 833 Test, deploymentId: 3a1cd6ee-0c67-4d17-9218-4cee834b0777. Deployment will require manual publishing
    [INFO] Waiting until Deployment 3a1cd6ee-0c67-4d17-9218-4cee834b0777 is validated
    [INFO] Deployment 3a1cd6ee-0c67-4d17-9218-4cee834b0777 has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  11.435 s
    [INFO] Finished at: 2025-06-14T19:04:09+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Cleaning up after release...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  39.849 s
[INFO] Finished at: 2025-06-14T19:04:09+02:00
[INFO] ------------------------------------------------------------------------
```
</details>

Results:
- Artifactory: https://artifacts.camunda.com/ui/native/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda/infra-833-test/1.0.0/
- Central Portal
    <img width="1580" alt="image" src="https://github.com/user-attachments/assets/ca5bf624-3f54-43a8-9123-83b76534974f" />

This changes has been tested the same way for all stable branches:
- `release/8.7`
- `release/8.6`
- `release/8.5`
- `release/8.4`
- `release/8.3`

There is no need to backport this change to `optimize` (8.6 & 8.7) and `operate` (8.5) stable branches, as they are not released to Maven Central, and `sonatype-oss-release` profile is not used.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
