### PR TITLE
Additional Integration test cases when scaling up

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -123,6 +123,7 @@ public class ScaleUpPartitionsTest {
     cluster.awaitHealthyTopology();
   }
 
+  @Test
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {
     Awaitility.await("until scaling is done")
         .timeout(Duration.ofMinutes(5))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -31,6 +31,8 @@ import org.awaitility.Awaitility;
 
 final class Utils {
 
+  public static final String DEFAULT_PROCESS_ID = "processId";
+
   static void scaleAndWait(final TestCluster cluster, final int newClusterSize) {
     final var response = scale(cluster, newClusterSize);
 
@@ -125,7 +127,7 @@ final class Utils {
   static List<Long> createInstanceWithAJobOnAllPartitions(
       final CamundaClient camundaClient, final String jobType, final int partitionsCount) {
     return createInstanceWithAJobOnAllPartitions(
-        camundaClient, jobType, partitionsCount, true, "processId");
+        camundaClient, jobType, partitionsCount, true, DEFAULT_PROCESS_ID);
   }
 
   static List<Long> createInstanceWithAJobOnAllPartitions(


### PR DESCRIPTION
## Description
Two additional Integration tests:
- the cluster is able to scale partitions more than once
- the node that took the snapshot for bootstrap deletes it when the scaling is completed
## Related issues

relates #31882 
