### PR TITLE
fix: upgrade spring-boot version to 3.3.13

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.12</version>
+    <version>3.3.13</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Description

This PR updates all org.apache.tomcat.embed dependencies (e.g., tomcat-embed-core) to 10.1.42 in the monorepo's parent pom as a fix for [this CVE](https://camunda.slack.com/archives/C0925P02X7X)

See https://github.com/spring-projects/spring-boot/releases/tag/v3.3.13