### PR TITLE
feat: update JSON dashboards with new API panels

### DIFF
--- a/monitor/grafana/dashboards/core-features-overview.json
+++ b/monitor/grafana/dashboards/core-features-overview.json
@@ -1,0 +1,2134 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_THANOS:_GLOBAL-VIEW",
+      "label": "Thanos: global-view",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_CLUSTER",
+      "type": "constant",
+      "label": "cluster",
+      "value": ".*",
+      "description": ""
+    },
+    {
+      "name": "VAR_POD",
+      "type": "constant",
+      "label": "pod",
+      "value": ".*",
+      "description": ""
+    }
+  ],
+  "__elements": {
+    "ceopv2m5x6wowa": {
+      "name": "Request Rate gRPC",
+      "uid": "ceopv2m5x6wowa",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Total number of gRPC calls handled per second, grouped by method. Useful for monitoring overall traffic volume and per-method activity.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "grpc_method"
+              },
+              "properties": [
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "targetBlank": true,
+                      "title": "Show details",
+                      "url": "/d/bep7p39l2r3eoe/grpc?folderUid=fel9jhmrxyltsc&orgId=1&from=now-6h&to=now&timezone=browser&var-region~=$region&var-namespace=$__all&var-grpc_method=${__value.raw}"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "sum by(grpc_method) (rate(grpc_server_handled_total{camunda_region=~\"$region\", namespace=~\"$namespace\", grpc_method=~\"$grpc_method\"}[$__rate_interval]))",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Request Rate gRPC",
+        "type": "timeseries"
+      }
+    },
+    "feopv1yehyps0f": {
+      "name": "p95 Latency gRPC",
+      "uid": "feopv1yehyps0f",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Shows high-percentile latency per gRPC method over the selected range, excluding the ActivateJobs method.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "line"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "transparent",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.3
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.95,\n  sum by (le, grpc_method) (\n    increase(grpc_server_handled_latency_seconds_bucket{\n      camunda_region=\"$region\",\n      grpc_method=~\"$grpc_method\",\n      grpc_method!~\"ActivateJobs\"\n    }[$__rate_interval])\n  )\n)\n",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Latency p95"
+          }
+        ],
+        "title": "p95 Latency gRPC",
+        "type": "timeseries"
+      }
+    },
+    "deopwfw0nde68b": {
+      "name": "Error Rate gRPC",
+      "uid": "deopwfw0nde68b",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Fraction of gRPC requests resulting in INTERNAL errors per method. High values may indicate server-side issues or crashes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "line"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.1
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum by(grpc_method) (rate(grpc_server_handled_total{camunda_region=~\"$region\", namespace=~\"$namespace\", grpc_method=~\"$grpc_method\", grpc_code=\"INTERNAL\"}[$__rate_interval])) / sum by(grpc_method) (rate(grpc_server_handled_total{camunda_region=~\"$region\", namespace=~\"$namespace\", grpc_method=~\"$grpc_method\"}[$__rate_interval]))",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Error Rate gRPC",
+        "type": "timeseries"
+      }
+    },
+    "aeopx01aoiiv4c": {
+      "name": "Latency Heatmap gRPC",
+      "uid": "aeopx01aoiiv4c",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Raw increase of latency bucket counts over time for all methods excluding ActivateJobs. Useful for histogram exploration and debugging tail latencies.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "scaleDistribution": {
+                "type": "linear"
+              }
+            }
+          },
+          "overrides": []
+        },
+        "options": {
+          "calculate": false,
+          "cellGap": 2,
+          "cellValues": {},
+          "color": {
+            "exponent": 0.5,
+            "fill": "dark-orange",
+            "mode": "scheme",
+            "reverse": false,
+            "scale": "exponential",
+            "scheme": "Spectral",
+            "steps": 128
+          },
+          "exemplars": {
+            "color": "rgba(255,0,255,0.7)"
+          },
+          "filterValues": {
+            "le": 1e-9
+          },
+          "legend": {
+            "show": true,
+            "showLegend": true
+          },
+          "rowsFrame": {
+            "layout": "auto"
+          },
+          "tooltip": {
+            "mode": "single",
+            "showColorScale": false,
+            "yHistogram": false
+          },
+          "yAxis": {
+            "axisPlacement": "left",
+            "reverse": false,
+            "unit": "dtdurations"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(grpc_server_handled_latency_seconds_bucket{camunda_region=~\"$region\", namespace=~\"$namespace\", grpc_method=~\"$grpc_method\", grpc_method!~\"ActivateJobs\"}[$__rate_interval])) by (le)",
+            "format": "heatmap",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Latency Heatmap gRPC",
+        "type": "heatmap"
+      }
+    },
+    "dep78ee16es5ce": {
+      "name": "Request Rate REST",
+      "uid": "dep78ee16es5ce",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Highest-requested API endpoints based on request rate, excluding internal /actuator and Prometheus paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 3,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    cluster=~\"$cluster\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\",\n    uri=~\"$uri\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n  }[$__rate_interval])\n)",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Requests per second",
+            "useBackend": false
+          }
+        ],
+        "title": "Request Rate REST",
+        "type": "timeseries"
+      }
+    },
+    "dep7o0du9lxxce": {
+      "name": "Request Rate REST (top 10)",
+      "uid": "dep7o0du9lxxce",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Highest-requested API endpoints based on request rate, excluding internal /actuator and Prometheus paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "decimals": 3,
+            "links": [],
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "uri"
+              },
+              "properties": [
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "targetBlank": true,
+                      "title": "Show details",
+                      "url": "/d/ceolah0px5og0e/api?orgId=1&from=now-6h&to=now&timezone=browser&var-region~=$region&var-namespace=$__all&var-container=$__all&var-uri=${__value.raw}"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "topk(10, sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    cluster=~\"$cluster\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n  }[4h])\n))",
+            "format": "table",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "Requests per second",
+            "useBackend": false
+          }
+        ],
+        "title": "Request Rate REST (top 10)",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "includeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "Time": "",
+                "Value": "Rate (req/s)",
+                "uri": ""
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    },
+    "eep78ety54bggd": {
+      "name": "Average Latency REST",
+      "uid": "eep78ety54bggd",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest average request duration, excluding known internal and noisy paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "line"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.3
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Latency (avg)"
+          }
+        ],
+        "title": "Average Latency REST",
+        "type": "timeseries"
+      }
+    },
+    "ceopr4mzesav4f": {
+      "name": "Average Latency REST (top 10)",
+      "uid": "ceopr4mzesav4f",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest average request duration, excluding known internal and noisy paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.3
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "uri"
+              },
+              "properties": [
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "title": "Show details",
+                      "url": "/d/ceolah0px5og0e/api?orgId=1&from=now-6h&to=now&timezone=browser&var-region~=$region&var-namespace=$__all&var-container=$__all&var-uri=${__value.raw}"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "topk(10,\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[4h])\n  )\n)\n",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": false,
+            "refId": "Latency (avg)"
+          }
+        ],
+        "title": "Average Latency REST (top 10)",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "includeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Avg Response Time (s)"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    },
+    "deopr4y2r1wxsa": {
+      "name": "Server error rate REST",
+      "uid": "deopr4y2r1wxsa",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest proportion of server-side errors (5xx), useful for spotting failing API routes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.01
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n))\n",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Error rate",
+            "useBackend": false
+          }
+        ],
+        "title": "Server error rate REST",
+        "type": "timeseries"
+      }
+    },
+    "bep78k0rlqf40a": {
+      "name": "Server error rate REST (top 10)",
+      "uid": "bep78k0rlqf40a",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest proportion of server-side errors (5xx), useful for spotting failing API routes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.01
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "uri"
+              },
+              "properties": [
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "targetBlank": true,
+                      "title": "Show details",
+                      "url": "/d/ceolah0px5og0e/api?orgId=1&from=now-6h&to=now&timezone=browser&var-region~=$region&var-namespace=$__all&var-container=$__all&var-uri=${__value.raw}"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"SERVER_ERROR\",\n      pod=~\"$pod\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n))\n",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": false,
+            "refId": "Error rate",
+            "useBackend": false
+          }
+        ],
+        "title": "Server error rate REST (top 10)",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "includeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Server Error Rate (%)"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    },
+    "bep78xfm9mzuod": {
+      "name": "Client error rate REST",
+      "uid": "bep78xfm9mzuod",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest proportion of server-side errors (5xx), useful for spotting failing API routes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.01
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[$__rate_interval])\n  )\n",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Error rate",
+            "useBackend": false
+          }
+        ],
+        "title": "Client error rate REST",
+        "type": "timeseries"
+      }
+    },
+    "fep79bllbuqdce": {
+      "name": "Client error rate REST (top 10)",
+      "uid": "fep79bllbuqdce",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "description": "Endpoints with the highest proportion of server-side errors (4xx).",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.01
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "uri"
+              },
+              "properties": [
+                {
+                  "id": "links",
+                  "value": [
+                    {
+                      "targetBlank": true,
+                      "title": "Show details",
+                      "url": "/d/ceolah0px5og0e/api?orgId=1&from=now-6h&to=now&timezone=browser&var-region~=$region&var-namespace=$__all&var-container=$__all&var-uri=${__value.raw}"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "topk(10, (\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      outcome=~\"CLIENT_ERROR\",\n      pod=~\"$pod\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n    }[4h])\n  )\n))\n",
+            "format": "table",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": true,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": false,
+            "refId": "Error rate",
+            "useBackend": false
+          }
+        ],
+        "title": "Client error rate REST (top 10)",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "includeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Client Error Rate (%)"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    }
+  },
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.6.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 9,
+          "libraryPanel": {
+            "name": "Request Rate gRPC",
+            "uid": "ceopv2m5x6wowa"
+          },
+          "title": "Request Rate gRPC"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+          },
+          "description": "Total number of gRPC calls handled per second, grouped by method. Useful for monitoring overall traffic volume and per-method activity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "grpc_method"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/bep7p39l2r3eoe/grpc?orgId=1&from=now-6h&to=now&timezone=browser&var-namespace=$__all&var-grpc_method=${__value.raw}&var-region~=$region\n"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 18,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by(grpc_method) (rate(grpc_server_handled_total{\n    camunda_region=~\"$region\",\n    cluster=~\"$cluster\",\n    grpc_method=~\"$grpc_method\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\"\n    }[$__rate_interval]))",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Request Rate gRPC",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Request Rate (req/s)"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Request Rate (req/s)"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 8,
+          "libraryPanel": {
+            "name": "p95 Latency gRPC",
+            "uid": "feopv1yehyps0f"
+          },
+          "title": "p95 Latency gRPC"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+          },
+          "description": "Shows high-percentile latency per gRPC method over the selected range, excluding the ActivateJobs method.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.3
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "grpc_method"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/bep7p39l2r3eoe/grpc?orgId=1&from=now-6h&to=now&timezone=browser&var-namespace=$__all&var-grpc_method=${__value.raw}&var-region~=$region\n"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 19,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "histogram_quantile(0.95,\n  sum by (le, grpc_method) (\n    increase(grpc_server_handled_latency_seconds_bucket{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      grpc_method=~\"$grpc_method\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval])\n  )\n)\n",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Latency p95"
+            }
+          ],
+          "title": "p95 Latency gRPC",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {}
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Value"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 10,
+          "libraryPanel": {
+            "name": "Error Rate gRPC",
+            "uid": "deopwfw0nde68b"
+          },
+          "title": "Error Rate gRPC"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+          },
+          "description": "Fraction of gRPC requests resulting in errors per method. High values may indicate server-side issues or crashes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "grpc_method"
+                },
+                "properties": [
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "targetBlank": true,
+                        "title": "Show details",
+                        "url": "/d/bep7p39l2r3eoe/grpc?orgId=1&from=now-6h&to=now&timezone=browser&var-namespace=$__all&var-grpc_method=${__value.raw}&var-region~=$region\n"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 20,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.6.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "\n  sum by(grpc_method) (\n    rate(grpc_server_handled_total{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      code!=\"OK\",\n      grpc_method=~\"$grpc_method\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(grpc_method) (\n    rate(grpc_server_handled_total{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      grpc_method=~\"$grpc_method\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\"\n    }[$__rate_interval])\n  )\n",
+              "format": "table",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Error Rate gRPC",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Error Rate (%)"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Error Rate (%)"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 25
+          },
+          "id": 11,
+          "libraryPanel": {
+            "name": "Latency Heatmap gRPC",
+            "uid": "aeopx01aoiiv4c"
+          },
+          "title": "Latency Heatmap gRPC"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "id": 4,
+          "libraryPanel": {
+            "name": "Request Rate REST",
+            "uid": "dep78ee16es5ce"
+          },
+          "title": "Request Rate REST"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 17,
+          "libraryPanel": {
+            "name": "Request Rate REST (top 10)",
+            "uid": "dep7o0du9lxxce"
+          },
+          "title": "Request Rate REST (top 10)"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 41
+          },
+          "id": 6,
+          "libraryPanel": {
+            "name": "Average Latency REST",
+            "uid": "eep78ety54bggd"
+          },
+          "title": "Average Latency REST"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 41
+          },
+          "id": 13,
+          "libraryPanel": {
+            "name": "Average Latency REST (top 10)",
+            "uid": "ceopr4mzesav4f"
+          },
+          "title": "Average Latency REST (top 10)"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 49
+          },
+          "id": 5,
+          "libraryPanel": {
+            "name": "Server error rate REST",
+            "uid": "deopr4y2r1wxsa"
+          },
+          "title": "Server error rate REST"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 49
+          },
+          "id": 14,
+          "libraryPanel": {
+            "name": "Server error rate REST (top 10)",
+            "uid": "bep78k0rlqf40a"
+          },
+          "title": "Server error rate REST (top 10)"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 57
+          },
+          "id": 15,
+          "libraryPanel": {
+            "name": "Client error rate REST",
+            "uid": "bep78xfm9mzuod"
+          },
+          "title": "Client error rate REST"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 57
+          },
+          "id": 16,
+          "libraryPanel": {
+            "name": "Client error rate REST (top 10)",
+            "uid": "fep79bllbuqdce"
+          },
+          "title": "Client error rate REST (top 10)"
+        }
+      ],
+      "title": "API",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 65,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.6.1",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "count by(alertname) (ALERTS{team=~\"operate|tasklist|optimize|zeebe\", label_cloud_camunda_io_sales_plan_type!=\"trial\", alertstate=\"firing\", namespace=~\"$namespace\"})",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+              }
+            }
+          ],
+          "title": "Alerts",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Alerts",
+      "type": "row"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "definition": "label_values(namespace)",
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "definition": "label_values(camunda_region)",
+        "includeAll": true,
+        "multi": true,
+        "name": "region",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(camunda_region)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "definition": "label_values(http_server_requests_seconds_count,container)",
+        "includeAll": true,
+        "multi": true,
+        "name": "container",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_requests_seconds_count,container)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "hide": 2,
+        "label": "cluster",
+        "name": "cluster",
+        "query": "${VAR_CLUSTER}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_CLUSTER}",
+          "text": "${VAR_CLUSTER}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_CLUSTER}",
+            "text": "${VAR_CLUSTER}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "label": "pod",
+        "name": "pod",
+        "query": "${VAR_POD}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_POD}",
+          "text": "${VAR_POD}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_POD}",
+            "text": "${VAR_POD}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "allowCustomValue": true,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "definition": "label_values(http_server_requests_seconds_count{container=~\"$container\", uri!~\"^/($|actuator($|/.*)|\\\\*\\\\*($|/.*)|\\\\*\\\\*/\\\\{regex:\\\\[\\\\\\\\w-]+\\\\})$\"},uri)",
+        "includeAll": true,
+        "multi": true,
+        "name": "uri",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_requests_seconds_count{container=~\"$container\", uri!~\"^/($|actuator($|/.*)|\\\\*\\\\*($|/.*)|\\\\*\\\\*/\\\\{regex:\\\\[\\\\\\\\w-]+\\\\})$\"},uri)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_THANOS:_GLOBAL-VIEW}"
+        },
+        "definition": "label_values(grpc_server_handled_latency_seconds_bucket,grpc_method)",
+        "includeAll": true,
+        "multi": true,
+        "name": "grpc_method",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(grpc_server_handled_latency_seconds_bucket,grpc_method)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Core Features Overview",
+  "uid": "fel9lob8vajggd",
+  "version": 56,
+  "weekStart": ""
+}

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -7,9 +7,236 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "VAR_CONTAINER",
+      "type": "constant",
+      "label": "container",
+      "value": ".*",
+      "description": ""
+    },
+    {
+      "name": "VAR_REGION",
+      "type": "constant",
+      "label": "region",
+      "value": ".*",
+      "description": ""
+    },
+    {
+      "name": "VAR_URI",
+      "type": "constant",
+      "label": "uri",
+      "value": ".*",
+      "description": ""
+    },
+    {
+      "name": "VAR_GRPC_METHOD",
+      "type": "constant",
+      "label": "grpc_method",
+      "value": ".*",
+      "description": ""
     }
   ],
