### PR TITLE
[Backport release-8.7.6] fix: setting issuer for audience

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -135,7 +135,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
               builder.getSslClientCertPath().toAbsolutePath().toString(),
               builder.getSslClientCertPassword(),
               builder.getClientId(),
-              builder.getAudience()));
+              builder.getIssuer()));
       payload.put("client_assertion_type", JWT_ASSERTION_TYPE);
     } else {
       payload.put("client_secret", builder.getClientSecret());
@@ -155,7 +155,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   }
 
   private static String getClientAssertion(
-      String certPath, String certStorePassword, String clientId, String audience) {
+      String certPath, String certStorePassword, String clientId, String issuer) {
     final X509Certificate certificate;
     final Algorithm algorithm;
     try (FileInputStream stream = new FileInputStream(certPath)) {
@@ -186,7 +186,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
         .withHeader(header)
         .withIssuer(clientId)
         .withSubject(clientId)
-        .withAudience(audience)
+        .withAudience(issuer)
         .withIssuedAt(now)
         .withNotBefore(now)
         .withExpiresAt(new Date(now.getTime() + 5 * 60 * 1000))

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -43,11 +43,13 @@ public final class OAuthCredentialsProviderBuilder {
   public static final String OAUTH_ENV_READ_TIMEOUT = "ZEEBE_AUTH_READ_TIMEOUT";
   public static final String OAUTH_ENV_SSL_CLIENT_CERT_PATH = "OAUTH_SSL_CLIENT_CERT_PATH";
   public static final String OAUTH_ENV_SSL_CLIENT_CERT_PASSWORD = "OAUTH_SSL_CLIENT_CERT_PASSWORD";
+  public static final String OAUTH_ENV_SSL_ISSUER = "OAUTH_SSL_ISSUER";
   private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;
 
   private String clientId;
+  private String issuer;
   private String clientSecret;
   private String audience;
   private String scope;
@@ -192,6 +194,7 @@ public final class OAuthCredentialsProviderBuilder {
   private void applySSLClientCertConfiguration() {
     applyEnvironmentValueIfNotNull(this::sslClientCertPath, OAUTH_ENV_SSL_CLIENT_CERT_PATH);
     applyEnvironmentValueIfNotNull(this::sslClientCertPassword, OAUTH_ENV_SSL_CLIENT_CERT_PASSWORD);
+    applyEnvironmentValueIfNotNull(this::issuer, OAUTH_ENV_SSL_ISSUER);
   }
 
   private void checkEnvironmentOverrides() {
@@ -310,6 +313,19 @@ public final class OAuthCredentialsProviderBuilder {
 
   public Path getSslClientCertPath() {
     return sslClientCertPath;
+  }
+
+  /** Issuer to be used when requesting access token from OAuth authorization server. */
+  public OAuthCredentialsProviderBuilder issuer(final String issuer) {
+    this.issuer = issuer;
+    return this;
+  }
+
+  /**
+   * @see OAuthCredentialsProviderBuilder#issuer(String)
+   */
+  public String getIssuer() {
+    return issuer;
   }
 
   public OAuthCredentialsProviderBuilder sslClientCertPassword(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -43,7 +43,7 @@ public final class OAuthCredentialsProviderBuilder {
   public static final String OAUTH_ENV_READ_TIMEOUT = "ZEEBE_AUTH_READ_TIMEOUT";
   public static final String OAUTH_ENV_SSL_CLIENT_CERT_PATH = "OAUTH_SSL_CLIENT_CERT_PATH";
   public static final String OAUTH_ENV_SSL_CLIENT_CERT_PASSWORD = "OAUTH_SSL_CLIENT_CERT_PASSWORD";
-  public static final String OAUTH_ENV_SSL_ISSUER = "OAUTH_SSL_ISSUER";
+  public static final String OAUTH_ENV_ISSUER = "OAUTH_ISSUER";
   private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;
@@ -194,7 +194,7 @@ public final class OAuthCredentialsProviderBuilder {
   private void applySSLClientCertConfiguration() {
     applyEnvironmentValueIfNotNull(this::sslClientCertPath, OAUTH_ENV_SSL_CLIENT_CERT_PATH);
     applyEnvironmentValueIfNotNull(this::sslClientCertPassword, OAUTH_ENV_SSL_CLIENT_CERT_PASSWORD);
-    applyEnvironmentValueIfNotNull(this::issuer, OAUTH_ENV_SSL_ISSUER);
+    applyEnvironmentValueIfNotNull(this::issuer, OAUTH_ENV_ISSUER);
   }
 
   private void checkEnvironmentOverrides() {


### PR DESCRIPTION
# Description
Backport of #33953 to `release-8.7.6`.

relates to camunda-cloud/identity#3440