### PR TITLE
ci: splitting steps per component for Core Features

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -4,6 +4,12 @@ name: Assign new issues to the default projects
 # owner: @camunda/monorepo-devops-team
 
 on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'The issue number to simulate'
+        required: true
+        type: number
   issues:
     types: [ opened, reopened, transferred, labeled ]
 

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -4,12 +4,6 @@ name: Assign new issues to the default projects
 # owner: @camunda/monorepo-devops-team
 
 on:
-  workflow_dispatch:
-    inputs:
-      issue_number:
-        description: 'The issue number to simulate'
-        required: true
-        type: number
   issues:
     types: [ opened, reopened, transferred, labeled ]
 
@@ -50,15 +44,30 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/92
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/zeebe
-      - id: add-to-core-features
-        name: Add to Core Features project
+      - id: add-operate-to-core-features
+        name: Add Operate issues to Core Features project
         uses: actions/add-to-project@v1.0.2
         if: ${{ steps.has-project.outputs.result == 'false' }}
         with:
           project-url: https://github.com/orgs/camunda/projects/173
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: component/operate, component/tasklist, component/optimize
-          label-operator: OR
+          labeled: component/operate
+      - id: add-tasklist-to-core-features
+        name: Add Tasklist issues to Core Features project
+        uses: actions/add-to-project@v1.0.2
+        if: ${{ steps.has-project.outputs.result == 'false' }}
+        with:
+          project-url: https://github.com/orgs/camunda/projects/173
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+          labeled: component/tasklist
+      - id: add-optimize-to-core-features
+        name: Add Optimize issues to Core Features project
+        uses: actions/add-to-project@v1.0.2
+        if: ${{ steps.has-project.outputs.result == 'false' }}
+        with:
+          project-url: https://github.com/orgs/camunda/projects/173
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+          labeled: component/optimize
       - id: add-to-data-layer
         name: Add to Data Layer project
         uses: actions/add-to-project@v1.0.2
@@ -126,7 +135,7 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           # any of the following labels:
           labeled: component/clients, scope/clients-spring, scope/clients-java, scope/spring-boot-starter-camunda, component/camunda-process-test
-      # this steops needs to stay as last step to not interfer with other steps
+      # this steps needs to stay as last step to not interfer with other steps
       - id: add-to-qualityboard
         name: Add to Quality Board project
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I'm splitting this per component (before we were using OR operator and doesn't seem to work, example: https://github.com/camunda/camunda/actions/runs/15706565576/job/44253669915)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
