### PR TITLE
feat: streamline API search DTO names

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/GroupFilterImpl.java
@@ -17,15 +17,15 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.GroupFilter;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.GroupFilterRequest;
 
-public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFilterRequest>
+public class GroupFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.GroupFilter>
     implements GroupFilter {
 
-  private final GroupFilterRequest filter;
+  private final io.camunda.client.protocol.rest.GroupFilter filter;
 
   public GroupFilterImpl() {
-    filter = new GroupFilterRequest();
+    filter = new io.camunda.client.protocol.rest.GroupFilter();
   }
 
   @Override
@@ -41,7 +41,7 @@ public class GroupFilterImpl extends TypedSearchRequestPropertyProvider<GroupFil
   }
 
   @Override
-  protected GroupFilterRequest getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.GroupFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MappingFilterImpl.java
@@ -17,15 +17,15 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.MappingFilter;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.MappingFilterRequest;
 
-public class MappingFilterImpl extends TypedSearchRequestPropertyProvider<MappingFilterRequest>
+public class MappingFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.MappingFilter>
     implements MappingFilter {
 
-  private final MappingFilterRequest filter;
+  private final io.camunda.client.protocol.rest.MappingFilter filter;
 
   public MappingFilterImpl() {
-    filter = new MappingFilterRequest();
+    filter = new io.camunda.client.protocol.rest.MappingFilter();
   }
 
   @Override
@@ -53,7 +53,7 @@ public class MappingFilterImpl extends TypedSearchRequestPropertyProvider<Mappin
   }
 
   @Override
-  protected MappingFilterRequest getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.MappingFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -228,14 +228,14 @@ public class ProcessInstanceFilterImpl
   @Override
   public ProcessInstanceFilter variables(
       final List<Consumer<VariableValueFilter>> variableFilters) {
-    filter.setVariables(VariableFilterMapper.toVariableValueFilterRequest(variableFilters));
+    filter.setVariables(VariableFilterMapper.toVariableValueFilterProperty(variableFilters));
     return this;
   }
 
   @Override
   public ProcessInstanceFilter variables(final Map<String, Object> variableValueFilters) {
     if (variableValueFilters != null && !variableValueFilters.isEmpty()) {
-      filter.setVariables(VariableFilterMapper.toVariableValueFilterRequest(variableValueFilters));
+      filter.setVariables(VariableFilterMapper.toVariableValueFilterProperty(variableValueFilters));
     }
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/RoleFilterImpl.java
@@ -17,15 +17,15 @@ package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.RoleFilter;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.RoleFilterRequest;
 
-public class RoleFilterImpl extends TypedSearchRequestPropertyProvider<RoleFilterRequest>
+public class RoleFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.RoleFilter>
     implements RoleFilter {
 
-  private final RoleFilterRequest filter;
+  private final io.camunda.client.protocol.rest.RoleFilter filter;
 
   public RoleFilterImpl() {
-    filter = new RoleFilterRequest();
+    filter = new io.camunda.client.protocol.rest.RoleFilter();
   }
 
   @Override
@@ -41,7 +41,7 @@ public class RoleFilterImpl extends TypedSearchRequestPropertyProvider<RoleFilte
   }
 
   @Override
-  protected RoleFilterRequest getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.RoleFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserFilterImpl.java
@@ -19,16 +19,16 @@ import io.camunda.client.api.search.filter.UserFilter;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.UserFilterRequest;
 import java.util.function.Consumer;
 
-public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilterRequest>
+public class UserFilterImpl
+    extends TypedSearchRequestPropertyProvider<io.camunda.client.protocol.rest.UserFilter>
     implements UserFilter {
 
-  private final UserFilterRequest filter;
+  private final io.camunda.client.protocol.rest.UserFilter filter;
 
   public UserFilterImpl() {
-    filter = new UserFilterRequest();
+    filter = new io.camunda.client.protocol.rest.UserFilter();
   }
 
   @Override
@@ -71,7 +71,7 @@ public class UserFilterImpl extends TypedSearchRequestPropertyProvider<UserFilte
   }
 
   @Override
-  protected UserFilterRequest getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.UserFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -146,7 +146,7 @@ public class UserTaskFilterImpl
       final List<Consumer<VariableValueFilter>> variableFilters) {
 
     filter.setProcessInstanceVariables(
-        VariableFilterMapper.toVariableValueFilterRequest(variableFilters));
+        VariableFilterMapper.toVariableValueFilterProperty(variableFilters));
     return this;
   }
 
