### PR TITLE
fix: Allow retrying `ADD_VARIABLE` operation with the same variable name

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
@@ -37,20 +37,34 @@ public class CreateRequestOperationValidator {
 
   public void validate(final CreateOperationRequestDto request, final String processInstanceId) {
     if (request.getOperationType() == null) {
-      throw new InvalidRequestException("Operation type must be defined.");
+      throw new InvalidRequestException(
+          String.format(
+              "Operation type must be defined for operation on processInstanceId=%s.",
+              processInstanceId));
     }
 
     if (isVariableOperation(request) && isRequiredVariableOperationFieldMissing(request)) {
       throw new InvalidRequestException(
-          "ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+          String.format(
+              "ScopeId, variable name, and variable value must be defined for %s operation on processInstanceId=%s.",
+              request.getOperationType(), processInstanceId));
     }
 
     if (request.getOperationType().equals(ADD_VARIABLE)) {
-      if (variableAlreadyExists(request, processInstanceId)
-          || hasNonFailedAddVariableOperation(request, processInstanceId)) {
+      if (variableAlreadyExists(request, processInstanceId)) {
         throw new InvalidRequestException(
             String.format(
-                "Variable with the name \"%s\" already exists.", request.getVariableName()));
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: "
+                    + "a variable with this name already exists.",
+                request.getVariableName(), request.getVariableScopeId(), processInstanceId));
+      }
+
+      if (hasNonFailedAddVariableOperation(request, processInstanceId)) {
+        throw new InvalidRequestException(
+            String.format(
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: "
+                    + "an ADD_VARIABLE operation for this variable already exists.",
+                request.getVariableName(), request.getVariableScopeId(), processInstanceId));
       }
     }
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -11,12 +11,18 @@ import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VAR
 import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
+import io.camunda.operate.webapp.rest.dto.OperationDto;
+import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +84,51 @@ public class CreateRequestOperationValidatorTest {
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+  }
+
+  @Test
+  void shouldFailValidationWhenVariableAlreadyExists() {
+    // given
+    final var request = new CreateOperationRequestDto(ADD_VARIABLE);
+    request.setVariableScopeId("scope");
+    request.setVariableName("name");
+    request.setVariableValue("val");
+
+    // simulate existing variable
+    when(mockVariableReader.getVariableByName("123", "scope", "name"))
+        .thenReturn(new VariableDto());
+
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Variable with the name \"name\" already exists.");
+
+    // shouldn't query for operations
+    verifyNoInteractions(mockOperationReader);
+  }
+
+  @ParameterizedTest(
+      name = "should fail when ADD_VARIABLE operation with state ''{0}'' exists for same variable")
+  @EnumSource(value = OperationState.class)
+  void shouldFailValidationWhenOperationWithStateExists(final OperationState opState) {
+    // given
+    final var request = new CreateOperationRequestDto(ADD_VARIABLE);
+    request.setVariableScopeId("scope");
+    request.setVariableName("name");
+    request.setVariableValue("val");
+
+    // no existing variable
+    when(mockVariableReader.getVariableByName("123", "scope", "name")).thenReturn(null);
+
+    // simulate pending operation
+    final var operation = new OperationDto().setState(opState);
+    when(mockOperationReader.getOperations(ADD_VARIABLE, "123", "scope", "name"))
+        .thenReturn(List.of(operation));
+
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Variable with the name \"name\" already exists.");
   }
 
   @ParameterizedTest(name = "should pass for {0} operation with valid scopeId, name, and value")

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -7,18 +7,23 @@
  */
 package io.camunda.operate.webapp.rest.validation;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VARIABLE;
+import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -36,88 +41,48 @@ public class CreateRequestOperationValidatorTest {
   }
 
   @Test
-  public void testValidateWithNullOperationType() {
-    final CreateOperationRequestDto operationRequest = new CreateOperationRequestDto(null);
+  public void shouldFailValidationWhenOperationTypeIsNull() {
+    final var request = new CreateOperationRequestDto(null);
 
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage()).isEqualTo("Operation type must be defined.");
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Operation type must be defined.");
   }
 
-  @Test
-  public void testValidateUpdateVariableWithNullScopeId() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.UPDATE_VARIABLE);
-
-    operationRequest.setVariableScopeId(null);
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+  private static Stream<Arguments> invalidAddOrUpdateVariableOperation() {
+    return Stream.of(
+        Arguments.of(UPDATE_VARIABLE, null, "name", "val"),
+        Arguments.of(UPDATE_VARIABLE, "scope", null, "val"),
+        // var name is empty
+        Arguments.of(UPDATE_VARIABLE, "scope", "", "val"),
+        Arguments.of(UPDATE_VARIABLE, "scope", "name", null),
+        Arguments.of(ADD_VARIABLE, null, "name", "val"),
+        Arguments.of(ADD_VARIABLE, "scope", null, "val"),
+        // var name is empty
+        Arguments.of(ADD_VARIABLE, "scope", "", "val"),
+        Arguments.of(ADD_VARIABLE, "scope", "name", null));
   }
 
