### PR TITLE
ci: add metadata to CI

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,7 +1,7 @@
+# type: Project Management
+# owner: @camunda/monorepo-devops-team
 ---
 name: Assign new issues to the default projects
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   issues:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
+# type: CI Helper
+# owner: @camunda/monorepo-devops-team
 ---
 name: Backport labeled merged pull requests
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request:

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -1,3 +1,7 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate). This workflow runs on a schedule
+# test location: /qa/core-application-e2e-test-suite
+# type: CI
+# owner: @camunda/qa-engineering
 ---
 name: C8 Orchestration Cluster E2E Tests Nightly
 
@@ -25,7 +29,7 @@ jobs:
         run: |
           if [[ "${{ matrix.branch }}" == "stable/8.6" || "${{ matrix.branch }}" == "stable/8.7" ]]; then
             echo "Using single services for Camunda 8.6 and 8.7"
-            DATABASE=elasticsearch docker compose up -d operate tasklist 
+            DATABASE=elasticsearch docker compose up -d operate tasklist
           else
             echo "Using standalone camunda container"
             DATABASE=elasticsearch docker compose up -d camunda

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -1,3 +1,6 @@
+# description: Runs End to End tests on the C8 Orchestration Cluster (ie, Tasklist, Operate) This workflow is run manually
+# type: CI
+# owner: @camunda/qa-engineering
 ---
 name: C8 Orchestration Cluster E2E Tests On Demand
 

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -1,7 +1,8 @@
+# description: For C8Run, this workflow runs a linting check, unit tests, a build, tests on unix, and end to end tests on windows
+# type: CI
+# owner: @camunda/distribution
 ---
 name: "C8Run: build/test"
-
-# owner: @camunda/distribution
 
 on:
   push:

--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -1,7 +1,7 @@
+# type: Project Management
+# owner: @camunda/distribution
 ---
 name: "C8Run: Issue Closed"
-
-# owner: @camunda/distribution
 
 on:
   issues:

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -1,7 +1,7 @@
+# type: Release
+# owner: @camunda/distribution
 ---
 name: "C8Run: Release"
-
-# owner: @camunda/distribution
 
 on:
   workflow_dispatch:

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -1,6 +1,6 @@
-name: Camunda Helm Chart Integration Test
-
+# type: CI
 # owner: @camunda/monorepo-devops-team
+name: Camunda Helm Chart Integration Test
 
 on:
   schedule:

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -1,7 +1,7 @@
+# type: CI Helper - Manual
+# owner: @camunda/monorepo-devops-team
 ---
 name: Deploy Camunda Docker Images to SaaS registry
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   workflow_dispatch:

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -1,7 +1,7 @@
+# type: Release
+# owner: @camunda/monorepo-devops-team
 ---
 name: Camunda Platform Release Dry Run from main
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   workflow_dispatch:

--- a/.github/workflows/camunda-platform-release-manual.yml
+++ b/.github/workflows/camunda-platform-release-manual.yml
@@ -1,7 +1,7 @@
+# type: Release
+# owner: @camunda/monorepo-devops-team
 ---
 name: Camunda Platform Release
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   workflow_dispatch:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -1,7 +1,7 @@
+# type: Release
+# owner: @camunda/monorepo-devops-team
 ---
 name: Camunda Platform Release Workflow
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   workflow_call:

--- a/.github/workflows/chatops-command-ci-problems.yml
+++ b/.github/workflows/chatops-command-ci-problems.yml
@@ -1,7 +1,7 @@
+# type: CI Helper - ChatOps
+# owner: @camunda/monorepo-devops-team
 ---
 name: chatops-command-ci-problems
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   repository_dispatch:

--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -1,7 +1,7 @@
+# type: CI Helper - ChatOps
+# owner: @camunda/monorepo-devops-team
 ---
 name: chatops-command-ci-disable-cache
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   repository_dispatch:

