### PR TITLE
[Backport stable/8.6] fix: remove the job reference from the element instance on job completed

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -230,7 +230,8 @@ public final class EventAppliers implements EventApplier {
 
   private void registerJobIntentEventAppliers(final MutableProcessingState state) {
     register(JobIntent.CANCELED, new JobCanceledApplier(state));
-    register(JobIntent.COMPLETED, new JobCompletedApplier(state));
+    register(JobIntent.COMPLETED, 1, new JobCompletedApplier(state));
+    register(JobIntent.COMPLETED, 2, new JobCompletedApplierV2(state));
     register(JobIntent.CREATED, new JobCreatedApplier(state));
     register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));
     register(JobIntent.FAILED, new JobFailedApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -230,7 +230,7 @@ public final class EventAppliers implements EventApplier {
 
   private void registerJobIntentEventAppliers(final MutableProcessingState state) {
     register(JobIntent.CANCELED, new JobCanceledApplier(state));
-    register(JobIntent.COMPLETED, 1, new JobCompletedApplier(state));
+    register(JobIntent.COMPLETED, 1, new JobCompletedV1Applier(state));
     register(JobIntent.COMPLETED, 2, new JobCompletedApplierV2(state));
     register(JobIntent.CREATED, new JobCreatedApplier(state));
     register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplierV2.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplierV2.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+class JobCompletedApplierV2 implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  JobCompletedApplierV2(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.complete(key, value);
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+    if (elementInstance != null) {
+      elementInstance.setJobKey(-1);
+      elementInstanceState.updateInstance(elementInstance);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedV1Applier.java
@@ -15,12 +15,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 
-class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
+class JobCompletedV1Applier implements TypedEventApplier<JobIntent, JobRecord> {
 
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
 
-  JobCompletedApplier(final MutableProcessingState state) {
+  JobCompletedV1Applier(final MutableProcessingState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
   }


### PR DESCRIPTION
# Description
Backport of #33775 to `stable/8.6`.

relates to #33237