### PR TITLE
Bugfix: output mappings on multi instance body applied twice

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBeh
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
-import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.MultiInstanceOutputCollectionBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -66,7 +65,6 @@ public final class MultiInstanceBodyProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
-  private final BpmnVariableMappingBehavior variableMappingBehavior;
 
   public MultiInstanceBodyProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -78,7 +76,6 @@ public final class MultiInstanceBodyProcessor
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     multiInstanceOutputCollectionBehavior = bpmnBehaviors.outputCollectionBehavior();
     compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
-    variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
   }
 
   @Override
@@ -179,10 +176,6 @@ public final class MultiInstanceBodyProcessor
     if (updatedOrFailure.isLeft()) {
       return updatedOrFailure;
     }
-
-    // we modify the output collection variable above
-    // if there is a mapping using this, it should get updated as well
-    variableMappingBehavior.applyOutputMappings(childContext, element.getInnerActivity());
 
     // test that completion condition can be evaluated correctly
     final Either<Failure, Boolean> satisfiesCompletionConditionOrFailure =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -1393,60 +1393,6 @@ public final class MultiInstanceActivityTest {
   }
 
   @Test
-  public void shouldApplyOutputMappingForOutputCollection() {
-    // given
-    final ServiceTask task = process(miBuilder).getModelElementById(ELEMENT_ID);
-    final var process =
-        task.builder()
-            .zeebeOutputExpression(OUTPUT_COLLECTION_VARIABLE, "resultsFromOutput")
-            .done();
-
-    ENGINE.deployment().withXmlResource(process).deploy();
-
-    // when
-    final long processInstanceKey =
-        ENGINE
-            .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
-            .create();
-
-    completeJobs(processInstanceKey, INPUT_COLLECTION.size());
-
-    // then
-    assertThat(
-            RecordingExporter.variableRecords()
-                .withScopeKey(processInstanceKey)
-                .withName(OUTPUT_COLLECTION_VARIABLE)
-                .getFirst()
-                .getValue())
-        .hasValue("[11,22,33]");
-
-    final var multiInstanceBody =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
-            .getFirst();
-
-    assertThat(
-            RecordingExporter.variableRecords()
-                .withName(OUTPUT_COLLECTION_VARIABLE)
-                .withScopeKey(multiInstanceBody.getKey())
-                .limit(INPUT_COLLECTION.size() + 1))
-        .extracting(r -> r.getValue().getValue())
-        .contains("[null,null,null]", "[11,null,null]", "[11,22,null]", "[11,22,33]");
-
-    assertThat(
-            RecordingExporter.records()
-                .betweenProcessInstance(processInstanceKey)
-                .variableRecords()
-                .withName("resultsFromOutput")
-                .withScopeKey(processInstanceKey))
-        .extracting(r -> r.getValue().getValue())
-        .containsExactly("[null,null,null]", "[11,null,null]", "[11,22,null]", "[11,22,33]");
-  }
-
-  @Test
   public void shouldTriggerInterruptingBoundaryEvent() {
     // given
     final ServiceTask task = process(miBuilder).getModelElementById(ELEMENT_ID);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Changes introduced in #25106 caused output mappings without keys to be applied twice on the multi-instance body. I reverted the changes implemented.

Output mappings needs to be applied on inner activity completion and before updating output collection of the multi-instance body. Updating output collection before applying output mappings to inner activity will result in incorrect output collection as it uses output element while updating the output collection. Therefore, we should keep the order of applying inner activity output mappings and updating output collection as it is.

Later, I tried to fix the issue by reducing the scope of applying output mappings after updating the output collection only when output collection expression is used inside inner activity's output mapping. However, that resulted in a tricky solution where I need to parse the output mapping expression to check if it uses output collection.

I ended up reverting the previous changes only.

As there is a straightforward workaround for the initial issue #23658, I am in favor of documenting this limitation that users need to use the output collection variable itself in the inner activity's output mapping expression.

## Related issues

closes #32318 
