### PR TITLE
fix: failure when persisting bigger batch operation chunks in RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -104,7 +104,7 @@ public class RdbmsWriter {
     userTaskWriter = new UserTaskWriter(executionQueue, userTaskMapper);
     formWriter = new FormWriter(executionQueue);
     mappingWriter = new MappingWriter(executionQueue);
-    batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue);
+    batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue, config);
     jobWriter = new JobWriter(executionQueue, jobMapper);
     sequenceFlowWriter = new SequenceFlowWriter(executionQueue, sequenceFlowMapper);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -16,13 +16,15 @@ public record RdbmsWriterConfig(
     Duration defaultHistoryTTL,
     Duration minHistoryCleanupInterval,
     Duration maxHistoryCleanupInterval,
-    int historyCleanupBatchSize) {
+    int historyCleanupBatchSize,
+    int batchOperationItemInsertBlockSize) {
 
   public static final int DEFAULT_QUEUE_SIZE = -1;
   public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
   public static final Duration DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(1);
   public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
   public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
+  public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
 
   public static Builder builder() {
     return new Builder();
@@ -36,34 +38,40 @@ public record RdbmsWriterConfig(
     private Duration minHistoryCleanupInterval = DEFAULT_MIN_HISTORY_CLEANUP_INTERVAL;
     private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
+    private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
 
-    public Builder partitionId(int partitionId) {
+    public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
       return this;
     }
 
-    public Builder maxQueueSize(int maxQueueSize) {
+    public Builder maxQueueSize(final int maxQueueSize) {
       this.maxQueueSize = maxQueueSize;
       return this;
     }
 
-    public Builder defaultHistoryTTL(Duration defaultHistoryTTL) {
+    public Builder defaultHistoryTTL(final Duration defaultHistoryTTL) {
       this.defaultHistoryTTL = defaultHistoryTTL;
       return this;
     }
 
-    public Builder minHistoryCleanupInterval(Duration minHistoryCleanupInterval) {
+    public Builder minHistoryCleanupInterval(final Duration minHistoryCleanupInterval) {
       this.minHistoryCleanupInterval = minHistoryCleanupInterval;
       return this;
     }
 
-    public Builder maxHistoryCleanupInterval(Duration maxHistoryCleanupInterval) {
+    public Builder maxHistoryCleanupInterval(final Duration maxHistoryCleanupInterval) {
       this.maxHistoryCleanupInterval = maxHistoryCleanupInterval;
       return this;
     }
 
-    public Builder historyCleanupBatchSize(int historyCleanupBatchSize) {
+    public Builder historyCleanupBatchSize(final int historyCleanupBatchSize) {
       this.historyCleanupBatchSize = historyCleanupBatchSize;
+      return this;
+    }
+
+    public Builder batchOperationItemInsertBlockSize(final int batchOperationItemInsertBlockSize) {
+      this.batchOperationItemInsertBlockSize = batchOperationItemInsertBlockSize;
       return this;
     }
 
@@ -75,7 +83,8 @@ public record RdbmsWriterConfig(
           defaultHistoryTTL,
           minHistoryCleanupInterval,
           maxHistoryCleanupInterval,
-          historyCleanupBatchSize);
+          historyCleanupBatchSize,
+          batchOperationItemInsertBlockSize);
     }
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
+import io.camunda.db.rdbms.write.RdbmsWriterConfig;
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class BatchOperationWriterTest {
+
+  private final ExecutionQueue executionQueue = Mockito.mock(ExecutionQueue.class);
+  private final BatchOperationWriter batchOperationWriter =
+      new BatchOperationWriter(
+          null,
+          executionQueue,
+          RdbmsWriterConfig.builder().batchOperationItemInsertBlockSize(10).build());
+
+  @Test
+  void testSplitCorrectly() {
+    // given
+    final var itemsDto =
+        new BatchOperationItemsDto(
+            "42",
+            LongStream.range(0, 25)
+                .boxed()
+                .map(i -> new BatchOperationItemDbModel("42", i, i, BatchOperationItemState.ACTIVE))
+                .toList());
+
+    // when
+    batchOperationWriter.insertItems(itemsDto);
+
+    final var payloadCaptor = ArgumentCaptor.forClass(QueueItem.class);
+    Mockito.verify(executionQueue, Mockito.times(3)).executeInQueue(payloadCaptor.capture());
+
+    final var capturedItems =
+        payloadCaptor.getAllValues().stream()
+            .map(q -> (BatchOperationItemsDto) q.parameter())
+            .toList();
+
+    assertThat(capturedItems.get(0).items()).hasSize(10);
+    assertThat(capturedItems.get(1).items()).hasSize(10);
+    assertThat(capturedItems.get(2).items()).hasSize(5);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.rdbms;
 
+import static io.camunda.db.rdbms.write.RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
+
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig;
@@ -83,6 +85,7 @@ public class RdbmsExporterWrapper implements Exporter {
                 .defaultHistoryTTL(readHistoryTTL(context))
                 .minHistoryCleanupInterval(readMinHistoryCleanupInterval(context))
                 .maxHistoryCleanupInterval(readMaxHistoryCleanupInterval(context))
+                .batchOperationItemInsertBlockSize(readBatchOperationItemInsertBlockSize(context))
                 .build());
 
     final var builder =
@@ -152,6 +155,13 @@ public class RdbmsExporterWrapper implements Exporter {
 
   private int readCleanupBatchSize(final Context context) {
     return readInt(context, "historyCleanupBatchSize", DEFAULT_CLEANUP_BATCH_SIZE);
+  }
+
+  private int readBatchOperationItemInsertBlockSize(final Context context) {
+    return readInt(
+        context,
+        "batchOperationItemInsertBlockSize",
+        DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE);
   }
 
   private Duration readDuration(


### PR DESCRIPTION
## Description

Splits larger chunk records into smaller blocks and insert them one after the other.

## Related issues

closes #33945 
