### PR TITLE
fix: authorized application search in auth context

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalService.java
@@ -142,9 +142,8 @@ public class CamundaOAuthPrincipalService {
             .map(TenantDTO::fromEntity)
             .toList();
 
-    final var ownerIds =
-        ownerTypeToIds.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
-    final var authorizedApplications = authorizationServices.getAuthorizedApplications(ownerIds);
+    final var authorizedApplications =
+        authorizationServices.getAuthorizedApplications(ownerTypeToIds);
 
     authContextBuilder
         .withAuthorizedApplications(authorizedApplications)

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -19,9 +19,10 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -70,8 +71,11 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(
-            Stream.concat(roles.stream().map(RoleEntity::roleId), Stream.of(storedUser.username()))
-                .collect(Collectors.toSet()));
+            Map.of(
+                EntityType.USER,
+                Set.of(storedUser.username()),
+                EntityType.ROLE,
+                roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet())));
 
     final var tenants =
         tenantServices.getTenantsByUserAndGroupsAndRoles(username, groups, roleIds).stream()

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -238,8 +238,15 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(List.of(tenantT1, groupTenant));
 
       when(authorizationServices.getAuthorizedApplications(
-              Set.of(
-                  "foo@camunda.test", "test-id", "test-id-2", "roleR1", "roleGroup", "group-g1")))
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("test-id", "test-id-2"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"),
+                  EntityType.USER,
+                  Set.of("foo@camunda.test"),
+                  EntityType.ROLE,
+                  Set.of("roleR1", "roleGroup"))))
           .thenReturn(List.of("*"));
 
       // when
@@ -294,7 +301,15 @@ public class CamundaOAuthPrincipalServiceTest {
       when(roleServices.findAll(expectedQuery)).thenReturn(List.of(roleR1));
 
       when(authorizationServices.getAuthorizedApplications(
-              Set.of("scooby-doo", "group-g1", "map-1", "map-2", "roleR1")))
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("map-1", "map-2"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"),
+                  EntityType.USER,
+                  Set.of("scooby-doo"),
+                  EntityType.ROLE,
+                  Set.of("roleR1"))))
           .thenReturn(List.of("app-1", "app-2"));
 
       // when

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -238,7 +238,8 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(List.of(tenantT1, groupTenant));
 
       when(authorizationServices.getAuthorizedApplications(
-              Set.of("test-id", "test-id-2", "roleR1", "roleGroup")))
+              Set.of(
+                  "foo@camunda.test", "test-id", "test-id-2", "roleR1", "roleGroup", "group-g1")))
           .thenReturn(List.of("*"));
 
       // when
@@ -292,7 +293,8 @@ public class CamundaOAuthPrincipalServiceTest {
                                   Set.of("scooby-doo")))));
       when(roleServices.findAll(expectedQuery)).thenReturn(List.of(roleR1));
 
-      when(authorizationServices.getAuthorizedApplications(Set.of("map-1", "map-2", "roleR1")))
+      when(authorizationServices.getAuthorizedApplications(
+              Set.of("scooby-doo", "group-g1", "map-1", "map-2", "roleR1")))
           .thenReturn(List.of("app-1", "app-2"));
 
       // when

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -27,6 +27,7 @@ import io.camunda.service.UserServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,7 +66,12 @@ public class CamundaUserDetailsServiceTest {
                 null));
 
     final var roleId = "admin";
