### PR TITLE
Take over 8.6 changes for the StandaloneSchemaManager to the main branch

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -834,7 +834,6 @@
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
-            <dependency>io.camunda:zeebe-elasticsearch-exporter</dependency>
             <dependency>io.camunda:zeebe-opensearch-exporter</dependency>
 
             <!-- Needed for Spring Actuators, and REST API -->

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.schema;
+
+import static io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
+import static io.camunda.webapps.schema.SupportedVersions.SUPPORTED_ELASTICSEARCH_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.Profile;
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ZeebeIntegration
+@Testcontainers
+final class StandaloneSchemaManagerIT {
+
+  public static final String ADMIN_USER = "camunda-admin";
+  public static final String ADMIN_PASSWORD = "admin123";
+  public static final String ADMIN_ROLE = "superuser";
+
+  public static final String APP_USER = "camunda-app";
+  public static final String APP_PASSWORD = "app123";
+  public static final String APP_ROLE = "camunda_app_role";
+  public static final String APP_ROLE_DEFINITION =
+      // language=yaml
+      """
+          camunda_app_role:
+            indices:
+              - names: ['zeebe-*', 'operate-*', 'tasklist-*', 'camunda-*']
+                privileges: ['manage', 'read', 'write']
+          """;
+
+  @TestZeebe(autoStart = false)
+  final TestStandaloneSchemaManager schemaManager =
+      new TestStandaloneSchemaManager()
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.className",
+              ElasticsearchExporter.class.getName())
+          .withProperty("zeebe.broker.exporters.elasticsearch.args.index.createTemplate", "true")
+          .withProperty("zeebe.broker.exporters.elasticsearch.args.retention.enabled", "true")
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD)
+          .withProperty("camunda.database.username", ADMIN_USER)
+          .withProperty("camunda.database.password", ADMIN_PASSWORD)
+          .withProperty("camunda.database.retention.enabled", "true");
+
+  @TestZeebe(autoStart = false)
+  final TestCamundaApplication camunda =
+      new TestCamundaApplication()
+          .withAdditionalProfile(Profile.CONSOLIDATED_AUTH)
+          .withProperty("camunda.database.username", APP_USER)
+          .withProperty("camunda.database.password", APP_PASSWORD)
+          .withProperty(CREATE_SCHEMA_PROPERTY, "false")
+          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.className",
+              ElasticsearchExporter.class.getName())
+          .withProperty("camunda.operate.elasticsearch.username", APP_USER)
+          .withProperty("camunda.operate.elasticsearch.password", APP_PASSWORD)
+          .withProperty("camunda.operate.zeebeelasticsearch.username", APP_USER)
+          .withProperty("camunda.operate.zeebeelasticsearch.password", APP_PASSWORD)
+          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.tasklist.elasticsearch.username", APP_USER)
+          .withProperty("camunda.tasklist.elasticsearch.password", APP_PASSWORD)
+          .withProperty("camunda.tasklist.zeebeelasticsearch.username", APP_USER)
+          .withProperty("camunda.tasklist.zeebeelasticsearch.password", APP_PASSWORD)
+          .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
+          .withExporter(
+              CamundaExporter.class.getSimpleName(),
+              cfg -> {
+                cfg.setClassName(CamundaExporter.class.getName());
+                cfg.setArgs(
+                    Map.of(
+                        "connect",
+                        Map.of("username", APP_USER, "password", APP_PASSWORD),
+                        "createSchema",
+                        false));
+              })
+          .withExporter(
+              ElasticsearchExporter.class.getSimpleName(),
+              cfg -> {
+                cfg.setClassName(ElasticsearchExporter.class.getName());
+                cfg.setArgs(
+                    Map.of(
+                        "index",
+                        Map.of("createTemplate", false),
+                        "retention",
+                        Map.of("enabled", false, "managePolicy", false),
+                        "authentication",
+                        Map.of("username", APP_USER, "password", APP_PASSWORD)));
+              });
+
+  @Container
+  private final ElasticsearchContainer es =
+      new ElasticsearchContainer(
+              DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                  .withTag(SUPPORTED_ELASTICSEARCH_VERSION))
+          // Enable security features
+          .withEnv("xpack.security.enabled", "true")
+          // Ensure a fast and reliable startup
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withStartupAttempts(3)
+          .withEnv("xpack.security.enabled", "true")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withCopyToContainer(
+              Transferable.of(APP_ROLE_DEFINITION), "/usr/share/elasticsearch/config/roles.yml")
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY);
+
+  @AutoClose private ElasticsearchClient esAdminClient;
+
+  @BeforeEach
+  void setup() throws IOException, InterruptedException {
+    // setup ES admin user
+    es.execInContainer("elasticsearch-users", "useradd", ADMIN_USER, "-p", ADMIN_PASSWORD);
+    es.execInContainer("elasticsearch-users", "roles", ADMIN_USER, "-a", ADMIN_ROLE);
+
+    // Create ES client for admin user
+    final var config = new ConnectConfiguration();
+    config.setUrl("http://" + es.getHttpHostAddress());
+    config.setUsername(ADMIN_USER);
+    config.setPassword(ADMIN_PASSWORD);
+    esAdminClient = new ElasticsearchConnector(config).createClient();
+
+    // create app user with APP_ROLE role
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .until(
+            () ->
+                esAdminClient
+                    .security()
+                    .putUser(r -> r.username(APP_USER).password(APP_PASSWORD).roles(APP_ROLE))
+                    .created());
+
+    // Connect to ES in Standalone Schema Manager
+    schemaManager
+        .withProperty("camunda.database.url", "http://" + es.getHttpHostAddress())
+        .withProperty(
+            "zeebe.broker.exporters.elasticsearch.args.url", "http://" + es.getHttpHostAddress());
+    // Connect to ES in Camunda
+    camunda
+        .withProperty("camunda.database.url", "http://" + es.getHttpHostAddress())
+        .withProperty("camunda.operate.elasticsearch.url", "http://" + es.getHttpHostAddress())
+        .withProperty("camunda.operate.zeebeelasticsearch.url", "http://" + es.getHttpHostAddress())
+        .withProperty("camunda.tasklist.elasticsearch.url", "http://" + es.getHttpHostAddress())
+        .withProperty(
+            "camunda.tasklist.zeebeelasticsearch.url", "http://" + es.getHttpHostAddress())
+        .updateExporterArgs(
+            CamundaExporter.class.getSimpleName(),
+            args -> ((Map) args.get("connect")).put("url", "http://" + es.getHttpHostAddress()))
+        .updateExporterArgs(
+            ElasticsearchExporter.class.getSimpleName(),
+            args -> args.put("url", "http://" + es.getHttpHostAddress()));
+  }
+
+  @Test
+  void canUseCamunda() {
+    // given
+    schemaManager.start();
+    camunda.start();
+
+    // when -- creating a process instance with user task
+    final long processInstanceKey;
+    try (final var camundaClient = camunda.newClientBuilder().build()) {
+      // Deploy process with user task
+      camundaClient
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("process-with-user-task")
+                  .startEvent()
+                  .userTask("user-task")
+                  .zeebeUserTask()
+                  .endEvent()
+                  .done(),
+              "process-with-user-task.bpmn")
+          .send()
+          .join();
+      processInstanceKey =
+          camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId("process-with-user-task")
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // then -- user task exists and can be completed
+      final var userTaskKey =
+          Awaitility.await("should create a user task")
+              .atMost(Duration.ofSeconds(60))
+              .ignoreExceptions()
+              .until(
+                  () ->
+                      camundaClient
+                          .newUserTaskSearchRequest()
+                          .send()
+                          .join()
+                          .items()
+                          .getFirst()
+                          .getUserTaskKey(),
+                  Objects::nonNull);
+      camundaClient.newUserTaskAssignCommand(userTaskKey).assignee("demo").send().join();
+      camundaClient.newUserTaskCompleteCommand(userTaskKey).send().join();
+
+      // then -- process instance is completed
+      Awaitility.await("process instance should be completed")
+          .atMost(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final var result =
+                    camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+                assertThat(result.getEndDate()).isNotNull();
+              });
+    }
+
+    Awaitility.await("Zeebe records templates exist and records are exported to Elasticsearch")
+        .atMost(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      esAdminClient
+                          .indices()
+                          .getIndexTemplate(r -> r.name("zeebe-record*"))
+                          .indexTemplates())
+                  .hasSizeGreaterThan(0);
+              assertThat(esAdminClient.count(r -> r.index("zeebe-record*")).count())
+                  .isGreaterThan(0);
+            });
+  }
+
+  @Test
+  void canArchiveProcessInstances() {
+    // given
+    schemaManager.start();
+    // Configure archiver to run frequently
+    camunda.updateExporterArgs(
+        CamundaExporter.class.getSimpleName(),
+        args ->
+            ((Map) args.computeIfAbsent("history", k -> new HashMap<>()))
+                .put("waitPeriodBeforeArchiving", "1s"));
+    camunda.start();
+
+    // when - a self-completing process instance is created
+    final long processInstanceKey;
+    try (final var camundaClient = camunda.newClientBuilder().build()) {
+      camundaClient
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("simple-process").startEvent().endEvent().done(),
+              "simple-process.bpmn")
+          .send()
+          .join();
+
+      processInstanceKey =
+          camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId("simple-process")
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+    }
+
+    // then - process instance is archived
+    Awaitility.await("process instance should be archived")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              // Verify that instance is in archived index
+              final var searchResponseFromArchive =
+                  esAdminClient.search(
+                      s ->
+                          s.index("operate-list-view-8.3.0_*-*-*")
+                              .query(q -> q.term(t -> t.field("key").value(processInstanceKey))),
+                      ProcessInstance.class);
+              assertThat(searchResponseFromArchive.hits().total().value()).isEqualTo(1);
+
+              // Verify it's not in the live index
+              final var searchResponseFromLive =
+                  esAdminClient.search(
+                      s ->
+                          s.index("operate-list-view-8.3.0_")
+                              .query(q -> q.term(t -> t.field("key").value(processInstanceKey))),
+                      ProcessInstance.class);
+              assertThat(searchResponseFromLive.hits().total().value()).isEqualTo(0);
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/StandaloneSchemaManagerIT.java
@@ -106,7 +106,9 @@ final class StandaloneSchemaManagerIT {
                         "connect",
                         Map.of("username", APP_USER, "password", APP_PASSWORD),
                         "createSchema",
-                        false));
+                        false,
+                        "history",
+                        Map.of("retention", Map.of("enabled", true))));
               })
           .withExporter(
               ElasticsearchExporter.class.getSimpleName(),

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -264,6 +265,27 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
   @Override
   public Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return apiAuthenticationMethod();
+  }
+
+  public TestCamundaApplication updateExporterArgs(
+      final String id, final Consumer<Map<String, Object>> modifier) {
+    final var exporterCfg = brokerProperties.getExporters().get(id);
+    final var argsCopy = deepCopy(exporterCfg.getArgs());
+    modifier.accept(argsCopy);
+    exporterCfg.setArgs(argsCopy);
+    return this;
+  }
+
+  private Map<String, Object> deepCopy(final Map<String, Object> map) {
+    final Map<String, Object> copy = new HashMap<>();
+    for (final Map.Entry<String, Object> entry : map.entrySet()) {
+      if (entry.getValue() instanceof final Map m) {
+        copy.put(entry.getKey(), deepCopy(m));
+      } else {
+        copy.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return copy;
   }
 
   public TestRestOperateClient newOperateClient() {

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneSchemaManager.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.application.StandaloneSchemaManager;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+public class TestStandaloneSchemaManager
+    extends TestSpringApplication<TestStandaloneSchemaManager> {
+  public TestStandaloneSchemaManager() {
+    super(StandaloneSchemaManager.class);
+  }
+
+  @Override
+  public TestStandaloneSchemaManager self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from("schema");
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return new NoopHealthActuator();
+  }
+
+  @Override
+  public boolean isGateway() {
+    return false;
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().web(WebApplicationType.NONE);
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -381,6 +381,9 @@ public class SchemaManager {
   }
 
   public boolean isSchemaReadyForUse() {
+    if (!config.schemaManager().isCreateSchema()) {
+      return true;
+    }
     return getMissingIndices(getAllIndexDescriptors()).isEmpty()
         && getMissingIndexTemplates(indexTemplateDescriptors).isEmpty()
         && validateIndices(getAllIndexDescriptors()).isEmpty();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -44,6 +44,7 @@ import io.camunda.exporter.tasks.BackgroundTaskManagerFactory;
 import io.camunda.search.schema.MappingSource;
 import io.camunda.search.schema.SchemaManager;
 import io.camunda.search.schema.SearchEngineClient;
+import io.camunda.search.schema.config.SchemaManagerConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
@@ -267,6 +268,8 @@ public class CamundaExporter implements Exporter {
   }
 
   private SchemaManager createSchemaManager() {
+    final var schemaManagerConfiguration = new SchemaManagerConfiguration();
+    schemaManagerConfiguration.setCreateSchema(configuration.isCreateSchema());
     return new SchemaManager(
         searchEngineClient,
         provider.getIndexDescriptors(),
@@ -275,7 +278,8 @@ public class CamundaExporter implements Exporter {
             b ->
                 b.connect(configuration.getConnect())
                     .index(configuration.getIndex())
-                    .retention(configuration.getHistory().getRetention())),
+                    .retention(configuration.getHistory().getRetention())
+                    .schemaManager(schemaManagerConfiguration)),
         clientAdapter.objectMapper());
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -60,7 +60,7 @@ class ElasticsearchAdapter implements ClientAdapter {
 
   @Override
   public void close() throws IOException {
-    client._transport().close();
+    client.close();
   }
 
   record ElasticsearchExporterEntityCacheProvider(ElasticsearchClient client)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticsearchExporterSchemaManager {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticsearchExporterSchemaManager.class.getPackageName());
+  private final ElasticsearchClient client;
+  private final ElasticsearchExporterConfiguration configuration;
+  private final Set<String> indexTemplatesCreated = new HashSet<>();
+
+  /**
+   * Creates a new schema manager, and it is to be used by the exporter to manage the Elasticsearch
+   * schema.
+   *
+   * @param client the Elasticsearch client
+   * @param configuration the exporter configuration
+   */
+  public ElasticsearchExporterSchemaManager(
+      final ElasticsearchClient client, final ElasticsearchExporterConfiguration configuration) {
+    this.client = client;
+    this.configuration = configuration;
+  }
+
+  /**
+   * Creates a new schema manager, and is only used by the StandaloneSchemaManager.
+   *
+   * @param configuration the exporter configuration
+   */
+  public ElasticsearchExporterSchemaManager(
+      final ElasticsearchExporterConfiguration configuration) {
+    this(new ElasticsearchClient(configuration, new SimpleMeterRegistry()), configuration);
+  }
+
+  public void createSchema(final String brokerVersion) {
+    if (!indexTemplatesCreated.contains(brokerVersion)) {
+      createIndexTemplates(brokerVersion);
+      updateRetentionPolicyForExistingIndices();
+    }
+  }
+
+  private void updateRetentionPolicyForExistingIndices() {
+    final boolean acknowledged;
+    if (configuration.retention.isEnabled()) {
+      acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
+    } else {
+      acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    }
+
+    if (!acknowledged) {
+      LOG.warn("Failed to acknowledge the the update of retention policy for existing indices");
+    }
+  }
+
+  private void createIndexTemplates(final String version) {
+    if (configuration.retention.isEnabled()) {
+      createIndexLifecycleManagementPolicy();
+    }
+
+    final IndexConfiguration index = configuration.index;
+
+    if (index.createTemplate) {
+      createComponentTemplate();
+
+      if (index.deployment) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT, version);
+      }
+      if (index.process) {
+        createValueIndexTemplate(ValueType.PROCESS, version);
+      }
+      if (index.error) {
+        createValueIndexTemplate(ValueType.ERROR, version);
+      }
+      if (index.incident) {
+        createValueIndexTemplate(ValueType.INCIDENT, version);
+      }
+      if (index.job) {
+        createValueIndexTemplate(ValueType.JOB, version);
+      }
+      if (index.jobBatch) {
+        createValueIndexTemplate(ValueType.JOB_BATCH, version);
+      }
+      if (index.message) {
+        createValueIndexTemplate(ValueType.MESSAGE, version);
+      }
+      if (index.messageBatch) {
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH, version);
+      }
+      if (index.messageSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION, version);
+      }
+      if (index.variable) {
+        createValueIndexTemplate(ValueType.VARIABLE, version);
+      }
+      if (index.variableDocument) {
+        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT, version);
+      }
+      if (index.processInstance) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE, version);
+      }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH, version);
+      }
+      if (index.processInstanceCreation) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION, version);
+      }
+      if (index.processInstanceModification) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
+      }
+      if (index.processMessageSubscription) {
+        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
+      }
+      if (index.adHocSubProcessActivityActivation) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      }
+      if (index.decisionRequirements) {
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
+      }
+      if (index.decision) {
+        createValueIndexTemplate(ValueType.DECISION, version);
+      }
+      if (index.decisionEvaluation) {
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION, version);
+      }
+      if (index.checkpoint) {
+        createValueIndexTemplate(ValueType.CHECKPOINT, version);
+      }
+      if (index.timer) {
+        createValueIndexTemplate(ValueType.TIMER, version);
+      }
+      if (index.messageStartEventSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, version);
+      }
+      if (index.processEvent) {
+        createValueIndexTemplate(ValueType.PROCESS_EVENT, version);
+      }
+      if (index.deploymentDistribution) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION, version);
+      }
+      if (index.escalation) {
+        createValueIndexTemplate(ValueType.ESCALATION, version);
+      }
+      if (index.signal) {
+        createValueIndexTemplate(ValueType.SIGNAL, version);
+      }
+      if (index.signalSubscription) {
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION, version);
+      }
+      if (index.resourceDeletion) {
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION, version);
+      }
+      if (index.commandDistribution) {
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION, version);
+      }
+      if (index.form) {
+        createValueIndexTemplate(ValueType.FORM, version);
+      }
+      if (index.userTask) {
+        createValueIndexTemplate(ValueType.USER_TASK, version);
+      }
+      if (index.processInstanceMigration) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION, version);
+      }
+      if (index.compensationSubscription) {
+        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION, version);
+      }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION, version);
+      }
+      if (index.asyncRequest) {
+        createValueIndexTemplate(ValueType.ASYNC_REQUEST, version);
+      }
+    }
+
+    indexTemplatesCreated.add(version);
+  }
+
+  private void createIndexLifecycleManagementPolicy() {
+    if (!client.putIndexLifecycleManagementPolicy()) {
+      LOG.warn(
+          "Failed to acknowledge the creation or update of the Index Lifecycle Management Policy");
+    }
+  }
+
+  private void createComponentTemplate() {
+    if (!client.putComponentTemplate()) {
+      LOG.warn("Failed to acknowledge the creation or update of the component template");
+    }
+  }
+
+  private void createValueIndexTemplate(final ValueType valueType, final String version) {
+    if (!client.putIndexTemplate(valueType, version)) {
+      LOG.warn(
+          "Failed to acknowledge the creation or update of the index template for value type {}",
+          valueType);
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backports the [changes made in 8.6](https://github.com/camunda/camunda/pull/28460) for the Standalone Schema Manager to the main (8.8) branch.
* StandaloneSchemaManager app is responsible for creating the Elasticsearch schema including the `camunda-*`, `operate-*`, `tasklist-*` and optionally `zeebe-record-*` indices and index templates. It is also responsible for the creation of ILM policies when configured.
* `camunda-*`, `operate-*`, `tasklist-*` are managed by the main SchemaManager class (started duing application bootstrapping). `zeebe-record-*` is managed by the `ElasticSearchExporterSchemaManager` that was extracted out of `ElasticSearchExporter`
* Backported `StandaloneSchemaManagerIT` integration test.
* Updated `SchemaManager` to skip schema readiness checks when schema creation is disabled via configuration, the avoid CamundaExporter from using cluster level privileges commands to check if the indices and index templates are created. The assumption is that the schema is initialized with the standalone app before the main application start. 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to #28989 
