### PR TITLE
fix: Reject ongoing requests targeting user task before task cancellation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -176,6 +176,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             processingState.getFormState(),
             processingState.getUserTaskState(),
+            processingState.getAsyncRequestState(),
             clock);
 
     jobBehavior =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -176,6 +176,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             processingState.getFormState(),
             processingState.getUserTaskState(),
+            processingState.getVariableState(),
             processingState.getAsyncRequestState(),
             clock);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -19,9 +19,9 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.immutable.FormState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
-import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
@@ -53,7 +53,7 @@ public final class BpmnUserTaskBehavior {
   private final ExpressionProcessor expressionBehavior;
   private final BpmnStateBehavior stateBehavior;
   private final FormState formState;
-  private final MutableUserTaskState userTaskState;
+  private final UserTaskState userTaskState;
   private final InstantSource clock;
 
   public BpmnUserTaskBehavior(
@@ -62,7 +62,7 @@ public final class BpmnUserTaskBehavior {
       final ExpressionProcessor expressionBehavior,
       final BpmnStateBehavior stateBehavior,
       final FormState formState,
-      final MutableUserTaskState userTaskState,
+      final UserTaskState userTaskState,
       final InstantSource clock) {
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
@@ -26,6 +28,9 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -50,10 +55,12 @@ public final class BpmnUserTaskBehavior {
   private final HeaderEncoder headerEncoder = new HeaderEncoder(LOGGER);
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
   private final ExpressionProcessor expressionBehavior;
   private final BpmnStateBehavior stateBehavior;
   private final FormState formState;
   private final UserTaskState userTaskState;
+  private final AsyncRequestState asyncRequestState;
   private final InstantSource clock;
 
   public BpmnUserTaskBehavior(
@@ -63,13 +70,16 @@ public final class BpmnUserTaskBehavior {
       final BpmnStateBehavior stateBehavior,
       final FormState formState,
       final UserTaskState userTaskState,
+      final AsyncRequestState asyncRequestState,
       final InstantSource clock) {
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
+    responseWriter = writers.response();
     this.expressionBehavior = expressionBehavior;
     this.stateBehavior = stateBehavior;
     this.formState = formState;
     this.userTaskState = userTaskState;
+    this.asyncRequestState = asyncRequestState;
     this.clock = clock;
   }
 
@@ -323,8 +333,39 @@ public final class BpmnUserTaskBehavior {
       return Optional.empty();
     }
 
+    rejectOngoingRequestsForUserTaskBeforeCancellation(userTask);
+
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELING, userTask);
     return Optional.of(userTask);
+  }
+
+  private void rejectOngoingRequestsForUserTaskBeforeCancellation(final UserTaskRecord userTask) {
+    asyncRequestState
+        .findAllRequestsByScopeKey(userTask.getElementInstanceKey())
+        .forEach(
+            request -> {
+              switch (request.valueType()) {
+                case USER_TASK ->
+                    responseWriter.writeRejection(
+                        userTask.getUserTaskKey(),
+                        request.intent(),
+                        userTask,
+                        ValueType.USER_TASK,
+                        RejectionType.INVALID_STATE,
+                        "user task was canceled during ongoing transition",
+                        request.requestId(),
+                        request.requestStreamId());
+                case VARIABLE_DOCUMENT -> {
+                  // TODO: write response with rejection for `VARIABLE_DOCUMENT:UPDATE` request
+                }
+                default -> {
+                  // TODO: log warning
+                }
+              }
+
+              stateWriter.appendFollowUpEvent(
+                  request.requestId(), AsyncRequestIntent.PROCESSED, request.record());
+            });
   }
 
   public void userTaskCanceled(final UserTaskRecord userTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -8,17 +8,13 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.immutable.AsyncRequestState.AsyncRequest;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
-import io.camunda.zeebe.engine.state.mutable.MutableAsyncRequestState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import java.util.Set;
 
 public final class UserTaskCancelingV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
@@ -26,13 +22,11 @@ public final class UserTaskCancelingV2Applier
   private final MutableUserTaskState userTaskState;
   private final MutableVariableState variableState;
   private final MutableElementInstanceState elementInstanceState;
-  private final MutableAsyncRequestState asyncRequestState;
 
   public UserTaskCancelingV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
     variableState = processingState.getVariableState();
     elementInstanceState = processingState.getElementInstanceState();
-    asyncRequestState = processingState.getAsyncRequestState();
   }
 
   @Override
@@ -42,21 +36,11 @@ public final class UserTaskCancelingV2Applier
     // Clean up data that may have been persisted by a previous transition
     variableState.removeVariableDocumentState(value.getElementInstanceKey());
     userTaskState.deleteIntermediateStateIfExists(key);
-    deleteAsyncRequestsIfExists(value);
     resetTaskListenerIndices(value);
 
     // Persist new data related to "canceling" user task transition
     userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
     userTaskState.deleteInitialAssignee(key);
-  }
-
-  private void deleteAsyncRequestsIfExists(final UserTaskRecord value) {
-    final var expectedValueTypes = Set.of(ValueType.USER_TASK, ValueType.VARIABLE_DOCUMENT);
-    asyncRequestState
-        .findAllRequestsByScopeKey(value.getElementInstanceKey())
-        .filter(metadata -> expectedValueTypes.contains(metadata.valueType()))
-        .map(AsyncRequest::record)
-        .forEach(asyncRequestState::deleteRequest);
   }
 
   private void resetTaskListenerIndices(final UserTaskRecord record) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -725,11 +725,7 @@ public class TaskListenerBlockedTransitionTest {
         AsyncRequestIntent.RECEIVED,
         UserTaskIntent.ASSIGNING,
         UserTaskIntent.COMPLETE_TASK_LISTENER,
-        // In case the user task is canceled during the ongoing transition,
-        // we should write a rejection for the original async request
-        // and write `AsyncRequestIntent.PROCESSED` event to cleanup the state.
-        // This will be implemented in the scope of a separate issue:
-        //  - https://github.com/camunda/camunda/issues/33024
+        AsyncRequestIntent.PROCESSED,
         UserTaskIntent.CANCELING,
         UserTaskIntent.CANCELED);
   }
@@ -770,6 +766,7 @@ public class TaskListenerBlockedTransitionTest {
         AsyncRequestIntent.RECEIVED,
         UserTaskIntent.ASSIGNING,
         UserTaskIntent.COMPLETE_TASK_LISTENER,
+        AsyncRequestIntent.PROCESSED,
         UserTaskIntent.CANCELING,
         UserTaskIntent.CANCELED);
   }


