### PR TITLE
Fix/reduce rdbms logging

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -34,7 +34,9 @@ public class DefaultExecutionQueue implements ExecutionQueue {
           "io.camunda.db.rdbms.sql.UserTaskMapper.deleteCandidateGroups",
           "io.camunda.db.rdbms.sql.IncidentMapper.updateHistoryCleanupDate",
           "io.camunda.db.rdbms.sql.DecisionInstanceMapper.updateHistoryCleanupDate",
-          "io.camunda.db.rdbms.sql.VariableMapper.updateHistoryCleanupDate");
+          "io.camunda.db.rdbms.sql.VariableMapper.updateHistoryCleanupDate",
+          "io.camunda.db.rdbms.sql.JobMapper.updateHistoryCleanupDate",
+          "io.camunda.db.rdbms.sql.SequenceFlowMapper.createIfNotExists");
 
   private final SqlSessionFactory sessionFactory;
   private final List<PreFlushListener> preFlushListeners = new ArrayList<>();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -72,7 +72,7 @@ public class HistoryCleanupService {
       final Long processInstanceKey, final OffsetDateTime endDate) {
     final OffsetDateTime historyCleanupDate = endDate.plus(defaultHistoryTTL);
 
-    LOG.debug(
+    LOG.trace(
         "Scheduling process instance cleanup for key {} at {}",
         processInstanceKey,
         historyCleanupDate);
@@ -87,7 +87,7 @@ public class HistoryCleanupService {
   }
 
   public Duration cleanupHistory(final int partitionId, final OffsetDateTime cleanupDate) {
-    LOG.debug("Cleanup history for partition {} with TTL before {}", partitionId, cleanupDate);
+    LOG.trace("Cleanup history for partition {} with TTL before {}", partitionId, cleanupDate);
 
     final var sample = metrics.measureHistoryCleanupDuration();
     final long start = System.currentTimeMillis();
@@ -124,7 +124,7 @@ public class HistoryCleanupService {
       LOG.debug("    Deleted {}s: {}", entry.getKey(), entry.getValue());
     }
 
-    LOG.info(
+    LOG.debug(
         "Cleanup history for partition {} with TTL before {} took {} ms. Deleted {} records",
         partitionId,
         cleanupDate,
@@ -133,7 +133,7 @@ public class HistoryCleanupService {
 
     final var nextDuration =
         calculateNewDuration(lastCleanupInterval.get(partitionId), numDeletedRecords);
-    LOG.debug("Schedule next cleanup for partition {} with TTL in {}", partitionId, nextDuration);
+    LOG.trace("Schedule next cleanup for partition {} with TTL in {}", partitionId, nextDuration);
 
     saveLastCleanupInterval(partitionId, nextDuration);
     return nextDuration;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -116,7 +116,7 @@ public class RdbmsExporter {
     if (registeredHandlers.containsKey(record.getValueType())) {
       for (final var handler : registeredHandlers.get(record.getValueType())) {
         if (handler.canExport(record)) {
-          LOG.debug(
+          LOG.trace(
               "[RDBMS Exporter] Exporting record {} with handler {}",
               record.getValue(),
               handler.getClass());


### PR DESCRIPTION
## Description

Reduce logging in RDBMS down to debug/trace.

Also ignore, that the following statements may not have changed any rows in DB:
- JobMapper.updateHistoryCleanupDate
- SequenceFlowMapper.createIfNotExists
