### PR TITLE
Bump postgresql version to address CVE-2025-49146

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -136,7 +136,7 @@
     <version.checker-qual>3.47.0</version.checker-qual>
     <version.java-jwt>4.4.0</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>
-    <version.postgresql>42.7.4</version.postgresql>
+    <version.postgresql>42.7.7</version.postgresql>
     <version.h2>2.3.232</version.h2>
     <version.aws-signing>2.3.1</version.aws-signing>
     <version.reactor-netty>1.1.22</version.reactor-netty>


### PR DESCRIPTION
## Description

This was raised to address https://cve-registry.infosec.camunda-it.rocks/finding/7229

I don't think Optmize is actually affected by this vulnerability (related to Postgres JDBC drivers) but the fix was easy so I thought I'd go for it.

Similar PRs were raised for other branches by renovate, see https://github.com/camunda/camunda/pulls?q=CVE-2025-49146+author%3Aapp%2Frenovate