### PR DESCRIPTION
## Description

This PR addresses issue, where canceling a user task during an ongoing transition (such as assign, update, or complete) would silently drop the in-flight request without sending a response. This led to a `SocketTimeoutException` on the client side.


The fix ensures that all async requests targeting a user task are explicitly rejected before the task enters the `CANCELING` state. This includes both:
- `USER_TASK:[ASSIGN,CLAIM,UPDATE,COMPLETE]` requests
- `VARIABLE_DOCUMENT:UPDATE` request

If any other unexpected request type is encountered, the request is ignored, but a debug log is emitted to help detect future mismatches.

### Key changes
- 🔧 Reject ongoing user task request with proper rejection response and reason.
- 🔧 Reject ongoing variable update request for the user task scope.
- 🔧 Emit `ASYNC_REQUEST:PROCESSED` event for each rejected request to ensure async request state is cleaned up.
- 🔧 Log unexpected request types gracefully during cancellation.
- 🧪 Adjusted & added new tests to verify that rejections are sent and no timeout occurs.
- 🧹 Cleaned up `UserTaskCancelingV2Applier` (async request cleanup logic is now centralized in `BpmnUserTaskBehavior`).
- 🧹 Refactored `BpmnUserTaskBehavior` to use `UserTaskState` instead of the mutable variant.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33024 
