### PR TITLE
Add missing s3 configs

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -339,10 +339,11 @@
       # backup:
         # Configure backup store. NOTE:- Use the same configuration on all brokers of this cluster.
 
-        # Set the backup store type. Supported values are [NONE, S3, GCS]. Default value is NONE
+        # Set the backup store type. Supported values are [NONE, S3, GCS, AZURE]. Default value is NONE
         # When NONE, no backup store is configured and no backup will be taken.
         # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
         # Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
+        # Use AZURE to use Azure Storage (https://learn.microsoft.com/en-us/azure/storage/)
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
         # store: NONE
 
@@ -396,6 +397,16 @@
           # Useful for using the same bucket for multiple Zeebe clusters. In this case, basePath must be unique.
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
           # basePath:
+
+          # Maximum number of connections allowed in a connection pool. This
+          # is used to restrict the maximum number of concurrent uploads as to
+          # avoid connection timeouts when uploading backups with large/many files.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_MAXCONCURRENTCONNECTIONS
+          # maxConcurrentConnections: 50
+
+          # Timeout for acquiring an already-established connection from a connection pool to a remote service.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_CONNECTIONAQUISITIONTIMEOUT
+          # connectionAcquisitionTimeout: PT45S
 
         # Configure the following if store is set to GCS
         # gcs:

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -343,7 +343,7 @@
         # When NONE, no backup store is configured and no backup will be taken.
         # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
         # Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
-        # Use AZURE to use Azure Storage (https://learn.microsoft.com/en-us/azure/storage/)
+        # Use AZURE to use Azure Storage (https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction)
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
         # store: NONE
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -314,6 +314,16 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_BASEPATH
           # basePath:
 
+          # Maximum number of connections allowed in a connection pool. This
+          # is used to restrict the maximum number of concurrent uploads as to
+          # avoid connection timeouts when uploading backups with large/many files.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_MAXCONCURRENTCONNECTIONS
+          # maxConcurrentConnections: 50
+
+          # Timeout for acquiring an already-established connection from a connection pool to a remote service.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_S3_CONNECTIONAQUISITIONTIMEOUT
+          # connectionAcquisitionTimeout: PT45S
+
         # Configure the following if store is set to GCS
         # gcs:
           # Name of the bucket where the backup will be stored.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -259,7 +259,7 @@
         # When NONE, no backup store is configured and no backup will be taken.
         # Use S3 to use any S3 compatible storage (https://docs.aws.amazon.com/AmazonS3/latest/API/Type_API_Reference.html).
         # Use GCS to use Google Cloud Storage (https://cloud.google.com/storage/)
-        # Use AZURE to use Azure Storage (https://learn.microsoft.com/en-us/azure/storage/)
+        # Use AZURE to use Azure Storage (https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction)
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_BACKUP_STORE
         # store: NONE
 

--- a/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
+++ b/zeebe/backup-stores/s3/src/main/java/io/camunda/zeebe/backup/s3/S3BackupConfig.java
@@ -83,20 +83,6 @@ public record S3BackupConfig(
     }
   }
 
