### PR TITLE
[Backport stable/8.6] fix: Allow retrying `ADD_VARIABLE` operation with the same variable name

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
@@ -37,20 +37,34 @@ public class CreateRequestOperationValidator {
 
   public void validate(final CreateOperationRequestDto request, final String processInstanceId) {
     if (request.getOperationType() == null) {
-      throw new InvalidRequestException("Operation type must be defined.");
+      throw new InvalidRequestException(
+          String.format(
+              "Operation type must be defined for operation on processInstanceId=%s.",
+              processInstanceId));
     }
 
     if (isVariableOperation(request) && isRequiredVariableOperationFieldMissing(request)) {
       throw new InvalidRequestException(
-          "ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+          String.format(
+              "ScopeId, variable name, and variable value must be defined for %s operation on processInstanceId=%s.",
+              request.getOperationType(), processInstanceId));
     }
 
     if (request.getOperationType().equals(ADD_VARIABLE)) {
-      if (variableAlreadyExists(request, processInstanceId)
-          || hasNonFailedAddVariableOperation(request, processInstanceId)) {
+      if (variableAlreadyExists(request, processInstanceId)) {
         throw new InvalidRequestException(
             String.format(
-                "Variable with the name \"%s\" already exists.", request.getVariableName()));
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: "
+                    + "a variable with this name already exists.",
+                request.getVariableName(), request.getVariableScopeId(), processInstanceId));
+      }
+
+      if (hasNonFailedAddVariableOperation(request, processInstanceId)) {
+        throw new InvalidRequestException(
+            String.format(
+                "Cannot add variable \"%s\" in scope \"%s\" of processInstanceId=%s: "
+                    + "an ADD_VARIABLE operation for this variable already exists.",
+                request.getVariableName(), request.getVariableScopeId(), processInstanceId));
       }
     }
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidator.java
@@ -10,12 +10,12 @@ package io.camunda.operate.webapp.rest.validation;
 import static io.camunda.operate.entities.OperationType.ADD_VARIABLE;
 import static io.camunda.operate.entities.OperationType.UPDATE_VARIABLE;
 
+import io.camunda.operate.entities.OperationState;
+import io.camunda.operate.entities.OperationType;
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
-import io.camunda.webapps.schema.entities.operation.OperationState;
-import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.util.EnumSet;
 import java.util.Set;
 import org.springframework.stereotype.Component;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -11,14 +11,20 @@ import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VAR
 import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import io.camunda.operate.entities.OperationState;
 import io.camunda.operate.entities.OperationType;
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.reader.VariableReader;
+import io.camunda.operate.webapp.rest.dto.OperationDto;
+import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -78,6 +84,51 @@ public class CreateRequestOperationValidatorTest {
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+  }
+
+  @Test
+  void shouldFailValidationWhenVariableAlreadyExists() {
+    // given
+    final var request = new CreateOperationRequestDto(ADD_VARIABLE);
+    request.setVariableScopeId("scope");
+    request.setVariableName("name");
+    request.setVariableValue("val");
+
+    // simulate existing variable
+    when(mockVariableReader.getVariableByName("123", "scope", "name"))
+        .thenReturn(new VariableDto());
+
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Variable with the name \"name\" already exists.");
+
+    // shouldn't query for operations
+    verifyNoInteractions(mockOperationReader);
+  }
+
+  @ParameterizedTest(
+      name = "should fail when ADD_VARIABLE operation with state ''{0}'' exists for same variable")
+  @EnumSource(value = OperationState.class)
+  void shouldFailValidationWhenOperationWithStateExists(final OperationState opState) {
+    // given
+    final var request = new CreateOperationRequestDto(ADD_VARIABLE);
+    request.setVariableScopeId("scope");
+    request.setVariableName("name");
+    request.setVariableValue("val");
+
+    // no existing variable
+    when(mockVariableReader.getVariableByName("123", "scope", "name")).thenReturn(null);
+
+    // simulate pending operation
+    final var operation = new OperationDto().setState(opState);
+    when(mockOperationReader.getOperations(ADD_VARIABLE, "123", "scope", "name"))
+        .thenReturn(List.of(operation));
+
+    // when - then
+    assertThatThrownBy(() -> underTest.validate(request, "123"))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Variable with the name \"name\" already exists.");
   }
 
   @ParameterizedTest(name = "should pass for {0} operation with valid scopeId, name, and value")

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.operate.webapp.rest.validation;
 
-import static io.camunda.webapps.schema.entities.operation.OperationType.ADD_VARIABLE;
-import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_VARIABLE;
+import static io.camunda.operate.entities.OperationType.ADD_VARIABLE;
+import static io.camunda.operate.entities.OperationType.UPDATE_VARIABLE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.verifyNoInteractions;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -54,7 +54,7 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Operation type must be defined.");
+        .hasMessage("Operation type must be defined for operation on processInstanceId=123.");
   }
 
   private static Stream<Arguments> invalidAddOrUpdateVariableOperation() {
@@ -83,7 +83,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
+        .hasMessage(
+            "ScopeId, variable name, and variable value must be defined for %s operation on processInstanceId=123.",
+            type);
   }
 
   @Test
@@ -101,7 +103,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Variable with the name \"name\" already exists.");
+        .hasMessage(
+            "Cannot add variable \"name\" in scope \"scope\" of processInstanceId=123: "
+                + "a variable with this name already exists.");
 
     // shouldn't query for operations
     verifyNoInteractions(mockOperationReader);
@@ -132,7 +136,9 @@ public class CreateRequestOperationValidatorTest {
     // when - then
     assertThatThrownBy(() -> underTest.validate(request, "123"))
         .isInstanceOf(InvalidRequestException.class)
-        .hasMessage("Variable with the name \"name\" already exists.");
+        .hasMessage(
+            "Cannot add variable \"name\" in scope \"scope\" of processInstanceId=123: "
+                + "an ADD_VARIABLE operation for this variable already exists.");
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/validation/CreateRequestOperationValidatorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -79,26 +80,18 @@ public class CreateRequestOperationValidatorTest {
         .hasMessage("ScopeId, name and value must be defined for UPDATE_VARIABLE operation.");
   }
 
-  @Test
-  public void testValidateUpdateVariable() {
-    final CreateOperationRequestDto operationRequest =
-        new CreateOperationRequestDto(UPDATE_VARIABLE);
+  @ParameterizedTest(name = "should pass for {0} operation with valid scopeId, name, and value")
+  @EnumSource(
+      value = OperationType.class,
+      names = {"ADD_VARIABLE", "UPDATE_VARIABLE"})
+  void shouldPassValidationForValidVariableOperation(final OperationType operationType) {
+    // given
+    final var request = new CreateOperationRequestDto(operationType);
+    request.setVariableScopeId("abc");
+    request.setVariableName("var");
+    request.setVariableValue("val");
 
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    assertDoesNotThrow(() -> underTest.validate(operationRequest, "123"));
-  }
-
-  @Test
-  public void testValidateAddVariable() {
-    final CreateOperationRequestDto operationRequest = new CreateOperationRequestDto(ADD_VARIABLE);
-
-    operationRequest.setVariableScopeId("abc");
-    operationRequest.setVariableName("var");
-    operationRequest.setVariableValue("val");
-
-    assertDoesNotThrow(() -> underTest.validate(operationRequest, "123"));
+    // when - then
+    assertDoesNotThrow(() -> underTest.validate(request, "123"));
   }
 }


### PR DESCRIPTION
# Description
Backport of #33928 to `stable/8.6`.

relates to #33337