### PR TITLE
Pause command redistribution

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1383,6 +1383,11 @@
           # PS: The default value is 5m. Increasing it to a higher value would cause the engine to store more data thus require more disk space. Increasing it above 15m is not recommended.
           # exportInterval: 5m
 
+        # distribution:
+          # Allows pausing command redistribution. The flag can be used to prevent the redistribution of commands when
+          # the broker is under heavy load.
+          # isCommandDistributionPaused: false
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1385,8 +1385,9 @@
 
         # distribution:
           # Allows pausing command redistribution. The flag can be used to prevent the redistribution of commands when
-          # the broker is under heavy load.
-          # isCommandDistributionPaused: false
+          # the broker is under heavy load. This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_DISTRIBUTION_PAUSECOMMANDDISTRIBUTION.
+          # The default value is false, meaning that command redistribution is not paused.
+          # pauseCommandDistribution: false
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1298,8 +1298,9 @@
 
         # distribution:
           # Allows pausing command redistribution. The flag can be used to prevent the redistribution of commands when
-          # the broker is under heavy load.
-          # isCommandDistributionPaused: false
+          # the broker is under heavy load.  This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_DISTRIBUTION_PAUSECOMMANDDISTRIBUTION.
+          # The default value is false, meaning that command redistribution is not paused.
+          # pauseCommandDistribution: false
 
         # Allows to configure the maximum depth of child process instances that can be created.
         # The root process instance is considered depth `1`, and each called instance is considered

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1296,6 +1296,11 @@
           # PS: The default value is 5m. Increasing it to a higher value would cause the engine to store more data thus require more disk space. Increasing it above 15m is not recommended.
           # exportInterval: 5m
 
+        # distribution:
+          # Allows pausing command redistribution. The flag can be used to prevent the redistribution of commands when
+          # the broker is under heavy load.
+          # isCommandDistributionPaused: false
+
         # Allows to configure the maximum depth of child process instances that can be created.
         # The root process instance is considered depth `1`, and each called instance is considered
         # to be one level deeper. If a call activity attempts to create a child process instance

--- a/docs/zeebe/generalized_distribution.md
+++ b/docs/zeebe/generalized_distribution.md
@@ -143,3 +143,13 @@ reached a maximum interval of 5 minutes.
 
 **Note** It is important to realise that this could result in a partition receiving a distribution
 more than once. This means the processor must always be idempotent!
