### PR TITLE
fix: distributed commands not starting

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -120,18 +120,6 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
             });
   }
 
-  public void startDistributingForPartition(final int partitionId) {
-    for (final var queue : DistributionQueue.getValues()) {
-      final var nextInQueue =
-          distributionState.getNextQueuedDistributionKey(queue.getQueueId(), partitionId);
-      if (nextInQueue.isPresent()
-          && distributionState.hasRetriableDistribution(nextInQueue.get(), partitionId)) {
-        return;
-      }
-      distributeNextInQueue(queue.getQueueId(), partitionId);
-    }
-  }
-
   /**
    * Starts a new command distribution request.
    *
@@ -210,11 +198,6 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
 
     getMetrics().addPendingDistribution(partition);
 
-    if (routingInfo.isPartitionScaling(partition)) {
-      // If the partition is currently being scaled up, we don't want to distribute the command yet.
-      return;
-    }
-
     final var canDistributeImmediately =
         distributionQueue
             .flatMap(queue -> distributionState.getNextQueuedDistributionKey(queue, partition))
@@ -225,7 +208,11 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
     // If there are, we skip distributing immediately and wait the preceding distribution to be
     // acknowledged which then triggers this distribution.
     if (canDistributeImmediately) {
-      startDistributing(partition, distributionRecord, distributionKey);
+      startDistributing(
+          partition,
+          distributionRecord,
+          distributionKey,
+          !routingInfo.isPartitionScaling(partition));
     }
   }
 
@@ -249,7 +236,8 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
                 startDistributing(
                     partition,
                     distributionState.getCommandDistributionRecord(nextDistributionKey, partition),
-                    nextDistributionKey));
+                    nextDistributionKey,
+                    true));
   }
 
   private void continueAfterQueue(final String queue) {
@@ -271,7 +259,8 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
   private void startDistributing(
       final int partition,
       final CommandDistributionRecord distributionRecord,
-      final long distributionKey) {
+      final long distributionKey,
+      final boolean executeSideEffect) {
     final var valueType = distributionRecord.getValueType();
     final var intent = distributionRecord.getIntent();
     final var queueId = distributionRecord.getQueueId();
@@ -291,20 +280,23 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
 
     getMetrics().addInflightDistribution(partition);
 
-    // This getter makes a hard copy of the command value, which we need to send the command to the
-    // other partition in a side effect. It does not appear to be possible to reuse a single
-    // instance for distributing to all partitions in the form of a method parameter, but it's not
-    // fully clear why that leads to problems. We suspect that it's because the command value is a
-    // mutable object, and it is somehow modified before the side effect is executed. Instead, we
-    // have to copy this value for every partition.
-    final var commandValue = distributionRecord.getCommandValue();
+    if (executeSideEffect) {
+      // This getter makes a hard copy of the command value, which we need to send the command to
+      // the
+      // other partition in a side effect. It does not appear to be possible to reuse a single
+      // instance for distributing to all partitions in the form of a method parameter, but it's not
+      // fully clear why that leads to problems. We suspect that it's because the command value is a
+      // mutable object, and it is somehow modified before the side effect is executed. Instead, we
+      // have to copy this value for every partition.
+      final var commandValue = distributionRecord.getCommandValue();
 
-    sideEffectWriter.appendSideEffect(
-        () -> {
-          interPartitionCommandSender.sendCommand(
-              partition, valueType, intent, distributionKey, commandValue);
-          return true;
-        });
+      sideEffectWriter.appendSideEffect(
+          () -> {
+            interPartitionCommandSender.sendCommand(
+                partition, valueType, intent, distributionKey, commandValue);
+            return true;
+          });
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -120,6 +120,18 @@ public final class CommandDistributionBehavior implements StreamProcessorLifecyc
             });
   }
 
+  public void startDistributingForPartition(final int partitionId) {
+    for (final var queue : DistributionQueue.getValues()) {
+      final var nextInQueue =
+          distributionState.getNextQueuedDistributionKey(queue.getQueueId(), partitionId);
+      if (nextInQueue.isPresent()
+          && distributionState.hasRetriableDistribution(nextInQueue.get(), partitionId)) {
+        return;
+      }
+      distributeNextInQueue(queue.getQueueId(), partitionId);
+    }
+  }
+
   /**
    * Starts a new command distribution request.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -86,7 +86,7 @@ public final class CommandRedistributor implements StreamProcessorLifecycleAware
                 "Excluding distribution {} for partition {} as it is currently scaling up.",
                 distributionKey,
                 record.getPartitionId());
-            return false;
+            return true;
           }
 
           final var retriable = RetriableDistribution.from(distributionKey, record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/MarkPartitionBootstrappedProcessor.java
@@ -90,7 +90,6 @@ public class MarkPartitionBootstrappedProcessor
             .withKey(scalingKey)
             .inQueue(DistributionQueue.SCALING)
             .distribute(command);
-        distributionBehavior.startDistributingForPartition(bootstrappedPartition);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
@@ -13,6 +13,7 @@ public enum DistributionQueue {
   SCALING("SCALING"),
   BATCH_OPERATION("BATCH_OPERATION");
 
+  private static final DistributionQueue[] VALUES = DistributionQueue.values();
   private final String queueId;
 
   DistributionQueue(final String queueId) {
@@ -21,5 +22,9 @@ public enum DistributionQueue {
 
   public String getQueueId() {
     return queueId;
+  }
+
+  public static DistributionQueue[] getValues() {
+    return VALUES;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -114,6 +114,7 @@ public class CommandDistributionScalingTest {
         .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
     verifyNoMoreInteractions(mockInterpartitionCommandSender);
     assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
+    assertThat(distributionState.hasRetriableDistribution(key, 3)).isTrue();
   }
 
   @Test
@@ -160,6 +161,7 @@ public class CommandDistributionScalingTest {
 
     assertThat(distributionState.hasPendingDistribution(key, 2)).isTrue();
     assertThat(distributionState.hasPendingDistribution(key, 3)).isTrue();
+    assertThat(distributionState.hasRetriableDistribution(key, 3)).isTrue();
     assertThat(distributionState.hasPendingDistribution(otherKey, 2)).isTrue();
     assertThat(distributionState.hasPendingDistribution(otherKey, 3)).isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionScalingTest.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -49,7 +48,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class CommandDistributionScalingTest {
   /* Injected from {@link ProcessingStateExtension} */
   private ZeebeDb<ZbColumnFamilies> zeebeDb;
-  private MutableRoutingState routingState;
   private MutableProcessingState state;
   private TransactionContext transactionContext;
 


### PR DESCRIPTION
## Description
When a partition is starting, it's included in command distribution, but the distribution itself is not starting yet: the events are just enqueued.
Once the partition becomes active, we need to start distributing immediately all the enqueued events.

Before this fix, each queue would start distributing only when one command was received for that queue, which is problematic as it could take a long time before such command is distributed.


## Related issues

closes #33960 
