### PR TITLE
[Backport main] fix: added `result` to Operate v1 DecisionInstance response

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTem
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.DECISION_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.RESULT;
 import static io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate.STATE;
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +35,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
   private static final Long FAKE_PROCESS_DEFINITION_KEY = 2251799813685253L;
   private static final Long FAKE_PROCESS_INSTANCE_KEY = 2251799813685255L;
   private static final Long DUMMY_LONG = 2251799813685252L;
+  private static final String DECISION_RESULT = "\"day-to-day expense\"";
   private final String firstDecisionEvaluationDate = "2024-02-15T22:40:10.834+0000";
   private final String secondDecisionEvaluationDate = "2024-02-15T22:41:10.834+0000";
   private final String evaluationFailureMessage = "evaluation failure message";
@@ -59,7 +61,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Invoice Classification")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -76,7 +78,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Assign Approver Group")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -131,14 +133,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceClassification",
             "Invoice Classification",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
 
     checkDecisionInstance =
         decisionInstanceResults.getItems().stream()
@@ -153,14 +157,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceAssignApprover",
             "Assign Approver Group",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
@@ -192,7 +192,8 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
             .setDecisionVersion((Integer) searchHitAsMap.get(DecisionInstance.DECISION_VERSION))
             .setDecisionType(
                 DecisionType.fromString(
-                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)));
+                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)))
+            .setResult((String) searchHitAsMap.get(DecisionInstance.RESULT));
 
     final String evaluationFailureMessage =
         (String) searchHitAsMap.get(DecisionInstance.EVALUATION_FAILURE_MESSAGE);
@@ -203,7 +204,6 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
     } else {
       decisionInstance.setEvaluationFailure(evaluationFailureMessage);
     }
-
     return decisionInstance;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -167,7 +167,8 @@ public class OpensearchDecisionInstanceDao
           .setDecisionDefinitionId(internalResult.decisionDefinitionId())
           .setDecisionName(internalResult.decisionName())
           .setDecisionVersion(internalResult.decisionVersion())
-          .setDecisionType(internalResult.decisionType());
+          .setDecisionType(internalResult.decisionType())
+          .setResult(internalResult.result());
 
       if (StringUtils.isNotEmpty(internalResult.evaluationDate())) {
         apiResult.setEvaluationDate(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
@@ -23,6 +23,7 @@ public class DecisionInstance {
       EVALUATION_DATE = DecisionInstanceTemplate.EVALUATION_DATE,
       EVALUATION_FAILURE = DecisionInstanceTemplate.EVALUATION_FAILURE,
       EVALUATION_FAILURE_MESSAGE = DecisionInstanceTemplate.EVALUATION_FAILURE_MESSAGE,
+      RESULT = DecisionInstanceTemplate.RESULT,
       PROCESS_DEFINITION_KEY = DecisionInstanceTemplate.PROCESS_DEFINITION_KEY,
       PROCESS_INSTANCE_KEY = DecisionInstanceTemplate.PROCESS_INSTANCE_KEY,
       DECISION_ID = DecisionInstanceTemplate.DECISION_ID,


### PR DESCRIPTION
# Description
Backport of #34076 to `main`.

relates to camunda/camunda#34069