### PR TITLE
[Backport main] fix: make ZEEBE_CLIENT_SECRET nullable

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -241,7 +241,17 @@ public final class OAuthCredentialsProviderBuilder {
   private void validate() {
     try {
       Objects.requireNonNull(clientId, String.format(INVALID_ARGUMENT_MSG, "client id"));
+<<<<<<< HEAD
       Objects.requireNonNull(clientSecret, String.format(INVALID_ARGUMENT_MSG, "client secret"));
+=======
+      if (sslClientCertConfigurationProvided()) {
+        // loading the certificate from the provided path to ensure it exists and is valid
+        final KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(
+            Files.newInputStream(Paths.get(sslClientCertPath.toAbsolutePath().toString())),
+            sslClientCertPassword.toCharArray());
+      }
+>>>>>>> 9d9e9b49 (fix: make ZEEBE_CLIENT_SECRET nullable)
       Objects.requireNonNull(audience, String.format(INVALID_ARGUMENT_MSG, "audience"));
       Objects.requireNonNull(
           authorizationServerUrl, String.format(INVALID_ARGUMENT_MSG, "authorization server URL"));

--- a/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
@@ -44,21 +44,6 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
-  void shouldFailWithNoClientSecret() {
-    // given
-    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
-
-    // when
-    builder.audience("a").clientId("b").authorizationServerUrl("http://some.url");
-
-    // then
-    assertThatCode(builder::build)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageEndingWith(
-            String.format(OAuthCredentialsProviderBuilder.INVALID_ARGUMENT_MSG, "client secret"));
-  }
-
-  @Test
   void shouldFailWithMalformedServerUrl() {
     // given
     final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();


### PR DESCRIPTION
# Description
Backport of #34164 to `main`.

relates to camunda/camunda#34002