### PR TITLE
Add clients migration handler

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
@@ -63,18 +63,18 @@ public class ClientMigrationHandler extends MigrationHandler<Members> {
       logger.debug("No permissions to migrate for client: {}", clientId);
       return;
     }
-    try {
-      for (final CreateAuthorizationRequest request : combinedPermissions) {
+    for (final CreateAuthorizationRequest request : combinedPermissions) {
+      try {
         authorizationServices.createAuthorization(request).join();
         logger.debug(
             "Migrated client permission with owner ID: {} and resource type: {}",
             request.ownerId(),
             request.resourceType());
-      }
-    } catch (final Exception e) {
-      if (!isConflictError(e)) {
-        throw new MigrationException(
-            String.format("Failed to migrate client permissions for client ID: %s", clientId), e);
+      } catch (final Exception e) {
+        if (!isConflictError(e)) {
+          throw new MigrationException(
+              String.format("Failed to migrate client permissions for client ID: %s", clientId), e);
+        }
       }
     }
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/ClientMigrationHandler.java
@@ -5,14 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migration.identity.transformer;
+package io.camunda.migration.identity;
 
 import static io.camunda.migration.identity.config.saas.StaticEntities.getOperateClientPermissions;
 import static io.camunda.migration.identity.config.saas.StaticEntities.getTasklistClientPermissions;
 import static io.camunda.migration.identity.config.saas.StaticEntities.getZeebeClientPermissions;
 
 import io.camunda.migration.api.MigrationException;
-import io.camunda.migration.identity.MigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Client;
 import io.camunda.migration.identity.console.ConsoleClient.Members;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
@@ -45,7 +45,8 @@ public class StaticConsoleRoleAuthorizationMigrationHandler extends MigrationHan
             if (!isConflictError(e)) {
               throw new MigrationException(
                   String.format(
-                      "Failed to migrate role permission with owner ID: %s and resource type: %s  ", request.ownerId(), request.resourceType()),
+                      "Failed to migrate role permission with owner ID: %s and resource type: %s  ",
+                      request.ownerId(), request.resourceType()),
                   e);
             }
           }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandler.java
@@ -7,21 +7,19 @@
  */
 package io.camunda.migration.identity;
 
-import static io.camunda.migration.identity.config.saas.StaticEntities.CLIENT_PERMISSIONS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
 
 import io.camunda.migration.api.MigrationException;
 import io.camunda.migration.identity.dto.NoopDTO;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AuthorizationServices;
-import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import java.util.List;
 
