### PR TITLE
Change gRPC to REST API in `RestErrorMapper`

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -164,12 +164,12 @@ public class RestErrorMapper {
             HttpStatus.SERVICE_UNAVAILABLE, pnfeMsg, pnfe.getClass().getName());
       case final PartitionInactiveException pie:
         final var pieMsg =
-            "Expected to handle gRPC request, but the target partition is currently inactive";
+            "Expected to handle REST API request, but the target partition is currently inactive";
         REST_GATEWAY_LOGGER.debug(pieMsg, pie);
         yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, pieMsg, pie.getClass().getName());
       case final NoTopologyAvailableException ntae:
         final var ntaeMsg =
-            "Expected to handle gRPC request, but the gateway does not know any partitions yet";
+            "Expected to handle REST API request, but the gateway does not know any partitions yet";
         REST_GATEWAY_LOGGER.debug(ntaeMsg, ntae);
         yield createProblemDetail(
             HttpStatus.SERVICE_UNAVAILABLE, ntaeMsg, ntae.getClass().getName());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This is the RestErrorMapper. Exceptions caught here will always be REST.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

N/A
