### PR TITLE
feat: skip persisting batch operation items to secondary storage on creation

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -29,9 +29,9 @@ public interface BatchOperationMapper {
 
   void incrementOperationsTotalCount(BatchOperationUpdateTotalCountDto dto);
 
-  void incrementFailedOperationsCount(BatchOperationUpdateCountsDto dto);
+  void incrementFailedOperationsCount(String batchOperationId);
 
-  void incrementCompletedOperationsCount(BatchOperationUpdateCountsDto dto);
+  void incrementCompletedOperationsCount(String batchOperationId);
 
   Long count(BatchOperationDbQuery query);
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterConfig.java
@@ -17,7 +17,13 @@ public record RdbmsWriterConfig(
     Duration minHistoryCleanupInterval,
     Duration maxHistoryCleanupInterval,
     int historyCleanupBatchSize,
-    int batchOperationItemInsertBlockSize) {
+    int batchOperationItemInsertBlockSize,
+    /*
+     * Export the batch operation items when the initial chunk records are processed. If set to
+     * <code>false</code>, the batch operation items will be exported only when they have been
+     * processed and are completed or failed.
+     */
+    boolean exportBatchOperationItemsOnCreation) {
 
   public static final int DEFAULT_QUEUE_SIZE = -1;
   public static final Duration DEFAULT_HISTORY_TTL = Duration.ofDays(30);
@@ -25,6 +31,7 @@ public record RdbmsWriterConfig(
   public static final Duration DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL = Duration.ofMinutes(60);
   public static final int DEFAULT_HISTORY_CLEANUP_BATCH_SIZE = 1000;
   public static final int DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE = 10000;
+  public static final boolean DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION = true;
 
   public static Builder builder() {
     return new Builder();
@@ -39,6 +46,8 @@ public record RdbmsWriterConfig(
     private Duration maxHistoryCleanupInterval = DEFAULT_MAX_HISTORY_CLEANUP_INTERVAL;
     private int historyCleanupBatchSize = DEFAULT_HISTORY_CLEANUP_BATCH_SIZE;
     private int batchOperationItemInsertBlockSize = DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
+    private boolean exportBatchOperationItemsOnCreation =
+        DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
 
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
@@ -75,6 +84,12 @@ public record RdbmsWriterConfig(
       return this;
     }
 
+    public Builder exportBatchOperationItemsOnCreation(
+        final boolean exportBatchOperationItemsOnCreation) {
+      this.exportBatchOperationItemsOnCreation = exportBatchOperationItemsOnCreation;
+      return this;
+    }
+
     @Override
     public RdbmsWriterConfig build() {
       return new RdbmsWriterConfig(
@@ -84,7 +99,8 @@ public record RdbmsWriterConfig(
           minHistoryCleanupInterval,
           maxHistoryCleanupInterval,
           historyCleanupBatchSize,
-          batchOperationItemInsertBlockSize);
+          batchOperationItemInsertBlockSize,
+          exportBatchOperationItemsOnCreation);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationItemDbModel.java
@@ -8,9 +8,12 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.search.entities.BatchOperationEntity;
+import java.time.OffsetDateTime;
 
 public record BatchOperationItemDbModel(
     String batchOperationId,
     long itemKey,
     long processInstanceKey,
-    BatchOperationEntity.BatchOperationItemState state) {}
+    BatchOperationEntity.BatchOperationItemState state,
+    OffsetDateTime processedDate,
+    String errorMessage) {}

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -54,10 +54,10 @@
 
   <insert id="insertItems"
     parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationItemsDto">
-    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY)
+    INSERT INTO ${prefix}BATCH_OPERATION_ITEM (BATCH_OPERATION_ID, ITEM_KEY, PROCESS_INSTANCE_KEY, STATE)
     VALUES
     <foreach collection="items" item="item" separator=",">
-      (#{batchOperationId}, #{item.itemKey}, #{item.processInstanceKey})
+      (#{batchOperationId}, #{item.itemKey}, #{item.processInstanceKey}, #{item.state})
     </foreach>
   </insert>
 
@@ -95,29 +95,17 @@
   </update>
 
   <update id="incrementFailedOperationsCount"
-    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
+    parameterType="java.lang.String">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_FAILED_COUNT = OPERATIONS_FAILED_COUNT + 1
-    WHERE BATCH_OPERATION_ID = #{batchOperationId}
-    AND EXISTS(
-      SELECT 1
-      FROM ${prefix}BATCH_OPERATION_ITEM i
-      WHERE i.BATCH_OPERATION_ID = t.BATCH_OPERATION_ID
-      AND i.ITEM_KEY = #{itemKey}
-    )
+    WHERE BATCH_OPERATION_ID = #{id}
   </update>
 
   <update id="incrementCompletedOperationsCount"
-    parameterType="io.camunda.db.rdbms.sql.BatchOperationMapper$BatchOperationUpdateCountsDto">
+    parameterType="java.lang.String">
     UPDATE ${prefix}BATCH_OPERATION t
     SET OPERATIONS_COMPLETED_COUNT = OPERATIONS_COMPLETED_COUNT + 1
-    WHERE BATCH_OPERATION_ID = #{batchOperationId}
-      AND EXISTS(
-      SELECT 1
-      FROM ${prefix}BATCH_OPERATION_ITEM i
-      WHERE i.BATCH_OPERATION_ID = t.BATCH_OPERATION_ID
-        AND i.ITEM_KEY = #{itemKey}
-    )
+    WHERE BATCH_OPERATION_ID = #{id}
   </update>
 
   <select id="count" resultType="java.lang.Long">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/BatchOperationWriterTest.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import java.time.OffsetDateTime;
 import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,7 +39,10 @@ class BatchOperationWriterTest {
             "42",
             LongStream.range(0, 25)
                 .boxed()
-                .map(i -> new BatchOperationItemDbModel("42", i, i, BatchOperationItemState.ACTIVE))
+                .map(
+                    i ->
+                        new BatchOperationItemDbModel(
+                            "42", i, i, BatchOperationItemState.ACTIVE, OffsetDateTime.now(), null))
                 .toList());
 
     // when

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.fixtures;
 
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.RANDOM;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
 
@@ -54,11 +55,9 @@ public final class BatchOperationFixtures {
     return models;
   }
 
-  public static List<Long> createAndSaveRandomBatchOperationItems(
+  public static List<BatchOperationItemDbModel> createAndSaveRandomBatchOperationItems(
       final RdbmsWriter rdbmsWriter, final String batchOperationKey, final int count) {
-    return createSaveReturnRandomBatchOperationItems(rdbmsWriter, batchOperationKey, count).stream()
-        .map(BatchOperationItemDbModel::itemKey)
-        .toList();
+    return createSaveReturnRandomBatchOperationItems(rdbmsWriter, batchOperationKey, count);
   }
 
   public static List<BatchOperationItemDbModel> createSaveReturnRandomBatchOperationItems(
@@ -92,7 +91,12 @@ public final class BatchOperationFixtures {
             .map(
                 itemKey ->
                     new BatchOperationItemDbModel(
-                        batchOperationKey, itemKey, itemKey, BatchOperationItemState.ACTIVE))
+                        batchOperationKey,
+                        itemKey,
+                        itemKey,
+                        BatchOperationItemState.ACTIVE,
+                        NOW,
+                        null))
             .toList();
 
     rdbmsWriter.getBatchOperationWriter().updateBatchAndInsertItems(batchOperationKey, batchItems);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -32,6 +32,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +73,8 @@ class RdbmsExporterBatchOperationsIT {
             null,
             new ExporterConfiguration(
                 "foo",
-                Map.of("maxQueueSize", 0, "exportPendingBatchOperationItems", exportPendingItems)),
+                Map.of(
+                    "maxQueueSize", 0, "exportBatchOperationItemsOnCreation", exportPendingItems)),
             1,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
             null));
@@ -216,7 +218,7 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   @Test
-  public void shouldMonitorCancelProcessInstanceBatchOperationNoExportPendingItems() {
+  public void shouldMonitorCancelProcessInstanceBatchOperationNoExportItemsOnCreation() {
     setup(false);
     // given
     final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
@@ -272,7 +274,7 @@ class RdbmsExporterBatchOperationsIT {
   }
 
   @Test
-  public void shouldMonitorFailedCancelProcessInstanceBatchOperationNoExportPendingItems() {
+  public void shouldMonitorFailedCancelProcessInstanceBatchOperationNoExportItemsOnCreation() {
     setup(false);
     // given
     final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
@@ -305,7 +307,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorResolveIncidentBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.RESOLVE_INCIDENT);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var incidentKey = 1L;
@@ -330,7 +333,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorFailedResolveIncidentBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.RESOLVE_INCIDENT);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var incidentKey = 1L;
@@ -355,7 +359,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorProcessInstanceMigrationBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;
@@ -380,7 +385,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorFailedProcessInstanceMigrationBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.MIGRATE_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;
@@ -405,7 +411,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorModifyProcessInstanceBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.MODIFY_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;
@@ -430,7 +437,8 @@ class RdbmsExporterBatchOperationsIT {
   @Test
   public void shouldMonitorFailedModifyProcessInstanceBatchOperation() {
     // given
-    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationCreatedRecord =
+        getBatchOperationCreatedRecord(1L, BatchOperationType.MODIFY_PROCESS_INSTANCE);
     final var batchOperationKey = batchOperationCreatedRecord.getKey();
     final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
     final var processInstanceKey = 1L;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -32,11 +32,13 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationItemValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableBatchOperationLifecycleManagementRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableGroupRecordValue;
@@ -433,6 +435,11 @@ public class RecordFixtures {
 
   protected static ImmutableRecord<RecordValue> getBatchOperationCreatedRecord(
       final Long position) {
+    return getBatchOperationCreatedRecord(position, BatchOperationType.CANCEL_PROCESS_INSTANCE);
+  }
+
+  protected static ImmutableRecord<RecordValue> getBatchOperationCreatedRecord(
+      final Long position, final BatchOperationType type) {
     final Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.BATCH_OPERATION_CREATION);
 
@@ -441,6 +448,11 @@ public class RecordFixtures {
         .withIntent(BatchOperationIntent.CREATED)
         .withPosition(position)
         .withTimestamp(System.currentTimeMillis())
+        .withValue(
+            ImmutableBatchOperationCreationRecordValue.builder()
+                .from((ImmutableBatchOperationCreationRecordValue) recordValueRecord.getValue())
+                .withBatchOperationType(type)
+                .build())
         .build();
   }
 

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchDBExtension.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -59,6 +60,12 @@ public abstract class SearchDBExtension implements BeforeAllCallback, AfterAllCa
       "idxtestform" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
 
   public static final FormIndex FORM_INDEX = new FormIndex(IDX_FORM_PREFIX, true);
+
+  public static final String IDX_BATCH_OPERATION_PREFIX =
+      "idxtestbatchoperation" + RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
+
+  public static final BatchOperationTemplate BATCH_OPERATION_INDEX =
+      new BatchOperationTemplate(IDX_BATCH_OPERATION_PREFIX, true);
 
   public static final String TEST_INTEGRATION_OPENSEARCH_AWS_URL =
       "test.integration.opensearch.aws.url";

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/batchoperation/CachedBatchOperationEntity.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.cache.batchoperation;
+
+import io.camunda.webapps.schema.entities.operation.OperationType;
+
+public record CachedBatchOperationEntity(String batchOperationId, OperationType type) {}

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -196,6 +196,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -278,7 +278,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new BatchOperationLifecycleManagementHandler(
                 indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new BatchOperationChunkCreatedHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()),
             new ProcessInstanceCancellationOperationHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
             new ProcessInstanceMigrationOperationHandler(
@@ -291,7 +291,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     if (configuration.getBatchOperation().isExportItemsOnCreation()) {
       exportHandlers.add(
           new BatchOperationChunkCreatedItemHandler(
-              indexDescriptors.get(BatchOperationTemplate.class).getFullQualifiedName()));
+              indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()));
     }
 
     indicesWithCustomErrorHandlers =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ElasticsearchBatchRequest;
+import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
@@ -50,7 +51,8 @@ class ElasticsearchAdapter implements ClientAdapter {
 
   @Override
   public BatchRequest createBatchRequest() {
-    return new ElasticsearchBatchRequest(client, new BulkRequest.Builder());
+    return new ElasticsearchBatchRequest(
+        client, new BulkRequest.Builder(), new ElasticsearchScriptBuilder());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -12,6 +12,7 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
+import io.camunda.exporter.cache.batchoperation.ElasticSearchBatchOperationCacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
@@ -22,6 +23,7 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import java.io.IOException;
 
@@ -67,6 +69,12 @@ class ElasticsearchAdapter implements ClientAdapter {
 
   record ElasticsearchExporterEntityCacheProvider(ElasticsearchClient client)
       implements ExporterEntityCacheProvider {
+
+    @Override
+    public CacheLoader<String, CachedBatchOperationEntity> getBatchOperationCacheLoader(
+        final String batchOperationIndexName) {
+      return new ElasticSearchBatchOperationCacheLoader(client, batchOperationIndexName);
+    }
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.adapters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
+import io.camunda.exporter.cache.batchoperation.OpenSearchBatchOperationCacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.OpenSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.OpenSearchProcessCacheLoader;
@@ -20,6 +21,7 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -67,6 +69,12 @@ class OpensearchAdapter implements ClientAdapter {
 
   record OpensearchExporterEntityCacheProvider(OpenSearchClient client)
       implements ExporterEntityCacheProvider {
+
+    @Override
+    public CacheLoader<String, CachedBatchOperationEntity> getBatchOperationCacheLoader(
+        final String batchOperationIndexName) {
+      return new OpenSearchBatchOperationCacheLoader(client, batchOperationIndexName);
+    }
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -15,6 +15,7 @@ import io.camunda.exporter.cache.form.OpenSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.OpenSearchProcessCacheLoader;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.OpensearchBatchRequest;
+import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.schema.SearchEngineClient;
@@ -50,7 +51,8 @@ class OpensearchAdapter implements ClientAdapter {
 
   @Override
   public BatchRequest createBatchRequest() {
-    return new OpensearchBatchRequest(client, new BulkRequest.Builder());
+    return new OpensearchBatchRequest(
+        client, new BulkRequest.Builder(), new OpensearchScriptBuilder());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -9,9 +9,13 @@ package io.camunda.exporter.cache;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 
 public interface ExporterEntityCacheProvider {
+
+  CacheLoader<String, CachedBatchOperationEntity> getBatchOperationCacheLoader(
+      String batchOperationIndexName);
 
   CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(String processIndexName);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.batchoperation;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch.core.search.SourceConfigBuilders;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticSearchBatchOperationCacheLoader
+    implements CacheLoader<String, CachedBatchOperationEntity> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticSearchBatchOperationCacheLoader.class);
+
+  private final ElasticsearchClient client;
+  private final String batchOperationIndexName;
+
+  public ElasticSearchBatchOperationCacheLoader(
+      final ElasticsearchClient client, final String batchOperationIndexName) {
+    this.client = client;
+    this.batchOperationIndexName = batchOperationIndexName;
+  }
+
+  @Override
+  public CachedBatchOperationEntity load(final String batchOperationId) throws IOException {
+    final var termQuery = QueryBuilders.ids(i -> i.values(batchOperationId));
+    final var sourceFilter =
+        SourceConfigBuilders.filter()
+            .includes(BatchOperationTemplate.ID, BatchOperationTemplate.TYPE)
+            .build();
+    final var response =
+        client.search(
+            request ->
+                request
+                    .index(batchOperationIndexName)
+                    .query(termQuery)
+                    .source(s -> s.filter(sourceFilter))
+                    .size(1),
+            BatchOperationEntity.class);
+    if (response.hits() != null && !response.hits().hits().isEmpty()) {
+      final var entity = response.hits().hits().getFirst().source();
+      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+    } else {
+      LOG.debug("BatchOperation '{}' not found in Elasticsearch", batchOperationId);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.batchoperation;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import java.io.IOException;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.search.SourceConfigBuilders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenSearchBatchOperationCacheLoader
+    implements CacheLoader<String, CachedBatchOperationEntity> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OpenSearchBatchOperationCacheLoader.class);
+
+  private final OpenSearchClient client;
+  private final String batchOperationIndexName;
+
+  public OpenSearchBatchOperationCacheLoader(
+      final OpenSearchClient client, final String batchOperationIndexName) {
+    this.client = client;
+    this.batchOperationIndexName = batchOperationIndexName;
+  }
+
+  @Override
+  public CachedBatchOperationEntity load(final String batchOperationId) throws IOException {
+    final var idQuery = QueryBuilders.ids().values(batchOperationId).build();
+    final var sourceFilter =
+        SourceConfigBuilders.filter()
+            .includes(BatchOperationTemplate.ID, BatchOperationTemplate.TYPE)
+            .build();
+    final var response =
+        client.search(
+            request ->
+                request
+                    .index(batchOperationIndexName)
+                    .query(q -> q.ids(idQuery))
+                    .source(s -> s.filter(sourceFilter))
+                    .size(1),
+            BatchOperationEntity.class);
+    if (response.hits() != null && !response.hits().hits().isEmpty()) {
+      final var entity = response.hits().hits().getFirst().source();
+      return new CachedBatchOperationEntity(entity.getId(), entity.getType());
+    } else {
+      LOG.debug("BatchOperation '{}' not found in OpenSearch", batchOperationId);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -17,6 +17,7 @@ public class ExporterConfiguration {
   private IndexConfiguration index = new IndexConfiguration();
   private BulkConfiguration bulk = new BulkConfiguration();
   private HistoryConfiguration history = new HistoryConfiguration();
+  private CacheConfiguration batchOperationCache = new CacheConfiguration();
   private CacheConfiguration processCache = new CacheConfiguration();
   private CacheConfiguration formCache = new CacheConfiguration();
   private PostExportConfiguration postExport = new PostExportConfiguration();
@@ -46,6 +47,14 @@ public class ExporterConfiguration {
 
   public void setBulk(final BulkConfiguration bulk) {
     this.bulk = bulk;
+  }
+
+  public CacheConfiguration getBatchOperationCache() {
+    return batchOperationCache;
+  }
+
+  public void setBatchOperationCache(final CacheConfiguration batchOperationCache) {
+    this.batchOperationCache = batchOperationCache;
   }
 
   public CacheConfiguration getProcessCache() {
@@ -117,6 +126,8 @@ public class ExporterConfiguration {
         + history
         + ", createSchema="
         + createSchema
+        + ", batchOperationCache="
+        + batchOperationCache
         + ", processCache="
         + processCache
         + ", formCache="

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -21,6 +21,7 @@ public class ExporterConfiguration {
   private CacheConfiguration formCache = new CacheConfiguration();
   private PostExportConfiguration postExport = new PostExportConfiguration();
   private IncidentNotifierConfiguration notifier = new IncidentNotifierConfiguration();
+  private BatchOperationConfiguration batchOperation = new BatchOperationConfiguration();
   private boolean createSchema = true;
 
   public ConnectConfiguration getConnect() {
@@ -95,6 +96,14 @@ public class ExporterConfiguration {
     this.history = history;
   }
 
+  public BatchOperationConfiguration getBatchOperation() {
+    return batchOperation;
+  }
+
+  public void setBatchOperation(final BatchOperationConfiguration batchOperation) {
+    this.batchOperation = batchOperation;
+  }
+
   @Override
   public String toString() {
     return "ExporterConfiguration{"
@@ -114,6 +123,8 @@ public class ExporterConfiguration {
         + formCache
         + ", postExport="
         + postExport
+        + ", batchOperation="
+        + batchOperation
         + '}';
   }
 
@@ -359,6 +370,32 @@ public class ExporterConfiguration {
 
     public void setM2mAudience(final String m2mAudience) {
       this.m2mAudience = m2mAudience;
+    }
+  }
+
+  public static final class BatchOperationConfiguration {
+
+    /**
+     * Export the batch operation items when the initial chunk records are processed. If set to
+     * <code>false</code>, the batch operation items will be exported only when they have been
+     * processed and are completed or failed.
+     */
+    private boolean exportItemsOnCreation = true;
+
+    public boolean isExportItemsOnCreation() {
+      return exportItemsOnCreation;
+    }
+
+    public void setExportItemsOnCreation(final boolean exportItemsOnCreation) {
+      this.exportItemsOnCreation = exportItemsOnCreation;
+    }
+
+    @Override
+    public String toString() {
+      return "BatchOperationConfiguration{"
+          + "exportItemsOnCreation="
+          + exportItemsOnCreation
+          + '}';
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
   @Override
   public void updateEntity(final Record<R> record, final OperationEntity entity) {
     entity
-        .setBatchOperationId(String.valueOf(record.getOperationReference()))
+        .setBatchOperationId(String.valueOf(record.getBatchOperationReference()))
         .setItemKey(getItemKey(record))
         .setProcessInstanceKey(getProcessInstanceKey(record));
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -18,8 +21,14 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 public class ProcessInstanceCancellationOperationHandler
     extends AbstractOperationStatusHandler<ProcessInstanceRecordValue> {
 
-  public ProcessInstanceCancellationOperationHandler(final String indexName) {
-    super(indexName, ValueType.PROCESS_INSTANCE);
+  public ProcessInstanceCancellationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(
+        indexName,
+        ValueType.PROCESS_INSTANCE,
+        OperationType.CANCEL_PROCESS_INSTANCE,
+        batchOperationCache);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
@@ -32,6 +32,11 @@ public class ProcessInstanceCancellationOperationHandler
   }
 
   @Override
+  public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
+    return super.handlesRecord(record) && record.getValue().getParentProcessInstanceKey() == -1;
+  }
+
+  @Override
   long getItemKey(final Record<ProcessInstanceRecordValue> record) {
     return record.getValue().getProcessInstanceKey();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandler.java
@@ -28,6 +28,11 @@ public class ProcessInstanceCancellationOperationHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
     return record.getValueType() == ValueType.PROCESS_INSTANCE
         && record.getValue().getBpmnElementType() == BpmnElementType.PROCESS

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -16,8 +19,14 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValu
 public class ProcessInstanceMigrationOperationHandler
     extends AbstractOperationStatusHandler<ProcessInstanceMigrationRecordValue> {
 
-  public ProcessInstanceMigrationOperationHandler(final String indexName) {
-    super(indexName, ValueType.PROCESS_INSTANCE_MIGRATION);
+  public ProcessInstanceMigrationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(
+        indexName,
+        ValueType.PROCESS_INSTANCE_MIGRATION,
+        OperationType.MIGRATE_PROCESS_INSTANCE,
+        batchOperationCache);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandler.java
@@ -26,6 +26,11 @@ public class ProcessInstanceMigrationOperationHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
@@ -31,6 +31,11 @@ public class ProcessInstanceModificationOperationHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFIED);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandler.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -16,8 +19,14 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordV
 public class ProcessInstanceModificationOperationHandler
     extends AbstractOperationStatusHandler<ProcessInstanceModificationRecordValue> {
 
-  public ProcessInstanceModificationOperationHandler(final String indexName) {
-    super(indexName, ValueType.PROCESS_INSTANCE_MODIFICATION);
+  public ProcessInstanceModificationOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(
+        indexName,
+        ValueType.PROCESS_INSTANCE_MODIFICATION,
+        OperationType.MODIFY_PROCESS_INSTANCE,
+        batchOperationCache);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
@@ -26,6 +26,11 @@ public class ResolveIncidentOperationHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<IncidentRecordValue> record) {
     return record.getIntent().equals(IncidentIntent.RESOLVED);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandler.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.exporter.handlers.batchoperation;
 
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -16,8 +19,10 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 public class ResolveIncidentOperationHandler
     extends AbstractOperationStatusHandler<IncidentRecordValue> {
 
-  public ResolveIncidentOperationHandler(final String indexName) {
-    super(indexName, ValueType.INCIDENT);
+  public ResolveIncidentOperationHandler(
+      final String indexName,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(indexName, ValueType.INCIDENT, OperationType.RESOLVE_INCIDENT, batchOperationCache);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -33,9 +33,27 @@ public interface BatchRequest {
       Map<String, Object> updateFields,
       String routing);
 
+  BatchRequest upsertWithScript(
+      String index,
+      String id,
+      ExporterEntity entity,
+      String script,
+      Map<String, Object> parameters);
+
+  BatchRequest upsertWithScriptAndRouting(
+      String index,
+      String id,
+      ExporterEntity entity,
+      String script,
+      Map<String, Object> parameters,
+      String routing);
+
   BatchRequest update(String index, String id, Map<String, Object> updateFields);
 
   BatchRequest update(String index, String id, ExporterEntity entity) throws PersistenceException;
+
+  BatchRequest updateWithScript(
+      String index, String id, String script, Map<String, Object> parameters);
 
   BatchRequest delete(String index, String id);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.store;
 
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -20,7 +21,6 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.BulkRequest.Builder;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.bulk.OperationType;
@@ -34,10 +34,15 @@ public class OpensearchBatchRequest implements BatchRequest {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchBatchRequest.class);
   private final OpenSearchClient osClient;
   private final BulkRequest.Builder bulkRequestBuilder;
+  private final OpensearchScriptBuilder scriptBuilder;
 
-  public OpensearchBatchRequest(final OpenSearchClient osClient, final Builder bulkRequestBuilder) {
+  public OpensearchBatchRequest(
+      final OpenSearchClient osClient,
+      final BulkRequest.Builder bulkRequestBuilder,
+      final OpensearchScriptBuilder scriptBuilder) {
     this.osClient = osClient;
     this.bulkRequestBuilder = bulkRequestBuilder;
+    this.scriptBuilder = scriptBuilder;
   }
 
   @Override
@@ -102,6 +107,47 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
+  public BatchRequest upsertWithScript(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters) {
+    return upsertWithScriptAndRouting(index, id, entity, script, parameters, null);
+  }
+
+  @Override
+  public BatchRequest upsertWithScriptAndRouting(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters,
+      final String routing) {
+    LOGGER.debug(
+        "Add upsert request with routing {} for index {} id {} entity {} and script {} with parameters {} ",
+        routing,
+        index,
+        id,
+        entity,
+        script,
+        parameters);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .upsert(entity)
+                        .script(scriptBuilder.getScriptWithParameters(script, parameters))
+                        .routing(routing)
+                        .retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
   public BatchRequest update(
       final String index, final String id, final Map<String, Object> updateFields) {
     LOGGER.debug(
@@ -128,6 +174,31 @@ public class OpensearchBatchRequest implements BatchRequest {
             op.update(
                 upd ->
                     upd.index(index).id(id).document(entity).retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest updateWithScript(
+      final String index,
+      final String id,
+      final String script,
+      final Map<String, Object> parameters) {
+    LOGGER.debug(
+        "Add upsert request with for index {} id {} and script {} with parameters {} ",
+        index,
+        id,
+        script,
+        parameters);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .script(scriptBuilder.getScriptWithParameters(script, parameters))
+                        .retryOnConflict(UPDATE_RETRY_COUNT)));
 
     return this;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -192,8 +192,7 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
                 + "} "
                 + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;"
                 + "ctx._source.operationsCompletedCount = params.operationsCompletedCount;"
-                + "ctx._source.operationsFailedCount = params.operationsFailedCount;"
-                + "ctx._source.operationsTotalCount = params.operationsTotalCount;")
+                + "ctx._source.operationsFailedCount = params.operationsFailedCount;")
         .lang("painless")
         .params(parameters)
         .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -176,8 +176,7 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
                             + "} "
                             + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;"
                             + "ctx._source.operationsCompletedCount = params.operationsCompletedCount;"
-                            + "ctx._source.operationsFailedCount = params.operationsFailedCount;"
-                            + "ctx._source.operationsTotalCount = params.operationsTotalCount;")
+                            + "ctx._source.operationsFailedCount = params.operationsFailedCount;")
                     .lang("painless")
                     .params(parameters))
         .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import co.elastic.clients.elasticsearch._types.Script;
+import co.elastic.clients.json.JsonData;
+import jakarta.json.JsonValue;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ElasticsearchScriptBuilder {
+  public static final String DEFAULT_SCRIPT_LANG = "painless";
+
+  public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
+    Objects.requireNonNull(parameters, "Script Parameters must not be null");
+    return new Script.Builder()
+        .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
+        .build();
+  }
+
+  public Map<String, JsonData> jsonParams(final Map<String, Object> params) {
+    return params.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> json(e.getValue())));
+  }
+
+  public <V> JsonData json(final V value) {
+    return JsonData.of(value == null ? JsonValue.NULL : value);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
@@ -20,7 +20,9 @@ public class ElasticsearchScriptBuilder {
   public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
     Objects.requireNonNull(parameters, "Script Parameters must not be null");
     return new Script.Builder()
-        .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
+        .source(script)
+        .params(jsonParams(parameters))
+        .lang(DEFAULT_SCRIPT_LANG)
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import jakarta.json.JsonValue;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.Script;
+
+public class OpensearchScriptBuilder {
+  public static final String DEFAULT_SCRIPT_LANG = "painless";
+
+  public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
+    Objects.requireNonNull(parameters, "Script Parameters must not be null");
+    return new Script.Builder()
+        .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
+        .build();
+  }
+
+  private Map<String, JsonData> jsonParams(final Map<String, Object> params) {
+    return params.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> json(e.getValue())));
+  }
+
+  private <A> JsonData json(final A value) {
+    return JsonData.of(value == null ? JsonValue.NULL : value);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -26,6 +26,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -74,6 +75,12 @@ final class CamundaExporterTest {
 
   private static final class NoopExporterEntityCacheProvider
       implements ExporterEntityCacheProvider {
+
+    @Override
+    public CacheLoader<String, CachedBatchOperationEntity> getBatchOperationCacheLoader(
+        final String batchOperationIndexName) {
+      return k -> null;
+    }
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import static io.camunda.search.test.utils.SearchDBExtension.BATCH_OPERATION_INDEX;
+import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import io.camunda.exporter.DefaultExporterResourceProvider;
+import io.camunda.exporter.cache.batchoperation.ElasticSearchBatchOperationCacheLoader;
+import io.camunda.exporter.cache.batchoperation.OpenSearchBatchOperationCacheLoader;
+import io.camunda.search.schema.config.IndexConfiguration;
+import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.search.schema.opensearch.OpensearchEngineClient;
+import io.camunda.search.test.utils.SearchDBExtension;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.Refresh;
+
+class BatchOperationCacheIT {
+
+  @RegisterExtension private static final SearchDBExtension SEARCH_DB = SearchDBExtension.create();
+
+  @BeforeEach
+  void setup() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      new ElasticsearchEngineClient(SEARCH_DB.esClient(), SEARCH_DB.objectMapper())
+          .createIndex(BATCH_OPERATION_INDEX, new IndexConfiguration());
+    }
+    new OpensearchEngineClient(SEARCH_DB.osClient(), SEARCH_DB.objectMapper())
+        .createIndex(BATCH_OPERATION_INDEX, new IndexConfiguration());
+  }
+
+  @AfterEach
+  void cleanup() throws IOException {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      SEARCH_DB
+          .esClient()
+          .indices()
+          .delete(req -> req.index(BATCH_OPERATION_INDEX.getFullQualifiedName()));
+    }
+    SEARCH_DB
+        .osClient()
+        .indices()
+        .delete(req -> req.index(BATCH_OPERATION_INDEX.getFullQualifiedName()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideBatchOperationCache")
+  void shouldReturnEmptyOptionalIfBatchOperationDoesNotExist(
+      final BatchOperationCacheArgument batchOperationCacheArgument) {
+    // when
+    final var batchOperation = batchOperationCacheArgument.batchOperationCache().get("1");
+
+    // then
+    assertThat(batchOperation).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideBatchOperationCache")
+  void shouldLoadBatchOperationEntityFromBackend(
+      final BatchOperationCacheArgument batchOperationCacheArgument) throws IOException {
+    // given
+    final var batchOperationEntity =
+        new BatchOperationEntity().setId("3").setType(OperationType.RESOLVE_INCIDENT);
+    batchOperationCacheArgument.indexer().accept(batchOperationEntity);
+
+    // when
+    final var batchOperation = batchOperationCacheArgument.batchOperationCache().get("3");
+
+    // then
+    final var expectedCachedBatchOperationEntity =
+        new CachedBatchOperationEntity("3", OperationType.RESOLVE_INCIDENT);
+    assertThat(batchOperation).isPresent().get().isEqualTo(expectedCachedBatchOperationEntity);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideFailingBatchOperationCache")
+  void shouldThrowExceptionIfQueryToElasticFailed(
+      final BatchOperationCacheArgument batchOperationCacheArgument) {
+    // given
+    final var failingBatchOperationCache = batchOperationCacheArgument.batchOperationCache();
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> failingBatchOperationCache.get("1"))
+        .isInstanceOf(ExporterEntityCache.CacheLoaderFailedException.class);
+  }
+
+  static Stream<Arguments> provideBatchOperationCache() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      return Stream.of(
+          Arguments.of(
+              Named.of(
+                  "ElasticSearch",
+                  getESBatchOperationCache(BATCH_OPERATION_INDEX.getFullQualifiedName()))),
+          Arguments.of(
+              Named.of(
+                  "OpenSearch",
+                  getOSBatchOperationCache(BATCH_OPERATION_INDEX.getFullQualifiedName()))));
+    } else {
+      return Stream.of(
+          Arguments.of(
+              Named.of(
+                  "OpenSearch",
+                  getOSBatchOperationCache(BATCH_OPERATION_INDEX.getFullQualifiedName()))));
+    }
+  }
+
+  static Stream<Arguments> provideFailingBatchOperationCache() {
+    if (System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "").isBlank()) {
+      return Stream.of(
+          Arguments.of(Named.of("ElasticSearch", getESBatchOperationCache("invalid-index-name"))),
+          Arguments.of(Named.of("OpenSearch", getOSBatchOperationCache("invalid-index-name"))));
+    } else {
+      return Stream.of(
+          Arguments.of(Named.of("OpenSearch", getOSBatchOperationCache("invalid-index-name"))));
+    }
+  }
+
+  static BatchOperationCacheArgument getESBatchOperationCache(final String indexName) {
+    return new BatchOperationCacheArgument(
+        new ExporterEntityCacheImpl<>(
+            10,
+            new ElasticSearchBatchOperationCacheLoader(SEARCH_DB.esClient(), indexName),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
+        BatchOperationCacheIT::indexInElasticSearch);
+  }
+
+  static BatchOperationCacheArgument getOSBatchOperationCache(final String indexName) {
+    return new BatchOperationCacheArgument(
+        new ExporterEntityCacheImpl<>(
+            10,
+            new OpenSearchBatchOperationCacheLoader(SEARCH_DB.osClient(), indexName),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "OS", new SimpleMeterRegistry())),
+        BatchOperationCacheIT::indexInOpenSearch);
+  }
+
+  private static void indexInElasticSearch(final BatchOperationEntity batchOperationEntity) {
+    try {
+      SEARCH_DB
+          .esClient()
+          .index(
+              request ->
+                  request
+                      .index(BATCH_OPERATION_INDEX.getFullQualifiedName())
+                      .id(batchOperationEntity.getId())
+                      .document(batchOperationEntity)
+                      .refresh(co.elastic.clients.elasticsearch._types.Refresh.True));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void indexInOpenSearch(final BatchOperationEntity batchOperationEntity) {
+    try {
+      SEARCH_DB
+          .osClient()
+          .index(
+              request ->
+                  request
+                      .index(BATCH_OPERATION_INDEX.getFullQualifiedName())
+                      .id(batchOperationEntity.getId())
+                      .document(batchOperationEntity)
+                      .refresh(Refresh.True));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  record BatchOperationCacheArgument(
+      ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      Consumer<BatchOperationEntity> indexer) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestBatchOperationCache.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestBatchOperationCache.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class TestBatchOperationCache
+    implements ExporterEntityCache<String, CachedBatchOperationEntity> {
+
+  private final HashMap<String, CachedBatchOperationEntity> cache = new HashMap<>();
+
+  @Override
+  public Optional<CachedBatchOperationEntity> get(final String entityKey) {
+    return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  @Override
+  public Map<String, CachedBatchOperationEntity> getAll(final Iterable<String> keys) {
+    final Map<String, CachedBatchOperationEntity> map = new HashMap<>();
+    keys.forEach(k -> map.put(k, get(k).orElse(null)));
+    return map;
+  }
+
+  @Override
+  public void put(final String entityKey, final CachedBatchOperationEntity entity) {
+    cache.put(entityKey, entity);
+  }
+
+  @Override
+  public void remove(final String entityKey) {
+    cache.remove(entityKey);
+  }
+
+  @Override
+  public void clear() {
+    cache.clear();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -8,6 +8,8 @@
 package io.camunda.exporter.handlers.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -28,8 +31,10 @@ class BatchOperationCreatedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-" + BatchOperationTemplate.INDEX_NAME;
+
+  private final ExporterEntityCache batchOperationCache = mock(ExporterEntityCache.class);
   private final BatchOperationCreatedHandler underTest =
-      new BatchOperationCreatedHandler(indexName);
+      new BatchOperationCreatedHandler(indexName, batchOperationCache);
 
   @Test
   void testGetHandledValueType() {
@@ -95,6 +100,8 @@ class BatchOperationCreatedHandlerTest {
     assertThat(entity.getType())
         .isEqualTo(OperationType.valueOf(recordValue.getBatchOperationType().name()));
     assertThat(entity.getState()).isEqualTo(BatchOperationEntity.BatchOperationState.CREATED);
+
+    verify(batchOperationCache).put(eq(entity.getId()), any());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.protocol.record.ImmutableRecord;
@@ -120,6 +121,9 @@ class BatchOperationStatusHandlerTest {
     void shouldFlushEntityFields() {
       final var entity = new OperationEntity();
       entity.setState(OperationState.COMPLETED);
+      entity.setBatchOperationId(String.valueOf(batchOperationKey));
+      entity.setItemKey(123L);
+      entity.setProcessInstanceKey(456L);
       entity.setCompletedDate(OffsetDateTime.now());
       entity.setErrorMessage("error message");
 
@@ -130,13 +134,17 @@ class BatchOperationStatusHandlerTest {
 
       // then
       verify(mockRequest, times(1))
-          .update(
+          .upsert(
               indexName,
               entity.getId(),
+              entity,
               Map.of(
-                  "state", entity.getState(),
-                  "completedDate", entity.getCompletedDate(),
-                  "errorMessage", entity.getErrorMessage()));
+                  OperationTemplate.STATE, entity.getState(),
+                  OperationTemplate.BATCH_OPERATION_ID, entity.getBatchOperationId(),
+                  OperationTemplate.ITEM_KEY, entity.getItemKey(),
+                  OperationTemplate.PROCESS_INSTANCE_KEY, entity.getProcessInstanceKey(),
+                  OperationTemplate.COMPLETED_DATE, entity.getCompletedDate(),
+                  OperationTemplate.ERROR_MSG, entity.getErrorMessage()));
     }
 
     @Test
@@ -150,6 +158,9 @@ class BatchOperationStatusHandlerTest {
 
     @Test
     abstract void shouldExtractCorrectItemKey();
+
+    @Test
+    abstract void shouldExtractCorrectProcessInstanceKey();
 
     abstract Record<T> createSuccessRecord();
 
@@ -170,6 +181,14 @@ class BatchOperationStatusHandlerTest {
       final var itemKey = handler.getItemKey(record);
 
       assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
     }
 
     @Override
@@ -209,6 +228,14 @@ class BatchOperationStatusHandlerTest {
     }
 
     @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
     Record<ProcessInstanceMigrationRecordValue> createSuccessRecord() {
       return factory.generateRecord(
           ValueType.PROCESS_INSTANCE_MIGRATION,
@@ -242,6 +269,14 @@ class BatchOperationStatusHandlerTest {
       final var itemKey = handler.getItemKey(record);
 
       assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
     }
 
     @Override
@@ -288,6 +323,14 @@ class BatchOperationStatusHandlerTest {
       final var itemKey = handler.getItemKey(record);
 
       assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -327,6 +327,23 @@ class BatchOperationStatusHandlerTest {
       super(new ProcessInstanceCancellationOperationHandler(indexName, batchOperationCache));
     }
 
+    @Test
+    void shouldNotHandleRecordOfSubprocess() {
+      final Record<ProcessInstanceRecordValue> record =
+          factory.generateRecord(
+              ValueType.PROCESS_INSTANCE,
+              b ->
+                  b.withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                      .withValue(
+                          ImmutableProcessInstanceRecordValue.builder()
+                              .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                              .withBpmnElementType(BpmnElementType.PROCESS)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
+
+      assertThat(handler.handlesRecord(record)).isFalse();
+    }
+
     @Override
     void shouldExtractCorrectItemKey() {
       final var record = createSuccessRecord();
@@ -353,6 +370,7 @@ class BatchOperationStatusHandlerTest {
                       ImmutableProcessInstanceRecordValue.builder()
                           .from(factory.generateObject(ProcessInstanceRecordValue.class))
                           .withBpmnElementType(BpmnElementType.PROCESS)
+                          .withParentProcessInstanceKey(-1L)
                           .build())
                   .withBatchOperationReference(batchOperationKey));
     }
@@ -367,6 +385,7 @@ class BatchOperationStatusHandlerTest {
                       ImmutableProcessInstanceRecordValue.builder()
                           .from(factory.generateObject(ProcessInstanceRecordValue.class))
                           .withBpmnElementType(BpmnElementType.PROCESS)
+                          .withParentProcessInstanceKey(-1L)
                           .build())
                   .withIntent(ProcessInstanceIntent.CANCEL)
                   .withBatchOperationReference(batchOperationKey));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -18,6 +18,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.ErrorCause;
 import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkRequest.Builder;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
@@ -28,6 +29,7 @@ import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import io.camunda.exporter.entities.TestExporterEntity;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -47,12 +49,15 @@ class ElasticsearchBatchRequestTest {
   private ElasticsearchBatchRequest batchRequest;
   private ElasticsearchClient elasticsearchClient;
   private Builder requestBuilder;
+  private ElasticsearchScriptBuilder scriptBuilder;
 
   @BeforeEach
   void setUp() throws IOException {
     elasticsearchClient = mock(ElasticsearchClient.class);
     requestBuilder = new Builder();
-    batchRequest = new ElasticsearchBatchRequest(elasticsearchClient, requestBuilder);
+    scriptBuilder = mock(ElasticsearchScriptBuilder.class);
+    batchRequest =
+        new ElasticsearchBatchRequest(elasticsearchClient, requestBuilder, scriptBuilder);
     final BulkResponse bulkResponse = mock(BulkResponse.class);
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
   }
@@ -171,6 +176,72 @@ class ElasticsearchBatchRequestTest {
   }
 
   @Test
+  void shouldUpsertWithScript() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(elasticsearchClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.action().script()).isEqualTo(scriptWithParameters);
+    assertThat(update.action().upsert()).isEqualTo(entity);
+  }
+
+  @Test
+  void shouldUpsertWithScriptAndRouting() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+    final String routing = "routing";
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(elasticsearchClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.routing()).isEqualTo(routing);
+    assertThat(update.action().script()).isEqualTo(scriptWithParameters);
+    assertThat(update.action().upsert()).isEqualTo(entity);
+  }
+
+  @Test
   void shouldUpdateWithFields() throws PersistenceException, IOException {
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
@@ -219,6 +290,36 @@ class ElasticsearchBatchRequestTest {
     assertThat(update.index()).isEqualTo(INDEX);
     assertThat(update.id()).isEqualTo(ID);
     assertThat(update.action().doc()).isEqualTo(entity);
+  }
+
+  @Test
+  void shouldUpdateWithScript() throws PersistenceException, IOException {
+    // Given
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.updateWithScript(INDEX, ID, script, params);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(elasticsearchClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.action().script()).isEqualTo(scriptWithParameters);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.entities.TestExporterEntity;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkRequest.Builder;
 import org.opensearch.client.opensearch.core.BulkResponse;
@@ -47,12 +49,14 @@ class OpensearchBatchRequestTest {
   private OpensearchBatchRequest batchRequest;
   private OpenSearchClient osClient;
   private Builder requestBuilder;
+  private OpensearchScriptBuilder scriptBuilder;
 
   @BeforeEach
   void setUp() throws IOException {
     osClient = mock(OpenSearchClient.class);
     requestBuilder = new Builder();
-    batchRequest = new OpensearchBatchRequest(osClient, requestBuilder);
+    scriptBuilder = mock(OpensearchScriptBuilder.class);
+    batchRequest = new OpensearchBatchRequest(osClient, requestBuilder, scriptBuilder);
     final BulkResponse bulkResponse = mock(BulkResponse.class);
     when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
   }
@@ -168,6 +172,68 @@ class OpensearchBatchRequestTest {
   }
 
   @Test
+  void shouldUpsertWithScript() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpsertWithScriptAndRouting() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+    final String routing = "routing";
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.routing()).isEqualTo(routing);
+  }
+
+  @Test
   void shouldUpdateWithFields() throws PersistenceException, IOException {
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
@@ -198,6 +264,35 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, entity);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpdateWithScript() throws PersistenceException, IOException {
+    // Given
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.updateWithScript(INDEX, ID, script, params);
     batchRequest.execute();
 
     // Then

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -40,6 +40,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapps-schema</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -87,6 +87,12 @@
 
     <!-- testing -->
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms;
 
 import static io.camunda.db.rdbms.write.RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
+import static io.camunda.db.rdbms.write.RdbmsWriterConfig.DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
@@ -86,6 +87,8 @@ public class RdbmsExporterWrapper implements Exporter {
                 .minHistoryCleanupInterval(readMinHistoryCleanupInterval(context))
                 .maxHistoryCleanupInterval(readMaxHistoryCleanupInterval(context))
                 .batchOperationItemInsertBlockSize(readBatchOperationItemInsertBlockSize(context))
+                .exportBatchOperationItemsOnCreation(
+                    readExportBatchOperationItemsOnCreation(context))
                 .build());
 
     final var builder =
@@ -164,6 +167,13 @@ public class RdbmsExporterWrapper implements Exporter {
         DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE);
   }
 
+  private boolean readExportBatchOperationItemsOnCreation(final Context context) {
+    return readBoolean(
+        context,
+        "exportBatchOperationItemsOnCreation",
+        DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION);
+  }
+
   private Duration readDuration(
       final Context context, final String property, final Duration defaultValue) {
     final var arguments = context.getConfiguration().getArguments();
@@ -183,10 +193,11 @@ public class RdbmsExporterWrapper implements Exporter {
     }
   }
 
-  private long readLong(final Context context, final String property, final long defaultValue) {
+  private boolean readBoolean(
+      final Context context, final String property, final boolean defaultValue) {
     final var arguments = context.getConfiguration().getArguments();
     if (arguments != null && arguments.containsKey(property)) {
-      return (Long) arguments.get(property);
+      return (Boolean) arguments.get(property);
     } else {
       return defaultValue;
     }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsBatchOperationCacheLoader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RdbmsBatchOperationCacheLoader
+    implements CacheLoader<String, CachedBatchOperationEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RdbmsBatchOperationCacheLoader.class);
+  private final BatchOperationReader reader;
+
+  public RdbmsBatchOperationCacheLoader(final BatchOperationReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public CachedBatchOperationEntity load(final @NotNull String key) throws Exception {
+    final var response = reader.findOne(key);
+    if (response.isPresent()) {
+      final var batchOperationEntity = response.get();
+      return new CachedBatchOperationEntity(
+          batchOperationEntity.batchOperationId(),
+          OperationType.valueOf(batchOperationEntity.operationType()));
+    }
+    LOG.debug("BatchOperation '{}' not found in RDBMS", key);
+    return null;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationChunkExportHandler.java
@@ -54,6 +54,8 @@ public class BatchOperationChunkExportHandler
         Long.toString(batchOperationId),
         value.getItemKey(),
         value.getProcessInstanceKey(),
-        BatchOperationItemState.ACTIVE);
+        BatchOperationItemState.ACTIVE,
+        null,
+        null);
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -17,8 +20,10 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 public class IncidentBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<IncidentRecordValue> {
 
-  public IncidentBatchOperationExportHandler(final BatchOperationWriter batchOperationWriter) {
-    super(batchOperationWriter);
+  public IncidentBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, OperationType.RESOLVE_INCIDENT);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/IncidentBatchOperationExportHandler.java
@@ -27,6 +27,11 @@ public class IncidentBatchOperationExportHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<IncidentRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<IncidentRecordValue> record) {
     return record.getIntent().equals(IncidentIntent.RESOLVED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -19,8 +22,9 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceRecordValue> {
 
   public ProcessInstanceCancellationBatchOperationExportHandler(
-      final BatchOperationWriter batchOperationWriter) {
-    super(batchOperationWriter);
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, OperationType.CANCEL_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceCancellationBatchOperationExportHandler.java
@@ -34,6 +34,11 @@ public class ProcessInstanceCancellationBatchOperationExportHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceRecordValue> record) {
     return record.getValue().getBpmnElementType() == BpmnElementType.PROCESS
         && record.getIntent().equals(ProcessInstanceIntent.ELEMENT_TERMINATED);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -18,8 +21,9 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceMigrationRecordValue> {
 
   public ProcessInstanceMigrationBatchOperationExportHandler(
-      final BatchOperationWriter batchOperationWriter) {
-    super(batchOperationWriter);
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, OperationType.MIGRATE_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceMigrationBatchOperationExportHandler.java
@@ -28,6 +28,11 @@ public class ProcessInstanceMigrationBatchOperationExportHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceMigrationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   boolean isCompleted(final Record<ProcessInstanceMigrationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceMigrationIntent.MIGRATED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter.rdbms.handlers.batchoperation;
 
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -18,8 +21,9 @@ public class ProcessInstanceModificationBatchOperationExportHandler
     extends RdbmsBatchOperationStatusExportHandler<ProcessInstanceModificationRecordValue> {
 
   public ProcessInstanceModificationBatchOperationExportHandler(
-      final BatchOperationWriter batchOperationWriter) {
-    super(batchOperationWriter);
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache) {
+    super(batchOperationWriter, batchOperationCache, OperationType.MODIFY_PROCESS_INSTANCE);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/ProcessInstanceModificationBatchOperationExportHandler.java
@@ -28,6 +28,11 @@ public class ProcessInstanceModificationBatchOperationExportHandler
   }
 
   @Override
+  long getProcessInstanceKey(final Record<ProcessInstanceModificationRecordValue> record) {
+    return record.getValue().getProcessInstanceKey();
+  }
+
+  @Override
   protected boolean isCompleted(final Record<ProcessInstanceModificationRecordValue> record) {
     return record.getIntent().equals(ProcessInstanceModificationIntent.MODIFIED);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/RdbmsBatchOperationStatusExportHandler.java
@@ -13,24 +13,35 @@ import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
 import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.util.DateUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 
 public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordValue>
     implements RdbmsExportHandler<T> {
   public static final String ERROR_MSG = "%s: %s";
-
+  @VisibleForTesting final OperationType relevantOperationType;
   private final BatchOperationWriter batchOperationWriter;
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache;
 
-  public RdbmsBatchOperationStatusExportHandler(final BatchOperationWriter batchOperationWriter) {
+  public RdbmsBatchOperationStatusExportHandler(
+      final BatchOperationWriter batchOperationWriter,
+      final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache,
+      final OperationType relevantOperationType) {
     this.batchOperationWriter = batchOperationWriter;
+    this.batchOperationCache = batchOperationCache;
+    this.relevantOperationType = relevantOperationType;
   }
 
   @Override
   public boolean canExport(final Record<T> record) {
     return record.getBatchOperationReference() != batchOperationReferenceNullValue()
-        && (isCompleted(record) || isFailed(record));
+        && (isCompleted(record) || isFailed(record))
+        && isRelevantForBatchOperation(record);
   }
 
   @Override
@@ -54,6 +65,17 @@ public abstract class RdbmsBatchOperationStatusExportHandler<T extends RecordVal
               DateUtil.toOffsetDateTime(record.getTimestamp()),
               String.format(ERROR_MSG, record.getRejectionType(), record.getRejectionReason())));
     }
+  }
+
+  boolean isRelevantForBatchOperation(final Record<T> record) {
+    final var cachedEntity =
+        batchOperationCache.get(String.valueOf(record.getBatchOperationReference()));
+
+    return cachedEntity
+        .filter(
+            cachedBatchOperationEntity ->
+                cachedBatchOperationEntity.type() == relevantOperationType)
+        .isPresent();
   }
 
   abstract long getItemKey(Record<T> record);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationStatusHandlerTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers.batchoperation;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.db.rdbms.write.domain.BatchOperationItemDbModel;
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
+import io.camunda.webapps.schema.entities.operation.OperationType;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class BatchOperationStatusHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final long batchOperationKey = 42L;
+
+  private final ExporterEntityCache<String, CachedBatchOperationEntity> batchOperationCache =
+      mock(ExporterEntityCache.class);
+  private final BatchOperationWriter batchOperationWriter = mock(BatchOperationWriter.class);
+
+  abstract class AbstractOperationStatusHandlerTest<T extends RecordValue> {
+
+    final RdbmsBatchOperationStatusExportHandler<T> handler;
+
+    AbstractOperationStatusHandlerTest(final RdbmsBatchOperationStatusExportHandler<T> handler) {
+      this.handler = handler;
+
+      Mockito.reset(batchOperationCache);
+      when(batchOperationCache.get(Mockito.anyString()))
+          .thenReturn(
+              Optional.of(
+                  new CachedBatchOperationEntity(
+                      String.valueOf(batchOperationKey), handler.relevantOperationType)));
+    }
+
+    @Test
+    void shouldHandleSuccessRecord() {
+      final var record = createSuccessRecord();
+
+      assertThat(handler.canExport(record)).isTrue();
+    }
+
+    @Test
+    void shouldNotHandleSuccessRecordWithoutBatchOperationKeyInMetadata() {
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createSuccessRecord())
+              .withBatchOperationReference(batchOperationReferenceNullValue())
+              .build();
+
+      assertThat(handler.canExport(record)).isFalse();
+    }
+
+    @Test
+    void shouldNotHandleSuccessRecordWhenNotRelevantType() {
+      Mockito.reset(batchOperationCache);
+      final var otherOperationType =
+          Arrays.stream(OperationType.values())
+              .filter(t -> !t.equals(handler.relevantOperationType))
+              .findAny()
+              .get();
+
+      when(batchOperationCache.get(Mockito.anyString()))
+          .thenReturn(
+              Optional.of(
+                  new CachedBatchOperationEntity(
+                      String.valueOf(batchOperationKey), otherOperationType)));
+
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createSuccessRecord())
+              .withBatchOperationReference(batchOperationKey)
+              .build();
+
+      assertThat(handler.canExport(record)).isFalse();
+    }
+
+    @Test
+    void shouldHandleFailureRecord() {
+      final var record = createFailureRecord();
+
+      assertThat(handler.canExport(record)).isTrue();
+    }
+
+    @Test
+    void shouldNotHandleFailureRecordWithoutBatchOperationKeyInMetadata() {
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createFailureRecord())
+              .withBatchOperationReference(batchOperationReferenceNullValue())
+              .build();
+
+      assertThat(handler.canExport(record)).isFalse();
+    }
+
+    @Test
+    void shouldNotHandleFailureRecordWhenNotRelevantType() {
+      Mockito.reset(batchOperationCache);
+      final var otherOperationType =
+          Arrays.stream(OperationType.values())
+              .filter(t -> !t.equals(handler.relevantOperationType))
+              .findAny()
+              .get();
+
+      when(batchOperationCache.get(Mockito.anyString()))
+          .thenReturn(
+              Optional.of(
+                  new CachedBatchOperationEntity(
+                      String.valueOf(batchOperationKey), otherOperationType)));
+
+      final var record =
+          ImmutableRecord.<T>builder()
+              .from(createFailureRecord())
+              .withBatchOperationReference(batchOperationKey)
+              .build();
+
+      assertThat(handler.canExport(record)).isFalse();
+    }
+
+    @Test
+    void shouldUpdateEntityOnSuccess() {
+      final var record = createSuccessRecord();
+
+      handler.export(record);
+
+      final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+      verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+      assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.COMPLETED);
+      assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+      assertThat(itemCaptor.getValue().errorMessage()).isNull();
+    }
+
+    @Test
+    void shouldUpdateEntityOnFailure() {
+      final var record = createFailureRecord();
+
+      handler.export(record);
+
+      final var itemCaptor = ArgumentCaptor.forClass(BatchOperationItemDbModel.class);
+      verify(batchOperationWriter).updateItem(itemCaptor.capture());
+
+      assertThat(itemCaptor.getValue().state()).isEqualTo(BatchOperationItemState.FAILED);
+      assertThat(itemCaptor.getValue().processedDate()).isNotNull();
+      assertThat(itemCaptor.getValue().errorMessage()).isNotNull();
+    }
+
+    @Test
+    abstract void shouldExtractCorrectItemKey();
+
+    @Test
+    abstract void shouldExtractCorrectProcessInstanceKey();
+
+    abstract Record<T> createSuccessRecord();
+
+    abstract Record<T> createFailureRecord();
+  }
+
+  @Nested
+  class ProcessInstanceModificationOperationHandlerTest
+      extends AbstractOperationStatusHandlerTest<ProcessInstanceModificationRecordValue> {
+
+    ProcessInstanceModificationOperationHandlerTest() {
+      super(
+          new ProcessInstanceModificationBatchOperationExportHandler(
+              batchOperationWriter, batchOperationCache));
+    }
+
+    @Override
+    void shouldExtractCorrectItemKey() {
+      final var record = createSuccessRecord();
+      final var itemKey = handler.getItemKey(record);
+
+      assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    Record<ProcessInstanceModificationRecordValue> createSuccessRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE_MODIFICATION,
+          b ->
+              b.withIntent(ProcessInstanceModificationIntent.MODIFIED)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Override
+    Record<ProcessInstanceModificationRecordValue> createFailureRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE_MODIFICATION,
+          b ->
+              b.withRejectionType(RejectionType.NOT_FOUND)
+                  .withIntent(ProcessInstanceModificationIntent.MODIFY)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+  }
+
+  @Nested
+  class ProcessInstanceMigrationOperationHandlerTest
+      extends AbstractOperationStatusHandlerTest<ProcessInstanceMigrationRecordValue> {
+
+    ProcessInstanceMigrationOperationHandlerTest() {
+      super(
+          new ProcessInstanceMigrationBatchOperationExportHandler(
+              batchOperationWriter, batchOperationCache));
+    }
+
+    @Override
+    void shouldExtractCorrectItemKey() {
+      final var record = createSuccessRecord();
+      final var itemKey = handler.getItemKey(record);
+
+      assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    Record<ProcessInstanceMigrationRecordValue> createSuccessRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE_MIGRATION,
+          b ->
+              b.withIntent(ProcessInstanceMigrationIntent.MIGRATED)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Override
+    Record<ProcessInstanceMigrationRecordValue> createFailureRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE_MIGRATION,
+          b ->
+              b.withRejectionType(RejectionType.NOT_FOUND)
+                  .withIntent(ProcessInstanceMigrationIntent.MIGRATE)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+  }
+
+  @Nested
+  class ProcessInstanceCancellationOperationHandlerTest
+      extends AbstractOperationStatusHandlerTest<ProcessInstanceRecordValue> {
+
+    ProcessInstanceCancellationOperationHandlerTest() {
+      super(
+          new ProcessInstanceCancellationBatchOperationExportHandler(
+              batchOperationWriter, batchOperationCache));
+    }
+
+    @Test
+    void shouldNotHandleRecordOfSubprocess() {
+      final Record<ProcessInstanceRecordValue> record =
+          factory.generateRecord(
+              ValueType.PROCESS_INSTANCE,
+              b ->
+                  b.withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                      .withValue(
+                          ImmutableProcessInstanceRecordValue.builder()
+                              .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                              .withBpmnElementType(BpmnElementType.PROCESS)
+                              .build())
+                      .withBatchOperationReference(batchOperationKey));
+
+      assertThat(handler.canExport(record)).isFalse();
+    }
+
+    @Override
+    void shouldExtractCorrectItemKey() {
+      final var record = createSuccessRecord();
+      final var itemKey = handler.getItemKey(record);
+
+      assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    Record<ProcessInstanceRecordValue> createSuccessRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE,
+          b ->
+              b.withIntent(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                  .withValue(
+                      ImmutableProcessInstanceRecordValue.builder()
+                          .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                          .withBpmnElementType(BpmnElementType.PROCESS)
+                          .withParentProcessInstanceKey(-1)
+                          .build())
+                  .withBatchOperationReference(batchOperationKey));
+    }
+
+    @Override
+    Record<ProcessInstanceRecordValue> createFailureRecord() {
+      return factory.generateRecord(
+          ValueType.PROCESS_INSTANCE_MIGRATION,
+          b ->
+              b.withRejectionType(RejectionType.NOT_FOUND)
+                  .withValue(
+                      ImmutableProcessInstanceRecordValue.builder()
+                          .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                          .withBpmnElementType(BpmnElementType.PROCESS)
+                          .withParentProcessInstanceKey(-1)
+                          .build())
+                  .withIntent(ProcessInstanceIntent.CANCEL)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+  }
+
+  @Nested
+  class ResolveIncidentOperationHandlerTest
+      extends AbstractOperationStatusHandlerTest<IncidentRecordValue> {
+
+    ResolveIncidentOperationHandlerTest() {
+      super(new IncidentBatchOperationExportHandler(batchOperationWriter, batchOperationCache));
+    }
+
+    @Override
+    void shouldExtractCorrectItemKey() {
+      final var record = createSuccessRecord();
+      final var itemKey = handler.getItemKey(record);
+
+      assertThat(itemKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    void shouldExtractCorrectProcessInstanceKey() {
+      final var record = createSuccessRecord();
+      final var processInstanceKey = handler.getProcessInstanceKey(record);
+
+      assertThat(processInstanceKey).isEqualTo(record.getValue().getProcessInstanceKey());
+    }
+
+    @Override
+    Record<IncidentRecordValue> createSuccessRecord() {
+      return factory.generateRecord(
+          ValueType.INCIDENT,
+          b ->
+              b.withIntent(IncidentIntent.RESOLVED).withBatchOperationReference(batchOperationKey));
+    }
+
+    @Override
+    Record<IncidentRecordValue> createFailureRecord() {
+      return factory.generateRecord(
+          ValueType.INCIDENT,
+          b ->
+              b.withRejectionType(RejectionType.NOT_FOUND)
+                  .withIntent(IncidentIntent.RESOLVE)
+                  .withBatchOperationReference(batchOperationKey));
+    }
+  }
+}


### PR DESCRIPTION
## Description

Added configurable behaviour to CamundaExporter and RdbmsExporter to not export all batch operation items directly in the beginning of a batch operation to not overload the exporters and databases with too many inserts. The items will first be inserted when the completed or failed record is processed.

When items are inserted first on completion/failure, I encountered a problem where a resolved incident on a canceled processInstance was also counted as an item for the batch operation because it also had the `batchOperationReference` property filled. To overcome this, I added a batchOperationCache to lookup the batchOperation and it's type during the monitoring phase and to see, if the record is relevant for the referenced batch operation 

### CamundaExporter
- added new config group `BatchOperationConfiguration`
  - added property `exportPendingItems`
- added a batchOperation cache to lookup batch operations during the monitoring phase

### RdbmsExporter
- added new configuration property `exportPendingBatchOperationItems`
- added a batchOperation cache to lookup batch operations during the monitoring phase

## Related issues

closes #33936
