### PR TITLE
Don't redirect to identity setup page is the api is unprotected

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -44,6 +44,11 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
       final HttpServletResponse response,
       final FilterChain filterChain)
       throws ServletException, IOException {
+    if (!securityConfig.isApiProtected()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
     final var hasConfiguredAdminUser =
         !securityConfig
             .getInitialization()

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -37,6 +37,7 @@ class AdminUserCheckFilterTest {
   void shouldRedirectIfNoAdminUserExistsOrIsConfigured() throws ServletException, IOException {
     // given
     final var securityConfig = new SecurityConfiguration();
+    securityConfig.getAuthentication().setUnprotectedApi(false);
     when(roleServices.searchMembers(any())).thenReturn(SearchQueryResult.empty());
     when(request.getContextPath()).thenReturn("localhost:8080");
     final AdminUserCheckFilter adminUserCheckFilter =
@@ -53,6 +54,7 @@ class AdminUserCheckFilterTest {
   void shouldNotRedirectIfAdminUserIsConfigured() throws ServletException, IOException {
     // given
     final var securityConfig = new SecurityConfiguration();
+    securityConfig.getAuthentication().setUnprotectedApi(false);
     securityConfig
         .getInitialization()
         .getDefaultRoles()
@@ -71,8 +73,24 @@ class AdminUserCheckFilterTest {
   void shouldNotRedirectIfAdminUserExists() throws ServletException, IOException {
     // given
     final var securityConfig = new SecurityConfiguration();
+    securityConfig.getAuthentication().setUnprotectedApi(false);
     when(roleServices.searchMembers(any()))
         .thenReturn(new SearchQueryResult.Builder<RoleMemberEntity>().total(1).build());
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldNotRedirectIfApiIsNotProtected() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    securityConfig.getAuthentication().setUnprotectedApi(true);
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
If the API is unprotected there's no need to create an admin user, whilst the demo user exists. This can be revisited once the demo user is removed by default. For now this ensures that QA and E2E keeps working.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #33533 
