### PR TITLE
fix: remove hardcoded default tenant access

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -446,26 +446,22 @@ public final class AuthorizationCheckBehavior {
       return AuthorizedTenants.ANONYMOUS;
     }
 
+    if (!multiTenancyEnabled) {
+      return AuthorizedTenants.DEFAULT_TENANTS;
+    }
+
     final var username = getUsername(command);
     if (username.isPresent()) {
       final var tenantIds =
           getAuthorizedTenantIds(command, EntityType.USER, username.get()).toList();
-      if (tenantIds.isEmpty()) {
-        return AuthorizedTenants.DEFAULT_TENANTS;
-      } else {
-        return new AuthenticatedAuthorizedTenants(tenantIds);
-      }
+      return new AuthenticatedAuthorizedTenants(tenantIds);
     }
 
     final var clientId = getClientId(command);
     if (clientId.isPresent()) {
       final var tenantIds =
           getAuthorizedTenantIds(command, EntityType.CLIENT, clientId.get()).toList();
-      if (tenantIds.isEmpty()) {
-        return AuthorizedTenants.DEFAULT_TENANTS;
-      } else {
-        return new AuthenticatedAuthorizedTenants(tenantIds);
-      }
+      return new AuthenticatedAuthorizedTenants(tenantIds);
     }
 
     final var tenantsOfMapping =
@@ -474,10 +470,7 @@ public final class AuthorizationCheckBehavior {
                 mapping ->
                     getAuthorizedTenantIds(command, EntityType.MAPPING, mapping.getMappingId()))
             .collect(Collectors.toSet());
-
-    return tenantsOfMapping.isEmpty()
-        ? AuthorizedTenants.DEFAULT_TENANTS
-        : new AuthenticatedAuthorizedTenants(tenantsOfMapping);
+    return new AuthenticatedAuthorizedTenants(tenantsOfMapping);
   }
 
   private Stream<PersistedMapping> getPersistedMappings(final AuthorizationRequest request) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -290,7 +290,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   @Test
