### PR TITLE
fix: CommandRedistributor cannot use the same RoutingInfo instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.engine.state.message.DbMessageState;
 import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.time.InstantSource;
 
@@ -44,6 +45,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final PendingProcessMessageSubscriptionState pendingProcessMessageSubscriptionState;
   private final UserTaskState userTaskState;
   private final BatchOperationState batchOperationState;
+  private final DbRoutingState routingState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -65,6 +67,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
             zeebeDb, transactionContext, transientProcessMessageSubscriptionState, clock);
     userTaskState = new DbUserTaskState(zeebeDb, transactionContext);
     batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
+    routingState = new DbRoutingState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -110,5 +113,10 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   @Override
   public BatchOperationState getBatchOperationState() {
     return batchOperationState;
+  }
+
+  @Override
+  public DbRoutingState getRoutingState() {
+    return routingState;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+
 public interface ScheduledTaskState {
 
   DistributionState getDistributionState();
@@ -26,4 +28,6 @@ public interface ScheduledTaskState {
   UserTaskState getUserTaskState();
 
   BatchOperationState getBatchOperationState();
+
+  DbRoutingState getRoutingState();
 }


### PR DESCRIPTION
## Description
`CommandRedistributor` must use another instance of `RoutingInfo` because it runs in another thread.
`RoutingInfo` uses `DbRoutingState` under the hood which is not thread safe.


## Related issues

closes #34083
