### PR TITLE
refactor(camunda-client-java): rename method newUserCreateCommand to newCreateUserCommand

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1587,7 +1587,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    *
    * camundaClient
-   *  .newUserCreateCommand()
+   *  .newCreateUserCommand()
    *  .username(username)
    *  .email(email)
    *  .name(name)
@@ -1599,7 +1599,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  CreateUserCommandStep1 newUserCreateCommand();
+  CreateUserCommandStep1 newCreateUserCommand();
 
   /**
    * Command to delete a user by username

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -966,7 +966,7 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public CreateUserCommandStep1 newUserCreateCommand() {
+  public CreateUserCommandStep1 newCreateUserCommand() {
     return new CreateUserCommandImpl(httpClient, jsonMapper);
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -863,7 +863,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    *
    * zeebeClient
-   *  .newUserCreateCommand()
+   *  .newCreateUserCommand()
    *  .username(username)
    *  .email(email)
    *  .name(name)
@@ -875,7 +875,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  CreateUserCommandStep1 newUserCreateCommand();
+  CreateUserCommandStep1 newCreateUserCommand();
 
   /**
    * Command to create a document.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -596,7 +596,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public CreateUserCommandStep1 newUserCreateCommand() {
+  public CreateUserCommandStep1 newCreateUserCommand() {
     return new CreateUserCommandImpl(httpClient, jsonMapper);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/client/user/CreateUserTest.java
@@ -36,7 +36,7 @@ public class CreateUserTest extends ClientRestTest {
   void shouldCreateUser() {
     // when
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME)
         .name(NAME)
         .email(EMAIL)
@@ -58,7 +58,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .name(NAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -74,7 +74,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .password(PASSWORD)
@@ -90,7 +90,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -106,7 +106,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)
@@ -126,7 +126,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)

--- a/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
@@ -36,7 +36,7 @@ public class CreateUserTest extends ClientRestTest {
   void shouldCreateUser() {
     // when
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME)
         .name(NAME)
         .email(EMAIL)
@@ -58,7 +58,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .name(NAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -74,7 +74,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .password(PASSWORD)
@@ -90,7 +90,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -106,7 +106,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)
@@ -126,7 +126,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserAuthorizationIT.java
@@ -125,7 +125,7 @@ class UserAuthorizationIT {
 
     final CreateUserResponse createUserResponse =
         adminClient
-            .newUserCreateCommand()
+            .newCreateUserCommand()
             .username(username)
             .name("name")
             .password("password")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserIntegrationTest.java
@@ -33,7 +33,7 @@ public class UserIntegrationTest {
 
     // when
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(username)
         .name(name)
         .password("some password")
@@ -65,7 +65,7 @@ public class UserIntegrationTest {
     final var username = "username";
 
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(username)
         .name("name")
         .password("some password")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByGroupSearchTest.java
@@ -73,7 +73,7 @@ public class UsersByGroupSearchTest {
 
   private static void createUser(final String username) {
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(username)
         .password("password")
         .name("name")

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByRoleIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersByRoleIntegrationTest.java
@@ -278,7 +278,7 @@ public class UsersByRoleIntegrationTest {
   private static CreateUserResponse createUser(
       final String username, final String name, final String email) {
     return camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(username)
         .email(email)
         .name(name)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersSearchIntegrationTest.java
@@ -34,7 +34,7 @@ public class UsersSearchIntegrationTest {
   @BeforeAll
   static void setup() {
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME_1)
         .password("password")
         .name(NAME_1)
@@ -44,7 +44,7 @@ public class UsersSearchIntegrationTest {
     assertUserCreated(USERNAME_1);
 
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME_2)
         .password("password2")
         .name(NAME_2)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsersUpdateIntegrationTest.java
@@ -34,7 +34,7 @@ public class UsersUpdateIntegrationTest {
     final var updatedEmail = "updated_email@email.com";
 
     camundaClient
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(username)
         .password("password")
         .name(name)

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -38,7 +38,7 @@ public final class EntityManager {
             user -> {
               this.users.put(user.username(), user);
               defaultClient
-                  .newUserCreateCommand()
+                  .newCreateUserCommand()
                   .username(user.username())
                   .password(user.password())
                   .name(user.username())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToGroupTest.java
@@ -40,7 +40,7 @@ class AssignUserToGroupTest {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
     username =
         client
-            .newUserCreateCommand()
+            .newCreateUserCommand()
             .name("User Name")
             .username(Strings.newRandomValidUsername())
             .email("foo@example.com")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -51,7 +51,7 @@ class AssignUserToTenantTest {
 
     // Create User
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME)
         .name("name")
         .email("email@example.com")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
@@ -40,7 +40,7 @@ class CreateUserTest {
     // when
     final var response =
         client
-            .newUserCreateCommand()
+            .newCreateUserCommand()
             .username("username")
             .name("name")
             .email("email@example.com")
@@ -63,7 +63,7 @@ class CreateUserTest {
   void shouldRejectIfUsernameAlreadyExists() {
     // given
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username("username")
         .name("name")
         .email("email@example.com")
@@ -75,7 +75,7 @@ class CreateUserTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .username("username")
                     .name("name")
                     .email("email@example.com")
@@ -93,7 +93,7 @@ class CreateUserTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUserCreateCommand()
+                    .newCreateUserCommand()
                     .name("name")
                     .email("email@example.com")
                     .password("password")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -44,7 +44,7 @@ class RemoveUserFromTenantTest {
 
     // Create User
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(USERNAME)
         .name("name")
         .email("email@example.com")
@@ -92,7 +92,7 @@ class RemoveUserFromTenantTest {
     // Given
     final var unassignedUsername = "username2";
     client
-        .newUserCreateCommand()
+        .newCreateUserCommand()
         .username(unassignedUsername)
         .name("name2")
         .email("email2@example.com")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignUserFromGroupTest.java
@@ -39,7 +39,7 @@ public class UnassignUserFromGroupTest {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
     username =
         client
-            .newUserCreateCommand()
+            .newCreateUserCommand()
             .name("User Name")
             .username(Strings.newRandomValidUsername())
             .email("foo@example.com")

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -68,7 +68,7 @@ public class AuthorizationsUtil implements CloseableSilently {
       final String username, final String password, final Permissions... permissions) {
     final var userCreateResponse =
         client
-            .newUserCreateCommand()
+            .newCreateUserCommand()
             .username(username)
             .password(password)
             .name("name")


### PR DESCRIPTION
## Description

Renames the title method in both `CamundaClient` and the deprecated `ZeebeClient`.

## Related issues

closes #33838
