### PR TITLE
feat: add kind listener type to job activation endpoint

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -17,6 +17,8 @@ package io.camunda.client.api.response;
 
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
 import java.util.Map;
 
 public interface ActivatedJob {
@@ -110,6 +112,16 @@ public interface ActivatedJob {
    *     BPMN_ELEMENT} or {@code EXECUTION_LISTENER}.
    */
   UserTaskProperties getUserTask();
+
+  /**
+   * @return the kind of the job.
+   */
+  JobKind getKind();
+
+  /**
+   * @return the listener event type of the job.
+   */
+  ListenerEventType getListenerEventType();
 
   /**
    * @return the record encoded as JSON

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/JobKind.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/JobKind.java
@@ -18,5 +18,6 @@ package io.camunda.client.api.search.enums;
 public enum JobKind {
   BPMN_ELEMENT,
   EXECUTION_LISTENER,
-  TASK_LISTENER
+  TASK_LISTENER,
+  UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/JobState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/JobState.java
@@ -24,4 +24,5 @@ public enum JobState {
   MIGRATED,
   RETRIES_UPDATED,
   TIMED_OUT,
+  UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
@@ -23,5 +23,6 @@ public enum ListenerEventType {
   END,
   START,
   UNSPECIFIED,
-  UPDATING
+  UPDATING,
+  UNKNOWN_ENUM_VALUE;
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -20,6 +20,9 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.UserTaskProperties;
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +48,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final long deadline;
   private final String variables;
   private final UserTaskProperties userTask;
+  private final JobKind kind;
+  private final ListenerEventType listenerEventType;
 
   private Map<String, Object> variablesAsMap;
 
@@ -71,6 +76,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementInstanceKey = job.getElementInstanceKey();
     tenantId = job.getTenantId();
     userTask = job.hasUserTask() ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
+    kind = EnumUtil.convert(job.getKind(), JobKind.class);
+    listenerEventType = EnumUtil.convert(job.getListenerEventType(), ListenerEventType.class);
   }
 
   public ActivatedJobImpl(
@@ -103,6 +110,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementInstanceKey = parseLongOrEmpty(job.getElementInstanceKey());
     tenantId = getOrEmpty(job.getTenantId());
     userTask = job.getUserTask() != null ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
+    kind = EnumUtil.convert(job.getKind(), JobKind.class);
+    listenerEventType = EnumUtil.convert(job.getListenerEventType(), ListenerEventType.class);
   }
 
   @Override
@@ -195,6 +204,16 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public UserTaskProperties getUserTask() {
     return userTask;
+  }
+
+  @Override
+  public JobKind getKind() {
+    return kind;
+  }
+
+  @Override
+  public ListenerEventType getListenerEventType() {
+    return listenerEventType;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -25,9 +25,12 @@ import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob.JobKind;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob.ListenerEventType;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UserTaskProperties;
 import java.time.Duration;
 import java.util.Arrays;
@@ -55,6 +58,8 @@ public final class ActivateJobsTest extends ClientTest {
             .setDeadline(1231)
             .setVariables("{\"key\": \"val\"}")
             .setTenantId("test-tenant-1")
+            .setKind(JobKind.BPMN_ELEMENT)
+            .setListenerEventType(ListenerEventType.START)
             .build();
 
     final ActivatedJob activatedJob2 =
@@ -73,6 +78,8 @@ public final class ActivateJobsTest extends ClientTest {
             .setDeadline(3131)
             .setVariables("{\"bar\": 3}")
             .setTenantId("test-tenant-2")
+            .setKind(JobKind.TASK_LISTENER)
+            .setListenerEventType(ListenerEventType.END)
             .build();
 
     gatewayService.onActivateJobsRequest(activatedJob1, activatedJob2);
@@ -109,6 +116,15 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
     assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
+    assertThat(job.getKind())
+        .isEqualTo(
+            EnumUtil.convert(
+                activatedJob1.getKind(), io.camunda.client.api.search.enums.JobKind.class));
+    assertThat(job.getListenerEventType())
+        .isEqualTo(
+            EnumUtil.convert(
+                activatedJob1.getListenerEventType(),
+                io.camunda.client.api.search.enums.ListenerEventType.class));
 
     job = response.getJobs().get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
@@ -127,6 +143,15 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
     assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
+    assertThat(job.getKind())
+        .isEqualTo(
+            EnumUtil.convert(
+                activatedJob2.getKind(), io.camunda.client.api.search.enums.JobKind.class));
+    assertThat(job.getListenerEventType())
+        .isEqualTo(
+            EnumUtil.convert(
+                activatedJob2.getListenerEventType(),
+                io.camunda.client.api.search.enums.ListenerEventType.class));
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
     assertThat(request.getType()).isEqualTo("foo");

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -23,12 +23,17 @@ import io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsComman
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.search.enums.JobKind;
+import io.camunda.client.api.search.enums.ListenerEventType;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
+import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.ActivatedJobResult;
 import io.camunda.client.protocol.rest.JobActivationRequest;
 import io.camunda.client.protocol.rest.JobActivationResult;
+import io.camunda.client.protocol.rest.JobKindEnum;
+import io.camunda.client.protocol.rest.JobListenerEventTypeEnum;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.UserTaskProperties;
 import io.camunda.client.util.ClientRestTest;
@@ -64,7 +69,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .retries(34)
             .deadline(1231L)
             .variables(singletonMap("key", "val"))
-            .tenantId("test-tenant-1");
+            .tenantId("test-tenant-1")
+            .kind(JobKindEnum.BPMN_ELEMENT)
+            .listenerEventType(JobListenerEventTypeEnum.START);
 
     final ActivatedJobResult activatedJob2 =
         new ActivatedJobResult()
@@ -81,7 +88,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .retries(334)
             .deadline(3131L)
             .variables(singletonMap("bar", 3))
-            .tenantId("test-tenant-2");
+            .tenantId("test-tenant-2")
+            .kind(JobKindEnum.BPMN_ELEMENT)
+            .listenerEventType(JobListenerEventTypeEnum.END);
 
     gatewayService.onActivateJobsRequest(
         new JobActivationResult().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
@@ -121,6 +130,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob1.getVariables());
     assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
+    assertThat(job.getKind()).isEqualTo(EnumUtil.convert(activatedJob1.getKind(), JobKind.class));
+    assertThat(job.getListenerEventType())
+        .isEqualTo(EnumUtil.convert(activatedJob1.getListenerEventType(), ListenerEventType.class));
 
     job = response.getJobs().get(1);
     assertThat(String.valueOf(job.getKey())).isEqualTo(activatedJob2.getJobKey());
@@ -142,6 +154,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob2.getVariables());
     assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
+    assertThat(job.getKind()).isEqualTo(EnumUtil.convert(activatedJob2.getKind(), JobKind.class));
+    assertThat(job.getListenerEventType())
+        .isEqualTo(EnumUtil.convert(activatedJob2.getListenerEventType(), ListenerEventType.class));
 
     final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
     assertThat(request.getType()).isEqualTo("foo");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchTest.java
@@ -45,13 +45,16 @@ public class JobSearchTest {
         .addResourceFromClasspath("form/job_search_process.form")
         .send()
         .join();
-    final Process process =
+    final Process process1 =
         deployProcessAndWaitForIt(camundaClient, "process/job_search_process.bpmn");
-    startProcessInstance(camundaClient, process.getBpmnProcessId());
-    waitForProcessInstancesToStart(camundaClient, 1);
+    startProcessInstance(camundaClient, process1.getBpmnProcessId());
+    final Process process2 =
+        deployProcessAndWaitForIt(camundaClient, "process/service_tasks_v1.bpmn");
+    startProcessInstance(camundaClient, process2.getBpmnProcessId());
+    waitForProcessInstancesToStart(camundaClient, 2);
 
     // Wait until the total number of jobs in the system reaches 1
-    waitUntilNewJobHasBeenCreated(1);
+    waitUntilNewJobHasBeenCreated(2);
 
     final var executionStartListenerJob =
         camundaClient
@@ -66,7 +69,7 @@ public class JobSearchTest {
     camundaClient.newCompleteCommand(executionStartListenerJob.getJobKey()).send().join();
 
     // Wait until the total number of jobs in the system reaches 2
-    waitUntilNewJobHasBeenCreated(2);
+    waitUntilNewJobHasBeenCreated(3);
 
     final var taskABpmnJob =
         camundaClient
@@ -83,7 +86,7 @@ public class JobSearchTest {
     camundaClient.newCompleteCommand(taskABpmnJob.getKey()).send().join();
 
     // Wait until the total number of jobs in the system reaches 3
-    waitUntilNewJobHasBeenCreated(3);
+    waitUntilNewJobHasBeenCreated(4);
 
     final var executionEndListenerJob =
         camundaClient
@@ -113,7 +116,7 @@ public class JobSearchTest {
         .send();
 
     // Wait until the total number of jobs in the system reaches 4
-    waitUntilNewJobHasBeenCreated(4);
+    waitUntilNewJobHasBeenCreated(5);
 
     final var userTaskListenerAssigningJob1 =
         camundaClient
@@ -139,7 +142,7 @@ public class JobSearchTest {
     waitUntilNewUserTaskHasBeenCreated();
 
     // Wait until the total number of jobs in the system reaches 5
-    waitUntilNewJobHasBeenCreated(5);
+    waitUntilNewJobHasBeenCreated(6);
 
     final var userTaskListenerAssigningJob2 =
         camundaClient
@@ -171,7 +174,7 @@ public class JobSearchTest {
         .send();
 
     // Wait until the total number of jobs in the system reaches 6
-    waitUntilNewJobHasBeenCreated(6);
+    waitUntilNewJobHasBeenCreated(7);
 
     final var taskCBpmnJob =
         camundaClient
@@ -207,7 +210,7 @@ public class JobSearchTest {
     final var result = camundaClient.newJobSearchRequest().send().join();
     // then
     assertThat(result.items())
-        .hasSize(6)
+        .hasSize(7)
         .extracting(Job::getType)
         .containsExactlyInAnyOrderElementsOf(
             List.of(
@@ -216,7 +219,29 @@ public class JobSearchTest {
                 "taskBTaskListener",
                 "taskCBpmn",
                 "taskAExecutionListener",
-                "taskBTaskListener"));
+                "taskBTaskListener",
+                "taskA"));
+  }
+
+  @Test
+  void shouldReturnActivatedJobWithKindAndListenerEventType() {
+    // given
+    final var result =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("taskA")
+            .maxJobsToActivate(1)
+            .workerName("worker2")
+            .timeout(Duration.ofSeconds(3))
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    // then
+    assertThat(result.getType()).isEqualTo("taskA");
+    assertThat(result.getWorker()).isEqualTo("worker2");
+    assertThat(result.getKind()).isEqualTo(JobKind.BPMN_ELEMENT);
+    assertThat(result.getListenerEventType()).isEqualTo(ListenerEventType.UNSPECIFIED);
   }
 
   @Test
@@ -436,7 +461,7 @@ public class JobSearchTest {
             .join();
 
     // then
-    assertThat(result.items()).hasSize(6);
+    assertThat(result.items()).hasSize(7);
     assertThat(result.items())
         .extracting(Job::getTenantId)
         .allMatch(t -> t.equals(taskABpmnJob.getTenantId()));
@@ -574,7 +599,7 @@ public class JobSearchTest {
             .join();
 
     // then
-    assertThat(result.items()).hasSize(6);
+    assertThat(result.items()).hasSize(7);
     assertThat(result.items().getFirst().getRetries()).isEqualTo(retries);
   }
 

--- a/search/search-domain/pom.xml
+++ b/search/search-domain/pom.xml
@@ -31,6 +31,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>

--- a/search/search-domain/src/main/java/io/camunda/util/EnumUtil.java
+++ b/search/search-domain/src/main/java/io/camunda/util/EnumUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.util;
+
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class EnumUtil {
+
+  private static final String UNKNOWN_ENUM_VALUE = "UNKNOWN_ENUM_VALUE";
+  private static final String UNKNOWN_DEFAULT_OPEN_API = "UNKNOWN_DEFAULT_OPEN_API";
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EnumUtil.class);
+
+  private EnumUtil() {}
+
+  public static <E> void logUnknownEnumValue(
+      final Object value, final String enumName, final E[] validValues) {
+    LOGGER.debug(
+        "Unexpected {} '{}', should be one of {}", enumName, value, Arrays.toString(validValues));
+  }
+
+  public static <E1 extends Enum<E1>, E2 extends Enum<E2>> E2 convert(
+      final E1 source, final Class<E2> targetClass) {
+    if (source == null) {
+      return null;
+    }
+    try {
+      if (source.name().equals(UNKNOWN_ENUM_VALUE)) {
+        return E2.valueOf(targetClass, UNKNOWN_DEFAULT_OPEN_API);
+      }
+      if (source.name().equals(UNKNOWN_DEFAULT_OPEN_API)) {
+        return E2.valueOf(targetClass, UNKNOWN_ENUM_VALUE);
+      }
+      return E2.valueOf(targetClass, source.name());
+    } catch (final IllegalArgumentException e) {
+      logUnknownEnumValue(source, source.getClass().getName(), targetClass.getEnumConstants());
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.util.EnumUtil;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
@@ -61,7 +62,6 @@ import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionReco
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
-import io.camunda.zeebe.protocol.record.value.JobKind;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -376,9 +376,14 @@ public final class ResponseMapper {
             .setRetries(job.getRetries())
             .setDeadline(job.getDeadline())
             .setVariables(bufferAsJson(job.getVariablesBuffer()))
-            .setTenantId(job.getTenantId());
+            .setTenantId(job.getTenantId())
+            .setKind(EnumUtil.convert(job.getJobKind(), ActivatedJob.JobKind.class))
+            .setListenerEventType(
+                EnumUtil.convert(
+                    job.getJobListenerEventType(), ActivatedJob.ListenerEventType.class));
 
-    if (job.getJobKind() == JobKind.TASK_LISTENER && !job.getCustomHeaders().isEmpty()) {
+    if (job.getJobKind().equals(io.camunda.zeebe.protocol.record.value.JobKind.TASK_LISTENER)
+        && !job.getCustomHeaders().isEmpty()) {
       builder.setUserTask(toUserTaskProperties(job.getCustomHeaders()));
     }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collections;
@@ -168,6 +169,7 @@ class ResponseMapperTest {
     private static JobRecord mockJobRecord(final ActivatedJobWithUserTaskPropsCase testCase) {
       final JobRecord jobRecord = mock(JobRecord.class);
       when(jobRecord.getJobKind()).thenReturn(testCase.jobKind);
+      when(jobRecord.getJobListenerEventType()).thenReturn(JobListenerEventType.START);
       when(jobRecord.getCustomHeaders()).thenReturn(testCase.headers);
       when(jobRecord.getTypeBuffer()).thenReturn(BufferUtil.wrapString("type"));
       when(jobRecord.getBpmnProcessId()).thenReturn("procId");

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -63,6 +65,9 @@ public class StreamActivatedJobsTest extends GatewayTest {
     assertThat(activatedJob.jobRecord().getVariables()).isEqualTo(fetchedVariables);
     assertThat(activatedJob.jobRecord().getTenantId())
         .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(activatedJob.jobRecord().getJobKind()).isEqualTo(JobKind.BPMN_ELEMENT);
+    assertThat(activatedJob.jobRecord().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.UNSPECIFIED);
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -52,6 +52,25 @@ message ActivateJobsResponse {
 }
 
 message ActivatedJob {
+  // Describes the kind of job.
+  enum JobKind {
+    BPMN_ELEMENT = 0;
+    EXECUTION_LISTENER = 1;
+    TASK_LISTENER = 2;
+  }
+
+  // Describes the listener event type of the job.
+  enum ListenerEventType {
+    ASSIGNING = 0;
+    CANCELING = 1;
+    COMPLETING = 2;
+    CREATING = 3;
+    END = 4;
+    START = 5;
+    UNSPECIFIED = 6;
+    UPDATING = 7;
+  }
+
   // the key, a unique identifier for the job
   int64 key = 1;
   // the type of the job (should match what was requested)
@@ -85,6 +104,10 @@ message ActivatedJob {
   string tenantId = 14;
   // Contains user task properties if the job is of kind TASK_LISTENER
   optional UserTaskProperties userTask = 15;
+  // the kind of the job.
+  JobKind kind = 16;
+  // the listener event type of the job.
+  ListenerEventType listenerEventType = 17;
 }
 
 message UserTaskProperties {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8599,6 +8599,10 @@ components:
             The unique key identifying the associated task, unique within the scope of the
             process instance.
           type: string
+        kind:
+          $ref: "#/components/schemas/JobKindEnum"
+        listenerEventType:
+          $ref: "#/components/schemas/JobListenerEventTypeEnum"
         userTask:
           $ref: "#/components/schemas/UserTaskProperties"
     UserTaskProperties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -49,6 +49,8 @@ import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.GroupUpdateResult;
+import io.camunda.zeebe.gateway.protocol.rest.JobKindEnum;
+import io.camunda.zeebe.gateway.protocol.rest.JobListenerEventTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleUpdateResult;
 import io.camunda.zeebe.gateway.protocol.rest.MatchedDecisionRuleItem;
@@ -196,7 +198,9 @@ public final class ResponseMapper {
         .variables(job.getVariables())
         .customHeaders(job.getCustomHeadersObjectMap())
         .userTask(toUserTaskProperties(job))
-        .tenantId(job.getTenantId());
+        .tenantId(job.getTenantId())
+        .kind(JobKindEnum.valueOf(job.getJobKind().name()))
+        .listenerEventType(JobListenerEventTypeEnum.valueOf(job.getJobListenerEventType().name()));
   }
 
   private static UserTaskProperties toUserTaskProperties(final JobRecord job) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import static io.camunda.zeebe.protocol.record.value.JobKind.TASK_LISTENER;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
@@ -24,6 +25,7 @@ import io.camunda.document.api.DocumentError.StoreDoesNotExist;
 import io.camunda.document.api.DocumentLink;
 import io.camunda.service.DocumentServices.DocumentErrorResponse;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
+import io.camunda.util.EnumUtil;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
@@ -90,7 +92,6 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedOutputValue;
-import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.util.Either;
@@ -199,13 +200,13 @@ public final class ResponseMapper {
         .customHeaders(job.getCustomHeadersObjectMap())
         .userTask(toUserTaskProperties(job))
         .tenantId(job.getTenantId())
-        .kind(JobKindEnum.valueOf(job.getJobKind().name()))
-        .listenerEventType(JobListenerEventTypeEnum.valueOf(job.getJobListenerEventType().name()));
+        .kind(EnumUtil.convert(job.getJobKind(), JobKindEnum.class))
+        .listenerEventType(
+            EnumUtil.convert(job.getJobListenerEventType(), JobListenerEventTypeEnum.class));
   }
 
   private static UserTaskProperties toUserTaskProperties(final JobRecord job) {
-    if (job.getJobKind() != JobKind.TASK_LISTENER
-        || CollectionUtils.isEmpty(job.getCustomHeaders())) {
+    if (job.getJobKind() != TASK_LISTENER || CollectionUtils.isEmpty(job.getCustomHeaders())) {
       return null;
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds the kind and listenerEventType fields to the response of the Activate Jobs endpoint. These additional fields provide more context about the nature of the job being activated.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #31905