-public class StaticConsoleAuthorizationMigrationHandler extends MigrationHandler<NoopDTO> {
+public class StaticConsoleRoleAuthorizationMigrationHandler extends MigrationHandler<NoopDTO> {
 
   final AuthorizationServices authorizationServices;
 
-  public StaticConsoleAuthorizationMigrationHandler(
+  public StaticConsoleRoleAuthorizationMigrationHandler(
       final AuthorizationServices authorizationServices,
       final Authentication servicesAuthentication) {
     this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
@@ -35,35 +33,19 @@ public class StaticConsoleAuthorizationMigrationHandler extends MigrationHandler
 
   @Override
   protected void process(final List<NoopDTO> batch) {
-    createRoleAuthorizations();
-    createClientAuthorizations();
-  }
-
-  private void createRoleAuthorizations() {
-    createAuthorizations(ROLE_PERMISSIONS, "role");
-  }
-
-  private void createClientAuthorizations() {
-    createAuthorizations(CLIENT_PERMISSIONS, "client");
-  }
-
-  private void createAuthorizations(
-      final List<CreateAuthorizationRequest> requests, final String entity) {
-    requests.forEach(
+    ROLE_PERMISSIONS.forEach(
         request -> {
           try {
             authorizationServices.createAuthorization(request).join();
             logger.debug(
-                "Migrated {} permission with owner ID: {} and resource type: {}",
-                entity,
+                "Migrated role permission with owner ID: {} and resource type: {}",
                 request.ownerId(),
                 request.resourceType());
           } catch (final Exception e) {
             if (!isConflictError(e)) {
               throw new MigrationException(
                   String.format(
-                      "Failed to migrate %s permission with owner ID: %s and resource type: %s  ",
-                      entity, request.ownerId(), request.resourceType()),
+                      "Failed to migrate role permission with owner ID: %s and resource type: %s  ", request.ownerId(), request.resourceType()),
                   e);
             }
           }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -8,12 +8,12 @@
 package io.camunda.migration.identity.config;
 
 import io.camunda.migration.identity.AuthorizationMigrationHandler;
+import io.camunda.migration.identity.ClientMigrationHandler;
 import io.camunda.migration.identity.GroupMigrationHandler;
 import io.camunda.migration.identity.StaticConsoleRoleAuthorizationMigrationHandler;
 import io.camunda.migration.identity.StaticConsoleRoleMigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.transformer.ClientMigrationHandler;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -13,6 +13,7 @@ import io.camunda.migration.identity.StaticConsoleRoleAuthorizationMigrationHand
 import io.camunda.migration.identity.StaticConsoleRoleMigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import io.camunda.migration.identity.transformer.ClientMigrationHandler;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
@@ -42,8 +43,9 @@ public class MigrationHandlerConfig {
   }
 
   @Bean
-  public StaticConsoleRoleAuthorizationMigrationHandler staticConsoleRoleAuthorizationMigrationHandler(
-      final AuthorizationServices authorizationService, final Authentication authentication) {
+  public StaticConsoleRoleAuthorizationMigrationHandler
+      staticConsoleRoleAuthorizationMigrationHandler(
+          final AuthorizationServices authorizationService, final Authentication authentication) {
     return new StaticConsoleRoleAuthorizationMigrationHandler(authorizationService, authentication);
   }
 
@@ -55,5 +57,13 @@ public class MigrationHandlerConfig {
       final ManagementIdentityClient managementIdentityClient) {
     return new AuthorizationMigrationHandler(
         authentication, authorizationService, consoleClient, managementIdentityClient);
+  }
+
+  @Bean
+  public ClientMigrationHandler clientMigrationHandler(
+      final ConsoleClient consoleClient,
+      final AuthorizationServices authorizationServices,
+      final Authentication servicesAuthentication) {
+    return new ClientMigrationHandler(consoleClient, authorizationServices, servicesAuthentication);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/MigrationHandlerConfig.java
@@ -9,7 +9,7 @@ package io.camunda.migration.identity.config;
 
 import io.camunda.migration.identity.AuthorizationMigrationHandler;
 import io.camunda.migration.identity.GroupMigrationHandler;
-import io.camunda.migration.identity.StaticConsoleAuthorizationMigrationHandler;
+import io.camunda.migration.identity.StaticConsoleRoleAuthorizationMigrationHandler;
 import io.camunda.migration.identity.StaticConsoleRoleMigrationHandler;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
@@ -42,9 +42,9 @@ public class MigrationHandlerConfig {
   }
 
   @Bean
-  public StaticConsoleAuthorizationMigrationHandler staticConsoleRoleAuthorizationMigrationHandler(
+  public StaticConsoleRoleAuthorizationMigrationHandler staticConsoleRoleAuthorizationMigrationHandler(
       final AuthorizationServices authorizationService, final Authentication authentication) {
-    return new StaticConsoleAuthorizationMigrationHandler(authorizationService, authentication);
+    return new StaticConsoleRoleAuthorizationMigrationHandler(authorizationService, authentication);
   }
 
   @Bean

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -123,7 +123,6 @@ public class StaticEntities {
                   PermissionType.READ_USER_TASK,
                   PermissionType.UPDATE_USER_TASK,
                   PermissionType.CREATE_PROCESS_INSTANCE)),
-          // TODO: add document permissions once implemented
           // VISITOR
           new CreateAuthorizationRequest(
               VISITOR_ROLE_ID,
@@ -158,116 +157,120 @@ public class StaticEntities {
               AuthorizationOwnerType.ROLE,
               "*",
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-              Set.of(PermissionType.READ))
-          // TODO: add document permissions once implemented
-          );
+              Set.of(PermissionType.READ)));
 
-  public static final List<CreateAuthorizationRequest> CLIENT_PERMISSIONS =
-      List.of(
-          // ZEEBE
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.MESSAGE,
-              Set.of(PermissionType.CREATE)),
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.SYSTEM,
-              AuthorizationResourceType.SYSTEM.getSupportedPermissionTypes()),
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.RESOURCE,
-              Set.of(
-                  PermissionType.CREATE,
-                  PermissionType.DELETE_FORM,
-                  PermissionType.DELETE_PROCESS,
-                  PermissionType.DELETE_DRD,
-                  PermissionType.DELETE_RESOURCE)),
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              Set.of(
-                  PermissionType.UPDATE_PROCESS_INSTANCE,
-                  PermissionType.UPDATE_USER_TASK,
-                  PermissionType.CREATE_PROCESS_INSTANCE,
-                  PermissionType.DELETE_PROCESS_INSTANCE)),
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.DECISION_DEFINITION,
-              Set.of(
-                  PermissionType.CREATE_DECISION_INSTANCE,
-                  PermissionType.DELETE_DECISION_INSTANCE)),
-          new CreateAuthorizationRequest(
-              ZEEBE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-              Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
-          // OPERATE
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.MESSAGE,
-              Set.of(PermissionType.READ)),
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.BATCH_OPERATION,
-              Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.RESOURCE,
-              Set.of(PermissionType.READ)),
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              Set.of(
-                  PermissionType.READ_PROCESS_DEFINITION,
-                  PermissionType.READ_PROCESS_INSTANCE,
-                  PermissionType.DELETE_PROCESS_INSTANCE)),
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.DECISION_DEFINITION,
-              Set.of(
-                  PermissionType.READ_DECISION_DEFINITION, PermissionType.READ_DECISION_INSTANCE)),
-          new CreateAuthorizationRequest(
-              OPERATE_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
-              Set.of(PermissionType.READ)),
-          // TASKLIST
-          new CreateAuthorizationRequest(
-              TASKLIST_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.RESOURCE,
-              Set.of(PermissionType.READ)),
-          new CreateAuthorizationRequest(
-              TASKLIST_CLIENT_ID,
-              AuthorizationOwnerType.CLIENT,
-              "*",
-              AuthorizationResourceType.PROCESS_DEFINITION,
-              Set.of(
-                  // TODO: add document permissions once implemented
-                  PermissionType.READ_PROCESS_DEFINITION,
-                  PermissionType.READ_USER_TASK,
-                  PermissionType.UPDATE_USER_TASK)));
+  public static final List<CreateAuthorizationRequest> getZeebeClientPermissions(
+      final String clientId) {
+    return List.of(
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.MESSAGE,
+            Set.of(PermissionType.CREATE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.SYSTEM,
+            AuthorizationResourceType.SYSTEM.getSupportedPermissionTypes()),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.RESOURCE,
+            Set.of(
+                PermissionType.CREATE,
+                PermissionType.DELETE_FORM,
+                PermissionType.DELETE_PROCESS,
+                PermissionType.DELETE_DRD,
+                PermissionType.DELETE_RESOURCE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            Set.of(
+                PermissionType.UPDATE_PROCESS_INSTANCE,
+                PermissionType.UPDATE_USER_TASK,
+                PermissionType.CREATE_PROCESS_INSTANCE,
+                PermissionType.DELETE_PROCESS_INSTANCE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.DECISION_DEFINITION,
+            Set.of(
+                PermissionType.CREATE_DECISION_INSTANCE, PermissionType.DELETE_DECISION_INSTANCE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+            Set.of(PermissionType.UPDATE, PermissionType.DELETE)));
+  }
+
+  public static final List<CreateAuthorizationRequest> getOperateClientPermissions(
+      final String clientId) {
+    return List.of(
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.MESSAGE,
+            Set.of(PermissionType.READ)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.BATCH_OPERATION,
+            Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.RESOURCE,
+            Set.of(PermissionType.READ)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            Set.of(
+                PermissionType.READ_PROCESS_DEFINITION,
+                PermissionType.READ_PROCESS_INSTANCE,
+                PermissionType.DELETE_PROCESS_INSTANCE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.DECISION_DEFINITION,
+            Set.of(PermissionType.READ_DECISION_DEFINITION, PermissionType.READ_DECISION_INSTANCE)),
+        new CreateAuthorizationRequest(
+            clientId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+            Set.of(PermissionType.READ)));
+  }
+
+  public static final List<CreateAuthorizationRequest> getTasklistClientPermissions(
+      final String ownerId) {
+    return List.of(
+        new CreateAuthorizationRequest(
+            ownerId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.RESOURCE,
+            Set.of(PermissionType.READ)),
+        new CreateAuthorizationRequest(
+            ownerId,
+            AuthorizationOwnerType.CLIENT,
+            "*",
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            Set.of(
+                PermissionType.READ_PROCESS_DEFINITION,
+                PermissionType.READ_USER_TASK,
+                PermissionType.UPDATE_USER_TASK)));
+  }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/transformer/ClientMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/transformer/ClientMigrationHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.transformer;
+
+import static io.camunda.migration.identity.config.saas.StaticEntities.getOperateClientPermissions;
+import static io.camunda.migration.identity.config.saas.StaticEntities.getTasklistClientPermissions;
+import static io.camunda.migration.identity.config.saas.StaticEntities.getZeebeClientPermissions;
+
+import io.camunda.migration.api.MigrationException;
+import io.camunda.migration.identity.MigrationHandler;
+import io.camunda.migration.identity.console.ConsoleClient;
+import io.camunda.migration.identity.console.ConsoleClient.Client;
+import io.camunda.migration.identity.console.ConsoleClient.Members;
+import io.camunda.migration.identity.console.ConsoleClient.Permission;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.AuthorizationServices;
+import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ClientMigrationHandler extends MigrationHandler<Members> {
+
+  final ConsoleClient consoleClient;
+  final AuthorizationServices authorizationServices;
+
+  public ClientMigrationHandler(
+      final ConsoleClient consoleClient,
+      final AuthorizationServices authorizationServices,
+      final Authentication servicesAuthentication) {
+    this.consoleClient = consoleClient;
+    this.authorizationServices = authorizationServices.withAuthentication(servicesAuthentication);
+  }
+
+  @Override
+  protected List<Members> fetchBatch(final int page) {
+    return List.of();
+  }
+
+  @Override
+  protected void process(final List<Members> batch) {
+    final var clientPermissions =
+        consoleClient.fetchMembers().clients().stream()
+            .collect(Collectors.toMap(Client::clientId, Client::permissions));
+
+    clientPermissions.forEach(this::handlePermission);
+  }
+
+  private void handlePermission(final String clientId, final List<Permission> permissions) {
+    final var combinedPermissions = getCombinedPermissions(clientId, permissions);
+    if (combinedPermissions.isEmpty()) {
+      logger.debug("No permissions to migrate for client: {}", clientId);
+      return;
+    }
+    try {
+      for (final CreateAuthorizationRequest request : combinedPermissions) {
+        authorizationServices.createAuthorization(request).join();
+        logger.debug(
+            "Migrated client permission with owner ID: {} and resource type: {}",
+            request.ownerId(),
+            request.resourceType());
+      }
+    } catch (final Exception e) {
+      if (!isConflictError(e)) {
+        throw new MigrationException(
+            String.format("Failed to migrate client permissions for client ID: %s", clientId), e);
+      }
+    }
+  }
+
+  public static List<CreateAuthorizationRequest> getCombinedPermissions(
+      final String clientId, final List<Permission> clientTypes) {
+
+    // Key used to group permission sets
+    record PermissionKey(
+        String ownerId,
+        AuthorizationOwnerType ownerType,
+        String resourceId,
+        AuthorizationResourceType resourceType) {}
+
+    final Map<PermissionKey, Set<PermissionType>> permissionMap = new HashMap<>();
+
+    final List<CreateAuthorizationRequest> allPermissions = new ArrayList<>();
+
+    if (clientTypes.contains(Permission.ZEEBE)) {
+      allPermissions.addAll(getZeebeClientPermissions(clientId));
+    }
+    if (clientTypes.contains(Permission.OPERATE)) {
+      allPermissions.addAll(getOperateClientPermissions(clientId));
+    }
+    if (clientTypes.contains(Permission.TASKLIST)) {
+      allPermissions.addAll(getTasklistClientPermissions(clientId));
+    }
+
+    for (final CreateAuthorizationRequest request : allPermissions) {
+      final PermissionKey key =
+          new PermissionKey(
+              request.ownerId(), request.ownerType(), request.resourceId(), request.resourceType());
+
+      permissionMap.merge(
+          key,
+          new HashSet<>(request.permissionTypes()),
+          (existing, incoming) -> {
+            existing.addAll(incoming);
+            return existing;
+          });
+    }
+
+    return permissionMap.entrySet().stream()
+        .map(
+            entry ->
+                new CreateAuthorizationRequest(
+                    entry.getKey().ownerId(),
+                    entry.getKey().ownerType(),
+                    entry.getKey().resourceId(),
+                    entry.getKey().resourceType(),
+                    entry.getValue()))
+        .toList();
+  }
+}

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.migration.identity.console.ConsoleClient;
+import io.camunda.migration.identity.console.ConsoleClient.Client;
+import io.camunda.migration.identity.console.ConsoleClient.Members;
+import io.camunda.migration.identity.console.ConsoleClient.Permission;
+import io.camunda.migration.identity.transformer.ClientMigrationHandler;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.AuthorizationServices;
+import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ClientMigrationHandlerTest {
+
+  final ConsoleClient consoleClient;
+  final ClientMigrationHandler migrationHandler;
+  private final AuthorizationServices authorizationServices;
+
+  public ClientMigrationHandlerTest(
+      @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices,
+      @Mock final ConsoleClient consoleClient) {
+    this.authorizationServices = authorizationServices;
+    this.consoleClient = consoleClient;
+    migrationHandler =
+        new ClientMigrationHandler(consoleClient, authorizationServices, Authentication.none());
+  }
+
+  @Test
+  public void shouldMigrateClients() {
+    // given
+    when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(new AuthorizationRecord()));
+    final var members =
+        new Members(
+            List.of(),
+            List.of(
+                new Client("client", "client-id", List.of(Permission.ZEEBE, Permission.OPERATE)),
+                new Client("tasklist-client", "tasklist-client-id", List.of(Permission.TASKLIST))));
+    when(consoleClient.fetchMembers()).thenReturn(members);
+
+    // when
+    migrationHandler.migrate();
+
+    // then
+    final ArgumentCaptor<CreateAuthorizationRequest> request =
+        ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
+    verify(authorizationServices, times(9)).createAuthorization(request.capture());
+    final var requests = request.getAllValues();
+    assertThat(requests)
+        .extracting(
+            CreateAuthorizationRequest::ownerId,
+            CreateAuthorizationRequest::ownerType,
+            CreateAuthorizationRequest::resourceType,
+            CreateAuthorizationRequest::permissionTypes)
+        .contains(
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.MESSAGE,
+                Set.of(PermissionType.CREATE, PermissionType.READ)),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.SYSTEM,
+                AuthorizationResourceType.SYSTEM.getSupportedPermissionTypes()),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.CREATE,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_RESOURCE,
+                    PermissionType.READ)),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.READ_PROCESS_INSTANCE)),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.DECISION_DEFINITION,
+                Set.of(
+                    PermissionType.CREATE_DECISION_INSTANCE,
+                    PermissionType.DELETE_DECISION_INSTANCE,
+                    PermissionType.READ_DECISION_DEFINITION,
+                    PermissionType.READ_DECISION_INSTANCE)),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                Set.of(PermissionType.UPDATE, PermissionType.DELETE, PermissionType.READ)),
+            tuple(
+                "client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.BATCH_OPERATION,
+                Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+            tuple(
+                "tasklist-client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.RESOURCE,
+                Set.of(PermissionType.READ)),
+            tuple(
+                "tasklist-client-id",
+                AuthorizationOwnerType.CLIENT,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.READ_USER_TASK,
+                    PermissionType.UPDATE_USER_TASK)));
+  }
+}

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/ClientMigrationHandlerTest.java
@@ -18,7 +18,6 @@ import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Client;
 import io.camunda.migration.identity.console.ConsoleClient.Members;
 import io.camunda.migration.identity.console.ConsoleClient.Permission;
