### PR TITLE
fix: enable AutoConfiguration for process migration app

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java
@@ -11,9 +11,11 @@ import io.camunda.application.commons.migration.AsyncMigrationsRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 @SpringBootConfiguration(proxyBeanMethods = false)
+@EnableAutoConfiguration
 public class StandaloneProcessMigration {
 
   public static void main(final String[] args) {
@@ -32,7 +34,7 @@ public class StandaloneProcessMigration {
         new SpringApplicationBuilder()
             .logStartupInfo(true)
             .web(WebApplicationType.SERVLET)
-            .sources(AsyncMigrationsRunner.class)
+            .sources(StandaloneProcessMigration.class, AsyncMigrationsRunner.class)
             .profiles(Profile.PROCESS_MIGRATION.getId())
             .addCommandLineProperties(true)
             .build(args);


### PR DESCRIPTION
## Description

Otherwise, spring web isn't initialized properly in the standalone app. It worked only when running it together with the single app or identity, as e.g. the identity migration config has [auto-configuration enabled](https://github.com/camunda/camunda/blob/main/dist/src/main/java/io/camunda/application/commons/migration/IdentityMigrationModuleConfiguration.java#L61).

The error when running [StandaloneProcessMigration](https://github.com/camunda/camunda/blob/main/dist/src/main/java/io/camunda/application/StandaloneProcessMigration.java) was:
```
APPLICATION FAILED TO START
***************************

Description:

Web application could not be started as there was no org.springframework.boot.web.servlet.server.ServletWebServerFactory bean defined in the context.

Action:

Check your application's dependencies for a supported servlet web server.
Check the configured web application type.


Process finished with exit code 1
```