-  void shouldGetDefaultAuthorizedTenantIdsIfUserKeyIsNotPresent() {
+  void shouldGetEmptyTenantIdsListIfUserKeyIsNotPresent() {
     // given
     final var command = mock(TypedRecord.class);
 
@@ -299,11 +299,11 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
         authorizationCheckBehavior.getAuthorizedTenantIds(command).getAuthorizedTenantIds();
 
     // then
-    assertThat(authorizedTenantIds).containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(authorizedTenantIds).isEmpty();
   }
 
   @Test
-  void shouldGetDefaultAuthorizedTenantIdsIfUserIsNotPresent() {
+  void shouldGetEmptyTenantIdListIfUserIsNotPresent() {
     // given
     final var command = mockCommand("not-exists");
 
@@ -311,14 +311,13 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
 
     // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds()).isEmpty();
     assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isTrue();
+        .isFalse();
     assertThat(
             authorizedTenantIds.isAuthorizedForTenantIds(
                 List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
-        .isTrue();
+        .isFalse();
     assertThat(authorizedTenantIds.isAuthorizedForTenantId("not-authorized")).isFalse();
   }
 
@@ -438,7 +437,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
   }
 
   @Test
-  void shouldGetDefaultAuthorizedTenantForMapping() {
+  void shouldGetEmptyListForTenantForMapping() {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
@@ -448,8 +447,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     // when
     // then
     assertThat(authorizationCheckBehavior.getAuthorizedTenantIds(command).getAuthorizedTenantIds())
-        .singleElement()
-        .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+        .isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.JobWorkerElementBuilder;
+import io.camunda.zeebe.engine.util.JobWorkerElementBuilderProvider;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeJobWorkerElementBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Collection;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Verifies the multi-tenant behavior of elements that are based on jobs and should be processed by
+ * job workers, ex. service tasks. See {@link JobWorkerElementTest} for the non-multi-tenant tests.
+ */
+@RunWith(Parameterized.class)
+public class JobWorkerElementMultiTenantTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(
+              config -> {
+                config.getAuthorizations().setEnabled(true);
+                config.getMultiTenancy().setEnabled(true);
+              });
+
+  ;
+
+  private static final String PROCESS_ID = "process";
+  private static String tenantId;
+  private static String username;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameter public JobWorkerElementBuilder elementBuilder;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> parameters() {
+    return JobWorkerElementBuilderProvider.buildersAsParameters();
+  }
+
+  private BpmnModelInstance process(
+      final Consumer<ZeebeJobWorkerElementBuilder<?>> elementModifier) {
+    final var processBuilder = Bpmn.createExecutableProcess(PROCESS_ID).startEvent();
+
+    final var jobWorkerElementBuilder = elementBuilder.build(processBuilder, elementModifier);
+    return jobWorkerElementBuilder.id("task").done();
+  }
+
+  @Before
+  public void setUp() {
+    tenantId = Strings.newRandomValidIdentityId();
+    username = Strings.newRandomValidIdentityId();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
+    ENGINE.user().newUser(username).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeJobType("test")))
+        .withTenantId(tenantId)
+        .deploy();
+
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceId(PROCESS_ID)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .create();
+  }
+
+  @Test
+  public void shouldActivateTaskWithCustomTenant() {
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // then
+    final io.camunda.zeebe.protocol.record.Record<ProcessInstanceRecordValue> taskActivating =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withTenantId(tenantId)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(elementBuilder.getElementType())
+            .getFirst();
+
+    Assertions.assertThat(taskActivating.getValue())
+        .hasElementId("task")
+        .hasBpmnElementType(elementBuilder.getElementType())
+        .hasFlowScopeKey(processInstanceKey)
+        .hasBpmnProcessId("process")
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldCompleteTaskWithCustomTenant() {
+    // given
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType("test")
+        .withAuthorizedTenantIds(tenantId)
+        .complete(username);
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withTenantId(tenantId)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(elementBuilder.getElementType(), ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(elementBuilder.getElementType(), ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementMultiTenantTest.java
@@ -55,8 +55,6 @@ public class JobWorkerElementMultiTenantTest {
                 config.getMultiTenancy().setEnabled(true);
               });
 
-  ;
-
   private static final String PROCESS_ID = "process";
   private static String tenantId;
   private static String username;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/MultiTenantJobOperationsTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.ERROR_THROWN;
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.FAILED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultiTenantJobOperationsTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(
+              config -> {
+                config.getAuthorizations().setEnabled(true);
+                config.getMultiTenancy().setEnabled(true);
+              });
+
+  private static final int NEW_RETRIES = 20;
+  private static final String PROCESS_ID = "process";
+  private static final String BOUNDARY_PROCESS_ID = "boundary_process";
+  private static final String BOUNDARY_JOB_TYPE = "test";
+  private static final String ERROR_CODE = "error";
+
+  private static String jobType;
+  private static String username;
+  private static String tenantId;
+
+  private static final BpmnModelInstance BOUNDARY_EVENT_PROCESS =
+      Bpmn.createExecutableProcess(BOUNDARY_PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeJobType(BOUNDARY_JOB_TYPE))
+          .boundaryEvent("error", b -> b.error(ERROR_CODE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @BeforeClass
+  public static void setUp() {
+    tenantId = UUID.randomUUID().toString();
+    username = UUID.randomUUID().toString();
+    final var user = ENGINE.user().newUser(username).create().getValue();
+    final var username = user.getUsername();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
+
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceId(PROCESS_ID)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .create();
+
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
+        .withResourceId(BOUNDARY_PROCESS_ID)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .create();
+  }
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldCompleteJobForCustomTenant() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    final io.camunda.zeebe.protocol.record.Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+
+    // when
+    final io.camunda.zeebe.protocol.record.Record<JobRecordValue> jobCompletedRecord =
+        ENGINE.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete(username);
+
+    // then
+    final JobRecordValue recordValue = jobCompletedRecord.getValue();
+
+    Assertions.assertThat(jobCompletedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.COMPLETED);
+
+    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldRejectCompletionIfTenantIsUnauthorized() {
+    // given
+    final String falseTenantId = UUID.randomUUID().toString();
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    final io.camunda.zeebe.protocol.record.Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE
+            .job()
+            .withKey(batchRecord.getValue().getJobKeys().get(0))
+            .withAuthorizedTenantIds(falseTenantId)
+            .expectRejection()
+            .complete();
+
+    // then
+    Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectThrowErrorIfTenantIsUnauthorized() {
+    // given
+    final String falseTenantId = "foo";
+    final var job = ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE
+            .job()
+            .withKey(job.getKey())
+            .withErrorCode("error")
+            .withAuthorizedTenantIds(falseTenantId)
+            .throwError();
+
+    // then
+    Assertions.assertThat(result).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldThrowErrorForCustomTenant() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE
+            .job()
+            .withKey(job.getKey())
+            .withErrorCode("error")
+            .withErrorMessage("error-message")
+            .throwError(username);
+
+    // then
+    Assertions.assertThat(result).hasRecordType(RecordType.EVENT).hasIntent(ERROR_THROWN);
+    Assertions.assertThat(result.getValue()).hasErrorCode("error").hasErrorMessage("error-message");
+    Assertions.assertThat(result.getValue()).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldUpdateJobTimeoutForCustomTenant() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    final var batchRecord =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withTenantId(tenantId)
+            .activate(username);
+
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final Record<JobRecordValue> updatedRecord =
+        ENGINE.job().withKey(jobKey).withTimeout(timeout).updateTimeout(username);
+
+    // then
+    Assertions.assertThat(updatedRecord.getValue()).hasTenantId(tenantId);
+    assertJobDeadline(updatedRecord, jobKey, job, timeout);
+  }
+
+  @Test
+  public void shouldUpdateRetriesForCustomTenant() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> updatedRecord =
+        ENGINE.job().withKey(jobKey).withRetries(NEW_RETRIES).updateRetries(username);
+
+    // then
+    Assertions.assertThat(updatedRecord.getValue()).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldRejectUpdateRetriesIfTenantIsUnauthorized() {
+    // given
+    final String falseTenantId = "foo";
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withRetries(NEW_RETRIES)
+            .withAuthorizedTenantIds(falseTenantId)
+            .expectRejection()
+            .updateRetries();
+
+    // then
+    Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectFailIfTenantIsUnauthorized() {
+    // given
+    final String falseTenantId = UUID.randomUUID().toString();
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withRetries(3)
+            .withAuthorizedTenantIds(falseTenantId)
+            .expectRejection()
+            .fail();
+
+    // then
+    Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldFailForCustomTenant() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
+
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final int retries = 23;
+
+    // when
+    final Record<JobRecordValue> failRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .withRetries(retries)
+            .fail(username);
+
+    // then
+    Assertions.assertThat(failRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);
+    Assertions.assertThat(failRecord.getValue()).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldCreateIncidentWithCustomTenant() {
+    // given
+    ENGINE.deployment().withXmlResource(BOUNDARY_EVENT_PROCESS).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(BOUNDARY_PROCESS_ID)
+            .withTenantId(tenantId)
+            .create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BOUNDARY_JOB_TYPE)
+        .withErrorCode("other-error")
+        .withAuthorizedTenantIds(tenantId)
+        .throwError(username);
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasTenantId(tenantId)
+        .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
+        .hasErrorMessage(
+            "Expected to throw an error event with the code 'other-error', but it was not caught. Available error events are [error]");
+  }
+
+  @Test
+  public void shouldRejectResolvingIncidentWithUnauthorizedTenant() {
+    // given
+    final String unauthorizedTenantId = Strings.newRandomValidIdentityId();
+    final String unauthorizedUser = Strings.newRandomValidIdentityId();
+    ENGINE.tenant().newTenant().withTenantId(unauthorizedTenantId).create();
+    ENGINE.user().newUser(unauthorizedUser).create();
+    ENGINE
+        .tenant()
+        .addEntity(unauthorizedTenantId)
+        .withEntityId(unauthorizedUser)
+        .withEntityType(EntityType.USER)
+        .add();
+    final Record<JobRecordValue> jobRecord =
+        ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    final long piKey = jobRecord.getValue().getProcessInstanceKey();
+    ENGINE.job().withType(jobType).withRetries(0).ofInstance(piKey).fail(username);
+
+    // when
+    final Record<IncidentRecordValue> resolvedIncident =
+        ENGINE.incident().ofInstance(piKey).expectRejection().resolve(unauthorizedUser);
+
+    // then
+    Assertions.assertThat(resolvedIncident).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfJobHasNoRetriesLeftWithCustomTenant() {
+    // given
+    final Record<JobRecordValue> jobRecord =
+        ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    final long piKey = jobRecord.getValue().getProcessInstanceKey();
+
+    // when
+    ENGINE.job().withType(jobType).withRetries(0).ofInstance(piKey).fail(username);
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(piKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue()).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldResolveIncidentWithCustomTenant() {
+    // given
+    final Record<JobRecordValue> jobRecord =
+        ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
+    final long piKey = jobRecord.getValue().getProcessInstanceKey();
+    ENGINE.job().withType(jobType).withRetries(0).ofInstance(piKey).fail(username);
+
+    // when
+    ENGINE.job().ofInstance(piKey).withType(jobType).withRetries(1).updateRetries(username);
+
+    final Record<IncidentRecordValue> resolvedIncident =
+        ENGINE.incident().ofInstance(piKey).resolve(username);
+
+    // then
+    Assertions.assertThat(resolvedIncident.getValue()).hasTenantId(tenantId);
+    Assertions.assertThat(resolvedIncident).hasIntent(IncidentIntent.RESOLVED);
+  }
+
+  private static void assertJobDeadline(
+      final Record<JobRecordValue> updatedRecord,
+      final long jobKey,
+      final JobRecordValue job,
+      final long timeout) {
+    Assertions.assertThat(updatedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.TIMEOUT_UPDATED);
+    assertThat(updatedRecord.getKey()).isEqualTo(jobKey);
+
+    assertThat(updatedRecord.getValue().getDeadline()).isNotEqualTo(job.getDeadline());
+
+    assertThat(updatedRecord.getValue().getDeadline())
+        .isCloseTo(
+            ENGINE.getClock().getCurrentTimeInMillis() + timeout,
+            within(Duration.ofMillis(100).toMillis()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
@@ -20,10 +20,8 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
-import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -217,37 +215,6 @@ public final class CompleteUserTaskTest {
 
     // then
     Assertions.assertThat(completedRecord).hasRejectionType(RejectionType.NOT_FOUND);
-  }
-
-  @Test
-  public void shouldCompleteUserTaskForCustomTenant() {
-    // given
-    final String tenantId = Strings.newRandomValidIdentityId();
-    final String username = Strings.newRandomValidIdentityId();
-    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
-    ENGINE.user().newUser(username).create();
-    ENGINE
-        .tenant()
-        .addEntity(tenantId)
-        .withEntityId(username)
-        .withEntityType(EntityType.USER)
-        .add();
-    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
-
-    // when
-    final Record<UserTaskRecordValue> completedRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).complete(username);
-
-    // then
-    final UserTaskRecordValue recordValue = completedRecord.getValue();
-
-    Assertions.assertThat(completedRecord)
-        .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.COMPLETING);
-
-    Assertions.assertThat(recordValue).hasTenantId(tenantId);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/MultiTenantUserTaskOperationsTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultiTenantUserTaskOperationsTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(
+              config -> {
+                config.getAuthorizations().setEnabled(true);
+                config.getMultiTenancy().setEnabled(true);
+              });
+
+  private static final String PROCESS_ID = "process";
+  private static String tenantId;
+  private static String username;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("task").zeebeUserTask();
+
+    consumer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+
+  @BeforeClass
+  public static void setUp() {
+    tenantId = Strings.newRandomValidIdentityId();
+    username = Strings.newRandomValidIdentityId();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
+    ENGINE.user().newUser(username).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
+    ENGINE
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE_USER_TASK)
+        .withResourceId(PROCESS_ID)
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withOwnerId(username)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .create();
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+  }
+
+  @Test
+  public void shouldAssignUserTaskForCustomTenant() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final var assigningRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").assign(username);
+
+    // then
+    Assertions.assertThat(assigningRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+
+    final var assigningRecordValue = assigningRecord.getValue();
+    final var assignedRecordValue =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
+
+    assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure ASSIGNING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
+        .allSatisfy(
+            recordValue ->
+                Assertions.assertThat(recordValue)
+                    .hasAction("assign")
+                    .hasAssignee("foo")
+                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
+                    .hasTenantId(tenantId));
+  }
+
+  @Test
+  public void shouldClaimUserTaskForCustomTenant() {
+    // given
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final var claimingRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").claim(username);
+
+    // then
+    Assertions.assertThat(claimingRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.CLAIMING);
+
+    final var claimingRecordValue = claimingRecord.getValue();
+    final var assignedRecordValue =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
+
+    assertThat(List.of(claimingRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure CLAIMING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
+        .allSatisfy(
+            recordValue ->
+                Assertions.assertThat(recordValue)
+                    .hasAction("claim")
+                    .hasAssignee("foo")
+                    .hasTenantId(tenantId));
+  }
+
+  @Test
+  public void shouldUpdateUserTaskForCustomTenant() {
+    // given
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final var updatingRecord = ENGINE.userTask().ofInstance(processInstanceKey).update(username);
+
+    // then
+    Assertions.assertThat(updatingRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.UPDATING);
+
+    final var updatingRecordValue = updatingRecord.getValue();
+    final var updatedRecordValue =
+        RecordingExporter.userTaskRecords(UserTaskIntent.UPDATED).getFirst().getValue();
+
+    assertThat(List.of(updatingRecordValue, updatedRecordValue))
+        .describedAs("Ensure both UPDATING and UPDATED records have consistent attribute values")
+        .allSatisfy(recordValue -> Assertions.assertThat(recordValue).hasTenantId(tenantId));
+  }
+
+  @Test
+  public void shouldCompleteUserTaskForCustomTenant() {
+    // given
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).complete(username);
+
+    // then
+    final UserTaskRecordValue recordValue = completedRecord.getValue();
+
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+
+    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Remove hardcoded default tenant access.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29518
