### PR TITLE
fix: reduce JUnit test timeout of HealthMonitoringTest

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/HealthMonitoringTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/HealthMonitoringTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.Timeout;
 public class HealthMonitoringTest {
 
   private final EmbeddedBrokerRule embeddedBrokerRule = new EmbeddedBrokerRule();
-  private final Timeout timeout = Timeout.seconds(5 * 60);
+  private final Timeout timeout = Timeout.seconds(60);
 
   @Rule public final RuleChain chain = RuleChain.outerRule(timeout).around(embeddedBrokerRule);
 


### PR DESCRIPTION
## Description

[CI executions of this test](https://github.com/camunda/camunda/actions/runs/15703291824/job/44243104273) on `main` show runtimes of around 1 second, no need to have 5min as upper boundary.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

[Slack discussion](https://camunda.slack.com/archives/C08F5RD5X8B/p1750156349517749?thread_ts=1750155583.029909&cid=C08F5RD5X8B)
