### PR TITLE
Add command to create an initial admin user

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateAdminProcessor.java
@@ -32,9 +32,9 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 
 public class UserCreateAdminProcessor implements TypedRecordProcessor<UserRecord> {
-  private static final String USER_ALREADY_EXISTS_ERROR_MESSAGE =
+  public static final String USER_ALREADY_EXISTS_ERROR_MESSAGE =
       "Expected to create user with username '%s', but a user with this username already exists";
-  private static final String ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE =
+  public static final String ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE =
       "Expected to create admin user, but role with id '%s' does not exist";
 
   private final KeyGenerator keyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateAdminProcessor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+
+public class UserCreateAdminProcessor implements TypedRecordProcessor<UserRecord> {
+  private static final String USER_ALREADY_EXISTS_ERROR_MESSAGE =
+      "Expected to create user with username '%s', but a user with this username already exists";
+  private static final String ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE =
+      "Expected to create admin user, but role with id '%s' does not exist";
+
+  private final KeyGenerator keyGenerator;
+  private final UserState userState;
+  private final RoleState roleState;
+  private final TypedCommandWriter commandWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+
+  public UserCreateAdminProcessor(
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    this.keyGenerator = keyGenerator;
+    userState = processingState.getUserState();
+    roleState = processingState.getRoleState();
+    commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    this.authCheckBehavior = authCheckBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<UserRecord> command) {
+    final var record = command.getValue();
+    final var adminRoleId = DefaultRole.ADMIN.getId();
+
+    checkUserCreateAuthorization(command)
+        .flatMap(ignored -> checkRoleUpdateAuthorization(command))
+        .flatMap(ignored -> checkUserDoesNotExist(record.getUsername()))
+        .flatMap(ignored -> checkAdminRoleExists(adminRoleId))
+        .ifRightOrLeft(
+            ignored -> {
+              final var key = keyGenerator.nextKey();
+              commandWriter.appendFollowUpCommand(key, UserIntent.CREATE, record);
+              commandWriter.appendFollowUpCommand(
+                  key,
+                  RoleIntent.ADD_ENTITY,
+                  new RoleRecord()
+                      .setRoleId(adminRoleId)
+                      .setEntityId(record.getUsername())
+                      .setEntityType(EntityType.USER));
+            },
+            rejection -> {
+              rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+            });
+  }
+
+  private Either<Rejection, Void> checkUserCreateAuthorization(
+      final TypedRecord<UserRecord> command) {
+    final var authRequest =
+        new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.CREATE);
+    return authCheckBehavior.isAuthorized(authRequest);
+  }
+
+  private Either<Rejection, Void> checkRoleUpdateAuthorization(
+      final TypedRecord<UserRecord> command) {
+    final var authRequest =
+        new AuthorizationRequest(command, AuthorizationResourceType.ROLE, PermissionType.UPDATE);
+    return authCheckBehavior.isAuthorized(authRequest);
+  }
+
+  private Either<Rejection, Void> checkUserDoesNotExist(final String username) {
+    return userState
+        .getUser(username)
+        .map(
+            user -> {
+              final var message = USER_ALREADY_EXISTS_ERROR_MESSAGE.formatted(user.getUsername());
+              return Either.<Rejection, Void>left(
+                  new Rejection(RejectionType.ALREADY_EXISTS, message));
+            })
+        .orElseGet(() -> Either.right(null));
+  }
+
+  private Either<Rejection, Void> checkAdminRoleExists(final String adminRoleId) {
+    return roleState
+        .getRole(adminRoleId)
+        .map(
+            adminRole -> {
+              return Either.<Rejection, Void>right(null);
+            })
+        .orElseGet(
+            () -> {
+              final var message = ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(adminRoleId);
+              return Either.left(new Rejection(RejectionType.NOT_FOUND, message));
+            });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -42,7 +42,7 @@ public class UserProcessors {
                 keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
         .onCommand(
             ValueType.USER,
-            UserIntent.CREATE_ADMIN,
+            UserIntent.CREATE_INITIAL_ADMIN,
             new UserCreateAdminProcessor(
                 keyGenerator, processingState, writers, authCheckBehavior));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -39,6 +39,11 @@ public class UserProcessors {
             ValueType.USER,
             UserIntent.DELETE,
             new UserDeleteProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior));
+                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
+        .onCommand(
+            ValueType.USER,
+            UserIntent.CREATE_ADMIN,
+            new UserCreateAdminProcessor(
+                keyGenerator, processingState, writers, authCheckBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMembershipState.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public final class DbMembershipState implements MutableMembershipState {
   private final EntityKeyAndRelationKey entityKeyAndRelationKey = new EntityKeyAndRelationKey();
@@ -90,10 +91,24 @@ public final class DbMembershipState implements MutableMembershipState {
       final RelationType relationType,
       final String relationId,
       final BiConsumer<EntityType, String> visitor) {
+    forEachMember(
+        relationType,
+        relationId,
+        (key, value) -> {
+          visitor.accept(key, value);
+          return true; // continue iteration
+        });
+  }
+
+  @Override
+  public void forEachMember(
+      final RelationType relationType,
+      final String relationId,
+      final BiFunction<EntityType, String, Boolean> visitor) {
     entitiesByRelation.whileEqualPrefix(
         new RelationKey(relationType, relationId),
         (key, value) -> {
-          visitor.accept(key.entity().type(), key.entity().id());
+          return visitor.apply(key.entity().type(), key.entity().id());
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MembershipState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MembershipState.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.authorization.DbMembershipState.RelationTyp
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public interface MembershipState {
 
@@ -18,6 +19,11 @@ public interface MembershipState {
 
   void forEachMember(
       RelationType relationType, String relationId, BiConsumer<EntityType, String> visitor);
+
+  void forEachMember(
+      RelationType relationType,
+      String relationId,
+      BiFunction<EntityType, String, Boolean> visitor);
 
   boolean hasRelation(
       EntityType entityType, String entityId, RelationType relationType, String relationId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateAdminUsersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateAdminUsersTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import static io.camunda.zeebe.engine.processing.user.UserCreateAdminProcessor.ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE;
+import static io.camunda.zeebe.engine.processing.user.UserCreateAdminProcessor.USER_ALREADY_EXISTS_ERROR_MESSAGE;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class CreateAdminUsersTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateAdminUser() {
+    // given
+    // Create the admin role manually. Normally starting the broker does this, but it needs to be
+    // explicitly enabled in tests. If we'd do that here we won't be able to test the rejection if
+    // the role does not exist in this test class.
+    final var adminRoleId = DefaultRole.ADMIN.getId();
+    engine.role().newRole(adminRoleId).withName(adminRoleId).create();
+    final var username = UUID.randomUUID().toString();
+
+    // when
+    final var createdUser =
+        engine
+            .user()
+            .newAdminUser(username)
+            .withName("name")
+            .withEmail("email")
+            .withPassword("password")
+            .create()
+            .getValue();
+
+    // then
+    assertThat(createdUser)
+        .describedAs("Has created the user with the given properties")
+        .hasUsername(username)
+        .hasName("name")
+        .hasEmail("email")
+        .hasPassword("password");
+
+    Assertions.assertThat(
+            RecordingExporter.roleRecords(RoleIntent.ADD_ENTITY)
+                .withRoleId(adminRoleId)
+                .withEntityId(username)
+                .withEntityType(EntityType.USER)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectIfUserAlreadyExists() {
+    // given
+    // Create the admin role manually. Normally starting the broker does this, but it needs to be
+    // explicitly enabled in tests. If we'd do that here we won't be able to test the rejection if
+    // the role does not exist in this test class.
+    final var adminRoleId = DefaultRole.ADMIN.getId();
+    engine.role().newRole(adminRoleId).withName(adminRoleId).create();
+    final var username = UUID.randomUUID().toString();
+    engine
+        .user()
+        .newUser(username)
+        .withName("name")
+        .withEmail("email")
+        .withPassword("password")
+        .create();
+
+    // when
+    final var rejection =
+        engine
+            .user()
+            .newAdminUser(username)
+            .withName("Bar Foo")
+            .withEmail("bar@foo.com")
+            .withPassword("password")
+            .expectRejection()
+            .create();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(USER_ALREADY_EXISTS_ERROR_MESSAGE.formatted(username));
+  }
+
+  @Test
+  public void shouldRejectIfRoleDoesNotExist() {
+    // given
+    final var username = UUID.randomUUID().toString();
+
+    // when
+    final var rejection =
+        engine
+            .user()
+            .newAdminUser(username)
+            .withName("name")
+            .withEmail("email")
+            .withPassword("password")
+            .expectRejection()
+            .create();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(DefaultRole.ADMIN.getId()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserAuthorizationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class CreateInitialAdminUserAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .getDefaultRoles()
+                      .put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername()))));
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void beforeEach() {
+    // Remove the default user from the admin role so we can properly test without running into
+    // other rejections.
+    final var dummyAdminRoleId = "dummyAdmin";
+    engine.role().newRole(dummyAdminRoleId).withName(dummyAdminRoleId).create();
+    engine
+        .role()
+        .addEntity(dummyAdminRoleId)
+        .withEntityId(DEFAULT_USER.getUsername())
+        .withEntityType(EntityType.USER);
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(dummyAdminRoleId)
+        .withOwnerType(AuthorizationOwnerType.ROLE)
+        .withResourceType(AuthorizationResourceType.AUTHORIZATION)
+        .withPermissions(PermissionType.CREATE)
+        .withResourceId("*")
+        .create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(dummyAdminRoleId)
+        .withOwnerType(AuthorizationOwnerType.ROLE)
+        .withResourceType(AuthorizationResourceType.USER)
+        .withPermissions(PermissionType.CREATE)
+        .withResourceId("*")
+        .create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(dummyAdminRoleId)
+        .withOwnerType(AuthorizationOwnerType.ROLE)
+        .withResourceType(AuthorizationResourceType.ROLE)
+        .withPermissions(PermissionType.UPDATE)
+        .withResourceId("*")
+        .create(DEFAULT_USER.getUsername());
+    engine
+        .role()
+        .addEntity(dummyAdminRoleId)
+        .withEntityId(DEFAULT_USER.getUsername())
+        .withEntityType(EntityType.USER)
+        .add();
+    engine
+        .role()
+        .removeEntity("admin")
+        .withEntityId(DEFAULT_USER.getUsername())
+        .withEntityType(EntityType.USER)
+        .remove();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToCreateInitialAdminUser() {
+    // when
+    final var user =
+        engine
+            .user()
+            .newInitialAdminUser(UUID.randomUUID().toString())
+            .withPassword(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .withEmail(UUID.randomUUID().toString())
+            .create(DEFAULT_USER.getUsername())
+            .getValue();
+
+    // then
+    assertThat(
+            RecordingExporter.userRecords(UserIntent.CREATED)
+                .withUsername(user.getUsername())
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED)
+                .withEntityId(user.getUsername())
+                .withEntityType(EntityType.USER)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnAuthorizedToCreateInitialAdminUserWithoutUserCreatePermissions() {
+    // given
+    final var unauthorizedUser = createUser(DEFAULT_USER.getUsername());
+    addPermissionsToUser(unauthorizedUser, AuthorizationResourceType.ROLE, PermissionType.UPDATE);
+
+    // when
+    final var rejection =
+        engine
+            .user()
+            .newInitialAdminUser(UUID.randomUUID().toString())
+            .withPassword(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .withEmail(UUID.randomUUID().toString())
+            .expectRejection()
+            .create(unauthorizedUser.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'CREATE' on resource 'USER'");
+  }
+
+  @Test
+  public void shouldBeUnAuthorizedToCreateInitialAdminUserWithoutRoleUpdatePermissions() {
+    // given
+    final var unauthorizedUser = createUser(DEFAULT_USER.getUsername());
+    addPermissionsToUser(unauthorizedUser, AuthorizationResourceType.USER, PermissionType.CREATE);
+
+    // when
+    final var rejection =
+        engine
+            .user()
+            .newInitialAdminUser(UUID.randomUUID().toString())
+            .withPassword(UUID.randomUUID().toString())
+            .withName(UUID.randomUUID().toString())
+            .withEmail(UUID.randomUUID().toString())
+            .expectRejection()
+            .create(unauthorizedUser.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'ROLE'");
+  }
+
+  private UserRecordValue createUser(final String authorizedUsername) {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create(authorizedUsername)
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceId("*")
+        .create(DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
@@ -44,7 +44,7 @@ public class CreateInitialAdminUserTest {
     final var createdUser =
         engine
             .user()
-            .newAdminUser(username)
+            .newInitialAdminUser(username)
             .withName("name")
             .withEmail("email")
             .withPassword("password")
@@ -89,7 +89,7 @@ public class CreateInitialAdminUserTest {
     final var rejection =
         engine
             .user()
-            .newAdminUser(username)
+            .newInitialAdminUser(username)
             .withName("Bar Foo")
             .withEmail("bar@foo.com")
             .withPassword("password")
@@ -110,7 +110,7 @@ public class CreateInitialAdminUserTest {
     final var rejection =
         engine
             .user()
-            .newAdminUser(username)
+            .newInitialAdminUser(username)
             .withName("name")
             .withEmail("email")
             .withPassword("password")
@@ -147,7 +147,7 @@ public class CreateInitialAdminUserTest {
     final var rejection =
         engine
             .user()
-            .newAdminUser(UUID.randomUUID().toString())
+            .newInitialAdminUser(UUID.randomUUID().toString())
             .withName("name")
             .withEmail("email")
             .withPassword("password")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
-public class CreateAdminUsersTest {
+public class CreateInitialAdminUserTest {
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -31,11 +31,6 @@ public class RoleClient {
     return new RoleUpdateClient(writer, roleId);
   }
 
-  // TODO remove this method and use the one with role Id
-  public RoleAddEntityClient addEntity(final long roleKey) {
-    return new RoleAddEntityClient(writer, String.valueOf(roleKey));
-  }
-
   public RoleAddEntityClient addEntity(final String roleId) {
     return new RoleAddEntityClient(writer, roleId);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -27,7 +27,7 @@ public final class UserClient {
   }
 
   public UserCreationClient newAdminUser(final String username) {
-    return new UserCreationClient(writer, username, UserIntent.CREATE_ADMIN);
+    return new UserCreationClient(writer, username, UserIntent.CREATE_INITIAL_ADMIN);
   }
 
   public UpdateUserClient updateUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -26,7 +26,7 @@ public final class UserClient {
     return new UserCreationClient(writer, username, UserIntent.CREATE);
   }
 
-  public UserCreationClient newAdminUser(final String username) {
+  public UserCreationClient newInitialAdminUser(final String username) {
     return new UserCreationClient(writer, username, UserIntent.CREATE_INITIAL_ADMIN);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -50,7 +50,7 @@ public final class UserClient {
                 .withIntent(UserIntent.CREATED)
                 .withSourceRecordPosition(position)
                 .getFirst();
-    private final Function<Long, Record<UserRecordValue>> REJECTION_SUPPLIER;
+    private final Function<Long, Record<UserRecordValue>> rejectionSupplier;
 
     private final CommandWriter writer;
     private final UserIntent intent;
@@ -63,7 +63,7 @@ public final class UserClient {
       this.intent = intent;
       userCreationRecord = new UserRecord();
       userCreationRecord.setUsername(username);
-      REJECTION_SUPPLIER =
+      rejectionSupplier =
           (position) ->
               RecordingExporter.userRecords()
                   .onlyCommandRejections()
@@ -103,7 +103,7 @@ public final class UserClient {
     }
 
     public UserCreationClient expectRejection() {
-      expectation = REJECTION_SUPPLIER;
+      expectation = rejectionSupplier;
       return this;
     }
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
@@ -22,7 +22,7 @@ public enum UserIntent implements Intent {
   UPDATED(3),
   DELETE(4),
   DELETED(5),
-  CREATE_ADMIN(6);
+  CREATE_INITIAL_ADMIN(6);
 
   private final short value;
 
@@ -62,7 +62,7 @@ public enum UserIntent implements Intent {
       case 5:
         return DELETED;
       case 6:
-        return CREATE_ADMIN;
+        return CREATE_INITIAL_ADMIN;
       default:
         return UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
@@ -21,7 +21,8 @@ public enum UserIntent implements Intent {
   UPDATE(2),
   UPDATED(3),
   DELETE(4),
-  DELETED(5);
+  DELETED(5),
+  CREATE_ADMIN(6);
 
   private final short value;
 
@@ -60,6 +61,8 @@ public enum UserIntent implements Intent {
         return DELETE;
       case 5:
         return DELETED;
+      case 6:
+        return CREATE_ADMIN;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The initial admin user can only be created if there is no other users to assigned to the admin role. Users will get prompted to create it when doing something in the UI, basic auth is enabled and not admin user exists yet.

This became a new command in Zeebe to ensure we can handle creating the user and assigning the role atomically. Of course it also has the necessary validations to ensure users can only do this is a single time, that the user doesn't exist and that the admin role does exist.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33723 
