### PR TITLE
feat: v2 element instance queries 

### DIFF
--- a/operate/client/src/modules/api/v2/elementInstances/fetchElementInstance.ts
+++ b/operate/client/src/modules/api/v2/elementInstances/fetchElementInstance.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  GetElementInstanceResponseBody,
+} from '@vzeta/camunda-api-zod-schemas';
+import {requestWithThrow, RequestResult} from 'modules/request';
+
+const fetchElementInstance = async (params: {
+  elementInstanceKey: string;
+}): RequestResult<GetElementInstanceResponseBody> => {
+  return requestWithThrow<GetElementInstanceResponseBody>({
+    url: (
+      endpoints.getElementInstance.getUrl as (params: {
+        elementInstanceKey: string;
+      }) => string
+    )(params),
+    method: endpoints.getElementInstance.method,
+  });
+};
+
+export {fetchElementInstance};

--- a/operate/client/src/modules/api/v2/elementInstances/searchElementInstances.ts
+++ b/operate/client/src/modules/api/v2/elementInstances/searchElementInstances.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  QueryElementInstancesRequestBody,
+  QueryElementInstancesResponseBody,
+} from '@vzeta/camunda-api-zod-schemas';
+import {requestWithThrow, RequestResult} from 'modules/request';
+
+const searchElementInstances = async (
+  payload: QueryElementInstancesRequestBody,
+): RequestResult<QueryElementInstancesResponseBody> => {
+  return requestWithThrow<QueryElementInstancesResponseBody>({
+    url: endpoints.queryElementInstances.getUrl(),
+    method: endpoints.queryElementInstances.method,
+    body: payload,
+  });
+};
+
+export {searchElementInstances};

--- a/operate/client/src/modules/mocks/api/v2/elementInstances/fetchElementInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/elementInstances/fetchElementInstance.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockGetRequest} from '../../mockRequest';
+import {
+  GetElementInstanceResponseBody,
+  endpoints,
+} from '@vzeta/camunda-api-zod-schemas';
+
+const mockFetchElementInstance = (
+  elementInstanceKey: string,
+  contextPath = '',
+) =>
+  mockGetRequest<GetElementInstanceResponseBody>(
+    `${contextPath}${(
+      endpoints.getElementInstance.getUrl as (params: {
+        elementInstanceKey: string;
+      }) => string
+    )({elementInstanceKey})}`,
+  );
+
+export {mockFetchElementInstance};

--- a/operate/client/src/modules/mocks/api/v2/elementInstances/fetchElementInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/elementInstances/fetchElementInstance.ts
@@ -17,11 +17,9 @@ const mockFetchElementInstance = (
   contextPath = '',
 ) =>
   mockGetRequest<GetElementInstanceResponseBody>(
-    `${contextPath}${(
-      endpoints.getElementInstance.getUrl as (params: {
-        elementInstanceKey: string;
-      }) => string
-    )({elementInstanceKey})}`,
+    `${contextPath}${endpoints.getElementInstance.getUrl({
+      elementInstanceKey,
+    })}`,
   );
 
 export {mockFetchElementInstance};

--- a/operate/client/src/modules/mocks/api/v2/elementInstances/searchElementInstances.ts
+++ b/operate/client/src/modules/mocks/api/v2/elementInstances/searchElementInstances.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  QueryElementInstancesResponseBody,
+  endpoints,
+} from '@vzeta/camunda-api-zod-schemas';
+
+const mockSearchElementInstances = (contextPath = '') =>
+  mockPostRequest<QueryElementInstancesResponseBody>(
+    `${contextPath}${endpoints.queryElementInstances.getUrl()}`,
+  );
+
+export {mockSearchElementInstances};

--- a/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import {fetchElementInstance} from '../../api/v2/elementInstances/fetchElementInstance';
+import {ElementInstance} from '@vzeta/camunda-api-zod-schemas';
+
+const ELEMENT_INSTANCE_QUERY_KEY = 'elementInstance';
+
+function getQueryKey(elementInstanceKey?: string) {
+  return [ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey];
+}
+
+const useElementInstance = <T = ElementInstance>(
+  elementInstanceKey: string,
+  select?: (data: ElementInstance) => T,
+) => {
+  return useQuery({
+    queryKey: getQueryKey(elementInstanceKey),
+    queryFn: elementInstanceKey
+      ? async () => {
+          const {response, error} = await fetchElementInstance({
+            elementInstanceKey,
+          });
+
+          if (response !== null) return response;
+          throw error;
+        }
+      : skipToken,
+    select,
+  });
+};
+
+export {ELEMENT_INSTANCE_QUERY_KEY, useElementInstance};

--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import {searchElementInstances} from 'modules/api/v2/elementInstances/searchElementInstances';
+import {QueryElementInstancesRequestBody} from '@vzeta/camunda-api-zod-schemas';
+
+const ELEMENT_INSTANCES_SEARCH_QUERY_KEY = 'elementInstancesSearch';
+
+function getQueryKey(params: QueryElementInstancesRequestBody) {
+  return [ELEMENT_INSTANCES_SEARCH_QUERY_KEY, params];
+}
+
+const useElementInstancesSearch = (
+  params: QueryElementInstancesRequestBody,
+) => {
+  return useQuery({
+    queryKey: getQueryKey(params),
+    queryFn: () =>
+      searchElementInstances(params).then(({response, error}) => {
+        if (response !== null) return response;
+        throw error;
+      }),
+    enabled: !!params,
+  });
+};
+
+export {useElementInstancesSearch, ELEMENT_INSTANCES_SEARCH_QUERY_KEY};


### PR DESCRIPTION
## Description

This PR adds TanStack queries to prepare the migration of the element instances.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33207, #33200 