-    when(authorizationServices.getAuthorizedApplications(Set.of(roleId, "roleGroup", TEST_USER_ID)))
+    when(authorizationServices.getAuthorizedApplications(
+            Map.of(
+                EntityType.USER,
+                Set.of(TEST_USER_ID),
+                EntityType.ROLE,
+                Set.of(roleId, "roleGroup"))))
         .thenReturn(List.of("operate", "identity"));
     final var adminGroup = new GroupEntity(1L, "admin", "Admin Group", "description");
     when(groupServices.getGroupsByMemberId(TEST_USER_ID, EntityType.USER))

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -11,8 +11,11 @@ import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValuesAsList;
 
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public record AuthorizationFilter(
     Long authorizationKey,
@@ -20,7 +23,8 @@ public record AuthorizationFilter(
     String ownerType,
     List<String> resourceIds,
     String resourceType,
-    List<PermissionType> permissionTypes)
+    List<PermissionType> permissionTypes,
+    Map<EntityType, Set<String>> ownerTypeToOwnerIds)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<AuthorizationFilter> {
     private Long authorizationKey;
@@ -29,6 +33,7 @@ public record AuthorizationFilter(
     private List<String> resourceIds;
     private String resourceType;
     private List<PermissionType> permissionTypes;
+    private Map<EntityType, Set<String>> ownerTypeToOwnerIds;
 
     public Builder authorizationKey(final Long value) {
       authorizationKey = value;
@@ -72,10 +77,21 @@ public record AuthorizationFilter(
       return permissionTypes(collectValuesAsList(values));
     }
 
+    public Builder ownerTypeToOwnerIds(final Map<EntityType, Set<String>> value) {
+      ownerTypeToOwnerIds = value;
+      return this;
+    }
+
     @Override
     public AuthorizationFilter build() {
       return new AuthorizationFilter(
-          authorizationKey, ownerIds, ownerType, resourceIds, resourceType, permissionTypes);
+          authorizationKey,
+          ownerIds,
+          ownerType,
+          resourceIds,
+          resourceType,
+          permissionTypes,
+          ownerTypeToOwnerIds);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -98,6 +98,13 @@ public class AuthorizationServices
       // needed for frontend side checks
       return List.of("*");
     }
+
+    if (ownerIds == null || ownerIds.isEmpty()) {
+      // if no ownerIds are provided, we return an empty list to be defensive, we can't work out
+      // which applications the user has access to if we don't know the ownerIds
+      return List.of();
+    }
+
     return getAuthorizedResources(
         ownerIds, PermissionType.ACCESS, AuthorizationResourceType.APPLICATION);
   }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -119,7 +119,10 @@ public class AuthorizationServices
                         .page(p -> p.size(1))))
         .items()
         .stream()
-        .map(AuthorizationEntity::resourceId)
+        .map(
+            authorizationEntity -> {
+              return authorizationEntity.resourceId();
+            })
         .collect(Collectors.toList());
   }
 

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -21,6 +21,8 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
+import java.util.Map;
+import org.assertj.core.util.Arrays;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +69,7 @@ public class AuthorizationServiceTest {
     securityConfiguration.getAuthorizations().setEnabled(true);
 
     // when
-    final var authorizedApplications = services.getAuthorizedApplications(Set.of());
+    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
 
     // then
     assertThat(authorizedApplications).isEmpty();
@@ -79,7 +81,7 @@ public class AuthorizationServiceTest {
     securityConfiguration.getAuthorizations().setEnabled(false);
 
     // when
-    final var authorizedApplications = services.getAuthorizedApplications(Set.of());
+    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
 
     // then
     assertThat(authorizedApplications).containsExactly("*");
@@ -91,7 +93,7 @@ public class AuthorizationServiceTest {
     securityConfiguration.getAuthorizations().setEnabled(true);
 
     // when
-    final var authorizedApplications = services.getAuthorizedApplications(Set.of());
+    final var authorizedApplications = services.getAuthorizedApplications(Map.of());
 
     // then
     assertThat(authorizedApplications).isEmpty();

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -22,8 +22,6 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import java.util.Map;
-import org.assertj.core.util.Arrays;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -86,6 +86,30 @@ public class AuthorizationServiceTest {
   }
 
   @Test
+  public void noAuthorizedApplicationsWhenOwnerIdsIsEmpty() {
+    // given
+    securityConfiguration.getAuthorizations().setEnabled(true);
+
+    // when
+    final var authorizedApplications = services.getAuthorizedApplications(Set.of());
+
+    // then
+    assertThat(authorizedApplications).isEmpty();
+  }
+
+  @Test
+  public void noAuthorizedApplicationsWhenOwnerIdsIsNull() {
+    // given
+    securityConfiguration.getAuthorizations().setEnabled(true);
+
+    // when
+    final var authorizedApplications = services.getAuthorizedApplications(null);
+
+    // then
+    assertThat(authorizedApplications).isEmpty();
+  }
+
+  @Test
   public void shouldReturnSingleAuthorizationForGet() {
     // given
     final var entity = mock(AuthorizationEntity.class);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I noticed as part of discussions with @ThorbenLindhauer that the authorized application retrieval doesn't fully consider all possible ownerIds, but also that there is an unexpected behaviour that if there are no ownerIds then the filter send to secondary storage just returns any result for the resource type + permission pair (effectively circumventing the authorizations check for specific owners).
