### PR TITLE
fix: Revert "feat: add validation to setters in BrokerInfo (#33511)"

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -46,8 +46,8 @@ final class PartitionJoinTest {
 
               clusterCfg.setClusterSize(1);
               clusterCfg.setNodeId(0);
-              clusterCfg.setPartitionsCount(2);
-              clusterCfg.setReplicationFactor(3);
+              clusterCfg.setPartitionsCount(1);
+              clusterCfg.setReplicationFactor(1);
             });
 
     final var initialContactPoint =
@@ -64,11 +64,11 @@ final class PartitionJoinTest {
               clusterCfg.setInitialContactPoints(
                   List.of(initialContactPoint.getHostName() + ":" + initialContactPoint.getPort()));
 
-              // Static configuration initially results in a broker with only 1 partition
+              // Static configuration initially results in a broker without any partitions
               clusterCfg.setClusterSize(1);
               clusterCfg.setNodeId(1);
-              clusterCfg.setPartitionsCount(2);
-              clusterCfg.setReplicationFactor(1);
+              clusterCfg.setPartitionsCount(0);
+              clusterCfg.setReplicationFactor(0);
             });
 
     // when

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -130,10 +130,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setPartitionsCount(final int partitionsCount) {
-    if (partitionsCount <= 0) {
-      throw new IllegalArgumentException(
-          "partitionsCount must be positive, was " + partitionsCount);
-    }
     this.partitionsCount = partitionsCount;
     return this;
   }
@@ -146,9 +142,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setClusterSize(final int clusterSize) {
-    if (clusterSize <= 0) {
-      throw new IllegalArgumentException("clusterSize must be positive, was " + partitionsCount);
-    }
     this.clusterSize = clusterSize;
     return this;
   }
@@ -161,10 +154,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setReplicationFactor(final int replicationFactor) {
-    if (replicationFactor <= 0) {
-      throw new IllegalArgumentException(
-          "replicationFactor must be positive, was " + partitionsCount);
-    }
     this.replicationFactor = replicationFactor;
     return this;
   }


### PR DESCRIPTION
## Description

This reverts commit ef4b4bf1e30fb883c15b577963d71a2ce6db9d5e, reversing changes made to 5d212c80fc6f71259bea62f5b2ed2b17a3ae8601 as it caused instability in the CI, surfacing as the `[IT] Zeebe QA - Integration Tests` job to timeout.

See this [thread](https://camunda.slack.com/archives/C071KP5BTHB/p1749735479030829) for context and my [summary](https://camunda.slack.com/archives/C071KP5BTHB/p1750133979912179?thread_ts=1749735479.030829&cid=C071KP5BTHB) on identifying this as the culprit.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