-  "__elements": {},
+  "__elements": {
+    "dep78ee16es5ce": {
+      "name": "Request Rate REST",
+      "uid": "dep78ee16es5ce",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Highest-requested API endpoints based on request rate, excluding internal /actuator and Prometheus paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 3,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "reqps"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum by(uri, method) (\n  rate(http_server_requests_seconds_count{\n    camunda_region=~\"$region\",\n    cluster=~\"$cluster\",\n    container=~\"$container\",\n    namespace=~\"$namespace\",\n    pod=~\"$pod\",\n    uri=~\"$uri\",\n    uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$\"\n  }[$__rate_interval])\n)",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Requests per second",
+            "useBackend": false
+          }
+        ],
+        "title": "Request Rate REST",
+        "type": "timeseries"
+      }
+    },
+    "eep78ety54bggd": {
+      "name": "Average Latency REST",
+      "uid": "eep78ety54bggd",
+      "kind": 1,
+      "model": {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Endpoints with the highest average request duration, excluding known internal and noisy paths.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "line"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.3
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.6.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "thanos-global-view"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_sum{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n  /\n  sum by(uri, method) (\n    rate(http_server_requests_seconds_count{\n      camunda_region=~\"$region\",\n      cluster=~\"$cluster\",\n      container=~\"$container\",\n      namespace=~\"$namespace\",\n      pod=~\"$pod\",\n      uri=~\"$uri\",\n      uri!~\"^/actuator/health(/.*)?$|^/actuator/prometheus$|/v2/jobs/activation\"\n    }[$__rate_interval])\n  )\n",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{method}} {{uri}}",
+            "range": true,
+            "refId": "Latency (avg)"
+          }
+        ],
+        "title": "Average Latency REST",
+        "type": "timeseries"
+      }
+    }
+  },
   "__requires": [
     {
       "type": "panel",
@@ -10552,6 +10779,48 @@
         "x": 0,
         "y": 10
       },
+      "id": 668,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 669,
+          "libraryPanel": {
+            "name": "Request Rate REST",
+            "uid": "dep78ee16es5ce"
+          },
+          "title": "Request Rate REST"
+        },
+        {
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 670,
+          "libraryPanel": {
+            "name": "Average Latency REST",
+            "uid": "eep78ety54bggd"
+          },
+          "title": "Average Latency REST"
+        }
+      ],
+      "title": "REST",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
       "id": 162,
       "panels": [
         {
@@ -10893,7 +11162,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 76,
       "panels": [
@@ -12684,7 +12953,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 554,
       "panels": [
@@ -14097,7 +14366,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 355,
       "panels": [
@@ -15550,7 +15819,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 140,
       "panels": [
@@ -17307,7 +17576,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 671,
       "panels": [
@@ -18348,7 +18617,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 50,
       "panels": [
@@ -18823,7 +19092,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 615,
       "panels": [
@@ -20059,7 +20328,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "id": 629,
       "panels": [
@@ -20588,7 +20857,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 20
       },
       "id": 176,
       "panels": [
@@ -20840,7 +21109,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 21
       },
       "id": 315,
       "panels": [
@@ -21502,7 +21771,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 22
       },
       "id": 434,
       "panels": [
@@ -22097,7 +22366,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 23
       },
       "id": 545,
       "panels": [
@@ -22292,7 +22561,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 24
       },
       "id": 565,
       "panels": [
@@ -22611,7 +22880,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "id": 569,
       "panels": [
@@ -22919,7 +23188,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 572,
       "panels": [
@@ -23486,7 +23755,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 576,
       "panels": [
@@ -23903,7 +24172,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 28
       },
       "id": 581,
       "panels": [
@@ -24192,7 +24461,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 29
       },
       "id": 595,
       "panels": [
@@ -24592,7 +24861,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 30
       },
       "id": 665,
       "panels": [
@@ -24996,7 +25265,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 662,
       "panels": [
@@ -25235,6 +25504,86 @@
         ],
         "query": "committed, reserved",
         "type": "custom"
+      },
+      {
+        "hide": 2,
+        "label": "container",
+        "name": "container",
+        "query": "${VAR_CONTAINER}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_CONTAINER}",
+          "text": "${VAR_CONTAINER}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_CONTAINER}",
+            "text": "${VAR_CONTAINER}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "label": "region",
+        "name": "region",
+        "query": "${VAR_REGION}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_REGION}",
+          "text": "${VAR_REGION}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_REGION}",
+            "text": "${VAR_REGION}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "label": "uri",
+        "name": "uri",
+        "query": "${VAR_URI}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_URI}",
+          "text": "${VAR_URI}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_URI}",
+            "text": "${VAR_URI}",
+            "selected": false
+          }
+        ]
+      },
+      {
+        "hide": 2,
+        "label": "grpc_method",
+        "name": "grpc_method",
+        "query": "${VAR_GRPC_METHOD}",
+        "skipUrlSync": true,
+        "type": "constant",
+        "current": {
+          "value": "${VAR_GRPC_METHOD}",
+          "text": "${VAR_GRPC_METHOD}",
+          "selected": false
+        },
+        "options": [
+          {
+            "value": "${VAR_GRPC_METHOD}",
+            "text": "${VAR_GRPC_METHOD}",
+            "selected": false
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Description

We've recently built API panels in Grafana to [improve observability in Camunda](https://camunda.slack.com/archives/C01H4NG9XDY/p1749815687038819). This is the first version of the Core Features Overview with REST and gRPC panels integrated. I've exported the dashboard as JSON with `__inputs` and `__elements` (this is where library panels are stored and reusable) following the [contribution guide](https://github.com/camunda/camunda/tree/main/monitor#grafana). The rows object contain id references to lib panels.

These panels were defined so they could be [re-used in Zeebe](https://github.com/camunda/camunda/issues/17442), I've included the update in the same PR

There are a lot of improvement ideas from engineers feedback which will be tackled in [these sub-issues](https://github.com/camunda/camunda/issues/31230?issue=camunda%7Ccamunda%7C31664)

## Related issues

related to #31664
closes #17442