--- a/.github/workflows/chatops-command-dispatch.yml
+++ b/.github/workflows/chatops-command-dispatch.yml
@@ -1,7 +1,7 @@
+# type: CI Helper - ChatOps
+# owner: @camunda/monorepo-devops-team
 ---
 name: ChatOps Command Dispatch
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   issue_comment:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,7 +1,9 @@
+# description: Checks for license issues by using FOSSA. If a PR introduces a denied or flagged license, this check will fail
+# test location: /
+# type: CI
+# owner: @camunda/monorepo-devops-team
 ---
 name: Check Licenses
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   push:
@@ -111,7 +113,7 @@ jobs:
         # If none is found, fall back to the original base commit — this will cause the check to fail.
         base-revision: >-
           ${{
-            steps.info.outputs.base-revision-most-recent-with-scanning-results || 
+            steps.info.outputs.base-revision-most-recent-with-scanning-results ||
             steps.info.outputs.base-revision
           }}
         path: ${{ matrix.project.path }}

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -1,7 +1,7 @@
+# type: Preview Environments
+# owner: @camunda/monorepo-devops-team
 ---
 name: Check for PR conflicts
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
+# description: The Unified CI for the monorepo. This workflow runs tests for all modules in the monorepo. Any new tests are required to adhere to inclusion rules
+# test location: /
+# type: CI
+# owner: @camunda/monorepo-devops-team
 ---
 name: CI
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   push:

--- a/.github/workflows/critical-issue.yml
+++ b/.github/workflows/critical-issue.yml
@@ -1,3 +1,4 @@
+# type: Project Management
 name: Slack notification for critical issue
 on:
   issues:

--- a/.github/workflows/dispatch-release-8-3.yaml
+++ b/.github/workflows/dispatch-release-8-3.yaml
@@ -1,9 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.3
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
+name: Repo dispatch Release 8.3
 
 on:
   repository_dispatch:

--- a/.github/workflows/dispatch-release-8-4.yaml
+++ b/.github/workflows/dispatch-release-8-4.yaml
@@ -1,9 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.4
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
+name: Repo dispatch Release 8.4
 
 on:
   repository_dispatch:

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -1,10 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.5
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
-
+name: Repo dispatch Release 8.5
 on:
   repository_dispatch:
     types: [ trigger_release_8_5 ]

--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -1,9 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.6
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
+name: Repo dispatch Release 8.6
 
 on:
   repository_dispatch:

--- a/.github/workflows/dispatch-release-8-7.yaml
+++ b/.github/workflows/dispatch-release-8-7.yaml
@@ -1,9 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.7
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
+name: Repo dispatch Release 8.7
 
 on:
   repository_dispatch:

--- a/.github/workflows/dispatch-release-8-8.yaml
+++ b/.github/workflows/dispatch-release-8-8.yaml
@@ -1,10 +1,7 @@
-# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
-# given input.
-#
-name: Repo dispatch Release 8.8
-
+# description: This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the given input.
+# type: Release
 # owner: @camunda/monorepo-devops-team
-
+name: Repo dispatch Release 8.8
 on:
   repository_dispatch:
     types: [ trigger_release_8_8 ]

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -1,3 +1,7 @@
+# description: Workflow for Front-End end to end tests for Identity only. Tests will use a running instance of Identity for the API
+# test location: /identity/client/e2e/tests
+# type: CI
+# owner: @camunda/identity
 ---
 name: Identity E2E Tests
 on:

--- a/.github/workflows/identity-regression-test.yml
+++ b/.github/workflows/identity-regression-test.yml
@@ -1,3 +1,7 @@
+# description: Runs regression tests on Identity. Tests are defined as .http files
+# test location: /http
+# type: CI
+# owner: @camunda/identity
 name: Identity API Regression Tests
 
 on:

--- a/.github/workflows/issue-add-support-label.yml
+++ b/.github/workflows/issue-add-support-label.yml
@@ -1,7 +1,7 @@
+# type: Project Management
+# owner: @camunda/monorepo-devops-team
 ---
 name: Add support label to issue
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   issues:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
+# type: Project Management
+# owner: @camunda/monorepo-devops-team
 ---
 name: "Pull Request Labeler"
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request_target: {}