-import io.camunda.migration.identity.transformer.ClientMigrationHandler;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/StaticConsoleRoleAuthorizationMigrationHandlerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.migration.identity;
 
-import static io.camunda.migration.identity.config.saas.StaticEntities.CLIENT_PERMISSIONS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -17,7 +16,6 @@ import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -27,16 +25,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class StaticConsoleAuthorizationMigrationHandlerTest {
+public class StaticConsoleRoleAuthorizationMigrationHandlerTest {
 
   private final AuthorizationServices authorizationServices;
-  private final StaticConsoleAuthorizationMigrationHandler migrationHandler;
+  private final StaticConsoleRoleAuthorizationMigrationHandler migrationHandler;
 
-  public StaticConsoleAuthorizationMigrationHandlerTest(
+  public StaticConsoleRoleAuthorizationMigrationHandlerTest(
       @Mock(answer = Answers.RETURNS_SELF) final AuthorizationServices authorizationServices) {
     this.authorizationServices = authorizationServices;
     migrationHandler =
-        new StaticConsoleAuthorizationMigrationHandler(
+        new StaticConsoleRoleAuthorizationMigrationHandler(
             authorizationServices, Authentication.none());
   }
 
@@ -47,10 +45,8 @@ public class StaticConsoleAuthorizationMigrationHandlerTest {
     migrationHandler.migrate();
 
     final var results = ArgumentCaptor.forClass(CreateAuthorizationRequest.class);
-    Mockito.verify(authorizationServices, Mockito.times(30)).createAuthorization(results.capture());
+    Mockito.verify(authorizationServices, Mockito.times(16)).createAuthorization(results.capture());
     final var requests = results.getAllValues();
-    final var authorizations =
-        Stream.concat(ROLE_PERMISSIONS.stream(), CLIENT_PERMISSIONS.stream()).toList();
-    assertThat(requests).containsExactlyElementsOf(authorizations);
+    assertThat(requests).containsExactlyElementsOf(ROLE_PERMISSIONS);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -257,10 +257,10 @@ public class SaaSIdentityMigrationIT {
               final var migratedAuthorizations =
                   authorizations.items().stream()
                       .map(AuthorizationResponse::ownerId)
-                      .filter(id -> ROLE_IDS.contains(id) || CLIENT_IDS.contains(id))
+                      .filter(ROLE_IDS::contains)
                       .toList();
               assertThat(migratedAuthorizations.size())
-                  .isEqualTo(ROLE_PERMISSIONS.size() + CLIENT_PERMISSIONS.size());
+                  .isEqualTo(ROLE_PERMISSIONS.size());
             });
 
     // then
@@ -400,111 +400,7 @@ public class SaaSIdentityMigrationIT {
                 OwnerType.ROLE,
                 "*",
                 ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ)),
-            // Client permissions
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.MESSAGE,
-                Set.of(PermissionType.CREATE)),
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.SYSTEM,
-                Set.of(PermissionType.READ, PermissionType.UPDATE)),
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.RESOURCE,
-                Set.of(
-                    PermissionType.CREATE,
-                    PermissionType.DELETE_FORM,
-                    PermissionType.DELETE_PROCESS,
-                    PermissionType.DELETE_DRD,
-                    PermissionType.DELETE_RESOURCE)),
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.PROCESS_DEFINITION,
-                Set.of(
-                    PermissionType.UPDATE_PROCESS_INSTANCE,
-                    PermissionType.UPDATE_USER_TASK,
-                    PermissionType.CREATE_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.DECISION_DEFINITION,
-                Set.of(
-                    PermissionType.CREATE_DECISION_INSTANCE,
-                    PermissionType.DELETE_DECISION_INSTANCE)),
-            tuple(
-                ZEEBE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.UPDATE, PermissionType.DELETE)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.MESSAGE,
-                Set.of(PermissionType.READ)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.BATCH_OPERATION,
-                Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.RESOURCE,
-                Set.of(PermissionType.READ)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.PROCESS_DEFINITION,
-                Set.of(
-                    PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.READ_PROCESS_INSTANCE,
-                    PermissionType.DELETE_PROCESS_INSTANCE)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.DECISION_DEFINITION,
-                Set.of(
-                    PermissionType.READ_DECISION_DEFINITION,
-                    PermissionType.READ_DECISION_INSTANCE)),
-            tuple(
-                OPERATE_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
-                Set.of(PermissionType.READ)),
-            tuple(
-                TASKLIST_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.RESOURCE,
-                Set.of(PermissionType.READ)),
-            tuple(
-                TASKLIST_CLIENT_ID,
-                OwnerType.CLIENT,
-                "*",
-                ResourceType.PROCESS_DEFINITION,
-                Set.of(
-                    PermissionType.READ_PROCESS_DEFINITION,
-                    PermissionType.READ_USER_TASK,
-                    PermissionType.UPDATE_USER_TASK)));
+                Set.of(PermissionType.READ)));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/migration/SaaSIdentityMigrationIT.java
@@ -18,17 +18,12 @@ import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY
 import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
 import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
 import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
