### PR TITLE
[Backport main] fix: skip deserialize when verifyRepositoryExists

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -109,12 +109,14 @@ import org.opensearch.client.opensearch.indices.rollover.RolloverConditions;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
 import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
+import org.opensearch.client.opensearch.snapshot.GetRepositoryResponse;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.opensearch.client.opensearch.tasks.ListRequest;
 import org.opensearch.client.opensearch.tasks.ListResponse;
 import org.opensearch.client.opensearch.tasks.Status;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
 import org.slf4j.Logger;
 import org.springframework.context.ApplicationContext;
 
@@ -1056,7 +1058,16 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
 
   public void verifyRepositoryExists(final GetRepositoryRequest getRepositoriesRequest)
       throws IOException, OpenSearchException {
-    openSearchClient.snapshot().getRepository(getRepositoriesRequest);
+    final SimpleEndpoint<GetRepositoryRequest, Object> endpoint =
+        ((SimpleEndpoint<GetRepositoryRequest, GetRepositoryResponse>)
+                (GetRepositoryRequest._ENDPOINT))
+            .withResponseDeserializer(null);
+
+    openSearchAsyncClient
+        ._transport()
+        .performRequestAsync(
+            getRepositoriesRequest, endpoint, openSearchAsyncClient._transportOptions())
+        .join();
   }
 
   public GetSnapshotResponse getSnapshots(final GetSnapshotRequest getSnapshotRequest)

--- a/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/OptimizeOpenSearchClientTest.java
+++ b/optimize/util/optimize-commons/src/test/java/io/camunda/optimize/service/OptimizeOpenSearchClientTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
+
+@ExtendWith(MockitoExtension.class)
+public class OptimizeOpenSearchClientTest {
+  @Mock private OpenSearchAsyncClient openSearchAsyncClient;
+
+  @InjectMocks private OptimizeOpenSearchClient optimizeOpenSearchClient;
+
+  @Test
+  void shouldValidateRepositoryExistsDoNotDeserializeOpenSearchResponse() throws IOException {
+    final OpenSearchTransport openSearchTransport = mock(OpenSearchTransport.class);
+    when(openSearchAsyncClient._transport()).thenReturn(openSearchTransport);
+    when(openSearchTransport.performRequestAsync(any(), any(), any()))
+        .thenReturn(mock(CompletableFuture.class));
+
+    optimizeOpenSearchClient.verifyRepositoryExists(
+        GetRepositoryRequest.of(grr -> grr.name("test-repo")));
+
+    final ArgumentCaptor<SimpleEndpoint> endpointArgumentCaptor =
+        ArgumentCaptor.forClass(SimpleEndpoint.class);
+    verify(openSearchTransport).performRequestAsync(any(), endpointArgumentCaptor.capture(), any());
+    assertThat(endpointArgumentCaptor.getValue().responseDeserializer()).isNull();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #33906 to `main`.

relates to #33905
original author: @abremard