### PR TITLE
[stable/operate-8.5] fix operate icon type

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/CheckboxGroup/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/CheckboxGroup/index.tsx
@@ -18,7 +18,7 @@
 import React from 'react';
 import {Field, useForm} from 'react-final-form';
 import {Checkbox as CarbonCheckbox, Stack} from '@carbon/react';
-import {Icon} from '@carbon/react/icons';
+import {CarbonIconType as Icon} from '@carbon/react/icons';
 import {Checkbox} from 'modules/components/Checkbox';
 import {Group} from './styled';
 

--- a/operate/client/src/modules/components/Checkbox/index.tsx
+++ b/operate/client/src/modules/components/Checkbox/index.tsx
@@ -15,7 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Icon} from '@carbon/react/icons';
+import {CarbonIconType as Icon} from '@carbon/react/icons';
 import {FieldInputProps} from 'react-final-form';
 import {CheckBox, Stack} from './styled';
 

--- a/operate/client/src/modules/components/IconInput/IconTextArea.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextArea.tsx
@@ -15,7 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Icon} from '@carbon/react/icons';
+import {CarbonIconType as Icon} from '@carbon/react/icons';
 import {
   TextArea as BaseTextArea,
   IconButton as BaseIconButton,

--- a/operate/client/src/modules/components/IconInput/IconTextInput.tsx
+++ b/operate/client/src/modules/components/IconInput/IconTextInput.tsx
@@ -15,7 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Icon} from '@carbon/react/icons';
+import {CarbonIconType as Icon} from '@carbon/react/icons';
 import {
   TextInput as BaseTextInput,
   IconButton as BaseIconButton,

--- a/operate/client/src/modules/components/OperationItem/index.tsx
+++ b/operate/client/src/modules/components/OperationItem/index.tsx
@@ -15,8 +15,12 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Error, Tools, RetryFailed} from '@carbon/react/icons';
-import {Icon} from 'carbon-components-react';
+import {
+  CarbonIconType as Icon,
+  Error,
+  Tools,
+  RetryFailed,
+} from '@carbon/react/icons';
 import {Button, ButtonSize} from '@carbon/react';
 
 type ItemProps = {
@@ -33,7 +37,7 @@ type ItemProps = {
 const TYPE_DETAILS: Readonly<
   Record<
     ItemProps['type'],
-    {icon?: typeof Icon; testId: string; isDangerous?: boolean; label?: string}
+    {icon?: Icon; testId: string; isDangerous?: boolean; label?: string}
   >
 > = {
   RESOLVE_INCIDENT: {icon: RetryFailed, testId: 'retry-operation'},

--- a/operate/client/src/modules/components/StateIcon/index.tsx
+++ b/operate/client/src/modules/components/StateIcon/index.tsx
@@ -16,7 +16,7 @@
  */
 
 import {WarningFilled, CheckmarkOutline, RadioButtonChecked} from './styled';
-import {Icon, Error} from '@carbon/react/icons';
+import {CarbonIconType as Icon, Error} from '@carbon/react/icons';
 
 const stateIconsMap = {
   FAILED: WarningFilled,

--- a/operate/client/src/modules/types/carbon.d.ts
+++ b/operate/client/src/modules/types/carbon.d.ts
@@ -275,39 +275,3 @@ declare module '@carbon/elements' {
   } as const;
   export * from '@types/carbon__elements';
 }
-
-declare module '@carbon/react/icons' {
-  type Icon = React.FunctionComponent<
-    {
-      className?: string;
-      alt?: string;
-      'aria-label'?: string;
-      size?: 16 | 20 | 24 | 32;
-    } & React.HTMLAttributes<HTMLOrSVGElement>
-  >;
-
-  export const ArrowRight: Icon;
-  export const RowExpand: Icon;
-  export const RowCollapse: Icon;
-  export const CheckmarkOutline: Icon;
-  export const WarningFilled: Icon;
-  export const TrashCan: Icon;
-  export const Error: Icon;
-  export const Tools: Icon;
-  export const RetryFailed: Icon;
-  export const Edit: Icon;
-  export const Filter: Icon;
-  export const RadioButtonChecked: Icon;
-  export const Calendar: Icon;
-  export const Add: Icon;
-  export const Close: Icon;
-  export const Popup: Icon;
-  export const WarningAltFilled: Icon;
-  export const Subtract: Icon;
-  export const CenterCircle: Icon;
-  export const Checkmark: Icon;
-  export const Maximize: Icon;
-  export const Minimize: Icon;
-  export const MigrateAlt: Icon;
-  export const Move: Icon;
-}


### PR DESCRIPTION
## Description

The FE build was failing: https://github.com/camunda/camunda/actions/runs/15635725447/job/44050202639

This PR removes the locally defined `Icon` type and uses `CarbonIconType` instead.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
