### PR TITLE
ci: add timeout for helm update in benchmark tests

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -231,7 +231,7 @@ jobs:
           echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> "$GITHUB_OUTPUT"
       - name: Helm install
         run: >
-          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
+          helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark --wait --timeout 10m0s
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
## Description

The change adds the --wait and --timeout <timeout> flags to the Helm command to fail the workflow if the deployment is not healthy within the specified timeout.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
