### PR TITLE
deps: change alpine version to 3.22.0

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -18,7 +18,7 @@ docker buildx create --use
 export VERSION="${VERSION}"
 export DATE="$(date +%FT%TZ)"
 export REVISION="${REVISION}"
-export BASE_IMAGE=docker.io/library/alpine:3.21.3
+export BASE_IMAGE=docker.io/library/alpine:3.22.0
 
 # if CI (GHA) export the variables for pushing in a later step
 if [ "${CI}" = "true" ]; then

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -340,7 +340,7 @@ jobs:
           DATE="$(date +%FT%TZ)"
           export DATE
           export REVISION="${REVISION}"
-          export BASE_IMAGE=docker.io/library/alpine:3.21.3
+          export BASE_IMAGE=docker.io/library/alpine:3.22.0
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch,identity,keycloak,opensearch",
   "io.openshift.tags": "bpmn,optimization,camunda",
   "org.opencontainers.image.authors": "optimize@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.21.3",
+  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.22.0",
   "org.opencontainers.image.base.digest": $BASEDIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Provides business activity monitoring for workflows and uses BPMN-based analysis to uncover process bottlenecks",

--- a/optimize/docker/test/verify.sh
+++ b/optimize/docker/test/verify.sh
@@ -41,7 +41,7 @@ if [ -z "${DATE}" ]; then
 fi
 
 if [ -z "${BASE_IMAGE}" ]; then
-  echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.21.3"
+  echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.22.0"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Optimize has a failing docker build test due to a mismatch in alpine versions. Upgrade to `3.22.0` to match the correct version expected

Failing test: https://github.com/camunda/camunda/actions/runs/15757199160/job/44420863906

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
