### PR TITLE
ci: change image tag to 8.6-SNAPSHOT

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -12,6 +12,10 @@ if [ "${IS_MAIN}" = "true" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8-SNAPSHOT")
 fi
 
+if [ "${IS_STABLE_86}" = "true" ]; then
+    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8.6-SNAPSHOT")
+fi
+
 printf -v tag_arguments -- "-t %s " "${tags[@]}"
 docker buildx create --use
 

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -38,6 +38,7 @@ jobs:
           echo "VERSION=${{ steps.pom-info.outputs.project_version }}"
           echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_stable_branch }}"
           echo "IS_MAIN=${{ steps.define-values.outputs.is_main_branch }}"
+          echo "IS_STABLE_86=${{ github.ref == 'refs/heads/stable/optimize-8.6' }}"
           echo "REVISION=${{ steps.define-values.outputs.git_commit_hash }}"
         } >> "$GITHUB_ENV"
     - name: Login to Harbor registry


### PR DESCRIPTION
## Description

Replace docker image version from 8.6.0-SNAPSHOT to 8.6-SNAPSHOT

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
