### PR TITLE
chore(deps): Disable upgrades to major and minor versions of ElasticSearch and OpenSearch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -103,6 +103,20 @@
       "enabled": false
     },
     {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "elasticsearch",
+        "opensearchproject/opensearch"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Skip lucene major updates to avoid breaking changes.",
       "matchManagers": [
         "maven"


### PR DESCRIPTION
## Description

chore(deps): Disable upgrades to major and minor versions of ElasticSearch and OpenSearch

Such upgrades are done separately by the teams (see the similar config for Maven deps for ES and OS right above this new rule for blocking minor and major updates).

This is to ensure these PRs are not created in the future:
- https://github.com/camunda/camunda/pull/33667
- https://github.com/camunda/camunda/pull/33733

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
