### PR TITLE
fix: allow default tenant id in tenant request validator

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -18,6 +18,7 @@ import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateRequest;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.http.ProblemDetail;
@@ -63,7 +64,8 @@ public final class TenantRequestValidator {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted(propertyName));
     } else if (id.length() > MAX_LENGTH) {
       violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted(propertyName, MAX_LENGTH));
-    } else if (!ID_PATTERN.matcher(id).matches()) {
+    } else if (!ID_PATTERN.matcher(id).matches()
+        && !TenantOwned.DEFAULT_TENANT_IDENTIFIER.equals(id)) {
       violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted(propertyName, ID_REGEX));
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantRequestValidatorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantRequestValidatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.tenant;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
+import io.camunda.zeebe.gateway.rest.validator.TenantRequestValidator;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TenantRequestValidatorTest {
+
+  @ParameterizedTest
+  @MethodSource("validTenantIds")
+  void shouldPassTenantIdForCreateRequest(final String tenantId) {
+    // given
+    final TenantCreateRequest request =
+        new TenantCreateRequest()
+            .tenantId(tenantId)
+            .name("New tenant")
+            .description("A new tenant for testing");
+
+    // when
+    final var validationResult = TenantRequestValidator.validateTenantCreateRequest(request);
+
+    // then
+    assertThat(validationResult).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("validTenantIds")
+  void shouldPassTenantIdForMemberRequest(final String tenantId) {
+    // given
+    final String memberId = "member_123";
+
+    // when
+    final var validationResult =
+        TenantRequestValidator.validateMemberRequest(tenantId, memberId, EntityType.USER);
+
+    // then
+    assertThat(validationResult).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidTenantIds")
+  void shouldFailTenantIdForCreateRequest(final String tenantId, final String errorMessage) {
+    // given
+    final TenantCreateRequest request =
+        new TenantCreateRequest()
+            .tenantId(tenantId)
+            .name("New tenant")
+            .description("A new tenant for testing");
+
+    // when
+    final var validationResult = TenantRequestValidator.validateTenantCreateRequest(request);
+
+    // then
+    assertThat(validationResult)
+        .hasValueSatisfying(
+            problemDetail -> assertThat(problemDetail.getDetail()).isEqualTo(errorMessage));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidTenantIds")
+  void shouldFailTenantIdForMemberRequest(final String tenantId, final String errorMessage) {
+    // given
+    final String memberId = "member_123";
+
+    // when
+    final var validationResult =
+        TenantRequestValidator.validateMemberRequest(tenantId, memberId, EntityType.USER);
+
+    // then
+    assertThat(validationResult)
+        .hasValueSatisfying(
+            problemDetail -> assertThat(problemDetail.getDetail()).isEqualTo(errorMessage));
+  }
+
+  private static Stream<Arguments> validTenantIds() {
+    return Stream.of(Arguments.of("<default>"), Arguments.of("custom_1.2@3"));
+  }
+
+  private static Stream<Arguments> invalidTenantIds() {
+    return Stream.of(
+        Arguments.of(
+            "<custom>", ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("tenantId", ID_PATTERN) + "."),
+        Arguments.of("   ", ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tenantId") + "."),
+        Arguments.of("", ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tenantId") + "."),
+        Arguments.of(
+            "not blank", ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("tenantId", ID_PATTERN) + "."));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #32421 
