### PR TITLE
feat: Extend Java client with methods for searching incidents by processInstanceKey

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -117,8 +117,8 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
-import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
@@ -2406,7 +2406,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *    .send();
    * </pre>
    */
-  IncidentByProcessInstanceKeySearchRequest newIncidentSearchByProcessInstanceKey(
+  IncidentsByProcessInstanceSearchRequest newIncidentsByProcessInstanceSearchRequest(
       long processInstanceKey);
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -117,6 +117,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -2393,6 +2394,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the roles by group search request
    */
   RolesByGroupSearchRequest newRolesByGroupSearchRequest(String groupId);
+
+  /**
+   * Executes a search request to query incidents by process instance key.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+   *    .sort((s) -> s.incidentKey().desc())
+   *    .page((p) -> p.limit(100))
+   *    .send();
+   * </pre>
+   */
+  IncidentByProcessInstanceKeySearchRequest newIncidentSearchByProcessInstanceKey(
+      long processInstanceKey);
 
   /**
    * Executes a search request to query groups by role.

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentByProcessInstanceKeySearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentByProcessInstanceKeySearchRequest.java
@@ -15,30 +15,12 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.sort.IncidentSort;
 import java.util.function.Consumer;
 
-public interface TypedSearchRequest<
-    F extends SearchRequestFilter,
-    S extends SearchRequestSort<S>,
-    SELF extends TypedSearchRequest<F, S, SELF>> {
-
-  /**
-   * Sets the filter to be included in the search request.
-   *
-   * @param value the filter
-   * @return the builder for the search request
-   */
-  SELF filter(final F value);
-
-  /**
-   * Provides a fluent builder to create a filter to be included in the search request.
-   *
-   * @param fn consumer to create the filter
-   * @return the builder for the search request
-   */
-  SELF filter(final Consumer<F> fn);
+public interface IncidentByProcessInstanceKeySearchRequest
+    extends FinalSearchRequestStep<Incident> {
 
   /**
    * Sets the sorting the returned entities should be sorted by.
@@ -46,7 +28,7 @@ public interface TypedSearchRequest<
    * @param value the sort options
    * @return the builder for the search request
    */
-  SELF sort(final S value);
+  IncidentByProcessInstanceKeySearchRequest sort(IncidentSort value);
 
   /**
    * Provides a fluent builder to provide sorting options the returned entities should sorted by
@@ -54,7 +36,7 @@ public interface TypedSearchRequest<
    * @param fn consumer to create the sort options
    * @return the builder for the search request
    */
-  SELF sort(final Consumer<S> fn);
+  IncidentByProcessInstanceKeySearchRequest sort(Consumer<IncidentSort> fn);
 
   /**
    * Support for pagination.
@@ -62,7 +44,7 @@ public interface TypedSearchRequest<
    * @param value the next page
    * @return the builder for the search request
    */
-  SELF page(final SearchRequestPage value);
+  IncidentByProcessInstanceKeySearchRequest page(SearchRequestPage value);
 
   /**
    * Provides a fluent builder to support pagination.
@@ -70,24 +52,5 @@ public interface TypedSearchRequest<
    * @param fn consumer to support pagination
    * @return the builder for the search request
    */
-  SELF page(final Consumer<SearchRequestPage> fn);
-
-  public static interface SearchRequestFilter {}
-
-  public static interface SearchRequestSort<S extends SearchRequestSort<S>> {
-
-    /**
-     * Sort in ascending order
-     *
-     * @return the sort builder
-     */
-    S asc();
-
-    /**
-     * Sort in descending order
-     *
-     * @return the sort builder
-     */
-    S desc();
-  }
+  IncidentByProcessInstanceKeySearchRequest page(Consumer<SearchRequestPage> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByProcessInstanceSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByProcessInstanceSearchRequest.java
@@ -19,8 +19,7 @@ import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.sort.IncidentSort;
 import java.util.function.Consumer;
 
-public interface IncidentByProcessInstanceKeySearchRequest
-    extends FinalSearchRequestStep<Incident> {
+public interface IncidentsByProcessInstanceSearchRequest extends FinalSearchRequestStep<Incident> {
 
   /**
    * Sets the sorting the returned entities should be sorted by.
@@ -28,7 +27,7 @@ public interface IncidentByProcessInstanceKeySearchRequest
    * @param value the sort options
    * @return the builder for the search request
    */
-  IncidentByProcessInstanceKeySearchRequest sort(IncidentSort value);
+  IncidentsByProcessInstanceSearchRequest sort(IncidentSort value);
 
   /**
    * Provides a fluent builder to provide sorting options the returned entities should sorted by
@@ -36,7 +35,7 @@ public interface IncidentByProcessInstanceKeySearchRequest
    * @param fn consumer to create the sort options
    * @return the builder for the search request
    */
-  IncidentByProcessInstanceKeySearchRequest sort(Consumer<IncidentSort> fn);
+  IncidentsByProcessInstanceSearchRequest sort(Consumer<IncidentSort> fn);
 
   /**
    * Support for pagination.
@@ -44,7 +43,7 @@ public interface IncidentByProcessInstanceKeySearchRequest
    * @param value the next page
    * @return the builder for the search request
    */
-  IncidentByProcessInstanceKeySearchRequest page(SearchRequestPage value);
+  IncidentsByProcessInstanceSearchRequest page(SearchRequestPage value);
 
   /**
    * Provides a fluent builder to support pagination.
@@ -52,5 +51,5 @@ public interface IncidentByProcessInstanceKeySearchRequest
    * @param fn consumer to support pagination
    * @return the builder for the search request
    */
-  IncidentByProcessInstanceKeySearchRequest page(Consumer<SearchRequestPage> fn);
+  IncidentsByProcessInstanceSearchRequest page(Consumer<SearchRequestPage> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -128,8 +128,8 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
-import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
+import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
 import io.camunda.client.api.search.request.ProcessInstanceSearchRequest;
@@ -240,8 +240,8 @@ import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestIm
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
-import io.camunda.client.impl.search.request.IncidentByProcessInstanceKeySearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
+import io.camunda.client.impl.search.request.IncidentsByProcessInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByRoleSearchRequestImpl;
 import io.camunda.client.impl.search.request.ProcessDefinitionSearchRequestImpl;
@@ -1208,9 +1208,9 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public IncidentByProcessInstanceKeySearchRequest newIncidentSearchByProcessInstanceKey(
+  public IncidentsByProcessInstanceSearchRequest newIncidentsByProcessInstanceSearchRequest(
       final long processInstanceKey) {
-    return new IncidentByProcessInstanceKeySearchRequestImpl(
+    return new IncidentsByProcessInstanceSearchRequestImpl(
         httpClient, jsonMapper, processInstanceKey);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -128,6 +128,7 @@ import io.camunda.client.api.search.request.DecisionInstanceSearchRequest;
 import io.camunda.client.api.search.request.DecisionRequirementsSearchRequest;
 import io.camunda.client.api.search.request.ElementInstanceSearchRequest;
 import io.camunda.client.api.search.request.GroupsByRoleSearchRequest;
+import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
 import io.camunda.client.api.search.request.IncidentSearchRequest;
 import io.camunda.client.api.search.request.MappingsByRoleSearchRequest;
 import io.camunda.client.api.search.request.ProcessDefinitionSearchRequest;
@@ -239,6 +240,7 @@ import io.camunda.client.impl.search.request.DecisionRequirementsSearchRequestIm
 import io.camunda.client.impl.search.request.ElementInstanceSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.GroupsByRoleSearchRequestImpl;
+import io.camunda.client.impl.search.request.IncidentByProcessInstanceKeySearchRequestImpl;
 import io.camunda.client.impl.search.request.IncidentSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByGroupSearchRequestImpl;
 import io.camunda.client.impl.search.request.MappingsByRoleSearchRequestImpl;
@@ -1203,6 +1205,13 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public RolesByGroupSearchRequest newRolesByGroupSearchRequest(final String groupId) {
     return new RolesByGroupSearchRequestImpl(httpClient, jsonMapper, groupId);
+  }
+
+  @Override
+  public IncidentByProcessInstanceKeySearchRequest newIncidentSearchByProcessInstanceKey(
+      final long processInstanceKey) {
+    return new IncidentByProcessInstanceKeySearchRequestImpl(
+        httpClient, jsonMapper, processInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentByProcessInstanceKeySearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentByProcessInstanceKeySearchRequestImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.request;
+
+import static io.camunda.client.api.search.request.SearchRequestBuilders.incidentSort;
+import static io.camunda.client.api.search.request.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider.provideSearchRequestProperty;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.request.FinalSearchRequestStep;
+import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
+import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.client.api.search.sort.IncidentSort;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.SearchResponseMapper;
+import io.camunda.client.protocol.rest.IncidentSearchQueryResult;
+import io.camunda.client.protocol.rest.ProcessInstanceIncidentSearchQuery;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class IncidentByProcessInstanceKeySearchRequestImpl
+    implements IncidentByProcessInstanceKeySearchRequest {
+
+  private final ProcessInstanceIncidentSearchQuery request;
+  private final long processInstanceKey;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public IncidentByProcessInstanceKeySearchRequestImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long processInstanceKey) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    this.processInstanceKey = processInstanceKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new ProcessInstanceIncidentSearchQuery();
+  }
+
+  @Override
+  public FinalSearchRequestStep<Incident> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SearchResponse<Incident>> send() {
+    final HttpCamundaFuture<SearchResponse<Incident>> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        String.format("/process-instances/%d/incidents/search", processInstanceKey),
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        IncidentSearchQueryResult.class,
+        SearchResponseMapper::toIncidentSearchResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  public IncidentByProcessInstanceKeySearchRequest sort(final IncidentSort value) {
+    request.setSort(
+        SearchRequestSortMapper.toIncidentSearchQuerySortRequest(
+            provideSearchRequestProperty(value)));
+    return this;
+  }
+
+  @Override
+  public IncidentByProcessInstanceKeySearchRequest sort(final Consumer<IncidentSort> fn) {
+    return sort(incidentSort(fn));
+  }
+
+  @Override
+  public IncidentByProcessInstanceKeySearchRequest page(final SearchRequestPage value) {
+    request.setPage(provideSearchRequestProperty(value));
+    return this;
+  }
+
+  @Override
+  public IncidentByProcessInstanceKeySearchRequest page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentsByProcessInstanceSearchRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/IncidentsByProcessInstanceSearchRequestImpl.java
@@ -22,7 +22,7 @@ import static io.camunda.client.impl.search.request.TypedSearchRequestPropertyPr
 import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.search.request.FinalSearchRequestStep;
-import io.camunda.client.api.search.request.IncidentByProcessInstanceKeySearchRequest;
+import io.camunda.client.api.search.request.IncidentsByProcessInstanceSearchRequest;
 import io.camunda.client.api.search.request.SearchRequestPage;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.SearchResponse;
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class IncidentByProcessInstanceKeySearchRequestImpl
-    implements IncidentByProcessInstanceKeySearchRequest {
+public class IncidentsByProcessInstanceSearchRequestImpl
+    implements IncidentsByProcessInstanceSearchRequest {
 
   private final ProcessInstanceIncidentSearchQuery request;
   private final long processInstanceKey;
@@ -46,7 +46,7 @@ public class IncidentByProcessInstanceKeySearchRequestImpl
   private final JsonMapper jsonMapper;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public IncidentByProcessInstanceKeySearchRequestImpl(
+  public IncidentsByProcessInstanceSearchRequestImpl(
       final HttpClient httpClient, final JsonMapper jsonMapper, final long processInstanceKey) {
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
@@ -75,7 +75,7 @@ public class IncidentByProcessInstanceKeySearchRequestImpl
   }
 
   @Override
-  public IncidentByProcessInstanceKeySearchRequest sort(final IncidentSort value) {
+  public IncidentsByProcessInstanceSearchRequest sort(final IncidentSort value) {
     request.setSort(
         SearchRequestSortMapper.toIncidentSearchQuerySortRequest(
             provideSearchRequestProperty(value)));
@@ -83,18 +83,18 @@ public class IncidentByProcessInstanceKeySearchRequestImpl
   }
 
   @Override
-  public IncidentByProcessInstanceKeySearchRequest sort(final Consumer<IncidentSort> fn) {
+  public IncidentsByProcessInstanceSearchRequest sort(final Consumer<IncidentSort> fn) {
     return sort(incidentSort(fn));
   }
 
   @Override
-  public IncidentByProcessInstanceKeySearchRequest page(final SearchRequestPage value) {
+  public IncidentsByProcessInstanceSearchRequest page(final SearchRequestPage value) {
     request.setPage(provideSearchRequestProperty(value));
     return this;
   }
 
   @Override
-  public IncidentByProcessInstanceKeySearchRequest page(final Consumer<SearchRequestPage> fn) {
+  public IncidentsByProcessInstanceSearchRequest page(final Consumer<SearchRequestPage> fn) {
     return page(searchRequestPage(fn));
   }
 }

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -111,6 +111,12 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if test="filter.treePathOperations != null and !filter.treePathOperations.isEmpty()">
+      <foreach collection="filter.treePathOperations" item="operation">
+        AND TREE_PATH
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
 
     <!-- date filters -->
     <if test="filter.creationTimeOperations != null and !filter.creationTimeOperations.isEmpty()">
@@ -155,12 +161,13 @@
                           STATE,
                           CREATION_DATE,
                           JOB_KEY,
-                                   TENANT_ID,
-                                   PARTITION_ID,
-                                   HISTORY_CLEANUP_DATE)
+                          TENANT_ID,
+                          PARTITION_ID,
+                          TREE_PATH,
+                          HISTORY_CLEANUP_DATE)
     VALUES (#{incidentKey}, #{flowNodeInstanceKey}, #{flowNodeId}, #{processInstanceKey},
             #{processDefinitionId}, #{processDefinitionKey}, #{errorMessage}, #{errorMessageHash}, #{errorType},
-            #{state}, #{creationDate, jdbcType=TIMESTAMP}, #{jobKey}, #{tenantId}, #{partitionId},
+            #{state}, #{creationDate, jdbcType=TIMESTAMP}, #{jobKey}, #{tenantId}, #{partitionId}, #{treePath},
             #{historyCleanupDate, jdbcType=TIMESTAMP})
   </insert>
 
@@ -182,6 +189,7 @@
         CREATION_DATE          = #{creationDate, jdbcType=TIMESTAMP},
         JOB_KEY                = #{jobKey},
         TENANT_ID              = #{tenantId},
+        TREE_PATH              = #{treePath},
         HISTORY_CLEANUP_DATE   = #{historyCleanupDate, jdbcType=TIMESTAMP}
     WHERE INCIDENT_KEY = #{incidentKey}
   </update>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.SearchResponse;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@MultiDbTest
+class ProcessInstanceIncidentSearchTest {
+
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static final int AMOUNT_OF_PROCESS_INSTANCES_WITH_INCIDENTS = 3;
+  private static final int AMOUNT_OF_INCIDENTS = 2;
+
+  private static List<ProcessInstance> processInstancesSortedByKey;
+  private static List<Incident> incidentsSortedByKey;
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+
+    final var processes =
+        List.of(
+            "process_with_call_activity_1_v1.bpmn",
+            "process_with_call_activity_2_and_incident_v1.bpmn",
+            "process_with_incident_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+    startProcessInstance(camundaClient, "process_with_call_activity_1_v1");
+    waitForProcessInstancesToStart(camundaClient, 3);
+    waitUntilProcessInstanceHasIncidents(camundaClient, AMOUNT_OF_PROCESS_INSTANCES_WITH_INCIDENTS);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
+
+    processInstancesSortedByKey =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .sort(s -> s.processInstanceKey().asc())
+            .send()
+            .join()
+            .items();
+    incidentsSortedByKey =
+        camundaClient
+            .newIncidentSearchRequest()
+            .sort(s -> s.incidentKey().asc())
+            .send()
+            .join()
+            .items();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  void shouldThrowNotFoundExceptionIfProcessInstanceKeyNotFound() {
+    // given
+    final var processInstanceKey = 1234567890L;
+
+    // when
+    final var exception =
+        assertThrowsExactly(
+            ProblemException.class,
+            () ->
+                camundaClient
+                    .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+                    .send()
+                    .join());
+
+    // then
+    assertThat(exception.getMessage()).startsWith("Failed with code 404");
+    assertThat(exception.details()).isNotNull();
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+    assertThat(exception.details().getDetail())
+        .isEqualTo("Process instance with key 1234567890 not found");
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideProcessInstanceKeyAndExpectedAmountOfIncidents")
+  void testAllIncidentsAreFetched(
+      final long processInstanceKey, final List<Incident> expectedIncidents) {
+    // when
+    final SearchResponse<Incident> incidentsResult =
+        camundaClient.newIncidentSearchByProcessInstanceKey(processInstanceKey).send().join();
+
+    // then
+    assertThat(incidentsResult.items().size()).isEqualTo(expectedIncidents.size());
+    assertThat(incidentsResult.items()).containsExactlyElementsOf(expectedIncidents);
+  }
+
+  @Test
+  void shouldSortByIncidentKeyDescending() {
+    // given
+    final long processInstanceKey = processInstancesSortedByKey.getFirst().getProcessInstanceKey();
+
+    // when
+    final SearchResponse<Incident> incidentsResult =
+        camundaClient
+            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .sort(s -> s.incidentKey().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(incidentsResult.items().size()).isEqualTo(incidentsSortedByKey.size());
+
+    final var sortedIncidentsInDesc =
+        incidentsSortedByKey.stream()
+            .sorted(Comparator.comparingLong(inc -> -inc.getIncidentKey()))
+            .toList();
+    assertThat(incidentsResult.items()).containsExactlyElementsOf(sortedIncidentsInDesc);
+  }
+
+  @Test
+  void shouldPaginateWithLimitAndOffset() {
+    // given
+    final var processInstanceKey = processInstancesSortedByKey.getFirst().getProcessInstanceKey();
+
+    // when
+    final var response1 =
+        camundaClient
+            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var response2 =
+        camundaClient
+            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .page(p -> p.after(response1.page().endCursor()))
+            .send()
+            .join();
+
+    // then
+    assertThat(response1.page().totalItems()).isEqualTo(incidentsSortedByKey.size());
+    assertThat(response1.items()).containsExactly(incidentsSortedByKey.getFirst());
+
+    assertThat(response2.page().totalItems()).isEqualTo(incidentsSortedByKey.size());
+    assertThat(response2.items()).containsExactly(incidentsSortedByKey.get(1));
+  }
+
+  private static Stream<Arguments> provideProcessInstanceKeyAndExpectedAmountOfIncidents() {
+    final var processInstance1 = processInstancesSortedByKey.get(0);
+    final var processInstance1Incidents = incidentsSortedByKey;
+
+    final var processInstance2 = processInstancesSortedByKey.get(1);
+    final var processInstance2Incidents = incidentsSortedByKey;
+
+    final var processInstance3 = processInstancesSortedByKey.get(2);
+    final var processInstance3Incidents = List.of(incidentsSortedByKey.get(1));
+
+    return Stream.of(
+        Arguments.of(processInstance1.getProcessInstanceKey(), processInstance1Incidents),
+        Arguments.of(processInstance2.getProcessInstanceKey(), processInstance2Incidents),
+        Arguments.of(processInstance3.getProcessInstanceKey(), processInstance3Incidents));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceIncidentSearchTest.java
@@ -98,7 +98,7 @@ class ProcessInstanceIncidentSearchTest {
             ProblemException.class,
             () ->
                 camundaClient
-                    .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+                    .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
                     .send()
                     .join());
 
@@ -117,7 +117,7 @@ class ProcessInstanceIncidentSearchTest {
       final long processInstanceKey, final List<Incident> expectedIncidents) {
     // when
     final SearchResponse<Incident> incidentsResult =
-        camundaClient.newIncidentSearchByProcessInstanceKey(processInstanceKey).send().join();
+        camundaClient.newIncidentsByProcessInstanceSearchRequest(processInstanceKey).send().join();
 
     // then
     assertThat(incidentsResult.items().size()).isEqualTo(expectedIncidents.size());
@@ -132,7 +132,7 @@ class ProcessInstanceIncidentSearchTest {
     // when
     final SearchResponse<Incident> incidentsResult =
         camundaClient
-            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
             .sort(s -> s.incidentKey().desc())
             .send()
             .join();
@@ -148,20 +148,20 @@ class ProcessInstanceIncidentSearchTest {
   }
 
   @Test
-  void shouldPaginateWithLimitAndOffset() {
+  void shouldPaginateWithLimitAndCursor() {
     // given
     final var processInstanceKey = processInstancesSortedByKey.getFirst().getProcessInstanceKey();
 
     // when
     final var response1 =
         camundaClient
-            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
             .page(p -> p.limit(1))
             .send()
             .join();
     final var response2 =
         camundaClient
-            .newIncidentSearchByProcessInstanceKey(processInstanceKey)
+            .newIncidentsByProcessInstanceSearchRequest(processInstanceKey)
             .page(p -> p.after(response1.page().endCursor()))
             .send()
             .join();

--- a/qa/acceptance-tests/src/test/resources/process/process_with_call_activity_1_v1.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_call_activity_1_v1.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_051zr87" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="process_with_call_activity_1_v1" name="Process with call activity 1 v1" isExecutable="true">
+    <bpmn:startEvent id="SE_0" name="SE_0">
+      <bpmn:outgoing>Flow_004kmgk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_004kmgk" sourceRef="SE_0" targetRef="Activity_0w2l7u9" />
+    <bpmn:endEvent id="Event_1e6xvrw">
+      <bpmn:incoming>Flow_0oxnqyi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0oxnqyi" sourceRef="Activity_0w2l7u9" targetRef="Event_1e6xvrw" />
+    <bpmn:callActivity id="Activity_0w2l7u9" name="Call process 2">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="process_with_call_activity_2_v1" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_004kmgk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0oxnqyi</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_call_activity_1_v1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="SE_0">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="187" y="145" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1e6xvrw_di" bpmnElement="Event_1e6xvrw">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vgwnj1_di" bpmnElement="Activity_0w2l7u9">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_004kmgk_di" bpmnElement="Flow_004kmgk">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0oxnqyi_di" bpmnElement="Flow_0oxnqyi">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_call_activity_2_and_incident_v1.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_call_activity_2_and_incident_v1.bpmn
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1mvxe6a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="process_with_call_activity_2_v1" name="Process with call activity 2 v1" isExecutable="true">
+    <bpmn:startEvent id="SE_1" name="SE_1">
+      <bpmn:outgoing>Flow_1jecqqo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Activity_0x8bk4s" name="Call process 3">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="process_with_call_activity_3_v1" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ms6trq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0p2ol1s</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1jecqqo" sourceRef="SE_1" targetRef="Gateway_1rn30oc" />
+    <bpmn:parallelGateway id="Gateway_1rn30oc">
+      <bpmn:incoming>Flow_1jecqqo</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ms6trq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19ar0l7</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1ms6trq" sourceRef="Gateway_1rn30oc" targetRef="Activity_0x8bk4s" />
+    <bpmn:sequenceFlow id="Flow_19ar0l7" sourceRef="Gateway_1rn30oc" targetRef="Activity_1k0eshu" />
+    <bpmn:userTask id="Activity_1k0eshu" name="Non-existent task">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="non_existent" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19ar0l7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q31f6k</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0p2ol1s" sourceRef="Activity_0x8bk4s" targetRef="Gateway_1sg2vtc" />
+    <bpmn:parallelGateway id="Gateway_1sg2vtc">
+      <bpmn:incoming>Flow_0p2ol1s</bpmn:incoming>
+      <bpmn:incoming>Flow_1q31f6k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ngioot</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="Event_11zet0r">
+      <bpmn:incoming>Flow_1ngioot</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ngioot" sourceRef="Gateway_1sg2vtc" targetRef="Event_11zet0r" />
+    <bpmn:sequenceFlow id="Flow_1q31f6k" sourceRef="Activity_1k0eshu" targetRef="Gateway_1sg2vtc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_call_activity_2_v1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="SE_1">
+        <dc:Bounds x="182" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="187" y="315" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ndczpj_di" bpmnElement="Gateway_1rn30oc">
+        <dc:Bounds x="395" y="265" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wcm61v_di" bpmnElement="Activity_0x8bk4s">
+        <dc:Bounds x="590" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0c4b60e_di" bpmnElement="Gateway_1sg2vtc">
+        <dc:Bounds x="855" y="265" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11zet0r_di" bpmnElement="Event_11zet0r">
+        <dc:Bounds x="1072" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vvyole_di" bpmnElement="Activity_1k0eshu">
+        <dc:Bounds x="590" y="400" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1jecqqo_di" bpmnElement="Flow_1jecqqo">
+        <di:waypoint x="218" y="290" />
+        <di:waypoint x="395" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ms6trq_di" bpmnElement="Flow_1ms6trq">
+        <di:waypoint x="420" y="265" />
+        <di:waypoint x="420" y="120" />
+        <di:waypoint x="590" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ar0l7_di" bpmnElement="Flow_19ar0l7">
+        <di:waypoint x="420" y="315" />
+        <di:waypoint x="420" y="440" />
+        <di:waypoint x="590" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p2ol1s_di" bpmnElement="Flow_0p2ol1s">
+        <di:waypoint x="690" y="120" />
+        <di:waypoint x="880" y="120" />
+        <di:waypoint x="880" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ngioot_di" bpmnElement="Flow_1ngioot">
+        <di:waypoint x="905" y="290" />
+        <di:waypoint x="1072" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q31f6k_di" bpmnElement="Flow_1q31f6k">
+        <di:waypoint x="690" y="440" />
+        <di:waypoint x="880" y="440" />
+        <di:waypoint x="880" y="315" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/acceptance-tests/src/test/resources/process/process_with_incident_v1.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_incident_v1.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0u0hvur" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.34.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="process_with_call_activity_3_v1" name="Process with call activity 3 v1" isExecutable="true">
+    <bpmn:startEvent id="SE_2" name="SE_2">
+      <bpmn:outgoing>Flow_01lgkgj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_01lgkgj" sourceRef="SE_2" targetRef="Activity_0j7nphk" />
+    <bpmn:sequenceFlow id="Flow_1rex8zu" sourceRef="Activity_0j7nphk" targetRef="Event_06ulfij" />
+    <bpmn:endEvent id="Event_06ulfij">
+      <bpmn:incoming>Flow_1rex8zu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_0j7nphk" name="Call process 4">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="process_with_call_activity_4_v1" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_01lgkgj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rex8zu</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process_with_call_activity_3_v1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="SE_2">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="187" y="145" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14hacse_di" bpmnElement="Activity_0j7nphk">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06ulfij_di" bpmnElement="Event_06ulfij">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_01lgkgj_di" bpmnElement="Flow_01lgkgj">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rex8zu_di" bpmnElement="Flow_1rex8zu">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -235,7 +235,8 @@ public class RdbmsExporterWrapper implements Exporter {
         new DecisionInstanceExportHandler(rdbmsWriter.getDecisionInstanceWriter()));
     builder.withHandler(ValueType.GROUP, new GroupExportHandler(rdbmsWriter.getGroupWriter()));
     builder.withHandler(
-        ValueType.INCIDENT, new IncidentExportHandler(rdbmsWriter.getIncidentWriter()));
+        ValueType.INCIDENT,
+        new IncidentExportHandler(rdbmsWriter.getIncidentWriter(), processCache));
     builder.withHandler(
         ValueType.INCIDENT,
         new ProcessInstanceIncidentExportHandler(rdbmsWriter.getProcessInstanceWriter()));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR does the following:
* Extends the Java client with methods for searching incidents by processInstanceKey
* Fixes incident treePath for RDBMS exporters
* Adds acceptance tests for the new method

## Related issues

closes https://github.com/camunda/camunda/issues/33135 https://github.com/camunda/camunda/issues/33136
