### PR TITLE
fix: added `result` to Operate v1 DecisionInstance response

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
@@ -13,6 +13,7 @@ import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.DECIS
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.DECISION_TYPE;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.RESULT;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.STATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,6 +35,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
   private static final Long FAKE_PROCESS_DEFINITION_KEY = 2251799813685253L;
   private static final Long FAKE_PROCESS_INSTANCE_KEY = 2251799813685255L;
   private static final Long DUMMY_LONG = 2251799813685252L;
+  private static final String DECISION_RESULT = "\"day-to-day expense\"";
   private final String firstDecisionEvaluationDate = "2024-02-15T22:40:10.834+0000";
   private final String secondDecisionEvaluationDate = "2024-02-15T22:41:10.834+0000";
   private final String evaluationFailureMessage = "evaluation failure message";
@@ -58,7 +60,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Invoice Classification")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -75,7 +77,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Assign Approver Group")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -130,14 +132,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceClassification",
             "Invoice Classification",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
 
     checkDecisionInstance =
         decisionInstanceResults.getItems().stream()
@@ -152,14 +156,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceAssignApprover",
             "Assign Approver Group",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
@@ -191,7 +191,8 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
             .setDecisionVersion((Integer) searchHitAsMap.get(DecisionInstance.DECISION_VERSION))
             .setDecisionType(
                 DecisionType.fromString(
-                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)));
+                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)))
+            .setResult((String) searchHitAsMap.get(DecisionInstance.RESULT));
 
     final String evaluationFailureMessage =
         (String) searchHitAsMap.get(DecisionInstance.EVALUATION_FAILURE_MESSAGE);
@@ -202,7 +203,6 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
     } else {
       decisionInstance.setEvaluationFailure(evaluationFailureMessage);
     }
-
     return decisionInstance;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -166,7 +166,8 @@ public class OpensearchDecisionInstanceDao
           .setDecisionDefinitionId(internalResult.decisionDefinitionId())
           .setDecisionName(internalResult.decisionName())
           .setDecisionVersion(internalResult.decisionVersion())
-          .setDecisionType(internalResult.decisionType());
+          .setDecisionType(internalResult.decisionType())
+          .setResult(internalResult.result());
 
       if (StringUtils.isNotEmpty(internalResult.evaluationDate())) {
         apiResult.setEvaluationDate(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
@@ -23,6 +23,7 @@ public class DecisionInstance {
       EVALUATION_DATE = DecisionInstanceTemplate.EVALUATION_DATE,
       EVALUATION_FAILURE = DecisionInstanceTemplate.EVALUATION_FAILURE,
       EVALUATION_FAILURE_MESSAGE = DecisionInstanceTemplate.EVALUATION_FAILURE_MESSAGE,
+      RESULT = DecisionInstanceTemplate.RESULT,
       PROCESS_DEFINITION_KEY = DecisionInstanceTemplate.PROCESS_DEFINITION_KEY,
       PROCESS_INSTANCE_KEY = DecisionInstanceTemplate.PROCESS_INSTANCE_KEY,
       DECISION_ID = DecisionInstanceTemplate.DECISION_ID,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added `result` field to DecisionInstance operate V1 response mapping and added assertions for it to test cases.

Note that this is a bug that was introduced with https://github.com/camunda/camunda/issues/20255 where we had to adjust the mapping of entities to dto responses because of the deprecation of a field.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/34069