-  record Credentials(String accessKey, String secretKey) {
-    @Override
-    public String toString() {
-      return "Credentials{"
-          + "accessKey='"
-          + accessKey
-          + '\''
-          + ", secretKey='"
-          + "<redacted>"
-          + '\''
-          + '}';
-    }
-  }
-
   public static class Builder {
 
     private String bucketName;
@@ -154,8 +140,8 @@ public record S3BackupConfig(
       return this;
     }
 
-    public Builder withParallelUploadsLimit(final Integer parallelUploadsLimit) {
-      maxConcurrentConnections = parallelUploadsLimit;
+    public Builder withMaxConcurrentConnections(final Integer maxConcurrentConnections) {
+      this.maxConcurrentConnections = maxConcurrentConnections;
       return this;
     }
 
@@ -176,6 +162,20 @@ public record S3BackupConfig(
           Optional.ofNullable(basePath),
           maxConcurrentConnections,
           connectionAcquisitionTimeout);
+    }
+  }
+
+  record Credentials(String accessKey, String secretKey) {
+    @Override
+    public String toString() {
+      return "Credentials{"
+          + "accessKey='"
+          + accessKey
+          + '\''
+          + ", secretKey='"
+          + "<redacted>"
+          + '\''
+          + '}';
     }
   }
 }

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -76,7 +76,7 @@ final class BackupUploadIT {
             .forcePathStyleAccess(false)
             .withCompressionAlgorithm(null)
             .withConnectionAcquisitionTimeout(connectionAcquisitionTimeout)
-            .withParallelUploadsLimit(parallelUploadsLimit)
+            .withMaxConcurrentConnections(parallelUploadsLimit)
             .build();
 
     final S3AsyncClient asyncClient = S3BackupStore.buildClient(backupConfig);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/S3BackupStoreConfig.java
@@ -24,6 +24,12 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
   private boolean forcePathStyleAccess = false;
   private String compression;
 
+  /** Default from `SdkHttpConfigurationOption.MAX_CONNECTIONS` */
+  private int maxConcurrentConnections = 50;
+
+  /** Default from `SdkHttpConfigurationOption.DEFAULT_CONNECTION_ACQUIRE_TIMEOUT` */
+  private Duration connectionAcquisitionTimeout = Duration.ofSeconds(45);
+
   private String basePath;
 
   public String getBucketName() {
@@ -88,21 +94,37 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
 
   public void setCompression(final String algorithm) {
     if (Objects.equals(algorithm, "none")) {
-      this.compression = null;
+      compression = null;
     } else {
-      this.compression = algorithm;
+      compression = algorithm;
     }
-  }
-
-  public void setBasePath(final String basePath) {
-    this.basePath = basePath;
   }
 
   public String getBasePath() {
     return basePath;
   }
 
-  public static S3BackupConfig toStoreConfig(S3BackupStoreConfig config) {
+  public void setBasePath(final String basePath) {
+    this.basePath = basePath;
+  }
+
+  public int getMaxConcurrentConnections() {
+    return maxConcurrentConnections;
+  }
+
+  public void setMaxConcurrentConnections(final int maxConcurrentConnections) {
+    this.maxConcurrentConnections = maxConcurrentConnections;
+  }
+
+  public Duration getConnectionAcquisitionTimeout() {
+    return connectionAcquisitionTimeout;
+  }
+
+  public void setConnectionAcquisitionTimeout(final Duration connectionAcquisitionTimeout) {
+    this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
+  }
+
+  public static S3BackupConfig toStoreConfig(final S3BackupStoreConfig config) {
     final var builder =
         new Builder()
             .withBucketName(config.getBucketName())
@@ -111,7 +133,9 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
             .withApiCallTimeout(config.getApiCallTimeout())
             .forcePathStyleAccess(config.isForcePathStyleAccess())
             .withCompressionAlgorithm(config.getCompression())
-            .withBasePath(config.getBasePath());
+            .withBasePath(config.getBasePath())
+            .withMaxConcurrentConnections(config.getMaxConcurrentConnections())
+            .withConnectionAcquisitionTimeout(config.getConnectionAcquisitionTimeout());
     if (config.getAccessKey() != null && config.getSecretKey() != null) {
       builder.withCredentials(config.getAccessKey(), config.getSecretKey());
     }
@@ -129,6 +153,10 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     result = 31 * result + (forcePathStyleAccess ? 1 : 0);
     result = 31 * result + (compression != null ? compression.hashCode() : 0);
     result = 31 * result + (basePath != null ? basePath.hashCode() : 0);
+    result = 31 * result + maxConcurrentConnections;
+    result =
+        31 * result
+            + (connectionAcquisitionTimeout != null ? connectionAcquisitionTimeout.hashCode() : 0);
     return result;
   }
 
@@ -167,6 +195,12 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
     if (!Objects.equals(basePath, that.basePath)) {
       return false;
     }
+    if (maxConcurrentConnections != that.maxConcurrentConnections) {
+      return false;
+    }
+    if (!Objects.equals(connectionAcquisitionTimeout, that.connectionAcquisitionTimeout)) {
+      return false;
+    }
     return Objects.equals(apiCallTimeout, that.apiCallTimeout);
   }
 
@@ -196,6 +230,10 @@ public class S3BackupStoreConfig implements ConfigurationEntry {
         + compression
         + ", basePath="
         + basePath
+        + ", maxConcurrentConnections="
+        + maxConcurrentConnections
+        + ", connectionAcquisitionTimeout="
+        + connectionAcquisitionTimeout
         + '}';
   }
 }


### PR DESCRIPTION
## Description

This PR makes it so that the maxConcurrentConnections and connectionAcquisitionTimeout can be configured in the S3 backups. This feature is a leftover from https://github.com/camunda/camunda/pull/13641

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/34012
