### PR TITLE
fix: change type of Icon on OperationItem component

### DIFF
--- a/operate/client/src/modules/components/OperationItem/index.tsx
+++ b/operate/client/src/modules/components/OperationItem/index.tsx
@@ -16,10 +16,10 @@
  */
 
 import {
-  CarbonIconType as Icon,
   Error,
   Tools,
   RetryFailed,
+  CarbonIconType as Icon,
 } from '@carbon/react/icons';
 import {Button, ButtonSize} from '@carbon/react';
 
@@ -37,7 +37,12 @@ type ItemProps = {
 const TYPE_DETAILS: Readonly<
   Record<
     ItemProps['type'],
-    {icon?: Icon; testId: string; isDangerous?: boolean; label?: string}
+    {
+      icon?: Icon;
+      testId: string;
+      isDangerous?: boolean;
+      label?: string;
+    }
   >
 > = {
   RESOLVE_INCIDENT: {icon: RetryFailed, testId: 'retry-operation'},


### PR DESCRIPTION
## Description

Fix type for Icon on OperationItem component to avoid breaking TS errors on the CI when building the FE.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