-import static io.camunda.migration.identity.config.saas.StaticEntities.CLIENT_IDS;
-import static io.camunda.migration.identity.config.saas.StaticEntities.CLIENT_PERMISSIONS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.DEVELOPER_ROLE_ID;
-import static io.camunda.migration.identity.config.saas.StaticEntities.OPERATE_CLIENT_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.OPERATIONS_ENGINEER_ROLE_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_IDS;
 import static io.camunda.migration.identity.config.saas.StaticEntities.ROLE_PERMISSIONS;
-import static io.camunda.migration.identity.config.saas.StaticEntities.TASKLIST_CLIENT_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.TASK_USER_ROLE_ID;
 import static io.camunda.migration.identity.config.saas.StaticEntities.VISITOR_ROLE_ID;
-import static io.camunda.migration.identity.config.saas.StaticEntities.ZEEBE_CLIENT_ID;
 import static io.camunda.zeebe.qa.util.cluster.TestZeebePort.CLUSTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -259,8 +254,7 @@ public class SaaSIdentityMigrationIT {
                       .map(AuthorizationResponse::ownerId)
                       .filter(ROLE_IDS::contains)
                       .toList();
-              assertThat(migratedAuthorizations.size())
-                  .isEqualTo(ROLE_PERMISSIONS.size());
+              assertThat(migratedAuthorizations.size()).isEqualTo(ROLE_PERMISSIONS.size());
             });
 
     // then
