### PR TITLE
Ensure that the `ClusterConfiguration` is initialized when setting `BrokerInfo`

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -11,10 +11,15 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterChangeExecutorImpl;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.DynamicClusterConfigurationService;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
 
 public class ClusterConfigurationManagerStep
     implements io.camunda.zeebe.scheduler.startup.StartupStep<BrokerStartupContext> {
+
+  private static final int MAX_RETRIES = 10;
 
   @Override
   public String getName() {
@@ -24,8 +29,6 @@ public class ClusterConfigurationManagerStep
   @Override
   public ActorFuture<BrokerStartupContext> startup(
       final BrokerStartupContext brokerStartupContext) {
-    final ActorFuture<BrokerStartupContext> started =
-        brokerStartupContext.getConcurrencyControl().createFuture();
 
     final ClusterChangeExecutor clusterChangeExecutor =
         new ClusterChangeExecutorImpl(
@@ -34,30 +37,21 @@ public class ClusterConfigurationManagerStep
             brokerStartupContext.getMeterRegistry());
     final ClusterConfigurationService clusterConfigurationService =
         new DynamicClusterConfigurationService(clusterChangeExecutor);
-    clusterConfigurationService
+    return clusterConfigurationService
         .start(brokerStartupContext)
-        .onComplete(
-            (ignore, error) -> {
-              if (error == null) {
-                brokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
-                final var brokerInfo = brokerStartupContext.getBrokerInfo();
-                final var clusterConfiguration =
-                    brokerStartupContext
-                        .getBrokerClient()
-                        .getTopologyManager()
-                        .getClusterConfiguration();
-                brokerInfo
-                    .setClusterSize(clusterConfiguration.clusterSize())
-                    .setPartitionsCount(clusterConfiguration.partitionCount())
-                    .setReplicationFactor(clusterConfiguration.minReplicationFactor());
-
-                started.complete(brokerStartupContext);
-              } else {
-                started.completeExceptionally(error);
-              }
+        .andThen(
+            (ignore) -> getClusterConfiguration(brokerStartupContext, MAX_RETRIES),
+            brokerStartupContext.getConcurrencyControl())
+        .thenApply(
+            clusterConfiguration -> {
+              brokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
+              final var brokerInfo = brokerStartupContext.getBrokerInfo();
+              brokerInfo
+                  .setClusterSize(clusterConfiguration.clusterSize())
+                  .setPartitionsCount(clusterConfiguration.partitionCount())
+                  .setReplicationFactor(clusterConfiguration.minReplicationFactor());
+              return brokerStartupContext;
             });
-
-    return started;
   }
 
   @Override
@@ -82,5 +76,41 @@ public class ClusterConfigurationManagerStep
       stopFuture.complete(brokerStartupContext);
     }
     return stopFuture;
+  }
+
+  /**
+   * Retrieves the cluster configuration from the broker client, retrying if it is still
+   * uninitialized. This method will retry up to {@link #MAX_RETRIES} times, waiting 200
+   * milliseconds between each retry. If the configuration is still uninitialized after the maximum
+   * number of retries, it will complete exceptionally with an {@link IllegalStateException}.
+   *
+   * @param brokerStartupContext the context containing the broker client
+   * @param retriesLeft the number of retries left to attempt
+   * @return an ActorFuture that completes with the ClusterConfiguration
+   */
+  private ActorFuture<ClusterConfiguration> getClusterConfiguration(
+      final BrokerStartupContext brokerStartupContext, final int retriesLeft) {
+    if (retriesLeft <= 0) {
+      return CompletableActorFuture.completedExceptionally(
+          new IllegalStateException(
+              "Cluster configuration is still uninitialized after maximum retries of "
+                  + MAX_RETRIES));
+    }
+    final var configuration =
+        brokerStartupContext.getBrokerClient().getTopologyManager().getClusterConfiguration();
+    if (configuration.isUninitialized()) {
+      final ActorFuture<ClusterConfiguration> future =
+          brokerStartupContext.getConcurrencyControl().createFuture();
+      brokerStartupContext
+          .getConcurrencyControl()
+          .schedule(
+              Duration.ofMillis(200),
+              () -> {
+                getClusterConfiguration(brokerStartupContext, retriesLeft - 1).onComplete(future);
+              });
+      return future;
+    } else {
+      return CompletableActorFuture.completed(configuration);
+    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -25,7 +25,7 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
 
   private PartitionDistribution partitionDistribution;
 
-  private ClusterConfiguration initialClusterConfiguration;
+  private volatile ClusterConfiguration initialClusterConfiguration;
 
   private ClusterConfigurationManagerService clusterConfigurationManagerService;
   private final ClusterChangeExecutor clusterChangeExecutor;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -46,8 +46,8 @@ final class PartitionJoinTest {
 
               clusterCfg.setClusterSize(1);
               clusterCfg.setNodeId(0);
-              clusterCfg.setPartitionsCount(1);
-              clusterCfg.setReplicationFactor(1);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(3);
             });
 
     final var initialContactPoint =
@@ -64,11 +64,11 @@ final class PartitionJoinTest {
               clusterCfg.setInitialContactPoints(
                   List.of(initialContactPoint.getHostName() + ":" + initialContactPoint.getPort()));
 
-              // Static configuration initially results in a broker without any partitions
+              // Static configuration initially results in a broker with only 1 partition
               clusterCfg.setClusterSize(1);
               clusterCfg.setNodeId(1);
-              clusterCfg.setPartitionsCount(0);
-              clusterCfg.setReplicationFactor(0);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(1);
             });
 
     // when

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -130,6 +130,10 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setPartitionsCount(final int partitionsCount) {
+    if (partitionsCount <= 0) {
+      throw new IllegalArgumentException(
+          "partitionsCount must be positive, was " + partitionsCount);
+    }
     this.partitionsCount = partitionsCount;
     return this;
   }
@@ -142,6 +146,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setClusterSize(final int clusterSize) {
+    if (clusterSize <= 0) {
+      throw new IllegalArgumentException("clusterSize must be positive, was " + partitionsCount);
+    }
     this.clusterSize = clusterSize;
     return this;
   }
@@ -154,6 +161,10 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo setReplicationFactor(final int replicationFactor) {
+    if (replicationFactor <= 0) {
+      throw new IllegalArgumentException(
+          "replicationFactor must be positive, was " + partitionsCount);
+    }
     this.replicationFactor = replicationFactor;
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -147,7 +147,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public BrokerInfo setClusterSize(final int clusterSize) {
     if (clusterSize <= 0) {
-      throw new IllegalArgumentException("clusterSize must be positive, was " + partitionsCount);
+      throw new IllegalArgumentException("clusterSize must be positive, was " + clusterSize);
     }
     this.clusterSize = clusterSize;
     return this;
@@ -163,7 +163,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public BrokerInfo setReplicationFactor(final int replicationFactor) {
     if (replicationFactor <= 0) {
       throw new IllegalArgumentException(
-          "replicationFactor must be positive, was " + partitionsCount);
+          "replicationFactor must be positive, was " + replicationFactor);
     }
     this.replicationFactor = replicationFactor;
     return this;


### PR DESCRIPTION
## Description
There is a potential race condition between in `ClusterConfigurationManagerStep`:
- `DynamicClusterConfigurationService.start()`
-  `BrokerTopologyManagerImpl.getClusterConfiguration()`

We wait for the future from `start()` to complete and then we access the result of `getClusterConfiguration`. However BrokerTopologyManagerImpl is just a "listener" so it may have not been called yet.

This PR introduce a finite number of retries in getting the configuration. Considering how unfrequent this bug has been, probably just 1 retry should be enough. 
The retry is async and does not block any threads when waiting

## Related issues

closes #31534 
