### PR TITLE
feat: Refactor Java client's TypedSearchRequest interface

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface CreateBatchOperationCommandStep1 {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AdHocSubProcessActivityFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AdHocSubProcessActivityFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface AdHocSubProcessActivityFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationFilter.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationStateProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationTypeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface BatchOperationFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/BatchOperationItemFilter.java
@@ -20,7 +20,7 @@ import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.BatchOperationItemStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface BatchOperationItemFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionDefinitionFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface DecisionDefinitionFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
 import io.camunda.client.api.search.response.DecisionInstanceState;
 import java.time.OffsetDateTime;

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionRequirementsFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionRequirementsFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 /** Interface for defining Decision Requirements in search queries. */
 public interface DecisionRequirementsFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -18,7 +18,7 @@ package io.camunda.client.api.search.filter;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface ElementInstanceFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface GroupFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupUserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/GroupUserFilter.java
@@ -15,6 +15,6 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface GroupUserFilter extends SearchRequestFilter {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/IncidentFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/IncidentFilter.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface IncidentFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MappingFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface MappingFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessDefinitionFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface ProcessDefinitionFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilterBase.java
@@ -23,7 +23,7 @@ import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface RoleFilter extends SearchRequestFilter {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleUserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/RoleUserFilter.java
@@ -15,6 +15,6 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 
 public interface RoleUserFilter extends SearchRequestFilter {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserFilter.java
@@ -16,7 +16,7 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface UserFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -19,7 +19,7 @@ import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskVariableFilter.java
@@ -16,7 +16,7 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface UserTaskVariableFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableFilter.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface VariableFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableValueFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableValueFilter.java
@@ -16,7 +16,7 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.filter.builder.StringProperty;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import java.util.function.Consumer;
 
 public interface VariableValueFilter extends SearchRequestFilter {

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByProcessInstanceSearchRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/IncidentsByProcessInstanceSearchRequest.java
@@ -17,39 +17,8 @@ package io.camunda.client.api.search.request;
 
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.sort.IncidentSort;
-import java.util.function.Consumer;
 
-public interface IncidentsByProcessInstanceSearchRequest extends FinalSearchRequestStep<Incident> {
-
-  /**
-   * Sets the sorting the returned entities should be sorted by.
-   *
-   * @param value the sort options
-   * @return the builder for the search request
-   */
-  IncidentsByProcessInstanceSearchRequest sort(IncidentSort value);
-
-  /**
-   * Provides a fluent builder to provide sorting options the returned entities should sorted by
-   *
-   * @param fn consumer to create the sort options
-   * @return the builder for the search request
-   */
-  IncidentsByProcessInstanceSearchRequest sort(Consumer<IncidentSort> fn);
-
-  /**
-   * Support for pagination.
-   *
-   * @param value the next page
-   * @return the builder for the search request
-   */
-  IncidentsByProcessInstanceSearchRequest page(SearchRequestPage value);
-
-  /**
-   * Provides a fluent builder to support pagination.
-   *
-   * @param fn consumer to support pagination
-   * @return the builder for the search request
-   */
-  IncidentsByProcessInstanceSearchRequest page(Consumer<SearchRequestPage> fn);
-}
+public interface IncidentsByProcessInstanceSearchRequest
+    extends TypedSortableRequest<IncidentSort, IncidentsByProcessInstanceSearchRequest>,
+        TypedPageableRequest<IncidentsByProcessInstanceSearchRequest>,
+        FinalSearchRequestStep<Incident> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/TypedFilterableRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/TypedFilterableRequest.java
@@ -15,13 +15,25 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
-import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
+import java.util.function.Consumer;
 
-public interface TypedSearchRequest<
-        F extends SearchRequestFilter,
-        S extends SearchRequestSort<S>,
-        SELF extends TypedSearchRequest<F, S, SELF>>
-    extends TypedFilterableRequest<F, SELF>,
-        TypedSortableRequest<S, SELF>,
-        TypedPageableRequest<SELF> {}
+public interface TypedFilterableRequest<F, SELF extends TypedFilterableRequest<F, SELF>> {
+
+  /**
+   * Sets the filter to be included in the search request.
+   *
+   * @param value the filter
+   * @return the builder for the search request
+   */
+  SELF filter(final F value);
+
+  /**
+   * Provides a fluent builder to create a filter to be included in the search request.
+   *
+   * @param fn consumer to create the filter
+   * @return the builder for the search request
+   */
+  SELF filter(final Consumer<F> fn);
+
+  interface SearchRequestFilter {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/TypedPageableRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/TypedPageableRequest.java
@@ -13,8 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.search.filter;
+package io.camunda.client.api.search.request;
 
-import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
-public interface ClientFilter extends SearchRequestFilter {}
+public interface TypedPageableRequest<SELF extends TypedPageableRequest<SELF>> {
+
+  /**
+   * Support for pagination.
+   *
+   * @param value the next page
+   * @return the builder for the search request
+   */
+  SELF page(final SearchRequestPage value);
+
+  /**
+   * Provides a fluent builder to support pagination.
+   *
+   * @param fn consumer to support pagination
+   * @return the builder for the search request
+   */
+  SELF page(final Consumer<SearchRequestPage> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/TypedSortableRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/TypedSortableRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.request;
+
+import java.util.function.Consumer;
+
+public interface TypedSortableRequest<S, SELF extends TypedSortableRequest<S, SELF>> {
+
+  /**
+   * Sets the sorting the returned entities should be sorted by.
+   *
+   * @param value the sort options
+   * @return the builder for the search request
+   */
+  SELF sort(final S value);
+
+  /**
+   * Provides a fluent builder to provide sorting options the returned entities should sorted by
+   *
+   * @param fn consumer to create the sort options
+   * @return the builder for the search request
+   */
+  SELF sort(final Consumer<S> fn);
+
+  interface SearchRequestSort<S extends SearchRequestSort<S>> {
+
+    /**
+     * Sort in ascending order
+     *
+     * @return the sort builder
+     */
+    S asc();
+
+    /**
+     * Sort in descending order
+     *
+     * @return the sort builder
+     */
+    S desc();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationItemSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface BatchOperationItemSort extends SearchRequestSort<BatchOperationItemSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/BatchOperationSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface BatchOperationSort extends SearchRequestSort<BatchOperationSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ClientSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ClientSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface ClientSort extends SearchRequestSort<ClientSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionDefinitionSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface DecisionDefinitionSort extends SearchRequestSort<DecisionDefinitionSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionInstanceSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface DecisionInstanceSort extends SearchRequestSort<DecisionInstanceSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionRequirementsSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/DecisionRequirementsSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface DecisionRequirementsSort extends SearchRequestSort<DecisionRequirementsSort> {
   /** Sort by decision requirements key. */

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ElementInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ElementInstanceSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface ElementInstanceSort extends SearchRequestSort<ElementInstanceSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface GroupSort extends SearchRequestSort<GroupSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupUserSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/GroupUserSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface GroupUserSort extends SearchRequestSort<GroupUserSort> {
   GroupUserSort username();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/IncidentSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/IncidentSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface IncidentSort extends SearchRequestSort<IncidentSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/MappingSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/MappingSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface MappingSort extends SearchRequestSort<MappingSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessDefinitionSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface ProcessDefinitionSort extends SearchRequestSort<ProcessDefinitionSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/ProcessInstanceSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface ProcessInstanceSort extends SearchRequestSort<ProcessInstanceSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface RoleSort extends SearchRequestSort<RoleSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleUserSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/RoleUserSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface RoleUserSort extends SearchRequestSort<RoleUserSort> {
   RoleUserSort username();

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/UserSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/UserSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface UserSort extends SearchRequestSort<UserSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/UserTaskSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/UserTaskSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface UserTaskSort extends SearchRequestSort<UserTaskSort> {
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/VariableSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/VariableSort.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.sort;
 
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestSort;
+import io.camunda.client.api.search.request.TypedSortableRequest.SearchRequestSort;
 
 public interface VariableSort extends SearchRequestSort<VariableSort> {
   VariableSort variableKey();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -29,7 +29,7 @@ import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.response.CreateBatchOperationResponse;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.request.SearchRequestBuilders;
-import io.camunda.client.api.search.request.TypedSearchRequest.SearchRequestFilter;
+import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateBatchOperationResponseImpl;


### PR DESCRIPTION
## Description

While working on https://github.com/camunda/camunda/issues/33135 we needed a Search request interface for the Java client that included paginating and sorting options but no filtering options. However, [TypedSearchRequest](https://github.com/camunda/camunda/blob/15ebf00d3a9c5e1059f7caf4821f2acb892c32cc/clients/java/src/main/java/io/camunda/client/api/search/request/TypedSearchRequest.java) as an interface exposed methods for all 3 of those types of operations.

In this PR I created individual interfaces for each of those types of operations: 
* `TypedFilterableRequest.java` for filtering
* `TypedPageableRequest.java` for paginating and
* `TypedSortableRequest.java` for sorting

`TypedSearchRequest.java` is updated to extend those 3 interfaces, so its functionality should not really change.

`IncidentsByProcessInstanceSearchRequest.java` is also updated so it can extend the sorting and paginating interfaces instead of duplicating their behaviour.