--- a/.github/workflows/migration-labeler.yml
+++ b/.github/workflows/migration-labeler.yml
@@ -1,3 +1,4 @@
+# type: Project Management
 # owner: @vheinila
 name: Issue Migration Labeler
 
@@ -7,7 +8,7 @@ permissions:
 
 on:
   workflow_dispatch:
-    
+
 jobs:
   label_migrated_issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner:
+# owner: Engineering Ops
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,3 +1,5 @@
+# type: Project Management
+# owner:
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/operate-check-project-versions.yml
+++ b/.github/workflows/operate-check-project-versions.yml
@@ -1,3 +1,5 @@
+# type: Release
+# owner: @camunda/monorepo-devops-team
 name: Operate Check project versions
 
 on:

--- a/.github/workflows/operate-ci-build-observe-reusable.yml
+++ b/.github/workflows/operate-ci-build-observe-reusable.yml
@@ -1,7 +1,8 @@
-# This workflow is a reuseable job that builds operate and reports the status
+# description: This workflow is a reuseable job that builds operate and reports the status
 # called by: operate-ci-core-features.yml, preview-env-build-and-deploy.yml
 # test location: operate
-# owner:
+# type: CI
+# owner: @camunda/core-features
 ---
 name: Operate CI Build Observability Reusable
 

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -12,7 +12,8 @@
 # description: Automates the build process for operate workflows
 # called by: operate-ci-core-features.yml, preview-env-build-and-deploy.yml
 # test location:
-# owner:
+# type: CI
+# owner: @camunda/core-features
 ---
 name: Operate CI Reusable
 

--- a/.github/workflows/operate-ci-core-features.yml
+++ b/.github/workflows/operate-ci-core-features.yml
@@ -1,6 +1,7 @@
 # description: Runs integration tests CI tests owned by Core Features
 # test location: operate/qa/integration-tests
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 name: "[Legacy] Operate"
 on:
   workflow_dispatch:

--- a/.github/workflows/operate-ci-data-layer.yml
+++ b/.github/workflows/operate-ci-data-layer.yml
@@ -1,6 +1,7 @@
 # description: Runs the CI tests owned by Data Layer. Runs unit tests, and integration tests
 # test location: operate/common, operate/importer, operate/importer-8_7, operate/importer-common, operate/qa/integration-tests, operate/schema, operate/webapp
-# owner: Data Layer
+# type: CI
+# owner: @camunda/data-layer
 ---
 name: "[Legacy] Operate / [IT] Data Layer"
 on:

--- a/.github/workflows/operate-ci-fe.yml
+++ b/.github/workflows/operate-ci-fe.yml
@@ -1,7 +1,8 @@
-# Runs front end tests for Operate. Tests include a type check, linting, unit tests, and visual regression tests
+# description: Runs front end tests for Operate. Tests include a type check, linting, unit tests, and visual regression tests
 # test location: operate/client/e2e-playwright/a11y, operate/client/src/App
 # called by: ci.yml
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 name: Operate Frontend
 
 on:

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -16,7 +16,8 @@
 # description: Automates the CI test process for operate
 # called by: operate-ci-data-layer.yml, operate-ci-core-features.yml
 # test location: operate
-# owner: Data Layer, Core Features
+# type: CI
+# owner: @camunda/data-layer, @camunda/core-features
 ---
 name: Operate CI IT test reusable
 

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -1,6 +1,7 @@
 # description:  Workflow for tests for running Integration tests on a docker image
 # test location: operate/qa/integration-tests
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 name: "[Legacy] Operate / Docker Tests"
 on:
   push:

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -1,6 +1,7 @@
 # description: Workflow for Front-End end to end tests for Operate only. Tests will use a running instance of Operate for the API
 # test location: operate/client/e2e-playwright/tests
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 name: "[Legacy] Operate / E2E Tests"
 on:
   push:

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -1,6 +1,7 @@
 # description: Workflow for Front-End end unit tests
 # test location: operate/client/src/App
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 ---
 name: "[Legacy] Operate [FE]"
 on:

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -1,6 +1,7 @@
 # description: Visual regression tests for Operate
 # test location: operate/client/e2e-playwright