-  @Test
-  public void testValidateUpdateVariableWithNullVariableName() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.UPDATE_VARIABLE);
+  @ParameterizedTest(name = "should fail for {0} with scopeId=''{1}'', name=''{2}'', value=''{3}''")
+  @MethodSource("invalidAddOrUpdateVariableOperation")
+  void shouldFailValidationWhenRequiredFieldsForVariableOperationAreMissing(
+      final OperationType type, final String scopeId, final String name, final String value) {
+    final var request = new CreateOperationRequestDto(type);
+    request.setVariableScopeId(scopeId);
+    request.setVariableName(name);
+    request.setVariableValue(value);
 
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName(null);
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
-  public void testValidateUpdateVariableWithEmptyVariableName() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.UPDATE_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("");
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
-  public void testValidateUpdateVariableWithNullVariableValue() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.UPDATE_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue(null);
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
   }
 
   @Test
   public void testValidateUpdateVariable() {
     final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.UPDATE_VARIABLE);
+        new CreateOperationRequestDto(UPDATE_VARIABLE);
 
     operationRequest.setVariableScopeId("abc");
     operationRequest.setVariableName("var");
@@ -127,77 +92,8 @@ public class CreateRequestOperationValidatorTest {
   }
 
   @Test
-  public void testValidateAddVariableWithNullScopeId() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId(null);
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
-  public void testValidateAddVariableWithNullVariableName() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName(null);
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
-  public void testValidateAddVariableWithEmptyVariableName() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("");
-    operationRequest.setVariableValue("val");
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
-  public void testValidateAddVariableWithNullVariableValue() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue(null);
-
-    final InvalidRequestException exception =
-        assertThrows(
-            InvalidRequestException.class, () -> underTest.validate(operationRequest, "123"));
-
-    assertThat(exception.getMessage())
-        .isEqualTo("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
-  }
-
-  @Test
   public void testValidateAddVariable() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(OperationType.ADD_VARIABLE);
+    final CreateOperationRequestDto operationRequest = new CreateOperationRequestDto(ADD_VARIABLE);
 
     operationRequest.setVariableScopeId("abc");
     operationRequest.setVariableName("var");

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -54,7 +54,7 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Operation type must be defined.");
+        .hasMessage("Operation type must be defined for operation on processInstanceId=123.");
   }
 
   private static Stream<Arguments> invalidAddOrUpdateVariableOperation() {
@@ -83,7 +83,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+        .hasMessage(
+            "ScopeId, variable name, and variable value must be defined for %s operation on processInstanceId=123.",
+            type);
   }
 
   @Test
@@ -101,7 +103,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Variable with the name \"name\" already exists.");
+        .hasMessage(
+            "Cannot add variable \"name\" in scope \"scope\" of processInstanceId=123: "
+                + "a variable with this name already exists.");
 
     // shouldn't query for operations
     verifyNoInteractions(mockOperationReader);
@@ -132,7 +136,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Variable with the name \"name\" already exists.");
+        .hasMessage(
+            "Cannot add variable \"name\" in scope \"scope\" of processInstanceId=123: "
+                + "an ADD_VARIABLE operation for this variable already exists.");
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -79,26 +80,18 @@ public class CreateRequestOperationValidatorTest {
         .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
   }
 
-  @Test
-  public void testValidateUpdateVariable() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(UPDATE_VARIABLE);
+  @ParameterizedTest(name = "should pass for {0} operation with valid scopeId, name, and value")
+  @EnumSource(
+      value = OperationType.class,
+      names = {"ADD_VARIABLE", "UPDATE_VARIABLE"})
+  void shouldPassValidationForValidVariableOperation(final OperationType operationType) {
+    // given
+    final var request = new CreateOperationRequestDto(operationType);
+    request.setVariableScopeId("abc");
+    request.setVariableName("var");
+    request.setVariableValue("val");
 
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    assertDoesNotThrow(() -> underTest.validate(operationRequest, "123"));
-  }
-
-  @Test
-  public void testValidateAddVariable() {
-    final CreateOperationRequestDto operationRequest = new CreateOperationRequestDto(ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    assertDoesNotThrow(() -> underTest.validate(operationRequest, "123"));
+    // when - then
+    assertDoesNotThrow(() -> underTest.validate(request, "123"));
   }
 }


### PR DESCRIPTION
> [!TIP]
> For clarity, this PR was intentionally split into focused commits (improving tests, fix, and small refactoring).
Reviewing it commit-by-commit (rather than as one diff) will make it easier to understand the purpose and motivation of each change.


## Description

This PR fixes an issue related to `ADD_VARIABLE` operation request validation that prevented users from retrying a variable addition after a previous attempt had failed, even though the variable was never created.

### Motivation

When a variable addition via Operate UI or REST API failed, the validator would still block any subsequent `ADD_VARIABLE` request with the same name—even though no variable was actually created.

While this was a rare case before, the introduction of "updating" task listeners that can dynamically deny user task transitions (e.g., based on variable value validation logic) makes this a realistic and common scenario.
In such cases, users should be able to fix the value and trigger `ADD_VARIABLE` operation with same name.

### Fix
- Changed the check to exclude operations in the `FAILED` state.
- Added a dedicated unit test to confirm that a failed prior operation does not cause validation failure.

### Refactoring
- Extracted inline validation conditions into helper methods to improve the readability of `validate(...)` method.

### Test improvements
1. Parameterized missing‐field tests:
   - Consolidated many null/empty‐parameter test methods for both `ADD_VARIABLE` and `UPDATE_VARIABLE` into a single `@MethodSource`‐driven parameterized test.
2. Parameterized happy‐path tests:
   - Replaced two separate “valid request” tests with a single `@EnumSource({ADD_VARIABLE, UPDATE_VARIABLE})` test.
3. Added missing tests for `"Variable with the name already exists"` checks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33337
