### PR TITLE
Avoid pods from crashlooping when Elasticsearch is not ready

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -88,6 +88,11 @@ public class SchemaManager {
         schemaManagerMetrics);
   }
 
+  /**
+   * This method will retry with exponential backoff until the schema is successfully initialized.
+   * By default, retries are effectively unlimited to prevent pods from crashing when Elasticsearch
+   * is temporarily unavailable during startup.
+   */
   public void startup() {
     if (!config.schemaManager().isCreateSchema()) {
       LOG.info(

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -35,7 +35,7 @@ public class SchemaManagerConfiguration {
 
     public static final Duration DEFAULT_MIN_RETRY_DELAY = Duration.ofMillis(500);
     public static final Duration DEFAULT_MAX_RETRY_DELAY = Duration.ofSeconds(10);
-    public static final int DEFAULT_MAX_RETRIES = 12;
+    public static final int DEFAULT_MAX_RETRIES = Integer.MAX_VALUE;
 
     @Override
     public int defaultMaxRetries() {


### PR DESCRIPTION
## Problem

Pods can enter a crash loop if Elasticsearch is unavailable during application startup. This commonly occurs on creation or resuming of Non-HA clusters, when Elasticsearch cluster takes some time during master node election.

## Solution

1. **Increasing default retry attempts**: Changed from 12 to MAX_INTEGER attempts (effectively unlimited)
2. Applications remain alive but report "not ready" until schema initialization succeeds
3. Users can override retry limits via configuration if needed

### Behavior Changes

**Before**: 
```
Application starts → Schema init fails after 12 retries → Application crashes → Pod restart loop
```

**After**:
```
Application starts → Schema init retries indefinitely → Health check reports "not ready" → Schema succeeds → Health check reports "ready"
```

## Configuration

Users can customize retry behavior:

```yaml
camunda:
  database:
    schema-manager:
      retry:
        maxRetries: 2147483647  # Default: effectively unlimited  
        minRetryDelay: PT0.5S      # Default: 500ms
        maxRetryDelay: PT10S       # Default: 10s
```

To revert to the previous behavior:
```yaml
camunda:
  database:
    schema-manager:
      retry:
        maxRetries: 12  # Old default
```

Closes #33982.