-# owner: Core Features
+# type: CI
+# owner: @camunda/core-features
 name: "[Legacy] Operate / Visual Regression Tests"
 on:
   push:

--- a/.github/workflows/operate-release-dry-run-scheduled.yml
+++ b/.github/workflows/operate-release-dry-run-scheduled.yml
@@ -8,7 +8,7 @@
 # in dry-run mode (no changes or artifacts are pushed).
 #
 # This dry-run scheduled workflow is designed to provide an assurance check that the release process will execute as expected when performed live.
-
+# type: Release
 
 name: Operate Release dry-run scheduled
 

--- a/.github/workflows/operate-release-manual.yml
+++ b/.github/workflows/operate-release-manual.yml
@@ -16,6 +16,7 @@
 # "Run workflow" dropdown, selecting the workflow, filling in the input fields and clicking "Run workflow".
 #
 # Link to Release manual workflow: https://github.com/camunda/camunda/actions/workflows/release-manual.yml
+# type: Release
 
 name: Operate Release manual
 

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -18,6 +18,7 @@
 # - If specified, uploads the release to GitHub.
 # - If specified, uploads the Docker image to the Docker registry.
 # - If the release process fails, sends a notification to a (#operate-ci) Slack channel.
+# type: Release
 
 name: Operate Release (reusable workflow)
 

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -1,7 +1,8 @@
 # description: Reuseable workflow that executes the passed maven command
 # called by: operate-test-importer.yml, operate-test-backup-restore.yml
 # test location: operate
-# owner: Data Layer
+# type: CI
+# owner: @camunda/data-layer
 ---
 name: Operate Run Tests
 env:

--- a/.github/workflows/operate-test-backup-restore.yml
+++ b/.github/workflows/operate-test-backup-restore.yml
@@ -1,6 +1,7 @@
 # description: Workflow that runs the backup restore tests for Operate
 # test location: operate/qa/backup-restore-tests
-# owner: Data Layer
+# type: CI
+# owner: @camunda/data-layer
 name: Operate Run Test Backup/Restore
 on:
   schedule:

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -1,6 +1,7 @@
 # description: Workflow that runs Integration Tests that match **/*ZeebeImportIT.java or **/*ZeebeIT.java If the name of the Java class does not match either of those, then the test is not run
 # test location: operate/qa/integration-tests
-# owner: Data Layer
+# type: CI
+# owner: @camunda/data-layer
 name: "[Legacy] Operate / [IT] Import"
 on:
   push:

--- a/.github/workflows/optimize-check-c4.yml
+++ b/.github/workflows/optimize-check-c4.yml
@@ -1,4 +1,8 @@
-name: Check if C4 builds
+# description: Workflow to see if FE code in C4 directory in Optimize properly builds after there are any changes to it
+# test location: /optimize/c4
+# type: CI
+# owner: @camunda/core-features
+name: Optimize Check if C4 builds
 on:
   push:
     branches:

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -9,6 +9,11 @@
 # Environment variables are used to define the image tags used for Docker builds.
 # This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
 # and enables detailed reporting of test results.
+# description: Reuseable workflow for building Optimize and a docker image
+# test location: /optimize
+# called by:
+# type: CI
+# owner: @camunda/core-features
 
 name: Optimize CI Reusable
 

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -1,3 +1,7 @@
+# description: Workflow for running CI tests for Optimize. Runs integration tests, schema integrity tests, database upgrade tests, and deploys a SNAPSHOT of Optimize on a push to main
+# test location: /optimize/qa/schema-integrity-tests, /optimize/backend/src/it/java, optimize/upgrade/src/test/java/io/camunda/optimize/upgrade
+# type: CI
+# owner: @camunda/core-features
 name: Optimize CI
 on:
   pull_request:

