### PR TITLE
[Backport stable/8.5] fix: dot not return null RaftPartitions/ZeebePartitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -254,6 +254,7 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
   public Collection<RaftPartition> getRaftPartitions() {
     return partitions.values().stream()
         .map(Partition::raftPartition)
+        // raftPartition may be null before the partition is fully started
         .filter(Objects::nonNull)
         .toList();
   }
@@ -262,6 +263,7 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
   public Collection<ZeebePartition> getZeebePartitions() {
     return partitions.values().stream()
         .map(Partition::zeebePartition)
+        // zeebePartition may be null before the partition is fully started
         .filter(Objects::nonNull)
         .toList();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -251,12 +252,18 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
 
   @Override
   public Collection<RaftPartition> getRaftPartitions() {
-    return partitions.values().stream().map(Partition::raftPartition).toList();
+    return partitions.values().stream()
+        .map(Partition::raftPartition)
+        .filter(Objects::nonNull)
+        .toList();
   }
 
   @Override
   public Collection<ZeebePartition> getZeebePartitions() {
-    return partitions.values().stream().map(Partition::zeebePartition).toList();
+    return partitions.values().stream()
+        .map(Partition::zeebePartition)
+        .filter(Objects::nonNull)
+        .toList();
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #34165 to `stable/8.5`.

relates to 