### PR TITLE
fix: refactor context loader to consider simple mappings

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -7,11 +7,17 @@
  */
 package io.camunda.authentication;
 
+import static io.camunda.zeebe.protocol.record.value.EntityType.CLIENT;
+import static io.camunda.zeebe.protocol.record.value.EntityType.GROUP;
+import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING;
+import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
+
 import io.camunda.authentication.entity.AuthenticationContext.AuthenticationContextBuilder;
 import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -23,6 +29,7 @@ import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -74,44 +81,12 @@ public class CamundaOAuthPrincipalService {
 
   public OAuthContext loadOAuthContext(final Map<String, Object> claims)
       throws OAuth2AuthenticationException {
-    final var mappings = mappingServices.getMatchingMappings(claims);
-    final Set<String> mappingIds =
-        mappings.map(MappingEntity::mappingId).collect(Collectors.toSet());
-    if (mappingIds.isEmpty()) {
-      LOG.debug("No mappings found for these claims: {}", claims);
-    }
-
-    final Set<String> groups;
-    if (StringUtils.hasText(groupsClaim)) {
-      groups = new HashSet<>(oidcGroupsLoader.load(claims));
-    } else {
-      groups =
-          groupServices.getGroupsByMemberIds(mappingIds, EntityType.MAPPING).stream()
-              .map(GroupEntity::groupId)
-              .collect(Collectors.toSet());
-    }
-
-    final var roles = roleServices.getRolesByMappingsAndGroups(mappingIds, groups);
-    final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
-
-    final var tenants =
-        tenantServices.getTenantsByMappingsAndGroupsAndRoles(mappingIds, groups, roleIds).stream()
-            .map(TenantDTO::fromEntity)
-            .toList();
-
-    final var authContextBuilder =
-        new AuthenticationContextBuilder()
-            .withAuthorizedApplications(
-                authorizationServices.getAuthorizedApplications(
-                    Stream.concat(roles.stream().map(RoleEntity::roleId), mappingIds.stream())
-                        .collect(Collectors.toSet())))
-            .withTenants(tenants)
-            .withGroups(groups.stream().toList())
-            .withRoles(roles);
-
+    final var authContextBuilder = new AuthenticationContextBuilder();
     final var principals = oidcPrincipalLoader.load(claims);
     final var username = principals.username();
     final var clientId = principals.clientId();
+
+    final var principalIdentifiers = new HashMap<EntityType, Set<String>>();
 
     if (username == null && clientId == null) {
       throw new OAuth2AuthenticationException(
@@ -121,11 +96,59 @@ public class CamundaOAuthPrincipalService {
     }
     if (username != null) {
       authContextBuilder.withUsername(username);
+      principalIdentifiers.put(USER, Set.of(username));
     }
 
     if (clientId != null) {
       authContextBuilder.withClientId(clientId);
+      principalIdentifiers.put(CLIENT, Set.of(clientId));
     }
+
+    final var mappings = mappingServices.getMatchingMappings(claims);
+    final Set<String> mappingIds =
+        mappings.map(MappingEntity::mappingId).collect(Collectors.toSet());
+    if (mappingIds.isEmpty()) {
+      LOG.debug("No mappings found for these claims: {}", claims);
+    } else {
+      principalIdentifiers.put(MAPPING, mappingIds);
+    }
+
+    final Set<String> groups;
+    if (StringUtils.hasText(groupsClaim)) {
+      groups = new HashSet<>(oidcGroupsLoader.load(claims));
+    } else {
+      // TODO: Get groups for username and clientId
+      groups =
+          groupServices.getGroupsByMemberIds(mappingIds, MAPPING).stream()
+              .map(GroupEntity::groupId)
+              .collect(Collectors.toSet());
+      if (!groups.isEmpty()) {
+        principalIdentifiers.put(GROUP, groups);
+      }
+    }
+
+    final var roles =
+        roleServices.findAll(
+            RoleQuery.of(
+                roleQuery ->
+                    roleQuery.filter(
+                        roleFilter -> roleFilter.memberIdsByType(principalIdentifiers))));
+    final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
+
+    // TODO: Get tenants for username and clientId
+    final var tenants =
+        tenantServices.getTenantsByMappingsAndGroupsAndRoles(mappingIds, groups, roleIds).stream()
+            .map(TenantDTO::fromEntity)
+            .toList();
+
+    authContextBuilder
+        .withAuthorizedApplications(
+            authorizationServices.getAuthorizedApplications(
+                Stream.concat(roles.stream().map(RoleEntity::roleId), mappingIds.stream())
+                    .collect(Collectors.toSet())))
+        .withTenants(tenants)
+        .withGroups(groups.stream().toList())
+        .withRoles(roles);
 
     return new OAuthContext(mappingIds, authContextBuilder.build());
   }

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -117,7 +117,7 @@ public class CamundaOAuthPrincipalService {
     if (StringUtils.hasText(groupsClaim)) {
       groups = new HashSet<>(oidcGroupsLoader.load(claims));
     } else {
-      // TODO: Get groups for username and clientId
+      // TODO: Get groups for username and clientId https://github.com/camunda/camunda/issues/26572
       groups =
           groupServices.getGroupsByMemberIds(mappingIds, MAPPING).stream()
               .map(GroupEntity::groupId)
@@ -135,7 +135,7 @@ public class CamundaOAuthPrincipalService {
                         roleFilter -> roleFilter.memberIdsByType(principalIdentifiers))));
     final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
 
-    // TODO: Get tenants for username and clientId
+    // TODO: Get tenants for username and clientId https://github.com/camunda/camunda/issues/26572
     final var tenants =
         tenantServices.getTenantsByMappingsAndGroupsAndRoles(mappingIds, groups, roleIds).stream()
             .map(TenantDTO::fromEntity)

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -18,6 +18,7 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.query.RoleQuery;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -211,9 +212,21 @@ public class CamundaOAuthPrincipalServiceTest {
 
       final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
       final var groupRole = new RoleEntity(3L, "roleGroup", "Role Group", "description");
-      when(roleServices.getRolesByMappingsAndGroups(
-              Set.of("test-id", "test-id-2"), Set.of("group-g1")))
-          .thenReturn(List.of(roleR1, groupRole));
+
+      final var expectedQuery =
+          RoleQuery.of(
+              roleQuery ->
+                  roleQuery.filter(
+                      roleFilter ->
+                          roleFilter.memberIdsByType(
+                              Map.of(
+                                  EntityType.MAPPING,
+                                  Set.of("test-id", "test-id-2"),
+                                  EntityType.GROUP,
+                                  Set.of("group-g1"),
+                                  EntityType.USER,
+                                  Set.of("foo@camunda.test")))));
+      when(roleServices.findAll(expectedQuery)).thenReturn(List.of(roleR1, groupRole));
 
       when(groupServices.getGroupsByMemberIds(Set.of("test-id", "test-id-2"), EntityType.MAPPING))
           .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
@@ -264,8 +277,20 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
       final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
-      when(roleServices.getRolesByMappingsAndGroups(Set.of("map-1", "map-2"), Set.of("group-g1")))
-          .thenReturn(List.of(roleR1));
+      final var expectedQuery =
+          RoleQuery.of(
+              roleQuery ->
+                  roleQuery.filter(
+                      roleFilter ->
+                          roleFilter.memberIdsByType(
+                              Map.of(
+                                  EntityType.MAPPING,
+                                  Set.of("map-1", "map-2"),
+                                  EntityType.GROUP,
+                                  Set.of("group-g1"),
+                                  EntityType.USER,
+                                  Set.of("scooby-doo")))));
+      when(roleServices.findAll(expectedQuery)).thenReturn(List.of(roleR1));
 
       when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "roleR1")))
           .thenReturn(List.of("app-1", "app-2"));

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -9,6 +9,7 @@ package io.camunda.search.filter;
 
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Map;
 import java.util.Set;
 
 public record RoleFilter(
@@ -20,7 +21,8 @@ public record RoleFilter(
     EntityType memberType,
     Set<String> roleIds,
     EntityType childMemberType,
-    String tenantId)
+    String tenantId,
+    Map<EntityType, Set<String>> memberIdsByType)
     implements FilterBase {
   public Builder toBuilder() {
     return new Builder()
@@ -31,7 +33,8 @@ public record RoleFilter(
         .memberType(memberType)
         .roleIds(roleIds)
         .childMemberType(childMemberType)
-        .tenantId(tenantId);
+        .tenantId(tenantId)
+        .memberIdsByType(memberIdsByType);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
@@ -44,6 +47,7 @@ public record RoleFilter(
     private Set<String> roleIds;
     private EntityType childMemberType;
     private String tenantId;
+    private Map<EntityType, Set<String>> memberIdsByType;
 
     public Builder roleId(final String value) {
       roleId = value;
@@ -94,6 +98,11 @@ public record RoleFilter(
       return this;
     }
 
+    public Builder memberIdsByType(final Map<EntityType, Set<String>> value) {
+      memberIdsByType = value;
+      return this;
+    }
+
     @Override
     public RoleFilter build() {
       if (memberIds != null && childMemberType == null) {
@@ -108,7 +117,8 @@ public record RoleFilter(
           memberType,
           roleIds,
           childMemberType,
-          tenantId);
+          tenantId,
+          memberIdsByType);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -82,15 +82,6 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
     return roles.stream().distinct().toList();
   }
 
-  public List<RoleEntity> getRolesByMappingsAndGroups(
-      final Set<String> mappings, final Set<String> groupIds) {
-    final var roles = new ArrayList<>(getRolesByMemberIds(mappings, EntityType.MAPPING));
-    final var groupRoles = getRolesByMemberIds(groupIds, EntityType.GROUP);
-
-    roles.addAll(groupRoles);
-    return roles.stream().distinct().toList();
-  }
-
   public List<RoleEntity> findAll(final RoleQuery query) {
     return roleSearchClient
         .withSecurityContext(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR resolves a couple of things
1. Solves the bug where the roles loaded do not consider all possible ways a principal can be assigned a role
2. Refactors the query/filter sent to ES so its a single call with OR vs multiple calls per member type

The intention is to extend this to the other membership based entities in the class.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to https://github.com/camunda/camunda/issues/26572
