### PR TITLE
fix: resolve group member email via console 

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -50,8 +50,9 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
             .collect(Collectors.toMap(Member::userId, Member::email));
     batch.forEach(
         group -> {
-          logger.debug("Migrating Group: {}", group);
           final var normalizedGroupId = normalizeGroupID(group);
+          logger.debug(
+              "Migrating Group: {} to a Group with the identifier: {}.", group, normalizedGroupId);
           try {
             final var groupDTO = new GroupDTO(normalizedGroupId, group.name(), "");
             groupServices.createGroup(groupDTO).join();
@@ -99,6 +100,11 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
                   user.getId());
               return;
             }
+            logger.debug(
+                "Adding User: {} with E-mail: {} to Group: {}",
+                user.getId(),
+                userEmail,
+                targetGroupId);
             final var groupMember = new GroupMemberDTO(targetGroupId, userEmail, EntityType.USER);
             groupServices.assignMember(groupMember).join();
           } catch (final Exception e) {

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -50,16 +50,17 @@ public class GroupMigrationHandler extends MigrationHandler<Group> {
             .collect(Collectors.toMap(Member::userId, Member::email));
     batch.forEach(
         group -> {
+          logger.debug("Migrating Group: {}", group);
+          final var normalizedGroupId = normalizeGroupID(group);
           try {
-            final var normalizedGroupId = normalizeGroupID(group);
             final var groupDTO = new GroupDTO(normalizedGroupId, group.name(), "");
             groupServices.createGroup(groupDTO).join();
-            assignUsersToGroup(group.id(), normalizedGroupId, userIdToEmailMapping);
           } catch (final Exception e) {
             if (!isConflictError(e)) {
               throw new MigrationException("Failed to migrate group with ID: " + group.id(), e);
             }
           }
+          assignUsersToGroup(group.id(), normalizedGroupId, userIdToEmailMapping);
         });
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -25,9 +25,11 @@ public class MigrationHandlerConfig {
   @Bean
   public GroupMigrationHandler groupMigrationHandler(
       final Authentication authentication,
+      final ConsoleClient consoleClient,
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices) {
-    return new GroupMigrationHandler(authentication, managementIdentityClient, groupServices);
+    return new GroupMigrationHandler(
+        authentication, consoleClient, managementIdentityClient, groupServices);
   }
 
   @Bean

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/console/ConsoleClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/console/ConsoleClient.java
@@ -44,7 +44,7 @@ public class ConsoleClient {
 
   public record Client(String name, String clientId, List<Permission> permissions) {}
 
-  public record Member(String originalUserId, List<Role> roles, String email, String name) {}
+  public record Member(String userId, List<Role> roles, String email, String name) {}
 
   public enum Permission {
     ZEEBE("Zeebe"),

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/ConsoleClientIT.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/ConsoleClientIT.java
@@ -57,7 +57,7 @@ public class ConsoleClientIT {
         {
           "members": [
             {
-              "originalUserId": "user123",
+              "userId": "user123",
               "roles": ["admin", "developer"],
               "email": "user@example.com",
               "name": "John Doe"
@@ -112,7 +112,7 @@ public class ConsoleClientIT {
     assertNotNull(members);
     assertEquals(1, members.members().size());
     assertEquals("John Doe", members.members().getFirst().name());
-    assertEquals("user123", members.members().getFirst().originalUserId());
+    assertEquals("user123", members.members().getFirst().userId());
     assertEquals("user@example.com", members.members().getFirst().email());
     assertEquals(2, members.members().getFirst().roles().size());
     assertEquals(Role.ADMIN, members.members().getFirst().roles().get(0));

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
@@ -11,12 +11,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.identity.sdk.users.dto.User;
+import io.camunda.migration.identity.console.ConsoleClient;
+import io.camunda.migration.identity.console.ConsoleClient.Member;
+import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import io.camunda.security.auth.Authentication;
@@ -40,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class GroupMigrationHandlerTest {
+  private final ConsoleClient consoleClient;
   private final ManagementIdentityClient managementIdentityClient;
 
   private final GroupServices groupService;
@@ -48,16 +53,20 @@ public class GroupMigrationHandlerTest {
 
   public GroupMigrationHandlerTest(
       @Mock final ManagementIdentityClient managementIdentityClient,
+      @Mock final ConsoleClient consoleClient,
       @Mock(answer = Answers.RETURNS_SELF) final GroupServices groupService) {
+    this.consoleClient = consoleClient;
     this.managementIdentityClient = managementIdentityClient;
     this.groupService = groupService;
     migrationHandler =
-        new GroupMigrationHandler(Authentication.none(), managementIdentityClient, groupService);
+        new GroupMigrationHandler(
+            Authentication.none(), consoleClient, managementIdentityClient, groupService);
   }
 
   @Test
   void stopWhenIdentityEndpointNotFound() {
     when(managementIdentityClient.fetchGroups(anyInt())).thenThrow(new NotImplementedException());
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     assertThrows(NotImplementedException.class, migrationHandler::migrate);
@@ -75,6 +84,7 @@ public class GroupMigrationHandlerTest {
         .thenReturn(List.of());
     when(groupService.createGroup(any(GroupDTO.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -100,6 +110,7 @@ public class GroupMigrationHandlerTest {
     when(managementIdentityClient.fetchGroups(anyInt()))
         .thenReturn(List.of(new Group("id1", "t1"), new Group("id2", "t2")))
         .thenReturn(List.of());
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -119,6 +130,7 @@ public class GroupMigrationHandlerTest {
         .thenReturn(List.of());
     when(groupService.createGroup(any(GroupDTO.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -144,6 +156,7 @@ public class GroupMigrationHandlerTest {
         .thenReturn(List.of());
     when(groupService.createGroup(any(GroupDTO.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -166,6 +179,7 @@ public class GroupMigrationHandlerTest {
         .thenReturn(List.of());
     when(groupService.createGroup(any(GroupDTO.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -192,6 +206,7 @@ public class GroupMigrationHandlerTest {
         .thenReturn(CompletableFuture.completedFuture(null));
     when(groupService.assignMember(any(GroupMemberDTO.class)))
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -234,6 +249,7 @@ public class GroupMigrationHandlerTest {
                         -1,
                         RejectionType.ALREADY_EXISTS,
                         "member already exists"))));
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
 
     // when
     migrationHandler.migrate();
@@ -241,5 +257,67 @@ public class GroupMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchGroups(anyInt());
     verify(groupService, times(2)).assignMember(any(GroupMemberDTO.class));
+  }
+
+  @Test
+  public void shouldResolveUserEmailFromConsoleResponseWhenMissingInIdentity() {
+    // given
+    final var groupId = "groupId";
+    final Group group = new Group(groupId, "Test Group");
+    when(managementIdentityClient.fetchGroups(anyInt()))
+        .thenReturn(List.of(group))
+        .thenReturn(List.of());
+    when(managementIdentityClient.fetchGroupUsers(groupId))
+        // no email present in identity response
+        .thenReturn(List.of(new User("user1", null, null, null)));
+    when(groupService.createGroup(any(GroupDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(groupService.assignMember(any(GroupMemberDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(consoleClient.fetchMembers())
+        .thenReturn(
+            new Members(
+                List.of(new Member("user1", List.of(), "user1@camunda.com", "User 1")), List.of()));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    final var groupMember = ArgumentCaptor.forClass(GroupMemberDTO.class);
+    verify(groupService).assignMember(groupMember.capture());
+    assertThat(groupMember.getValue().groupId())
+        .describedAs("Group ID should match the migrated group ID")
+        .isEqualTo("test_group");
+    assertThat(groupMember.getValue().memberId())
+        .describedAs("Member ID should match the user email")
+        .isEqualTo("user1@camunda.com");
+    assertThat(groupMember.getValue().memberType())
+        .describedAs("Entity type should be USER")
+        .isEqualTo(EntityType.USER);
+  }
+
+  @Test
+  public void shouldSkipMemberWhenEmailCantBeResolved() {
+    // given
+    final var groupId = "groupId";
+    final Group group = new Group(groupId, "Test Group");
+    when(managementIdentityClient.fetchGroups(anyInt()))
+        .thenReturn(List.of(group))
+        .thenReturn(List.of());
+    when(managementIdentityClient.fetchGroupUsers(groupId))
+        // no email present in identity response
+        .thenReturn(List.of(new User("user1", null, null, null)));
+    when(groupService.createGroup(any(GroupDTO.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // no email information from console either
+    when(consoleClient.fetchMembers()).thenReturn(new Members(List.of(), List.of()));
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    final var groupMember = ArgumentCaptor.forClass(GroupMemberDTO.class);
+    verify(groupService, never()).assignMember(groupMember.capture());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/IdentityMigrationIT.java
@@ -526,7 +526,7 @@ public class IdentityMigrationIT {
         {
           "members": [
             {
-              "originalUserId": "user123",
+              "userId": "user123",
               "roles": ["owner", "developer"],
               "email": "user@example.com",
               "name": "John Doe"


### PR DESCRIPTION
## Description

When running in SaaS mode, management identity is only returning userIds.
The migration handler for groups in SaaS thus needs to resolve the email
using the console migration response.

Note: I couldn't adapt `IdentityMigrationIT` as it runs in SM Keycloak mode, we need to add a functional SaaS IT setup of Management identity to properly test this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33860 