@@ -460,6 +454,102 @@ public class SaaSIdentityMigrationIT {
                     PermissionType.DELETE_DECISION_INSTANCE)));
   }
 
+  @Test
+  public void canMigrateClients() throws IOException, URISyntaxException, InterruptedException {
+    // when
+    migration.start();
+    final var restAddress = client.getConfiguration().getRestAddress().toString();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var authorizations =
+                  searchAuthorizations(restAddress).items().stream()
+                      .map(AuthorizationResponse::ownerType)
+                      .filter(OwnerType.CLIENT::equals)
+                      .toList();
+              assertThat(authorizations.size()).isEqualTo(9);
+            });
+
+    // then
+    assertThat(migration.getExitCode()).isEqualTo(0);
+
+    final var authorizations = searchAuthorizations(restAddress);
+    assertThat(authorizations.items())
+        .extracting(
+            AuthorizationResponse::ownerId,
+            AuthorizationResponse::ownerType,
+            AuthorizationResponse::resourceType,
+            AuthorizationResponse::permissionTypes)
+        .contains(
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.MESSAGE,
+                Set.of(PermissionType.CREATE, PermissionType.READ)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.SYSTEM,
+                Set.of(PermissionType.UPDATE, PermissionType.READ)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.RESOURCE,
+                Set.of(
+                    PermissionType.CREATE,
+                    PermissionType.DELETE_FORM,
+                    PermissionType.DELETE_PROCESS,
+                    PermissionType.DELETE_DRD,
+                    PermissionType.DELETE_RESOURCE,
+                    PermissionType.READ)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.UPDATE_PROCESS_INSTANCE,
+                    PermissionType.UPDATE_USER_TASK,
+                    PermissionType.CREATE_PROCESS_INSTANCE,
+                    PermissionType.DELETE_PROCESS_INSTANCE,
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.READ_PROCESS_INSTANCE)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.DECISION_DEFINITION,
+                Set.of(
+                    PermissionType.CREATE_DECISION_INSTANCE,
+                    PermissionType.DELETE_DECISION_INSTANCE,
+                    PermissionType.READ_DECISION_DEFINITION,
+                    PermissionType.READ_DECISION_INSTANCE)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.DECISION_REQUIREMENTS_DEFINITION,
+                Set.of(PermissionType.UPDATE, PermissionType.DELETE, PermissionType.READ)),
+            tuple(
+                "client123",
+                OwnerType.CLIENT,
+                ResourceType.BATCH_OPERATION,
+                Set.of(PermissionType.READ, PermissionType.CREATE, PermissionType.UPDATE)),
+            tuple(
+                "tasklist-client",
+                OwnerType.CLIENT,
+                ResourceType.RESOURCE,
+                Set.of(PermissionType.READ)),
+            tuple(
+                "tasklist-client",
+                OwnerType.CLIENT,
+                ResourceType.PROCESS_DEFINITION,
+                Set.of(
+                    PermissionType.READ_PROCESS_DEFINITION,
+                    PermissionType.READ_USER_TASK,
+                    PermissionType.UPDATE_USER_TASK)));
+  }
+
   private void createAuthorizations() throws IOException, InterruptedException, URISyntaxException {
     final HttpRequest request1 =
         HttpRequest.newBuilder()
@@ -636,7 +726,12 @@ public class SaaSIdentityMigrationIT {
               "name": "console-client",
               "clientId": "client123",
               "permissions": ["Operate", "Zeebe"]
-            }
+            },
+            {
+              "name": "Tasklist",
+              "clientId": "tasklist-client",
+              "permissions": ["Tasklist"]
+             }
           ]
         }
         """;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR corrects a wrong implementation for clients authorizations. Now the clients are retrieved from the console API and transformed into authorization records in the OC

## Related issues

closes #33038