--- a/.github/workflows/optimize-create-release-branch.yml
+++ b/.github/workflows/optimize-create-release-branch.yml
@@ -1,3 +1,4 @@
+# type: Release
 name: Optimize Create Release Branch
 on:
   workflow_dispatch:

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -1,4 +1,7 @@
-
+# description: Builds an Optimize docker image and a production .tar.gz, runs tests, and then deploys to artifactory and pushes to docker hub
+# called by: optiimize-ci.yml
+# type: CI
+# owner: @camunda/core-features
 name: Optimize Deploy Artifacts
 on:
   workflow_call:

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -1,8 +1,8 @@
-# NOTE:
-# This pipeline is currently not active. For more info, see:
-# https://github.com/camunda/camunda/issues/24886
-
-name: Optimize e2e cloud test
+# description: This test is disabled. See https://github.com/camunda/camunda/issues/24886 Otherwise, this is a Workflow for running end to end FE tests on Optimize in Cloud mode. Starts an instance of Optimize and uses that instance to run tests on
+# test location: /optimize/client/e2e/cloud-tests
+# type: CI
+# owner: @camunda/core-features
+name: Optimize E2E Cloud
 
 on:
   pull_request:

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -1,4 +1,8 @@
-name: Optimize e2e tests sm
+# description: This is a Workflow for running end to end FE tests on Optimize in Self-Managed mode. Starts an instance of Optimize and uses that instance to run tests on
+# test location: /optimize/client/e2e/sm-tests
+# type: CI
+# owner: @camunda/core-features
+name: Optimize E2E Self-Managed
 
 on:
   pull_request:
@@ -37,7 +41,7 @@ permissions:
 
 jobs:
   e2e-tests-sm:
-    name: E2E tests sm
+    name: E2E Self-Managed
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/optimize-hadolint.yml
+++ b/.github/workflows/optimize-hadolint.yml
@@ -1,4 +1,8 @@
-name: Optimize test dockerfiles with Hadolint
+# description: Runs Hadolint on Optimize's dockerfile. Hadolint is a dockerfile linting tool
+# test location: /optimize
+# type: CI
+# owner: @camunda/core-features
+name: Optimize Dockerfile Linting
 on: [pull_request]
 jobs:
   hadolint:

--- a/.github/workflows/optimize-health-status-report.yml
+++ b/.github/workflows/optimize-health-status-report.yml
@@ -1,3 +1,7 @@
+# description: Sends a daily report of Optimize tests to the #optimize-status slack channel
+# test location: /optimize
+# type: CI Helper
+# owner: @camunda/core-features
 name: Optimize health status report
 
 on:

--- a/.github/workflows/optimize-opened-issues-automation.yml
+++ b/.github/workflows/optimize-opened-issues-automation.yml
@@ -1,3 +1,4 @@
+# type: Project Management
 name: Optimize Opened Issues Automation
 on:
   issues:

--- a/.github/workflows/optimize-publish-c4.yml
+++ b/.github/workflows/optimize-publish-c4.yml
@@ -1,3 +1,6 @@
+# description: Publishes the C4 bundle for Optimize. This is abundle of react components which are imported and used in Optimize. They are published here: https://www.npmjs.com/package/@camunda/camunda-optimize-composite-components
+# type: CI Helper - Manual
+# owner: @camunda/core-features
 name: Optimize publish c4 to npm
 
 on:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -1,3 +1,4 @@
+# type: Release
 name: Optimize Release Camunda Optimize C8
 
 on:

--- a/.github/workflows/optimize-zeebe-compatibility.yml
+++ b/.github/workflows/optimize-zeebe-compatibility.yml
@@ -1,3 +1,7 @@
+# description: Runs Optimize Integration tests on various version of Zeebe to ensure compatibility
+# test location: /optimize
+# type: CI
+# owner: @camunda/core-features
 name: Optimize Zeebe Compatibility
 on:
   schedule:

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -1,7 +1,7 @@
+# type: Preview Environment
+# owner: @camunda/monorepo-devops-team
 ---
 name: Preview Environment Build and Deploy
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request:

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -1,7 +1,7 @@
+# type: Preview Environment
+# owner: @camunda/monorepo-devops-team
 ---
 name: Preview Env Clean
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   schedule:

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -1,7 +1,7 @@
+# type: Preview Environment
+# owner: @camunda/monorepo-devops-team
 ---
 name: Preview Env Teardown
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request:

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -5,10 +5,10 @@
 #
 # It is allowed to have merge commits in a pull request.
 # An example is a pull request that builds upon the work of another pull request.
+# type: CI Helper
+# owner: @camunda/monorepo-devops-team
 
 name: Reject Merge Commits
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request: {}

--- a/.github/workflows/renovatelint.yml
+++ b/.github/workflows/renovatelint.yml
@@ -1,7 +1,7 @@
+# type: CI Helper
+# owner: @camunda/monorepo-devops-team
 ---
 name: Renovate lint
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   pull_request:

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -1,9 +1,9 @@
 # This workflow receives a run ID and triggers a retry of its failed jobs.
 # This is useful, for example, to retry dependency update PRs automatically in case of network
 # errors, flaky tests, etc.
-name: Retry Workflow Run
-
+# type: CI Helper
 # owner: @camunda/monorepo-devops-team
+name: Retry Workflow Run
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -3,6 +3,7 @@
 # The SBOM provides a list of dependencies and helps track potential security risks.
 # The workflow runs on a schedule for testing purposes and can be manually triggered.
 # The generated SBOM is uploaded as an artifact for further analysis or distribution.
+# type: Release
 
 name: Generate and Attach SBOM
 

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -1,7 +1,7 @@
+# type: CI Helper
+# owner: @camunda/monorepo-devops-team
 ---
 name: Statistics Daily
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   schedule:

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -1,4 +1,7 @@
-# This is a workflow for 'Tasklist Backup and Restore' tests (supported only for 8.7 and lower versions).
+# description: This is a workflow for 'Tasklist Backup and Restore' tests (supported only for 8.7 and lower versions).
+# test location: /tasklist/qa/backup-restore-tests
+# type: CI
+# owner: @camunda/data-layer
 name: Tasklist Backup and restore tests (reusable)
 
 on:

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -9,6 +9,11 @@
 # Environment variables are used to define the image tags used for Docker builds.
 # This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
 # and enables detailed reporting of test results.
+# description: Reuseable workflow for building Tasklist and a docker image
+# test location: /tasklist
+# called by: tasklist-ci.yml, preview-env-build-and-deploy.yml
+# type: CI
+# owner: @camunda/core-features
 
 name: Tasklist CI Reusable
 

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -1,3 +1,8 @@
+# description: Workflow for running Front End tests for Tasklist. Does a type check, two lint checks (eslint and stylelint), unit tests, visual regression tests, and accessibility testing (a11y)
+# test location: /tasklist/client
+# called by: ci.yml
+# type: CI
+# owner: @camunda/core-features
 name: Tasklist Frontend Jobs
 
 on:

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -13,6 +13,11 @@
 # CI IT test reusable GitHub Actions Workflow
 # Triggers on a workflow_call event and accepts inputs for branch name and fork count
 # Performs integration tests for the tasklist service with parallel execution.
+# description:
+# test location:
+# called by: tasklist-ci.yml
+# type: CI
+# owner: @camunda/core-features
 
 name: Tasklist CI IT test reusable
 

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -1,5 +1,7 @@
-# This GitHub Actions workflow that is triggered on push to `main` and `stable/**` branch or on any pull request creation
-# and invokes `ci-build-reusable` and `ci-test-reusable` workflows.
+# description: Workflow for running CI tests for Tasklist. Runs a build and Integration Tests
+# test location: /tasklist
+# type: CI
+# owner: @camunda/core-features
 ---
 name: Tasklist CI
 on:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -1,3 +1,8 @@
