### PR TITLE
fix: Fix changelog generation for dry run (32376)

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 0.8.0, 0.9.0 ]
+        version: [ 1.0.2, 1.0.0-alpha1 ]
         include:
-          - version: 0.8.0
+          - version: 1.0.2
             latest: true
-          - version: 0.9.0
+          - version: 1.0.0-alpha1
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ 0.8.2, 0.8.2-alpha1 ]
+        version: [ 0.8.0, 0.9.0 ]
         include:
-          - version: 0.8.2
+          - version: 0.8.0
             latest: true
-          - version: 0.8.2-alpha1
+          - version: 0.9.0
             latest: false
     with:
       releaseBranch: ${{ inputs.branch || 'main' }}


### PR DESCRIPTION
## Description

As we started automatically generating the change log for all versions, the dry run process started failing as it was running on the non-existing versions (0.8.2, 0.8.2-alpha1). A quick fix for this which verifies also the changelog generation is to use some real versions in dry run, for which there are tags present in git.

Tested this approach here:
https://github.com/camunda/camunda/actions/runs/15731680452/job/44335756801
<img width="680" alt="image" src="https://github.com/user-attachments/assets/dfefa8fb-69cb-49f9-ac81-78244073e1fe" />



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
https://github.com/camunda/camunda/issues/32376
closes #
