### PR TITLE
[Backport stable/operate-8.5] fix: added `result` to Operate v1 DecisionInstance response

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/dao/DecisionInstanceDaoIT.java
@@ -22,6 +22,7 @@ import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.DECIS
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.DECISION_TYPE;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.RESULT;
 import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.STATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,6 +44,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
   private static final Long FAKE_PROCESS_DEFINITION_KEY = 2251799813685253L;
   private static final Long FAKE_PROCESS_INSTANCE_KEY = 2251799813685255L;
   private static final Long DUMMY_LONG = 2251799813685252L;
+  private static final String DECISION_RESULT = "\"day-to-day expense\"";
   private final String evaluationFailureMessage = "evaluation failure message";
   @Autowired private DecisionInstanceDao dao;
   @Autowired private DecisionInstanceTemplate decisionInstanceIndex;
@@ -64,7 +66,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Invoice Classification")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -81,7 +83,7 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             .setDecisionName("Assign Approver Group")
             .setDecisionVersion(1)
             .setDecisionType(DecisionType.DECISION_TABLE)
-            .setResult("\"day-to-day expense\"")
+            .setResult(DECISION_RESULT)
             .setTenantId(DEFAULT_TENANT_ID));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
@@ -136,14 +138,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceClassification",
             "Invoice Classification",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
 
     checkDecisionInstance =
         decisionInstanceResults.getItems().stream()
@@ -158,14 +162,16 @@ public class DecisionInstanceDaoIT extends OperateSearchAbstractIT {
             DECISION_TYPE,
             STATE,
             PROCESS_DEFINITION_KEY,
-            PROCESS_INSTANCE_KEY)
+            PROCESS_INSTANCE_KEY,
+            RESULT)
         .containsExactly(
             "invoiceAssignApprover",
             "Assign Approver Group",
             DecisionType.DECISION_TABLE,
             DecisionInstanceState.EVALUATED,
             FAKE_PROCESS_DEFINITION_KEY,
-            FAKE_PROCESS_INSTANCE_KEY);
+            FAKE_PROCESS_INSTANCE_KEY,
+            DECISION_RESULT);
   }
 
   @Test

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDecisionInstanceDao.java
@@ -200,7 +200,8 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
             .setDecisionVersion((Integer) searchHitAsMap.get(DecisionInstance.DECISION_VERSION))
             .setDecisionType(
                 DecisionType.fromString(
-                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)));
+                    (String) searchHitAsMap.get(DecisionInstance.DECISION_TYPE)))
+            .setResult((String) searchHitAsMap.get(DecisionInstance.RESULT));
 
     final String evaluationFailureMessage =
         (String) searchHitAsMap.get(DecisionInstance.EVALUATION_FAILURE_MESSAGE);
@@ -211,7 +212,6 @@ public class ElasticsearchDecisionInstanceDao extends ElasticsearchDao<DecisionI
     } else {
       decisionInstance.setEvaluationFailure(evaluationFailureMessage);
     }
-
     return decisionInstance;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/opensearch/OpensearchDecisionInstanceDao.java
@@ -175,7 +175,8 @@ public class OpensearchDecisionInstanceDao
           .setDecisionDefinitionId(internalResult.decisionDefinitionId())
           .setDecisionName(internalResult.decisionName())
           .setDecisionVersion(internalResult.decisionVersion())
-          .setDecisionType(internalResult.decisionType());
+          .setDecisionType(internalResult.decisionType())
+          .setResult(internalResult.result());
 
       if (StringUtils.isNotEmpty(internalResult.evaluationDate())) {
         apiResult.setEvaluationDate(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/DecisionInstance.java
@@ -32,6 +32,7 @@ public class DecisionInstance {
       EVALUATION_DATE = DecisionInstanceTemplate.EVALUATION_DATE,
       EVALUATION_FAILURE = DecisionInstanceTemplate.EVALUATION_FAILURE,
       EVALUATION_FAILURE_MESSAGE = DecisionInstanceTemplate.EVALUATION_FAILURE_MESSAGE,
+      RESULT = DecisionInstanceTemplate.RESULT,
       PROCESS_DEFINITION_KEY = DecisionInstanceTemplate.PROCESS_DEFINITION_KEY,
       PROCESS_INSTANCE_KEY = DecisionInstanceTemplate.PROCESS_INSTANCE_KEY,
       DECISION_ID = DecisionInstanceTemplate.DECISION_ID,


### PR DESCRIPTION
# Description
Backport of #34076 to `stable/operate-8.5`.

relates to camunda/camunda#34069