### PR TITLE
test: adjust port number to not confuse people

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
@@ -1097,7 +1097,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Test
         void shouldReadGrpcAddress() {
           assertThat(camundaClientProperties.getRestAddress())
-              .isEqualTo(URI.create("http://localhost:8080"));
+              .isEqualTo(URI.create("http://localhost:18088"));
         }
       }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessorTest.java
@@ -1095,7 +1095,7 @@ public class CamundaClientPropertiesPostProcessorTest {
         @Autowired CamundaClientProperties camundaClientProperties;
 
         @Test
-        void shouldReadGrpcAddress() {
+        void shouldReadRestAddress() {
           assertThat(camundaClientProperties.getRestAddress())
               .isEqualTo(URI.create("http://localhost:18088"));
         }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/rest-address.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/resources/properties/8.7/rest-address.yaml
@@ -1,4 +1,4 @@
 camunda:
   client:
     zeebe:
-      rest-address: http://localhost:8080
+      rest-address: http://localhost:18088


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adjusts a test to use another port than before.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
