### PR TITLE
feat: remove duplicated log lines in AzureBackupStore & GcsBackupStore

### DIFF
--- a/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/zeebe/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -125,7 +125,6 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    LOG.info("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var persistedManifest = manifestManager.createInitialManifest(backup);

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -66,7 +66,6 @@ public final class GcsBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> save(final Backup backup) {
-    LOG.info("Saving {}", backup.id());
     return CompletableFuture.runAsync(
         () -> {
           final var persistedManifest = manifestManager.createInitialManifest(backup);


### PR DESCRIPTION
## Description
PR #33596 added these two log lines to AzureBackupStore & GcsBackupStore by mistake, which now results in duplicated log lines
