### PR TITLE
ci: change docker version to 8.7-SNAPSHOT

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -14,7 +14,7 @@ fi
 
 # temporarily needed for https://github.com/camunda/product-hub/issues/2618
 if [ "${IS_STABLE_87}" = "true" ]; then
-    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8.7.0-SNAPSHOT")
+    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8.7-SNAPSHOT")
 fi
 
 printf -v tag_arguments -- "-t %s " "${tags[@]}"


### PR DESCRIPTION
## Description

Replace docker image version from `8.7.0-SNAPSHOT` to `8.7-SNAPSHOT`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

#30477 
