### PR TITLE
fix: dot not return null RaftPartitions/ZeebePartitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -300,6 +300,7 @@ public final class PartitionManagerImpl
   public Collection<RaftPartition> getRaftPartitions() {
     return partitions.values().stream()
         .map(Partition::raftPartition)
+        // raftPartition may be null before the partition is fully started
         .filter(Objects::nonNull)
         .toList();
   }
@@ -308,6 +309,7 @@ public final class PartitionManagerImpl
   public Collection<ZeebePartition> getZeebePartitions() {
     return partitions.values().stream()
         .map(Partition::zeebePartition)
+        // zeebePartition may be null before the partition is fully started
         .filter(Objects::nonNull)
         .toList();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -297,12 +298,18 @@ public final class PartitionManagerImpl
 
   @Override
   public Collection<RaftPartition> getRaftPartitions() {
-    return partitions.values().stream().map(Partition::raftPartition).toList();
+    return partitions.values().stream()
+        .map(Partition::raftPartition)
+        .filter(Objects::nonNull)
+        .toList();
   }
 
   @Override
   public Collection<ZeebePartition> getZeebePartitions() {
-    return partitions.values().stream().map(Partition::zeebePartition).toList();
+    return partitions.values().stream()
+        .map(Partition::zeebePartition)
+        .filter(Objects::nonNull)
+        .toList();
   }
 
   @Override


### PR DESCRIPTION
## Description
The partition is inserted into the `PartitionManagerImpl.partitions` map before it has terminated bootstrapping. 
As a result, a lot of methods in `BrokerAdminEndpoint` fail because of a  `NullPointerException` while iterating through the partition list.


 