@@ -154,14 +154,14 @@ public class UserTaskFilterImpl
   public UserTaskFilter processInstanceVariables(final Map<String, Object> variableValueFilters) {
     if (variableValueFilters != null && !variableValueFilters.isEmpty()) {
       filter.setProcessInstanceVariables(
-          VariableFilterMapper.toVariableValueFilterRequest(variableValueFilters));
+          VariableFilterMapper.toVariableValueFilterProperty(variableValueFilters));
     }
     return this;
   }
 
   @Override
   public UserTaskFilter localVariables(final List<Consumer<VariableValueFilter>> variableFilters) {
-    filter.setLocalVariables(VariableFilterMapper.toVariableValueFilterRequest(variableFilters));
+    filter.setLocalVariables(VariableFilterMapper.toVariableValueFilterProperty(variableFilters));
     return this;
   }
 
@@ -169,7 +169,7 @@ public class UserTaskFilterImpl
   public UserTaskFilter localVariables(final Map<String, Object> variableValueFilters) {
     if (variableValueFilters != null && !variableValueFilters.isEmpty()) {
       filter.setLocalVariables(
-          VariableFilterMapper.toVariableValueFilterRequest(variableValueFilters));
+          VariableFilterMapper.toVariableValueFilterProperty(variableValueFilters));
     }
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskVariableFilterImpl.java
@@ -19,17 +19,17 @@ import io.camunda.client.api.search.filter.UserTaskVariableFilter;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.UserTaskVariableFilterRequest;
 import java.util.function.Consumer;
 
 public class UserTaskVariableFilterImpl
-    extends TypedSearchRequestPropertyProvider<UserTaskVariableFilterRequest>
+    extends TypedSearchRequestPropertyProvider<
+        io.camunda.client.protocol.rest.UserTaskVariableFilter>
     implements UserTaskVariableFilter {
 
-  private final UserTaskVariableFilterRequest filter;
+  private final io.camunda.client.protocol.rest.UserTaskVariableFilter filter;
 
   public UserTaskVariableFilterImpl() {
-    filter = new UserTaskVariableFilterRequest();
+    filter = new io.camunda.client.protocol.rest.UserTaskVariableFilter();
   }
 
   @Override
@@ -47,7 +47,7 @@ public class UserTaskVariableFilterImpl
   }
 
   @Override
