### PR TITLE
deps: upgrade spring-boot version to 3.4.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,6 +89,7 @@
     <version.scala>2.13.16</version.scala>
     <version.slf4j>2.0.17</version.slf4j>
     <version.snakeyaml>2.4</version.snakeyaml>
+    <version.tomcat>10.1.42</version.tomcat>
     <version.javax>1.3.2</version.javax>
     <version.wiremock>3.13.1</version.wiremock>
     <version.conscrypt>2.5.2</version.conscrypt>
@@ -1078,6 +1079,30 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${version.log4j}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${version.tomcat}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -89,7 +89,6 @@
     <version.scala>2.13.16</version.scala>
     <version.slf4j>2.0.17</version.slf4j>
     <version.snakeyaml>2.4</version.snakeyaml>
-    <version.tomcat>10.1.42</version.tomcat>
     <version.javax>1.3.2</version.javax>
     <version.wiremock>3.13.1</version.wiremock>
     <version.conscrypt>2.5.2</version.conscrypt>
@@ -105,7 +104,7 @@
     <version.rest-assured>5.5.5</version.rest-assured>
     <version.spring>6.2.6</version.spring>
     <version.spring-security>6.5.1</version.spring-security>
-    <version.spring-boot>3.4.5</version.spring-boot>
+    <version.spring-boot>3.4.7</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>
@@ -1079,30 +1078,6 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${version.log4j}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-annotations-api</artifactId>
-        <version>${version.tomcat}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${version.tomcat}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${version.tomcat}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Description

This PR updates all org.apache.tomcat.embed dependencies (e.g., tomcat-embed-core) to `10.1.42` in the monorepo's parent pom as a fix for [this CVE](https://camunda.slack.com/archives/C0925P02X7X)

## Related issues

closes #34020
