### PR TITLE
When scaling, ensure follower receive the initial snapshot for bootstrap

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -79,7 +79,11 @@ public class ScaleUpPartitionsTest {
     scaleToPartitions(desiredPartitionCount);
     awaitScaleUpCompletion(desiredPartitionCount);
 
-    createInstanceWithAJobOnAllPartitions(camundaClient, JOB_TYPE, desiredPartitionCount, false);
+    for (int i = 0; i < 20; i++) {
+      createInstanceWithAJobOnAllPartitions(camundaClient, JOB_TYPE, desiredPartitionCount, false);
+    }
+
+    cluster.awaitHealthyTopology();
   }
 
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -111,16 +111,8 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   public void start() {
-    initializeFromFileSystem();
+    setLatestSnapshot(loadLatestSnapshot(snapshotsDirectory));
     purgePendingSnapshotsDirectory();
-  }
-
-  private void initializeFromFileSystem() {
-    final FileBasedSnapshot latestSnapshot = loadLatestSnapshot(snapshotsDirectory);
-    currentPersistedSnapshotRef.set(latestSnapshot);
-    if (latestSnapshot != null) {
-      availableSnapshots.add(latestSnapshot);
-    }
   }
 
   public void close() {
@@ -258,6 +250,13 @@ public final class FileBasedSnapshotStoreImpl {
 
   public Optional<PersistedSnapshot> getLatestSnapshot() {
     return Optional.ofNullable(currentPersistedSnapshotRef.get());
+  }
+
+  private void setLatestSnapshot(final FileBasedSnapshot snapshot) {
+    currentPersistedSnapshotRef.set(snapshot);
+    if (snapshot != null) {
+      availableSnapshots.add(snapshot);
+    }
   }
 
   public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
@@ -705,7 +704,7 @@ public final class FileBasedSnapshotStoreImpl {
       throw new CorruptedSnapshotException(
           "Failed to open restored snapshot in %s".formatted(snapshotPath));
     }
-    initializeFromFileSystem();
+    setLatestSnapshot(snapshot);
   }
 
   public ActorFuture<Void> restore(final PersistedSnapshot snapshot) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -743,7 +743,7 @@ public final class FileBasedSnapshotStoreImpl {
   public ActorFuture<PersistedSnapshot> copyForBootstrap(
       final PersistedSnapshot persistedSnapshot, final BiConsumer<Path, Path> copySnapshot) {
     final var snapshotPath = persistedSnapshot.getPath();
-    final var zeroedSnapshotId = new FileBasedSnapshotId(0, 0, 0, 0, brokerId);
+    final var zeroedSnapshotId = new FileBasedSnapshotId(1, 1, 0, 0, brokerId);
 
     final var destinationFolder = buildSnapshotDirectory(zeroedSnapshotId, true);
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -111,12 +111,16 @@ public final class FileBasedSnapshotStoreImpl {
   }
 
   public void start() {
+    initializeFromFileSystem();
+    purgePendingSnapshotsDirectory();
+  }
+
+  private void initializeFromFileSystem() {
     final FileBasedSnapshot latestSnapshot = loadLatestSnapshot(snapshotsDirectory);
     currentPersistedSnapshotRef.set(latestSnapshot);
     if (latestSnapshot != null) {
       availableSnapshots.add(latestSnapshot);
     }
-    purgePendingSnapshotsDirectory();
   }
 
   public void close() {
@@ -701,6 +705,7 @@ public final class FileBasedSnapshotStoreImpl {
       throw new CorruptedSnapshotException(
           "Failed to open restored snapshot in %s".formatted(snapshotPath));
     }
+    initializeFromFileSystem();
   }
 
   public ActorFuture<Void> restore(final PersistedSnapshot snapshot) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -449,6 +449,8 @@ public class FileBasedSnapshotStoreTest {
     final var copiedSnapshot =
         snapshotStore.copyForBootstrap(persistedSnapshot, SnapshotCopyUtil::copyAllFiles).join();
 
+    snapshotStore.delete().join();
+
     final var files = copiedSnapshot.files();
     snapshotStore.restore(copiedSnapshot.getId(), files);
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -427,8 +427,8 @@ public class FileBasedSnapshotStoreTest {
     assertThat(copiedSnapshot)
         .satisfies(
             s -> {
-              assertThat(s.getId()).isEqualTo("0-0-0-0-0");
-              assertThat(s.getPath().getFileName().toString()).isEqualTo("0-0-0-0-0");
+              assertThat(s.getId()).isEqualTo("1-1-0-0-0");
+              assertThat(s.getPath().getFileName().toString()).isEqualTo("1-1-0-0-0");
               assertThat(s.getMetadata())
                   .isEqualTo(
                       FileBasedSnapshotMetadata.forBootstrap(FileBasedSnapshotStoreImpl.VERSION));
@@ -464,7 +464,7 @@ public class FileBasedSnapshotStoreTest {
         .satisfies(s -> assertThat(s.get().getId()).isEqualTo(copiedSnapshot.getId()));
 
     assertThat(rootDirectory.resolve("snapshots"))
-        .isDirectoryContaining(p -> p.getFileName().startsWith("0-0-0-0-0"));
+        .isDirectoryContaining(p -> p.getFileName().startsWith("1-1-0-0-0"));
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -104,7 +104,7 @@ public class SnapshotTransferTest {
         .succeedsWithin(Duration.ofSeconds(30))
         .satisfies(
             snapshot -> {
-              assertThat(snapshot.getId()).isEqualTo("0-0-0-0-0");
+              assertThat(snapshot.getId()).isEqualTo("1-1-0-0-0");
               assertThat(snapshot.getMetadata())
                   .isEqualTo(FileBasedSnapshotMetadata.forBootstrap(1));
               assertThat(snapshot.isBootstrap()).isTrue();


### PR DESCRIPTION
## Description
When the snapshot was restored, it was not added to the available snapshot & latest snapshot variables.
As a result, the leader would not try to replicate the snapshot as it didn't know it had one.

Moreover, the snapshot index is initialized for all followers to be equal to 0, which was the index of the snapshot for bootstrap. The simple solution is to make the log for the new partition start at index 1, as if all the state in the snapshot was sent as a single entry, which has been already compacted.

Similar, the term of the snapshot cannot be zero, so it has been initialized to 1. 

## Related issues

closes #33889
