### PR TITLE
Add endpoint to create the initial admin user

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -78,6 +78,7 @@ public class WebSecurityConfig {
       Set.of(
           // these v2 endpoints are public
           "/v2/license",
+          "/v2/setup/user",
           // deprecated Tasklist v1 Public Endpoints
           "/v1/external/process/**");
   private static final Set<String> WEBAPP_PATHS =

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.filters;
 
-import io.camunda.search.query.RoleQuery;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
@@ -63,16 +62,7 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
     }
 
     try {
-      final var adminRoleMembers =
-          roleServices.searchMembers(
-              RoleQuery.of(
-                  builder ->
-                      builder.filter(
-                          filter ->
-                              filter.joinParentId(ADMIN_ROLE_ID).memberType(EntityType.USER))));
-      final var adminRoleHasMembers = adminRoleMembers.total() > 0;
-
-      if (!adminRoleHasMembers) {
+      if (!roleServices.hasMembersOfType(ADMIN_ROLE_ID, EntityType.USER)) {
         LOG.debug("No user with admin role exists. Redirecting to identity setup page.");
         final var redirectUrl = String.format("%s%s", request.getContextPath(), REDIRECT_PATH);
         response.sendRedirect(redirectUrl);

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -12,8 +12,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.search.entities.RoleMemberEntity;
-import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.RoleServices;
 import jakarta.servlet.FilterChain;
@@ -38,7 +36,7 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     securityConfig.getAuthentication().setUnprotectedApi(false);
-    when(roleServices.searchMembers(any())).thenReturn(SearchQueryResult.empty());
+    when(roleServices.hasMembersOfType(any(), any())).thenReturn(false);
     when(request.getContextPath()).thenReturn("localhost:8080");
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
@@ -74,8 +72,7 @@ class AdminUserCheckFilterTest {
     // given
     final var securityConfig = new SecurityConfiguration();
     securityConfig.getAuthentication().setUnprotectedApi(false);
-    when(roleServices.searchMembers(any()))
-        .thenReturn(new SearchQueryResult.Builder<RoleMemberEntity>().total(1).build());
+    when(roleServices.hasMembersOfType(any(), any())).thenReturn(true);
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
 

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerRoleUpdateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.role.BrokerRoleCreateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.role.BrokerRoleDeleteRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,6 +61,19 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.role().read())))
         .searchRoleMembers(query);
+  }
+
+  public boolean hasMembersOfType(final String roleId, final EntityType entityType) {
+    final var query =
+        RoleQuery.of(
+            builder ->
+                builder.filter(
+                    filter ->
+                        filter
+                            .joinParentId(DefaultRole.ADMIN.getId())
+                            .memberType(EntityType.USER)));
+    final var members = searchMembers(query);
+    return members.total() > 0;
   }
 
   public List<RoleEntity> getRolesByMemberIds(

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserDeleteRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.StringUtils;
@@ -63,6 +64,16 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
     final String encodedPassword = passwordEncoder.encode(request.password());
     return sendBrokerRequest(
         new BrokerUserCreateRequest()
+            .setUsername(request.username())
+            .setName(request.name())
+            .setEmail(request.email())
+            .setPassword(encodedPassword));
+  }
+
+  public CompletableFuture<UserRecord> createInitialAdminUser(final UserDTO request) {
+    final String encodedPassword = passwordEncoder.encode(request.password());
+    return sendBrokerRequest(
+        new BrokerUserCreateRequest(UserIntent.CREATE_INITIAL_ADMIN)
             .setUsername(request.username())
             .setName(request.name())
             .setEmail(request.email())

--- a/service/src/main/java/io/camunda/service/exception/ForbiddenException.java
+++ b/service/src/main/java/io/camunda/service/exception/ForbiddenException.java
@@ -19,4 +19,8 @@ public class ForbiddenException extends RuntimeException {
         UNAUTHORIZED_ERROR_MESSAGE.formatted(
             authorization.permissionType(), authorization.resourceType()));
   }
+
+  public ForbiddenException(final String message) {
+    super(message);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -35,7 +35,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class UserCreateAdminProcessor implements TypedRecordProcessor<UserRecord> {
+public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<UserRecord> {
   public static final String USER_ALREADY_EXISTS_ERROR_MESSAGE =
       "Expected to create user with username '%s', but a user with this username already exists";
   public static final String ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE =
@@ -53,7 +53,7 @@ public class UserCreateAdminProcessor implements TypedRecordProcessor<UserRecord
   private final MembershipState membershipState;
   private final StateWriter stateWriter;
 
-  public UserCreateAdminProcessor(
+  public UserCreateInitialAdminProcessor(
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,
       final Writers writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -43,7 +43,7 @@ public class UserProcessors {
         .onCommand(
             ValueType.USER,
             UserIntent.CREATE_INITIAL_ADMIN,
-            new UserCreateAdminProcessor(
+            new UserCreateInitialAdminProcessor(
                 keyGenerator, processingState, writers, authCheckBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -308,6 +308,7 @@ public final class EventAppliers implements EventApplier {
     register(UserIntent.CREATED, new UserCreatedApplier(state.getUserState()));
     register(UserIntent.UPDATED, new UserUpdatedApplier(state.getUserState()));
     register(UserIntent.DELETED, new UserDeletedApplier(state));
+    register(UserIntent.INITIAL_ADMIN_CREATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerMessageSubscriptionAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
-import static io.camunda.zeebe.engine.processing.user.UserCreateAdminProcessor.ADMIN_ROLE_HAS_USERS_ERROR_MESSAGE;
-import static io.camunda.zeebe.engine.processing.user.UserCreateAdminProcessor.ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE;
-import static io.camunda.zeebe.engine.processing.user.UserCreateAdminProcessor.USER_ALREADY_EXISTS_ERROR_MESSAGE;
+import static io.camunda.zeebe.engine.processing.user.UserCreateInitialAdminProcessor.ADMIN_ROLE_HAS_USERS_ERROR_MESSAGE;
+import static io.camunda.zeebe.engine.processing.user.UserCreateInitialAdminProcessor.ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE;
+import static io.camunda.zeebe.engine.processing.user.UserCreateInitialAdminProcessor.USER_ALREADY_EXISTS_ERROR_MESSAGE;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
@@ -15,6 +15,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -41,7 +42,7 @@ public class CreateInitialAdminUserTest {
     final var username = UUID.randomUUID().toString();
 
     // when
-    final var createdUser =
+    final var createdAdminUser =
         engine
             .user()
             .newInitialAdminUser(username)
@@ -52,13 +53,20 @@ public class CreateInitialAdminUserTest {
             .getValue();
 
     // then
-    assertThat(createdUser)
-        .describedAs("Has created the user with the given properties")
+    assertThat(createdAdminUser)
         .hasUsername(username)
         .hasName("name")
         .hasEmail("email")
         .hasPassword("password");
-
+    assertThat(
+            RecordingExporter.userRecords(UserIntent.CREATED)
+                .withUsername(username)
+                .getFirst()
+                .getValue())
+        .hasUsername(username)
+        .hasName("name")
+        .hasEmail("email")
+        .hasPassword("password");
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ADD_ENTITY)
                 .withRoleId(adminRoleId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateInitialAdminUserTest.java
@@ -105,7 +105,7 @@ public class CreateInitialAdminUserTest {
             .create();
 
     assertThat(rejection)
-        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(USER_ALREADY_EXISTS_ERROR_MESSAGE.formatted(username));
   }
 
@@ -126,7 +126,7 @@ public class CreateInitialAdminUserTest {
             .create();
 
     assertThat(rejection)
-        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
             ADMIN_ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(DefaultRole.ADMIN.getId()));
   }
@@ -163,7 +163,7 @@ public class CreateInitialAdminUserTest {
             .create();
 
     assertThat(rejection)
-        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(ADMIN_ROLE_HAS_USERS_ERROR_MESSAGE.formatted(adminRoleId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -47,14 +47,14 @@ public final class UserClient {
     private final CommandWriter writer;
     private final UserIntent intent;
 
-    private final Function<Long, Record<UserRecordValue>> SUCCESS_SUPPLIER =
+    private final Function<Long, Record<UserRecordValue>> successSupplier =
         (position) ->
             RecordingExporter.userRecords()
                 .withIntent(this::getSuccessEventIntent)
                 .withSourceRecordPosition(position)
                 .getFirst();
-    private Function<Long, Record<UserRecordValue>> expectation = SUCCESS_SUPPLIER;
-    private final Function<Long, Record<UserRecordValue>> REJECTION_SUPPLIER =
+    private Function<Long, Record<UserRecordValue>> expectation = successSupplier;
+    private final Function<Long, Record<UserRecordValue>> rejectionSupplier =
         (position) ->
             RecordingExporter.userRecords()
                 .onlyCommandRejections()
@@ -110,7 +110,7 @@ public final class UserClient {
     }
 
     public UserCreationClient expectRejection() {
-      expectation = REJECTION_SUPPLIER;
+      expectation = rejectionSupplier;
       return this;
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -44,18 +44,24 @@ public final class UserClient {
 
   public static class UserCreationClient {
 
-    private static final Function<Long, Record<UserRecordValue>> SUCCESS_SUPPLIER =
-        (position) ->
-            RecordingExporter.userRecords()
-                .withIntent(UserIntent.CREATED)
-                .withSourceRecordPosition(position)
-                .getFirst();
-    private final Function<Long, Record<UserRecordValue>> rejectionSupplier;
-
     private final CommandWriter writer;
     private final UserIntent intent;
-    private final UserRecord userCreationRecord;
+
+    private final Function<Long, Record<UserRecordValue>> SUCCESS_SUPPLIER =
+        (position) ->
+            RecordingExporter.userRecords()
+                .withIntent(this::getSuccessEventIntent)
+                .withSourceRecordPosition(position)
+                .getFirst();
     private Function<Long, Record<UserRecordValue>> expectation = SUCCESS_SUPPLIER;
+    private final Function<Long, Record<UserRecordValue>> REJECTION_SUPPLIER =
+        (position) ->
+            RecordingExporter.userRecords()
+                .onlyCommandRejections()
+                .withIntent(this::getCommandIntent)
+                .withSourceRecordPosition(position)
+                .getFirst();
+    private final UserRecord userCreationRecord;
 
     public UserCreationClient(
         final CommandWriter writer, final String username, final UserIntent intent) {
@@ -63,13 +69,14 @@ public final class UserClient {
       this.intent = intent;
       userCreationRecord = new UserRecord();
       userCreationRecord.setUsername(username);
-      rejectionSupplier =
-          (position) ->
-              RecordingExporter.userRecords()
-                  .onlyCommandRejections()
-                  .withIntent(intent)
-                  .withSourceRecordPosition(position)
-                  .getFirst();
+    }
+
+    public UserIntent getCommandIntent() {
+      return intent;
+    }
+
+    public UserIntent getSuccessEventIntent() {
+      return intent == UserIntent.CREATE ? UserIntent.CREATED : UserIntent.INITIAL_ADMIN_CREATED;
     }
 
     public UserCreationClient withUsername(final String username) {
@@ -103,7 +110,7 @@ public final class UserClient {
     }
 
     public UserCreationClient expectRejection() {
-      expectation = rejectionSupplier;
+      expectation = REJECTION_SUPPLIER;
       return this;
     }
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -45,6 +45,7 @@ tags:
   - name: Process instance
   - name: Resource
   - name: Role
+  - name: Setup
   - name: Signal
   - name: Tenant
   - name: User
@@ -4580,6 +4581,35 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /setup/user:
+    post:
+      tags:
+        - Setup
+      operationId: createAdminUser
+      summary: Create admin user
+      description: Creates a new user and assign the admin role to it.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserRequest"
+        required: true
+      responses:
+        "201":
+          description: |
+            The user was created and got assigned the admin role successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserCreateResult"
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
 
   /incidents/search:
     post:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -92,7 +92,7 @@ public class RestErrorMapper {
     return switch (error) {
       case final ForbiddenException fe:
         REST_GATEWAY_LOGGER.trace("Expected to handle REST request, but was forbidden", fe);
-        yield createProblemDetail(HttpStatus.FORBIDDEN, fe.getMessage(), fe.getClass().getName());
+        yield mapForbiddenExceptionToProblem(fe);
       case final CamundaSearchException cse:
         yield mapCamundaSearchExceptionToProblem(cse);
       case final CamundaBrokerException cse:
@@ -367,5 +367,9 @@ public class RestErrorMapper {
               HttpStatus.INTERNAL_SERVER_ERROR, errorMessage, "INTERNAL_ERROR");
         }
     }
+  }
+
+  public static @NotNull ProblemDetail mapForbiddenExceptionToProblem(final ForbiddenException fe) {
+    return createProblemDetail(HttpStatus.FORBIDDEN, fe.getMessage(), fe.getClass().getName());
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.setup;
+
+import io.camunda.service.UserServices;
+import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/setup")
+public class SetupController {
+  private final UserServices userServices;
+
+  public SetupController(final UserServices userServices) {
+    this.userServices = userServices;
+  }
+
+  @CamundaPostMapping(path = "/user")
+  public CompletableFuture<ResponseEntity<Object>> createAdminUser(
+      @RequestBody final UserRequest request) {
+    return RequestMapper.toUserDTO(request)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            dto ->
+                RequestMapper.executeServiceMethod(
+                    () ->
+                        userServices
+                            .withAuthentication(RequestMapper.getAnonymousAuthentication())
+                            .createInitialAdminUser(dto),
+                    ResponseMapper::toUserCreateResponse));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/setup/SetupController.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.setup;
 
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.service.RoleServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.exception.ForbiddenException;
@@ -27,20 +29,33 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/v2/setup")
 public class SetupController {
 
+  public static final String WRONG_AUTHENTICATION_METHOD_ERROR_MESSAGE =
+      "The initial admin user can only be created with basic authentication.";
   public static final String ADMIN_EXISTS_ERROR_MESSAGE =
       "Expected to create an initial admin user, but found existing admin users. Please ask your admin to create a new user with the '%s' role."
           .formatted(DefaultRole.ADMIN.getId());
   private final UserServices userServices;
   private final RoleServices roleServices;
+  private final SecurityConfiguration securityConfiguration;
 
-  public SetupController(final UserServices userServices, final RoleServices roleServices) {
+  public SetupController(
+      final UserServices userServices,
+      final RoleServices roleServices,
+      final SecurityConfiguration securityConfiguration) {
     this.userServices = userServices;
     this.roleServices = roleServices;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @CamundaPostMapping(path = "/user")
   public CompletableFuture<ResponseEntity<Object>> createAdminUser(
       @RequestBody final UserRequest request) {
+    if (securityConfiguration.getAuthentication().getMethod() != AuthenticationMethod.BASIC) {
+      final var exception = new ForbiddenException(WRONG_AUTHENTICATION_METHOD_ERROR_MESSAGE);
+      return RestErrorMapper.mapProblemToCompletedResponse(
+          RestErrorMapper.mapForbiddenExceptionToProblem(exception));
+    }
+
     if (roleServices
         .withAuthentication(RequestMapper.getAnonymousAuthentication())
         .hasMembersOfType(DefaultRole.ADMIN.getId(), EntityType.USER)) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -29,13 +29,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @WebMvcTest(UserController.class)
 public class UserControllerTest extends RestControllerTest {
@@ -43,14 +41,10 @@ public class UserControllerTest extends RestControllerTest {
   private static final String USER_BASE_URL = "/v2/users";
 
   @MockBean private UserServices userServices;
-  @MockBean private PasswordEncoder passwordEncoder;
 
   @BeforeEach
   void setup() {
     when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
-    when(passwordEncoder.encode(any()))
-        .thenAnswer(
-            (Answer<String>) invocationOnMock -> invocationOnMock.getArgument(0).toString());
   }
 
   @ParameterizedTest

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUserCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUserCreateRequest.java
@@ -19,7 +19,11 @@ public class BrokerUserCreateRequest extends BrokerExecuteCommand<UserRecord> {
   private final UserRecord requestDto = new UserRecord();
 
   public BrokerUserCreateRequest() {
-    super(ValueType.USER, UserIntent.CREATE);
+    this(UserIntent.CREATE);
+  }
+
+  public BrokerUserCreateRequest(final UserIntent intent) {
+    super(ValueType.USER, intent);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
@@ -22,7 +22,8 @@ public enum UserIntent implements Intent {
   UPDATED(3),
   DELETE(4),
   DELETED(5),
-  CREATE_INITIAL_ADMIN(6);
+  CREATE_INITIAL_ADMIN(6),
+  INITIAL_ADMIN_CREATED(7);
 
   private final short value;
 
@@ -41,6 +42,7 @@ public enum UserIntent implements Intent {
       case CREATED:
       case UPDATED:
       case DELETED:
+      case INITIAL_ADMIN_CREATED:
         return true;
       default:
         return false;
@@ -63,6 +65,8 @@ public enum UserIntent implements Intent {
         return DELETED;
       case 6:
         return CREATE_INITIAL_ADMIN;
+      case 7:
+        return INITIAL_ADMIN_CREATED;
       default:
         return UNKNOWN;
     }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/DeploymentDistributionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/DeploymentDistributionRecordStream.java
@@ -26,6 +26,7 @@ public final class DeploymentDistributionRecordStream
     return new DeploymentDistributionRecordStream(wrappedStream);
   }
 
+  @Override
   public DeploymentDistributionRecordStream withPartitionId(final int partitionId) {
     return valueFilter(v -> v.getPartitionId() == partitionId);
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ExporterRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ExporterRecordStream.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.test.util.stream.StreamWrapper;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public abstract class ExporterRecordStream<
@@ -66,6 +67,10 @@ public abstract class ExporterRecordStream<
 
   public S withIntent(final Intent intent) {
     return filter(m -> m.getIntent() == intent);
+  }
+
+  public S withIntent(final Supplier<Intent> intent) {
+    return withIntent(intent.get());
   }
 
   public S withPartitionId(final int partitionId) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This endpoint allows creating an initial admin user. That means it's 1 atomic action to create a user and assign it to the admin role. This is not a normal flow to create admin users! It should only be used once. Once an admin user exists this should be used to create more admins. Hence the check and `FORBIDDEN` if an admin already exists.

Notably this endpoint is unprotected. When creating the initial admin user there won't be any users yet, so it's not possible to have authentication here.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33724 
