### PR TITLE
fix: skip deserialize when verifyRepositoryExists

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -17,6 +17,7 @@ import static io.camunda.optimize.service.exceptions.ExceptionHelper.safe;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static java.lang.String.format;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.ImportRequestDto;
@@ -111,12 +112,14 @@ import org.opensearch.client.opensearch.indices.rollover.RolloverConditions;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
+import org.opensearch.client.opensearch.snapshot.GetRepositoryResponse;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.opensearch.client.opensearch.tasks.ListRequest;
 import org.opensearch.client.opensearch.tasks.ListResponse;
 import org.opensearch.client.opensearch.tasks.Status;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 import org.springframework.context.ApplicationContext;
 
 @Slf4j
@@ -1048,9 +1051,19 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     }
   }
 
+  @VisibleForTesting
   public void verifyRepositoryExists(final GetRepositoryRequest getRepositoriesRequest)
       throws IOException, OpenSearchException {
-    openSearchClient.snapshot().getRepository(getRepositoriesRequest);
+    final SimpleEndpoint<GetRepositoryRequest, Object> endpoint =
+        ((SimpleEndpoint<GetRepositoryRequest, GetRepositoryResponse>)
+                (GetRepositoryRequest._ENDPOINT))
+            .withResponseDeserializer(null);
+
+    openSearchAsyncClient
+        ._transport()
+        .performRequestAsync(
+            getRepositoriesRequest, endpoint, openSearchAsyncClient._transportOptions())
+        .join();
   }
 
   public GetSnapshotResponse getSnapshots(final GetSnapshotRequest getSnapshotRequest)

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -17,7 +17,6 @@ import static io.camunda.optimize.service.exceptions.ExceptionHelper.safe;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static java.lang.String.format;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.camunda.optimize.dto.optimize.DataImportSourceType;
 import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.ImportRequestDto;
@@ -1051,7 +1050,6 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     }
   }
 
-  @VisibleForTesting
   public void verifyRepositoryExists(final GetRepositoryRequest getRepositoriesRequest)
       throws IOException, OpenSearchException {
     final SimpleEndpoint<GetRepositoryRequest, Object> endpoint =

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/OptimizeOpenSearchClientTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/OptimizeOpenSearchClientTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
+
+@ExtendWith(MockitoExtension.class)
+public class OptimizeOpenSearchClientTest {
+  @Mock private OpenSearchAsyncClient openSearchAsyncClient;
+
+  @InjectMocks private OptimizeOpenSearchClient optimizeOpenSearchClient;
+
+  @Test
+  void shouldValidateRepositoryExistsDoNotDeserializeOpenSearchResponse() throws IOException {
+    final OpenSearchTransport openSearchTransport = mock(OpenSearchTransport.class);
+    when(openSearchAsyncClient._transport()).thenReturn(openSearchTransport);
+    when(openSearchTransport.performRequestAsync(any(), any(), any()))
+        .thenReturn(mock(CompletableFuture.class));
+
+    optimizeOpenSearchClient.verifyRepositoryExists(
+        GetRepositoryRequest.of(grr -> grr.name("test-repo")));
+
+    final ArgumentCaptor<SimpleEndpoint> endpointArgumentCaptor =
+        ArgumentCaptor.forClass(SimpleEndpoint.class);
+    verify(openSearchTransport).performRequestAsync(any(), endpointArgumentCaptor.capture(), any());
+    assertThat(endpointArgumentCaptor.getValue().responseDeserializer()).isNull();
+  }
+}


### PR DESCRIPTION
## Description

Looking at the [stacktrace](https://jira.camunda.com/secure/attachment/101824/101824_camunda-onboarding-optimize-f4bf86648-rzryp.txt)
```
Caused by: java.lang.RuntimeException: Missing required property 'RepositorySettings.location'
	at org.opensearch.client.transport.aws.AwsSdk2Transport.extractAndWrapCause(AwsSdk2Transport.java:667)
	at org.opensearch.client.transport.aws.AwsSdk2Transport.performRequest(AwsSdk2Transport.java:206)
	at org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotClient.getRepository(OpenSearchSnapshotClient.java:308)
	at io.camunda.optimize.service.db.os.OptimizeOpenSearchClient.verifyRepositoryExists(OptimizeOpenSearchClient.java:1038)
```

The same bug described in [this PR](https://github.com/camunda/camunda/pull/27225#issue-2802453741) is happening for Optimize backups. S3 backup response doesn't return a `location` field which makes the deserialization break. Same as in Tasklist, we don't need the response so we can skip it.

## Related issues

closes #33905