-  protected UserTaskVariableFilterRequest getSearchRequestProperty() {
+  protected io.camunda.client.protocol.rest.UserTaskVariableFilter getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableFilterMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableFilterMapper.java
@@ -28,23 +28,23 @@ import java.util.stream.Stream;
 
 public class VariableFilterMapper {
 
-  public static List<VariableValueFilterRequest> toVariableValueFilterRequest(
+  public static List<VariableValueFilterProperty> toVariableValueFilterProperty(
       final List<Consumer<VariableValueFilter>> variableValueFilters) {
-    return toVariableValueFilterRequest(
+    return toVariableValueFilterProperty(
         variableValueFilters.stream()
             .map(SearchRequestBuilders::variableValueFilter)
             .map(
                 TypedSearchRequestPropertyProvider
-                    ::<VariableValueFilterRequest>provideSearchRequestProperty));
+                    ::<VariableValueFilterProperty>provideSearchRequestProperty));
   }
 
-  public static List<VariableValueFilterRequest> toVariableValueFilterRequest(
+  public static List<VariableValueFilterProperty> toVariableValueFilterProperty(
       final Map<String, Object> variableValueFilters) {
-    return toVariableValueFilterRequest(
+    return toVariableValueFilterProperty(
         variableValueFilters.entrySet().stream()
             .map(
                 entry ->
-                    new VariableValueFilterRequest()
+                    new VariableValueFilterProperty()
                         .name(entry.getKey())
                         .value(
                             entry.getValue() == null
@@ -52,10 +52,10 @@ public class VariableFilterMapper {
                                 : new StringFilterProperty().$eq(entry.getValue().toString()))));
   }
 
-  static List<VariableValueFilterRequest> toVariableValueFilterRequest(
-      final Stream<VariableValueFilterRequest> filterStream) {
+  static List<VariableValueFilterProperty> toVariableValueFilterProperty(
+      final Stream<VariableValueFilterProperty> filterStream) {
     final List<String> violations = new ArrayList<>();
-    final List<VariableValueFilterRequest> filters =
+    final List<VariableValueFilterProperty> filters =
         filterStream
             .map(filter -> checkVariableValueNotNull(filter, violations))
             .collect(Collectors.toList());
@@ -66,8 +66,8 @@ public class VariableFilterMapper {
     return filters;
   }
 
-  static VariableValueFilterRequest checkVariableValueNotNull(
-      final VariableValueFilterRequest filter, final List<String> violations) {
+  static VariableValueFilterProperty checkVariableValueNotNull(
+      final VariableValueFilterProperty filter, final List<String> violations) {
     if (filter.getValue() == null || filter.getValue().equals(new StringFilterProperty())) {
       violations.add("Variable value cannot be null for variable '" + filter.getName() + "'");
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableValueFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableValueFilterImpl.java
@@ -19,17 +19,17 @@ import io.camunda.client.api.search.filter.VariableValueFilter;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
-import io.camunda.client.protocol.rest.VariableValueFilterRequest;
+import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import java.util.function.Consumer;
 
 public class VariableValueFilterImpl
-    extends TypedSearchRequestPropertyProvider<VariableValueFilterRequest>
+    extends TypedSearchRequestPropertyProvider<VariableValueFilterProperty>
     implements VariableValueFilter {
 
-  private final VariableValueFilterRequest filter;
+  private final VariableValueFilterProperty filter;
 
   public VariableValueFilterImpl() {
-    filter = new VariableValueFilterRequest();
+    filter = new VariableValueFilterProperty();
   }
 
   @Override
@@ -53,7 +53,7 @@ public class VariableValueFilterImpl
   }
 
   @Override
-  protected VariableValueFilterRequest getSearchRequestProperty() {
+  protected VariableValueFilterProperty getSearchRequestProperty() {
     return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/filter/ProcessDefinitionStatisticsFilterImpl.java
@@ -161,7 +161,7 @@ public class ProcessDefinitionStatisticsFilterImpl
   @Override
   public ProcessDefinitionStatisticsFilter variables(
       final List<Consumer<VariableValueFilter>> variableValueFilters) {
-    filter.setVariables(VariableFilterMapper.toVariableValueFilterRequest(variableValueFilters));
+    filter.setVariables(VariableFilterMapper.toVariableValueFilterProperty(variableValueFilters));
     return this;
   }
 
@@ -169,7 +169,7 @@ public class ProcessDefinitionStatisticsFilterImpl
   public ProcessDefinitionStatisticsFilter variables(
       final Map<String, Object> variableValueFilters) {
     if (variableValueFilters != null && !variableValueFilters.isEmpty()) {
-      filter.setVariables(VariableFilterMapper.toVariableValueFilterRequest(variableValueFilters));
+      filter.setVariables(VariableFilterMapper.toVariableValueFilterProperty(variableValueFilters));
     }
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.client.api.search.filter;
 
-import io.camunda.client.protocol.rest.VariableValueFilterRequest;
+import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
@@ -65,7 +65,7 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
   ProcessInstanceFilter processDefinitionVersion(final Integer processDefinitionVersion);
 
   /** Filter by variable */
-  ProcessInstanceFilter variable(final VariableValueFilterRequest variable);
+  ProcessInstanceFilter variable(final VariableValueFilterProperty variable);
 
   /** Filter by batchOperationId */
   ProcessInstanceFilter batchOperationId(final String batchOperationId);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.client.api.search.filter;
 
-import io.camunda.client.protocol.rest.UserTaskVariableFilterRequest;
+import io.camunda.client.protocol.rest.UserTaskVariableFilter;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 import java.util.List;
 
@@ -112,5 +112,5 @@ public interface UserTaskFilter extends SearchRequestFilter {
    * @param variableValueFilters from the task
    * @return the updated filter
    */
-  UserTaskFilter variables(final List<UserTaskVariableFilterRequest> variableValueFilters);
+  UserTaskFilter variables(final List<UserTaskVariableFilter> variableValueFilters);
 }

--- a/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ProcessDefinitionStatisticsTest.java
@@ -30,7 +30,7 @@ import io.camunda.client.protocol.rest.ProcessDefinitionStatisticsFilter;
 import io.camunda.client.protocol.rest.ProcessInstanceStateEnum;
 import io.camunda.client.protocol.rest.ProcessInstanceStateFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
-import io.camunda.client.protocol.rest.VariableValueFilterRequest;
+import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -65,10 +65,12 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
-    final List<VariableValueFilterRequest> variables =
+    final List<VariableValueFilterProperty> variables =
         Arrays.asList(
-            new VariableValueFilterRequest().name("n1").value(new StringFilterProperty().$eq("v1")),
-            new VariableValueFilterRequest()
+            new VariableValueFilterProperty()
+                .name("n1")
+                .value(new StringFilterProperty().$eq("v1")),
+            new VariableValueFilterProperty()
                 .name("n2")
                 .value(new StringFilterProperty().$eq("v2")));
     client
@@ -183,10 +185,12 @@ public class ProcessDefinitionStatisticsTest extends ClientRestTest {
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
-    final List<VariableValueFilterRequest> variables =
+    final List<VariableValueFilterProperty> variables =
         Arrays.asList(
-            new VariableValueFilterRequest().name("n1").value(new StringFilterProperty().$eq("v1")),
-            new VariableValueFilterRequest()
+            new VariableValueFilterProperty()
+                .name("n1")
+                .value(new StringFilterProperty().$eq("v1")),
+            new VariableValueFilterProperty()
                 .name("n2")
                 .value(new StringFilterProperty().$eq("v2")));
 

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -66,10 +66,12 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
-    final List<VariableValueFilterRequest> variables =
+    final List<VariableValueFilterProperty> variables =
         Arrays.asList(
-            new VariableValueFilterRequest().name("n1").value(new StringFilterProperty().$eq("v1")),
-            new VariableValueFilterRequest()
+            new VariableValueFilterProperty()
+                .name("n1")
+                .value(new StringFilterProperty().$eq("v1")),
+            new VariableValueFilterProperty()
                 .name("n2")
                 .value(new StringFilterProperty().$eq("v2")));
     client
@@ -208,10 +210,12 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     final Map<String, Object> variablesMap = new LinkedHashMap<>();
     variablesMap.put("n1", "v1");
     variablesMap.put("n2", "v2");
-    final List<VariableValueFilterRequest> variables =
+    final List<VariableValueFilterProperty> variables =
         Arrays.asList(
-            new VariableValueFilterRequest().name("n1").value(new StringFilterProperty().$eq("v1")),
-            new VariableValueFilterRequest()
+            new VariableValueFilterProperty()
+                .name("n1")
+                .value(new StringFilterProperty().$eq("v1")),
+            new VariableValueFilterProperty()
                 .name("n2")
                 .value(new StringFilterProperty().$eq("v2")));
 

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -24,7 +24,7 @@ import io.camunda.client.protocol.rest.IntegerFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import io.camunda.client.protocol.rest.UserTaskFilter;
 import io.camunda.client.protocol.rest.UserTaskSearchQuery;
-import io.camunda.client.protocol.rest.VariableValueFilterRequest;
+import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.client.util.ClientRestTest;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -171,11 +171,13 @@ public final class SearchUserTaskTest extends ClientRestTest {
   @Test
   void shouldSearchUserTaskByProcessInstanceVariable() {
     // when
-    final VariableValueFilterRequest userTaskVariableFilterRequest =
-        new VariableValueFilterRequest().name("test").value(new StringFilterProperty().$eq("test"));
-    final ArrayList<VariableValueFilterRequest> listFilter = new ArrayList<>();
+    final VariableValueFilterProperty userTaskVariableFilterProperty =
+        new VariableValueFilterProperty()
+            .name("test")
+            .value(new StringFilterProperty().$eq("test"));
+    final ArrayList<VariableValueFilterProperty> listFilter = new ArrayList<>();
 
-    listFilter.add(userTaskVariableFilterRequest);
+    listFilter.add(userTaskVariableFilterProperty);
 
     client
         .newUserTaskSearchRequest()
@@ -191,11 +193,13 @@ public final class SearchUserTaskTest extends ClientRestTest {
   @Test
   void shouldSearchUserTaskByLocalVariable() {
     // when
-    final VariableValueFilterRequest userTaskVariableFilterRequest =
-        new VariableValueFilterRequest().name("test").value(new StringFilterProperty().$eq("test"));
-    final ArrayList<VariableValueFilterRequest> listFilter = new ArrayList<>();
+    final VariableValueFilterProperty userTaskVariableFilterProperty =
+        new VariableValueFilterProperty()
+            .name("test")
+            .value(new StringFilterProperty().$eq("test"));
+    final ArrayList<VariableValueFilterProperty> listFilter = new ArrayList<>();
 
-    listFilter.add(userTaskVariableFilterRequest);
+    listFilter.add(userTaskVariableFilterProperty);
 
     client
         .newUserTaskSearchRequest()

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5306,9 +5306,9 @@ components:
         filter:
           description: The tenant search filters.
           allOf:
-            - $ref: "#/components/schemas/TenantFilterRequest"
+            - $ref: "#/components/schemas/TenantFilter"
 
-    TenantFilterRequest:
+    TenantFilter:
       description: Tenant filter request
       type: object
       properties:
@@ -5392,7 +5392,7 @@ components:
         filter:
           description: The user task variable search filters.
           allOf:
-            - $ref: "#/components/schemas/UserTaskVariableFilterRequest"
+            - $ref: "#/components/schemas/UserTaskVariableFilter"
     UserTaskSearchQueryResult:
       description: User task search query response.
       type: object
@@ -5461,12 +5461,12 @@ components:
           type: array
           description: Process instance variables associated with the user task.
           items:
-            $ref: "#/components/schemas/VariableValueFilterRequest"
+            $ref: "#/components/schemas/VariableValueFilterProperty"
         localVariables:
           type: array
           description: Local variables associated with the user task.
           items:
-            $ref: "#/components/schemas/VariableValueFilterRequest"
+            $ref: "#/components/schemas/VariableValueFilterProperty"
         userTaskKey:
           type: string
           description: The key for this user task.
@@ -5479,7 +5479,7 @@ components:
         elementInstanceKey:
           type: string
           description: The key of the element instance.
-    VariableValueFilterRequest:
+    VariableValueFilterProperty:
       type: object
       properties:
         name:
@@ -5492,7 +5492,7 @@ components:
       required:
         - name
         - value
-    UserTaskVariableFilterRequest:
+    UserTaskVariableFilter:
       description: The user task variable search filters.
       type: object
       properties:
@@ -6103,7 +6103,7 @@ components:
           description: The process instance variables.
           type: array
           items:
-            $ref: "#/components/schemas/VariableValueFilterRequest"
+            $ref: "#/components/schemas/VariableValueFilterProperty"
         processInstanceKey:
           description: The key of this process instance.
           allOf:
@@ -7229,7 +7229,7 @@ components:
         filter:
           description: The user search filters.
           allOf:
-            - $ref: "#/components/schemas/UserFilterRequest"
+            - $ref: "#/components/schemas/UserFilter"
     MappingSearchQuerySortRequest:
       type: object
       properties:
@@ -7258,8 +7258,8 @@ components:
         filter:
           description: The mapping search filters.
           allOf:
-            - $ref: "#/components/schemas/MappingFilterRequest"
-    UserFilterRequest:
+            - $ref: "#/components/schemas/MappingFilter"
+    UserFilter:
       description: User search filter.
       type: object
       properties:
@@ -7275,7 +7275,7 @@ components:
           description: The email of the user.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
-    MappingFilterRequest:
+    MappingFilter:
       description: Mapping search filter.
       type: object
       properties:
@@ -7555,8 +7555,8 @@ components:
         filter:
           description: The role search filters.
           allOf:
-            - $ref: "#/components/schemas/RoleFilterRequest"
-    RoleFilterRequest:
+            - $ref: "#/components/schemas/RoleFilter"
+    RoleFilter:
       description: Role filter request
       type: object
       properties:
@@ -7744,8 +7744,8 @@ components:
         filter:
           description: The group search filters.
           allOf:
-            - $ref: "#/components/schemas/GroupFilterRequest"
-    GroupFilterRequest:
+            - $ref: "#/components/schemas/GroupFilter"
+    GroupFilter:
       description: Group filter request
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -18,19 +18,29 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
-import io.camunda.search.filter.*;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.BatchOperationFilter;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.DecisionRequirementsFilter;
+import io.camunda.search.filter.FilterBase;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.MappingFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter.Builder;
+import io.camunda.search.filter.RoleFilter;
+import io.camunda.search.filter.TenantFilter;
+import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
+import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -570,8 +580,7 @@ public final class SearchQueryRequestMapper {
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
   }
 
-  private static VariableFilter toUserTaskVariableFilter(
-      final UserTaskVariableFilterRequest filter) {
+  private static VariableFilter toUserTaskVariableFilter(final UserTaskVariableFilter filter) {
     if (filter == null) {
       return FilterBuilders.variable().build();
     }
@@ -905,7 +914,8 @@ public final class SearchQueryRequestMapper {
     return validationErrors.isEmpty() ? Either.right(builder) : Either.left(validationErrors);
   }
 
-  private static TenantFilter toTenantFilter(final TenantFilterRequest filter) {
+  private static TenantFilter toTenantFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.TenantFilter filter) {
     final var builder = FilterBuilders.tenant();
     if (filter != null) {
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantId);
@@ -914,7 +924,8 @@ public final class SearchQueryRequestMapper {
     return builder.build();
   }
 
-  private static GroupFilter toGroupFilter(final GroupFilterRequest filter) {
+  private static GroupFilter toGroupFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.GroupFilter filter) {
     final var builder = FilterBuilders.group();
     if (filter != null) {
       ofNullable(filter.getGroupId()).ifPresent(builder::groupId);
@@ -923,7 +934,8 @@ public final class SearchQueryRequestMapper {
     return builder.build();
   }
 
-  private static RoleFilter toRoleFilter(final RoleFilterRequest filter) {
+  private static RoleFilter toRoleFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.RoleFilter filter) {
     final var builder = FilterBuilders.role();
     if (filter != null) {
       ofNullable(filter.getRoleId()).ifPresent(builder::roleId);
@@ -932,7 +944,8 @@ public final class SearchQueryRequestMapper {
     return builder.build();
   }
 
-  private static MappingFilter toMappingFilter(final MappingFilterRequest filter) {
+  private static MappingFilter toMappingFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.MappingFilter filter) {
     final var builder = FilterBuilders.mapping();
     if (filter != null) {
       ofNullable(filter.getClaimName()).ifPresent(builder::claimName);
@@ -1091,7 +1104,8 @@ public final class SearchQueryRequestMapper {
         : Either.left(validationErrors);
   }
 
-  private static UserFilter toUserFilter(final UserFilterRequest filter) {
+  private static UserFilter toUserFilter(
+      final io.camunda.zeebe.gateway.protocol.rest.UserFilter filter) {
 
     final var builder = FilterBuilders.user();
     if (filter != null) {
@@ -1478,7 +1492,7 @@ public final class SearchQueryRequestMapper {
   }
 
   private static Either<List<String>, List<VariableValueFilter>> toVariableValueFilters(
-      final List<VariableValueFilterRequest> filters) {
+      final List<VariableValueFilterProperty> filters) {
     if (CollectionUtils.isEmpty(filters)) {
       return Either.right(List.of());
     }


### PR DESCRIPTION
## Description

Streamline names of search API DTOs to drop `Request` suffix

## Breaking changes

* The following API DTOs used in experimental API in the deprecated `ZeebeClient` have changed
  * `UserTaskVariableFilterRequest` used in `UserTaskFilter`'s `variables` method, now named `UserTaskVariableFilter`
  * `VariableValueFilterRequest` used in `ProcessInstanceFilter`'s `variable` method, now named `VariableValueFilterProperty`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33912 