+# description: Runs Tasklist integration tests in a docker environment
+# test location: /tasklist/qa/integration-tests
+# called by: ci.yml
+# type: CI
+# owner: @camunda/core-features
 ---
 name: Tasklist Docker Tests
 on:

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -1,3 +1,7 @@
+# description: This is a Workflow for running end to end FE tests on Tasklist. Starts an instance of Tasklist and uses that instance to run tests on
+# test location: /tasklist/client/e2e
+# type: CI
+# owner: @camunda/core-features
 ---
 name: Tasklist E2E Tests
 on:

--- a/.github/workflows/tasklist-update_visual_snapshots.yml
+++ b/.github/workflows/tasklist-update_visual_snapshots.yml
@@ -1,3 +1,7 @@
+# description: This is a Workflow runs tests and created updated screenshots of Tasklist
+# test location: /tasklist/client/
+# type: CI Helper
+# owner: @camunda/core-features
 name: Tasklist Update Visual Regression Snapshots
 
 on:

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -1,6 +1,6 @@
-name: Update Identity Version
-
+# type: CI Helper - Manual
 # owner: @camunda/monorepo-devops-team
+name: Update Identity Version
 
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -1,3 +1,7 @@
+# description: Runs Integration tests on different versions of AWS OS
+# test location: /zeebe/exporters/opensearch-exporter, /search/search-client-connect, /zeebe/exporters/camunda-exporter, /qa/acceptance-tests
+# type: CI
+# owner: @camunda/core-features, @camunda/data-layer
 name: AWS OpenSearch Manual/Scheduled Run Integration Tests
 
 on:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -1,3 +1,7 @@
+# description: This step for helm install deploys a camunda cluster in zeebe-io with additional tools for benchmarking. We use this worklow to start weekly medic benchmarks. The health of the cluster and results of the benchmarks are monitored by the zeebe team regularly. https://grafana.dev.zeebe.io/login
+# called by: zeebe-medic-benchmarks.yml, zeebe-pr-benchmark.yaml
+# type: CI
+# owner: @camunda/core-features
 name: Zeebe Benchmark
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -1,3 +1,8 @@
+# description:  Workflow for running CI tests for Zeebe. Runs smoke tests, property tests, performance tests, strace tests, docker checks. If the branch running is `main`, this workflow will configure synk and push an image to dockerhub. Also handles auto-merging of backports
+# test location: /
+# called by: ci.yml
+# type: CI
+# owner: @camunda/core-features
 name: Zeebe CI
 
 on:

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -1,8 +1,10 @@
-# This workflow runs our daily scheduled acceptance tests. It runs each test suite against the
+# description: This workflow runs our daily scheduled acceptance tests. It runs each test suite against the
 # development head (e.g. main) and all officially supported branches.
 #
 # As this is meant to be run via scheduling, the workflow itself only runs on the default branch
 # (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+# type: CI
+# owner @camunda/core-features
 name: Zeebe Daily tests
 
 on:

--- a/.github/workflows/zeebe-dispatch-qa.yaml
+++ b/.github/workflows/zeebe-dispatch-qa.yaml
@@ -1,6 +1,6 @@
-# This workflow runs our acceptance tests, triggered by our engineering process automation cluster. It runs the test suite against the
-# given branch.
-#
+# description: This workflow runs our acceptance tests, triggered by our engineering process automation cluster. It runs the test suite against the given branch.
+# type: CI
+# owner @camunda/core-features
 name: Zeebe Repo dispatch QA tests
 
 on:

