### PR TITLE
Fix oauth jwt refresh expiry 8.7 when using mTLS (client_assertion)

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -71,7 +71,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
       JSON_MAPPER.readerFor(ZeebeClientCredentials.class);
   private static final Logger LOG = LoggerFactory.getLogger(OAuthCredentialsProvider.class);
   private final URL authorizationServerUrl;
-  private final String payload;
+  private final OAuthCredentialsProviderBuilder builder;
   private final String clientId;
   private final OAuthCredentialsCache credentialsCache;
   private final Duration connectionTimeout;
@@ -79,8 +79,8 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
 
   OAuthCredentialsProvider(final OAuthCredentialsProviderBuilder builder) {
     authorizationServerUrl = builder.getAuthorizationServer();
+    this.builder = builder;
     clientId = builder.getClientId();
-    payload = createParams(builder);
     credentialsCache = new OAuthCredentialsCache(builder.getCredentialsCache());
     connectionTimeout = builder.getConnectTimeout();
     readTimeout = builder.getReadTimeout();
@@ -224,6 +224,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
     connection.setRequestProperty("User-Agent", "zeebe-client-java/" + VersionUtil.getVersion());
 
     try (final OutputStream os = connection.getOutputStream()) {
+      final String payload = createParams(builder);
       final byte[] input = payload.getBytes(StandardCharsets.UTF_8);
       os.write(input, 0, input.length);
     }


### PR DESCRIPTION
## Description

fix for [bug](https://github.com/camunda/camunda/issues/34002?reload=1?reload=1) causing refresh token fail when `client_assertion` is used (payload remained unchanged/expired)
changes:
- payload string as a field
- `createParams(builder)` moved to the `request()`


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
bug https://github.com/camunda/camunda/issues/34002?reload=1?reload=1
closes https://github.com/camunda/camunda/issues/34002
