### PR TITLE
feat: local variable assertions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -310,15 +310,31 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariableNames(String... variableNames);
 
   /**
-   * Verifies that the process instance has the given local variables. The verification fails if at
-   * least one variable doesn't exist.
+   * Verifies that the given BPMN element has the specified local variables. Local variables are
+   * scoped to the element and do not appear in the parent scope. The verification fails if at least
+   * one variable doesn't exist.
    *
-   * <p>The assertion waits until all variables exist.
+   * <p>The assertion waits until all local variables exist for the element.
    *
+   * @param elementId the id of the BPMN element
    * @param variableNames the variable names
    * @return the assertion object
    */
-  ProcessInstanceAssert hasLocalVariableNames(String... variableNames);
+  ProcessInstanceAssert hasLocalVariableNames(String elementId, String... variableNames);
+
+  /**
+   * Verifies that the given BPMN element has the specified local variables. Local variables are
+   * scoped to the element and do not appear in the parent scope. The verification fails if at least
+   * one variable doesn't exist.
+   *
+   * <p>The assertion waits until all local variables exist for the element.
+   *
+   * @param selector the selector for the BPMN element
+   * @param variableNames the variable names
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasLocalVariableNames(ElementSelector selector, String... variableNames);
 
   /**
    * Verifies that the process instance has the variable with the given value. The verification
@@ -333,16 +349,35 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariable(String variableName, Object variableValue);
 
   /**
-   * Verifies that the process instance has the local variable with the given value. The
-   * verification fails if the variable doesn't exist or has a different value.
+   * Verifies that the given BPMN element has the local variable with the specified value. Local
+   * variables are scoped to the element and do not appear in the parent scope. The verification
+   * fails if the variable doesn't exist or has a different value.
    *
    * <p>The assertion waits until the variable exists and has the given value.
    *
+   * @param elementId the id of the BPMN element
    * @param variableName the variable name
    * @param variableValue the variable value
    * @return the assertion object
    */
-  ProcessInstanceAssert hasLocalVariable(final String variableName, final Object variableValue);
+  ProcessInstanceAssert hasLocalVariable(
+      String elementId, String variableName, Object variableValue);
+
+  /**
+   * Verifies that the given BPMN element has the local variable with the specified value. Local
+   * variables are scoped to the element and do not appear in the parent scope. The verification
+   * fails if the variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until the variable exists and has the given value.
+   *
+   * @param selector the selector for the BPMN element
+   * @param variableName the variable name
+   * @param variableValue the variable value
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasLocalVariable(
+      ElementSelector selector, String variableName, Object variableValue);
 
   /**
    * Verifies that the process instance has the given variables. The verification fails if at least
@@ -356,15 +391,31 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariables(Map<String, Object> variables);
 
   /**
-   * Verifies that the process instance has the given local variables. The verification fails if at
-   * least one variable doesn't exist or has a different value.
+   * Verifies that the given element associated with the process instance has the given local
+   * variables. Local variables are scoped to the element and do not appear in the parent scope. The
+   * verification fails if at least one variable doesn't exist or has a different value.
    *
-   * <p>The assertion waits until all variables exist and have the given value.
+   * <p>The assertion waits until all variables exist and have the given values.
    *
+   * @param elementId the id of the BPMN element
    * @param variables the expected variables
    * @return the assertion object
    */