+
+### Pausing redistribution
+
+In some cases we want to pause the redistribution of commands. This can be useful when a partition
+is under heavy load, and we want to prevent it from receiving more commands.
+
+To pause command redistribution we can set the `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_DISTRIBUTION_PAUSECOMMANDDISTRIBUTION`
+(i.e. `zeebe.broker.experimental.engine.distribution.pauseCommandDistribution`) flag to `true` and
+restart the brokers. This will prevent the `CommandRedistributor` from scheduling the retry cycle
+and allow an engineer to investigate any issues.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/DistributionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/DistributionCfg.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+
+public class DistributionCfg implements ConfigurationEntry {
+
+  private boolean isCommandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
+
+  public boolean isCommandDistributionPaused() {
+    return isCommandDistributionPaused;
+  }
+
+  public void setCommandDistributionPaused(final boolean commandDistributionPaused) {
+    isCommandDistributionPaused = commandDistributionPaused;
+  }
+
+  @Override
+  public String toString() {
+    return "DistributionCfg{" + "isCommandDistributionPaused=" + isCommandDistributionPaused + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/DistributionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/DistributionCfg.java
@@ -13,18 +13,18 @@ import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 
 public class DistributionCfg implements ConfigurationEntry {
 
-  private boolean isCommandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
+  private boolean pauseCommandDistribution = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
 
-  public boolean isCommandDistributionPaused() {
-    return isCommandDistributionPaused;
+  public boolean isPauseCommandDistribution() {
+    return pauseCommandDistribution;
   }
 
-  public void setCommandDistributionPaused(final boolean commandDistributionPaused) {
-    isCommandDistributionPaused = commandDistributionPaused;
+  public void setPauseCommandDistribution(final boolean pauseCommandDistribution) {
+    this.pauseCommandDistribution = pauseCommandDistribution;
   }
 
   @Override
   public String toString() {
-    return "DistributionCfg{" + "isCommandDistributionPaused=" + isCommandDistributionPaused + '}';
+    return "DistributionCfg{" + "pauseCommandDistribution=" + pauseCommandDistribution + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -135,7 +135,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setBatchOperationQueryPageSize(batchOperations.getQueryPageSize())
         .setBatchOperationQueryInClauseSize(batchOperations.getQueryInClauseSize())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
-        .setCommandDistributionPaused(distribution.isCommandDistributionPaused())
+        .setCommandDistributionPaused(distribution.isPauseCommandDistribution())
         .setMaxProcessDepth(getMaxProcessDepth());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -19,6 +19,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private ValidatorsCfg validators = new ValidatorsCfg();
   private BatchOperationCfg batchOperations = new BatchOperationCfg();
   private UsageMetricsCfg usageMetrics = new UsageMetricsCfg();
+  private DistributionCfg distribution = new DistributionCfg();
   private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
 
   @Override
@@ -28,6 +29,7 @@ public final class EngineCfg implements ConfigurationEntry {
     jobs.init(globalConfig, brokerBase);
     batchOperations.init(globalConfig, brokerBase);
     validators.init(globalConfig, brokerBase);
+    distribution.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -78,6 +80,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.usageMetrics = usageMetrics;
   }
 
+  public DistributionCfg getDistribution() {
+    return distribution;
+  }
+
+  public void setDistribution(final DistributionCfg distribution) {
+    this.distribution = distribution;
+  }
+
   public int getMaxProcessDepth() {
     return maxProcessDepth;
   }
@@ -99,6 +109,10 @@ public final class EngineCfg implements ConfigurationEntry {
         + validators
         + ", batchOperations="
         + batchOperations
+        + ", usageMetrics="
+        + usageMetrics
+        + ", distribution="
+        + distribution
         + ", maxProcessDepth="
         + maxProcessDepth
         + '}';
@@ -121,6 +135,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setBatchOperationQueryPageSize(batchOperations.getQueryPageSize())
         .setBatchOperationQueryInClauseSize(batchOperations.getQueryInClauseSize())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
+        .setCommandDistributionPaused(distribution.isCommandDistributionPaused())
         .setMaxProcessDepth(getMaxProcessDepth());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -40,6 +40,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_BATCH_OPERATION_QUERY_PAGE_SIZE = 10000;
   // Oracle can only have 1000 elements in `IN` clause
   public static final int DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE = 1000;
+  public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
@@ -64,6 +65,8 @@ public final class EngineConfiguration {
   private int batchOperationQueryInClauseSize = DEFAULT_BATCH_OPERATION_QUERY_IN_CLAUSE_SIZE;
 
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
+
+  private boolean commandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -222,6 +225,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setUsageMetricsExportInterval(
       final Duration usageMetricsExportInterval) {
     this.usageMetricsExportInterval = usageMetricsExportInterval;
+    return this;
+  }
+
+  public boolean isCommandDistributionPaused() {
+    return commandDistributionPaused;
+  }
+
+  public EngineConfiguration setCommandDistributionPaused(final boolean commandDistributionPaused) {
+    this.commandDistributionPaused = commandDistributionPaused;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -251,7 +251,8 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers,
         processingState,
-        partitionsCount);
+        partitionsCount,
+        config.isCommandDistributionPaused());
 
     UserProcessors.addUserProcessors(
         keyGenerator,
@@ -606,7 +607,8 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
-      final int staticPartitionsCount) {
+      final int staticPartitionsCount,
+      final boolean isCommandDistributionPaused) {
 
     {
       final var scheduledTaskState = scheduledTaskStateSupplier.get();
@@ -620,7 +622,8 @@ public final class EngineProcessors {
                   scheduledTaskState.getDistributionState()),
               RoutingInfo.dynamic(
                   scheduledTaskState.getRoutingState(),
-                  RoutingInfo.forStaticPartitions(staticPartitionsCount))));
+                  RoutingInfo.forStaticPartitions(staticPartitionsCount)),
+              isCommandDistributionPaused));
     }
 
     final var distributionState = processingState.getDistributionState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -77,7 +77,7 @@ public final class CommandRedistributor implements StreamProcessorLifecycleAware
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     if (isDistributionPaused) {
-      LOG.debug("Command distribution is paused, skipping retry cycle.");
+      LOG.debug("Command distribution is paused, skipping retry scheduling.");
       return;
     }
     context


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Allow Camunda Platform admins to pause the redistribution of commands when partitions in the Zeebe cluster are overloaded and can't process any more commands.

👀 The PR adds a new `DistributionCfg` class that provides a configuration flag for pausing command redistribution. The flag will be used to prevent the CommandRedistributor class from scheduling a command distribution retry cycle runner.

🔀 Alternative: Instead of a new config class, we can add the new flag to the `ProcessingCfg` class (used [here](https://github.com/camunda/camunda/blob/76c0b0a0c8a8d3525a8b26fe9fd2aaec0e04a450/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java#L162-L163)) and pass it to the [`StreamProcessorContext` instance](https://github.com/camunda/camunda/blob/51da6910056e98b2e1bd4cd4bb66b607152b5219/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java#L12), which is then passed to the `CommadRedistributor#onRecovered(ReadonlyStreamProcessorContext)` [method](https://github.com/camunda/camunda/blob/1857d4b2ee89e5e427687fd3bd8897d187137da6/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java#L78) that schedules the redistribution runner.
- This reduces the refactoring required on the `CommandRedistributor` class, but I wonder if the `ProcessingCfg` class is a good place for the flag (from a UX perspective).

🔀 Alternative 2: Instead of a boolean config flag, we can allow the configuration of the retry interval. However, a better UX for this option would be to expose the reconfiguration of the retry interval through the Management REST API, as it can be called multiple times if the problem isn't resolved in time without requiring a restart of the brokers. We can consider this as a next step.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29495
