### PR TITLE
ci: temporarily disable CompleteProcessInstanceAfterLeaderChangeTest due to timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,7 +690,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 40
+    timeout-minutes: 25
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -690,7 +690,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 25
+    timeout-minutes: 40
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     strategy:

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/CompleteProcessInstanceAfterLeaderChangeTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -27,6 +28,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+@Ignore("Causes non-deterministic timeouts and GHA job cancellations")
 @RunWith(Parameterized.class)
 public class CompleteProcessInstanceAfterLeaderChangeTest {
 


### PR DESCRIPTION
## Description

Outcome of https://camunda.slack.com/archives/C071KP5BTHB/p1749735479030829 to mitigate impact of `[IT] Zeebe QA - Integration Tests` job running into hard 25min timeouts (although historically it took only ~15mins).

GHA job logs showing that `` might be the problem:

* https://github.com/camunda/camunda/actions/runs/15610760945/job/43970871204
* https://github.com/camunda/camunda/actions/runs/15610413293/job/43969780301
* https://github.com/camunda/camunda/actions/runs/15677840555/job/44162200048?pr=33816

(NB: `Timeout.seconds(120)` aka 2mins per test case in several Zeebe junit test suites seems pretty high given that we aim the overall job to take only 15mins)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
