### PR TITLE
test: Enable CPT connector tests again

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
@@ -29,12 +29,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@Disabled("Disabled until the Connector container startup issue is solved")
 @SpringBootTest(
     properties = {
       "io.camunda.process.test.connectors-enabled=true",

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestConnectorsIT.java
@@ -29,11 +29,9 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Disabled("Disabled until the Connector container startup issue is solved")
 public class CamundaProcessTestConnectorsIT {
 
   // The ID is part of the connector configuration in the BPMN element

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestConnectorsIT.java
@@ -29,12 +29,10 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@Disabled("Disabled until the Connector container startup issue is solved")
 @SpringBootTest(
     classes = {CamundaSpringProcessTestConnectorsIT.class},
     properties = {


### PR DESCRIPTION
## Description

The Connector tests in the CPT modules were disabled because of an issue with the Connectors image. The issue is fixed. We can enable the tests again.

This reverts commit 3db6c0ef1f45cd8a7af2fb0463721df36286bac4.

## Related issues