--- a/.github/workflows/zeebe-e2e-testbench.yaml
+++ b/.github/workflows/zeebe-e2e-testbench.yaml
@@ -1,3 +1,7 @@
+# description: Runs end to end testbench tests on specified generation, branch, and cluster
+# type: CI
+# called by: zeebe-weekly-e2e.yml
+# owner @camunda/core-features
 name: Run Zeebe E2E Tests
 
 on:

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -1,3 +1,6 @@
+# description: Deploys new zeebe benchmarks weekly. Old benchmarks are removed. Multiple kinds of benchmarks are created - Data, Normal, Mixed, Latency
+# type: CI
+# owner @camunda/core-features
 name: Zeebe Weekly medic benchmark
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -1,3 +1,6 @@
+# description: Create a zeebe benchmark for an individual PR. When a PR is closed, the benchmark is cleaned up and removed
+# type: CI
+# owner @camunda/core-features
 name: Zeebe Pull Request Benchmark
 on:
   pull_request:

--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -1,3 +1,7 @@
+# description: Run testbench on a specific branch and generation
+# called by: zeebe-daily-qa.yml, zeebe-dspatch-qa.yml
+# type: CI
+# owner @camunda/core-features
 name: Zeebe QA Testbench run
 
 on:

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -1,8 +1,8 @@
+# type: Release
+# owner: @camunda/monorepo-devops-team
 ---
 # NOTE: This workflow is not just for Zeebe, but also for 8.6+ monorepo release!
 name: Zeebe Release Dry Run from stable branches
-
-# owner: @camunda/monorepo-devops-team
 
 on:
   workflow_dispatch: {}

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -1,5 +1,6 @@
-# This workflow either scans all distribute-able projects with snyk, or updates the relevant
-# projects on the Snyk servers
+# description: This workflow either scans all distribute-able projects with snyk, or updates the relevant projects on the Snyk servers
+# type: Project Management
+# owner @camunda/core-features
 name: Zeebe Snyk
 
 on:

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -1,3 +1,13 @@
+# description: Starts a test in the testbench cluster: https://console.cloud.camunda.io/org/9061128c-7381-4caa-abbe-e97057e0e1eb/cluster/eeef5734-cfd6-47a5-a2ed-5fe13269e589
+#  This is used to orchestrate several tests for Zeebe that are not part of the regular ci build.
+#  To start a test we create a process instance in Testbench cluster using curl v2/process-instances.
+#  The call itself is not doing any tests. But the process started by it will start different tests
+# against a new camunda cluster with the specified version. This is started daily by the github
+# action zeebe-daily-qa.yml. Github workflows just start the process instance and do not monitor it.
+#  The results of these tests are posted to #zeebe-ci via Testbench workers once the test is completed.
+# called by: zeebe-e2e-testbench.yaml, zeebe-qa-testbench.yaml, zeebe-update-long-running-migrating-benchmark.yaml
+# type: CI
+# owner @camunda/core-features
 name: Start a Zeebe test in Testbench
 
 on:

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -1,3 +1,6 @@
+# description: Run weekly benchmark test on a long running migration
+# type: CI
+# owner @camunda/core-features
 name: Zeebe Long Running Migrating Benchmark
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -1,3 +1,7 @@
+# description: Tests rolling updates for Zeebe. Detailed information can be found at /docs/zeebe/rolling_updates.md
+# test location: /zeebe/qa/update-tests
+# type: CI
+# owner: @camunda/core-features
 name: Zeebe Version Compatibility
 on:
   workflow_dispatch:

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -1,8 +1,7 @@
-# This workflow runs e2e tests weekly. It runs each test suite against the
-# development head (e.g. main).
-
-# As this is meant to be run via scheduling, the workflow itself only runs on the default branch
-# (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+# description: This workflow runs e2e tests weekly. It runs each test suite against the development head (e.g. main).
+#  As this is meant to be run via scheduling, the workflow itself only runs on the default branch (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+# type: CI
+# owner: @camunda/core-features
 name: Zeebe Weekly E2E tests
 
 on:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds metadata to each CI file so that it is clear what the file is doing and who owns it

Metadata includes a description, a type (eg, CI, Release, etc.), an owning team, filepath location of tests (optional, only applicable to CI files that are running tests), and a list of workflows that use a particular workflow (optional field)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/product-hub/issues/2813
