### PR TITLE
ci: add weekly summary job to post failing test statistics in Slack

### DIFF
--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -1,0 +1,121 @@
+# description: Generates a weekly summary about CI aspects like failing tests and posts it to Slack
+# type: CI Helper
+# owner: @camunda/monorepo-devops-team
+
+---
+name: Statistics Weekly
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Monday
+  pull_request:
+    paths:
+      - '.github/workflows/statistics-weekly.yml'
+  workflow_dispatch: {}
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  failed-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL;
+            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+
+      - name: Login to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2
+        with:
+          credentials_json: ${{ steps.secrets.outputs.gcloud_sa_key }}
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2
+
+      - name: Print Google Cloud SDK version used
+        shell: bash
+        run: |
+          gcloud info
+
+      - name: Create message with BigQuery data
+        id: message
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          # shellcheck disable=SC2016
+          TOP5_FAILINGTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_fails FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 7 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "failure" AND ((build_trigger="merge_group" AND build_base_ref="refs/heads/main") OR (build_trigger="push" AND build_ref="refs/heads/main")) GROUP BY test_class_name, test_name ORDER BY number_of_fails DESC LIMIT 5')
+
+          {
+            echo "MESSAGE<<EOF"
+            echo ":fire: *Top 5 failing tests on \`main\` last week:*"
+            echo ""
+            echo "$TOP5_FAILINGTESTS" | jq -c '.[]' | while read -r top_failingtest; do
+              NUMBER_OF_FAILS=$(echo "$top_failingtest" | jq -r '.number_of_fails')
+              FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_failingtest" | jq -r '.test_class_name')
+              TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
+              TEST_NAME=$(echo "$top_failingtest" | jq -r '.test_name')
+              SUFFIX=""
+
+              # Try to find GH issues about related (failing) tests:
+              # First, search specifically by test class name + test name
+              GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title $TEST_NAME" --json number --jq '.[].number' | head -n 1)
+              if [ -z "$GH_ISSUE_ID" ]; then
+                # If nothing found, search by test class name
+                GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME" --json number --jq '.[].number' | head -n 1)
+              fi
+              if [ -n "$GH_ISSUE_ID" ]; then
+                SUFFIX=" (<https://github.com/camunda/camunda/issues/$GH_ISSUE_ID|GH issue>)"
+              fi
+
+              printf "• %sx \`%s.%s\`%s\n\n" "$NUMBER_OF_FAILS" "$TEST_CLASS_NAME" "$TEST_NAME" "$SUFFIX"
+
+            done
+            echo ""
+            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1w%2Fw&to=now-1w%2Fw&timezone=browser&var-branch=main|Grafana for links and more details>."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Debug notification
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo '${{ steps.message.outputs.MESSAGE }}'
+
+      - name: Send notification
+        if: github.event_name != 'pull_request'
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPOCI_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          # For posting a rich message using Block Kit
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.message.outputs.MESSAGE }}"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

This PR is similar to #28509 to add a CI job that posts statistics regarding the CI on regular basis to Slack. It is meant to be extensible for the future, and not just post 1 type of information - we should reuse the same job.

Information that this PR includes:

* Weekly top 5 number of failing tests on push and in merge queue to `main` branch (where no test failures are expected)
    * Those tests are worse than flaky tests as they didn't succeed even after 4 retries and fail the build
    * We have only a few failing tests across multiple 1000 builds on `main` and merge queue every week, but those failures are [good to know for devs](https://camunda.slack.com/archives/C071KP5BTHB/p1750765110679319?thread_ts=1750745509.108819&cid=C071KP5BTHB) -> identify issues like https://github.com/camunda/camunda/issues/34209

Example run for this week can be seen in [this PR output as debug info](https://github.com/camunda/camunda/actions/runs/15850066027/job/44681090143?pr=34211#step:8:30)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - not needed since it is a scheduled job on `main`

## Related issues

[Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1750765110679319?thread_ts=1750745509.108819&cid=C071KP5BTHB)