-  ProcessInstanceAssert hasLocalVariables(Map<String, Object> variables);
+  ProcessInstanceAssert hasLocalVariables(String elementId, Map<String, Object> variables);
+
+  /**
+   * Verifies that the given element associated with the process instance has the given local
+   * variables. Local variables are scoped to the element and do not appear in the parent scope. The
+   * verification fails if at least one variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until all variables exist and have the given values.
+   *
+   * @param selector the selector for the BPMN element
+   * @param variables the expected variables
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasLocalVariables(ElementSelector selector, Map<String, Object> variables);
 
   /**
    * Verifies that the process instance has no active incidents. The verification fails if there is

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -310,6 +310,17 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariableNames(String... variableNames);
 
   /**
+   * Verifies that the process instance has the given local variables. The verification fails if at
+   * least one variable doesn't exist.
+   *
+   * <p>The assertion waits until all variables exist.
+   *
+   * @param variableNames the variable names
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasLocalVariableNames(String... variableNames);
+
+  /**
    * Verifies that the process instance has the variable with the given value. The verification
    * fails if the variable doesn't exist or has a different value.
    *
@@ -322,6 +333,18 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasVariable(String variableName, Object variableValue);
 
   /**
+   * Verifies that the process instance has the local variable with the given value. The
+   * verification fails if the variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until the variable exists and has the given value.
+   *
+   * @param variableName the variable name
+   * @param variableValue the variable value
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasLocalVariable(final String variableName, final Object variableValue);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist or has a different value.
    *
@@ -331,6 +354,17 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasVariables(Map<String, Object> variables);
+
+  /**
+   * Verifies that the process instance has the given local variables. The verification fails if at
+   * least one variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until all variables exist and have the given value.
+   *
+   * @param variables the expected variables
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasLocalVariables(Map<String, Object> variables);
 
   /**
    * Verifies that the process instance has no active incidents. The verification fails if there is

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -245,8 +245,17 @@ public class ProcessInstanceAssertj
   }
 
   @Override
-  public ProcessInstanceAssert hasLocalVariableNames(final String... variableNames) {
-    variableAssertj.hasLocalVariableNames(getProcessInstanceKey(), variableNames);
+  public ProcessInstanceAssert hasLocalVariableNames(
+      final String elementId, final String... variableNames) {
+    variableAssertj.hasLocalVariableNames(
+        getProcessInstanceKey(), elementSelector.apply(elementId), variableNames);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariableNames(
+      final ElementSelector selector, final String... variableNames) {
+    variableAssertj.hasLocalVariableNames(getProcessInstanceKey(), selector, variableNames);
     return this;
   }
 
@@ -258,8 +267,17 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasLocalVariable(
-      final String variableName, final Object variableValue) {
-    variableAssertj.hasLocalVariable(getProcessInstanceKey(), variableName, variableValue);
+      final String elementId, final String variableName, final Object variableValue) {
+    variableAssertj.hasLocalVariable(
+        getProcessInstanceKey(), elementSelector.apply(elementId), variableName, variableValue);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariable(
+      final ElementSelector selector, final String variableName, final Object variableValue) {
+    variableAssertj.hasLocalVariable(
+        getProcessInstanceKey(), selector, variableName, variableValue);
     return this;
   }
 
@@ -270,8 +288,17 @@ public class ProcessInstanceAssertj
   }
 
   @Override
-  public ProcessInstanceAssert hasLocalVariables(final Map<String, Object> variables) {
-    variableAssertj.hasLocalVariables(getProcessInstanceKey(), variables);
+  public ProcessInstanceAssert hasLocalVariables(
+      final String elementId, final Map<String, Object> variables) {
+    variableAssertj.hasLocalVariables(
+        getProcessInstanceKey(), elementSelector.apply(elementId), variables);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariables(
+      final ElementSelector selector, final Map<String, Object> variables) {
+    variableAssertj.hasLocalVariables(getProcessInstanceKey(), selector, variables);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -245,14 +245,33 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasLocalVariableNames(final String... variableNames) {
+    variableAssertj.hasLocalVariableNames(getProcessInstanceKey(), variableNames);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariable(final String variableName, final Object variableValue) {
     variableAssertj.hasVariable(getProcessInstanceKey(), variableName, variableValue);
     return this;
   }
 
   @Override
+  public ProcessInstanceAssert hasLocalVariable(
+      final String variableName, final Object variableValue) {
+    variableAssertj.hasLocalVariable(getProcessInstanceKey(), variableName, variableValue);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariables(final Map<String, Object> variables) {
     variableAssertj.hasVariables(getProcessInstanceKey(), variables);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariables(final Map<String, Object> variables) {
+    variableAssertj.hasLocalVariables(getProcessInstanceKey(), variables);
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -19,7 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.Variable;
+import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.impl.assertions.util.AssertionJsonMapper;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
@@ -46,8 +51,25 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     this.dataSource = dataSource;
   }
 
-  public void hasLocalVariableNames(final long processInstanceKey, final String... variableNames) {
-    hasVariableNames(() -> getAllProcessInstanceVariables(processInstanceKey), variableNames);
+  public void hasLocalVariableNames(
+      final long processInstanceKey,
+      final ElementSelector selector,
+      final String... variableNames) {
+
+    withLocalVariableAssertion(
+        processInstanceKey,
+        selector,
+        instance -> {
+          hasVariableNames(
+              () ->
+                  toMap(
+                      dataSource.findVariables(
+                          filter ->
+                              filter
+                                  .processInstanceKey(processInstanceKey)
+                                  .scopeKey(instance.getElementInstanceKey()))),
+              variableNames);
+        });
   }
 
   public void hasVariableNames(final long processInstanceKey, final String... variableNames) {
@@ -90,10 +112,19 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   }
 
   public void hasLocalVariable(
-      final long processInstanceKey, final String variableName, final Object variableValue) {
+      final long processInstanceKey,
+      final ElementSelector selector,
+      final String variableName,
+      final Object variableValue) {
 
-    hasVariable(
-        variableName, variableValue, () -> getAllProcessInstanceVariables(processInstanceKey));
+    withLocalVariableAssertion(
+        processInstanceKey,
+        selector,
+        instance ->
+            hasVariable(
+                variableName,
+                variableValue,
+                () -> findLocalVariables(processInstanceKey, instance.getElementInstanceKey())));
   }
 
   public void hasVariable(
@@ -144,9 +175,23 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   }
 
   public void hasLocalVariables(
-      final long processInstanceKey, final Map<String, Object> expectedVariables) {
+      final long processInstanceKey,
+      final ElementSelector selector,
+      final Map<String, Object> expectedVariables) {
 
-    hasVariables(expectedVariables, () -> getAllProcessInstanceVariables(processInstanceKey));
+    withLocalVariableAssertion(
+        processInstanceKey,
+        selector,
+        instance ->
+            hasVariables(
+                expectedVariables,
+                () ->
+                    toMap(
+                        dataSource.findVariables(
+                            filter ->
+                                filter
+                                    .processInstanceKey(processInstanceKey)
+                                    .scopeKey(instance.getElementInstanceKey())))));
   }
 
   public void hasVariables(
@@ -212,12 +257,65 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
     }
   }
 
-  private Map<String, String> getGlobalProcessInstanceVariables(final long processInstanceKey) {
-    return toMap(dataSource.findGlobalVariablesByProcessInstanceKey(processInstanceKey));
+  private void withLocalVariableAssertion(
+      final long processInstanceKey,
+      final ElementSelector selector,
+      final Consumer<ElementInstance> assertionCallback) {
+
+    awaitElementInstanceAssertion(
+        f -> {
+          f.processInstanceKey(processInstanceKey);
+          selector.applyFilter(f);
+        },
+        elementInstances -> {
+          final Optional<ElementInstance> instance =
+              elementInstances.stream().filter(selector::test).findFirst();
+
+          assertThat(instance)
+              .withFailMessage(
+                  "No element [%s] found for process instance [key: %s]",
+                  selector.describe(), processInstanceKey)
+              .isPresent();
+
+          assertionCallback.accept(instance.get());
+        });
   }
 
-  private Map<String, String> getAllProcessInstanceVariables(final long processInstanceKey) {
-    return toMap(dataSource.findVariables(f -> f.processInstanceKey(processInstanceKey)));
+  private void awaitElementInstanceAssertion(
+      final Consumer<ElementInstanceFilter> filter,
+      final Consumer<List<ElementInstance>> assertion) {
+    // If await() times out, the exception doesn't contain the assertion error. Use a reference to
+    // store the error's failure message.
+    final AtomicReference<String> failureMessage = new AtomicReference<>("?");
+    try {
+      Awaitility.await()
+          .ignoreException(ClientException.class)
+          .untilAsserted(
+              () -> dataSource.findElementInstances(filter),
+              elementInstances -> {
+                try {
+                  assertion.accept(elementInstances);
+                } catch (final AssertionError e) {
+                  failureMessage.set(e.getMessage());
+                  throw e;
+                }
+              });
+
+    } catch (final ConditionTimeoutException ignore) {
+      fail(failureMessage.get());
+    }
+  }
+
+  private Map<String, String> findLocalVariables(
+      final long processInstanceKey, final long elementInstanceKey) {
+
+    return toMap(
+        dataSource.findVariables(
+            filter -> filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey)));
+  }
+
+  private Map<String, String> getGlobalProcessInstanceVariables(final long processInstanceKey) {
+    return toMap(dataSource.findGlobalVariablesByProcessInstanceKey(processInstanceKey));
   }
 
   private Map<String, String> toMap(final List<Variable> variables) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -258,7 +258,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
                                   .filter(userTaskSelector::test)
                                   .collect(Collectors.toList());
                           Assertions.assertThat(tasks).isNotEmpty();
-                          userTaskKey.set(items.get(0).getUserTaskKey());
+                          userTaskKey.set(tasks.get(0).getUserTaskKey());
                         });
               });
     } catch (final ConditionTimeoutException | TerminalFailureException e) {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertIT.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@CamundaProcessTest
+public class VariableAssertIT {
+
+  private CamundaProcessTestContext processTestContext;
+  private CamundaClient client;
+
+  @Test
+  void shouldMatchLocalVariables() {
+    // Given
+    final long processDefinitionKey = deployProcessModel(processModelWithLocalVariables());
+
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    assertThat(processInstanceEvent).hasLocalVariable("local_variable", "value");
+
+    processTestContext.completeUserTask(t -> t.getName().equals("User Task"));
+
+    assertThat(processInstanceEvent).isCompleted();
+
+    Assertions.assertThatThrownBy(
+            () -> assertThat(processInstanceEvent).hasVariable("local_variable", "value"))
+        .hasMessage(
+            "Process instance [key: 2251799813685294] should have a variable "
+                + "'local_variable' with value '\"value\"' but the variable doesn't exist.");
+  }
+
+  @Test
+  void shouldMatchShadowingLocalVariables() {
+    // Given
+    final long processDefinitionKey = deployProcessModel(processModelWithLocalVariablesB());
+
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    processTestContext.completeJob("test");
+
+    assertThat(processInstanceEvent).hasVariable("var_key", "parent_value");
+    assertThat(processInstanceEvent).hasLocalVariable("var_key", "child_value");
+
+    processTestContext.completeUserTask(t -> t.getName().equals("User Task"));
+
+    assertThat(processInstanceEvent).isCompleted().hasVariable("var_key", "parent_value");
+  }
+
+  @Test
+  void shouldMatchShadowingLocalVariablesInSubProcess() {
+    // Given
+    final long subprocessDefinitionKey = deployProcessModel(childProcessModelWithLocalVariables());
+    final long processDefinitionKey =
+        deployProcessModel(processModelWithLocalVariablesAndChildProcess());
+
+    // When
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    assertThat(processInstanceEvent)
+        .isActive()
+        .hasVariable("parent_key", "parent_value")
+        .hasVariable("shadowed_variable", "A")
+        .hasLocalVariable("local_variable", "parent_ut_value");
+
+    Assertions.assertThatThrownBy(
+            () -> assertThat(processInstanceEvent).hasVariableNames("local_variable"))
+        .hasMessage(
+            "Process instance [key: 2251799813685296] should have the variables "
+                + "['local_variable'] but ['local_variable'] don't exist.");
+
+    processTestContext.completeUserTask(t -> t.getName().equals("Parent User Task"));
+
+    assertThat(ProcessInstanceSelectors.byProcessId("child-process-1"))
+        .isActive()
+        .hasVariable("parent_key", "parent_value")
+        .hasVariable("shadowed_variable", "A")
+        .hasLocalVariable("child_local_variable", "child_value")
+        .hasLocalVariable("shadowed_variable", "B");
+
+    Assertions.assertThatThrownBy(
+            () -> assertThat(processInstanceEvent).hasVariable("shadowed_variable", "B"))
+        .hasMessage(
+            "Process instance [key: 2251799813685296] should have a variable "
+                + "'shadowed_variable' with value '\"B\"' but was '\"A\"'.");
+
+    processTestContext.completeUserTask(t -> t.getName().equalsIgnoreCase("Child User Task"));
+
+    assertThat(processInstanceEvent)
+        .isCompleted()
+        .hasVariable("parent_key", "parent_value")
+        .hasVariable("shadowed_variable", "B")
+        .hasVariable("child_key", "child_value");
+
+    Assertions.assertThatThrownBy(
+            () -> assertThat(processInstanceEvent).hasVariableNames("child_local_variable"))
+        .hasMessage(
+            "Process instance [key: 2251799813685296] should have the variables "
+                + "['child_local_variable'] but ['child_local_variable'] don't exist.");
+  }
+
+  /**
+   * Deploys a process model and waits until it is accessible via the API.
+   *
+   * @return the process definition key
+   */
+  private long deployProcessModel(final BpmnModelInstance processModel) {
+    final DeploymentEvent deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(processModel, "test-process.bpmn")
+            .send()
+            .join();
+    return deploymentEvent.getProcesses().stream().findFirst().get().getProcessDefinitionKey();
+  }
+
+  private BpmnModelInstance processModelWithLocalVariablesAndChildProcess() {
+    return Bpmn.createExecutableProcess("test-process")
+        .startEvent()
+        .zeebeOutputExpression("\"parent_value\"", "parent_key")
+        .zeebeOutputExpression("\"A\"", "shadowed_variable")
+        .userTask("user-task-parent-id")
+        .name("Parent User Task")
+        .zeebeInputExpression("\"parent_ut_value\"", "local_variable")
+        .zeebeUserTask()
+        .callActivity()
+        .zeebeProcessId("child-process-1")
+        .endEvent("success-end")
+        .done();
+  }
+
+  private BpmnModelInstance childProcessModelWithLocalVariables() {
+    return Bpmn.createExecutableProcess("child-process-1")
+        .startEvent()
+        .userTask("user-task-child-id")
+        .name("Child User Task")
+        .zeebeInputExpression("\"child_value\"", "child_local_variable")
+        .zeebeInputExpression("\"B\"", "shadowed_variable")
+        .zeebeOutputExpression("\"child_value\"", "child_key")
+        .zeebeOutputExpression("\"B\"", "shadowed_variable")
+        .zeebeUserTask()
+        .endEvent("child-end")
+        .done();
+  }
+
+  private BpmnModelInstance processModelWithLocalVariables() {
+    return Bpmn.createExecutableProcess("test-process-local-variables")
+        .startEvent()
+        .userTask("user-task-id")
+        .name("User Task")
+        .zeebeInputExpression("\"value\"", "local_variable")
+        .zeebeUserTask()
+        .endEvent("success-end")
+        .done();
+  }
+
+  private BpmnModelInstance processModelWithLocalVariablesB() {
+    return Bpmn.createExecutableProcess("test-process-local-variables")
+        .startEvent()
+        .serviceTask("service-task-id")
+        .zeebeJobType("test")
+        .zeebeOutputExpression("\"parent_value\"", "var_key")
+        .userTask("user-task-id")
+        .name("User Task")
+        .zeebeInputExpression("\"child_value\"", "var_key")
+        .zeebeUserTask()
+        .endEvent("success-end")
+        .done();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -743,9 +743,6 @@ public class CamundaProcessTestContextIT {
     Assertions.assertThatThrownBy(
             () -> assertThat(DecisionSelectors.byId("decision_overall_happiness")).isEvaluated())
         .hasMessage("No DecisionInstance [decision_overall_happiness] found.");
-    Assertions.assertThatThrownBy(
-            () -> assertThat(DecisionSelectors.byId("decision_language_happiness")).isEvaluated())
-        .hasMessage("No DecisionInstance [decision_language_happiness] found.");
   }
 
   /**


### PR DESCRIPTION
## Description

Adds three new assertions that check for all variables including local variables: `hasLocalVariableNames`, `hasLocalVariable` and `hasLocalVariables`. Each of these assertions expects either an elementName or an ElementSelector to help discriminate between local variables of the same name, but associated with different BPMN elements. 

#closes [32648](https://github.com/camunda/camunda/issues/32648)