### PR TITLE
2794 add logs for deprecated zeebe clients

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.ClientProperties}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.ClientProperties}
  */
 @Deprecated
 public final class ClientProperties {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 /**
  * Implementations of this interface must be thread-safe.
  *
- * @deprecated since 8.8 for removal in 8.9. replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10. replaced by {@link
  *     io.camunda.client.CredentialsProvider}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -63,7 +63,7 @@ import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 /**
  * The client to communicate with a Zeebe broker/cluster.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.CamundaClient}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.CamundaClient}
  */
 @Deprecated
 public interface ZeebeClient extends AutoCloseable, JobClient {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.CamundaClientBuilder}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.CamundaClientCloudBuilderStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.CamundaClientConfiguration}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * <p>This annotation was originally copied from io.grpc.ExperimentalApi, licensed under the Apache
  * License, Version 2.0. Copyright 2015 The gRPC Authors. Changes have been made since.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.ExperimentalApi}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
@@ -51,7 +51,7 @@ import java.util.Map;
  * Null values won't pass in the JSON with variables: {@code { "a": "b" } }
  *
  * @see ZeebeObjectMapper
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.api.JsonMapper}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.api.JsonMapper}
  */
 @Deprecated
 public interface JsonMapper {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.api.CamundaFuture}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.api.CamundaFuture}
  */
 @Deprecated
 public interface ZeebeFuture<T> extends Future<T>, CompletionStage<T> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
@@ -22,7 +22,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.api.CamundaFuture}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
+ *     io.camunda.client.api.CamundaFuture}
  */
 @Deprecated
 public interface ZeebeFuture<T> extends Future<T>, CompletionStage<T> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ActivateJobsCommandStep1}
  */
 @Deprecated
@@ -36,7 +36,7 @@ public interface ActivateJobsCommandStep1
   ActivateJobsCommandStep2 jobType(String jobType);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep2}
    */
   @Deprecated
@@ -53,7 +53,7 @@ public interface ActivateJobsCommandStep1
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.AddPermissionsCommandStep1}
  */
 @Deprecated
@@ -36,7 +36,7 @@ public interface AddPermissionsCommandStep1 {
   AddPermissionsCommandStep2 resourceType(ResourceTypeEnum resourceType);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep2}
    */
   @Deprecated
@@ -52,7 +52,7 @@ public interface AddPermissionsCommandStep1 {
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep3}
    */
   interface AddPermissionsCommandStep3 {
@@ -75,7 +75,7 @@ public interface AddPermissionsCommandStep1 {
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep4}
    */
   interface AddPermissionsCommandStep4

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.AssignUserTaskCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.BroadcastSignalCommandStep1}
  */
 @Deprecated
@@ -36,7 +36,7 @@ public interface BroadcastSignalCommandStep1
   BroadcastSignalCommandStep2 signalName(String signalName);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.BroadcastSignalCommandStep1.BroadcastSignalCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.CancelProcessInstanceResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CancelProcessInstanceCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientException.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ClientException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientHttpException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientHttpException.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ClientHttpException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientStatusException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientStatusException.java
@@ -19,7 +19,7 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ClientStatusException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.response.PinClockResponse;
 import java.time.Instant;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ClockPinCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.ResetClockResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ClockResetCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CommandWithCommunicationApiStep}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CommandWithOneOrMoreTenantsStep}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CommandWithOperationReferenceStep}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CommandWithTenantStep}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CompleteJobCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * request handling before sending it the gateway. The list of options might be extended in the
  * future.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CompleteUserTaskCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CorrelateMessageCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentBatchCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentBatchCommandStep1.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CreateDocumentBatchCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentCommandStep1.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CreateDocumentCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentLinkCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentLinkCommandStep1.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 /**
  * Command to create a document link in the document store.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CreateDocumentLinkCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CreateProcessInstanceCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateUserCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.CreateUserResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.CreateUserCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteDocumentCommandStep1.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.response.DeleteDocumentResponse;
 /**
  * Command to delete a document from the document store.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.DeleteDocumentCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteResourceCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.DeleteResourceCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.DeployResourceCommandStep1}
  */
 @Deprecated
@@ -103,7 +103,7 @@ public interface DeployResourceCommandStep1
       BpmnModelInstance processDefinition, String resourceName);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DocumentBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DocumentBuilderStep1.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.DocumentBuilderStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.EvaluateDecisionCommandStep1}
  */
 @Deprecated
@@ -46,7 +46,7 @@ public interface EvaluateDecisionCommandStep1
   EvaluateDecisionCommandStep2 decisionKey(long decisionKey);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.EvaluateDecisionCommandStep1.EvaluateDecisionCommandStep2}
    */
   interface EvaluateDecisionCommandStep2

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.FailJobCommandStep1}
  */
 public interface FailJobCommandStep1 extends CommandWithCommunicationApiStep<FailJobCommandStep1> {
@@ -39,7 +39,7 @@ public interface FailJobCommandStep1 extends CommandWithCommunicationApiStep<Fai
   FailJobCommandStep2 retries(int remainingRetries);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2}
    */
   interface FailJobCommandStep2 extends FinalCommandStep<FailJobResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FinalCommandStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FinalCommandStep.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.ZeebeFuture;
 import java.time.Duration;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.FinalCommandStep}
  */
 public interface FinalCommandStep<T> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/InternalClientException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/InternalClientException.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 /**
  * Exception which is thrown on internal errors inside the client itself.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.InternalClientException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MalformedResponseException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MalformedResponseException.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.command;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.MalformedResponseException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.response.MigrateProcessInstanceResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.MigrateProcessInstanceCommandStep1}
  */
 @Deprecated
@@ -72,7 +72,7 @@ public interface MigrateProcessInstanceCommandStep1
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.MigrateProcessInstanceCommandStep1.MigrateProcessInstanceCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlan.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlan.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.command.MigrationPlanBuilderImpl.MappingInstr
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.MigrationPlan}
  */
 @Deprecated
@@ -47,7 +47,7 @@ public interface MigrationPlan {
   public List<MappingInstruction> getMappingInstructions();
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderStep1}
    */
   @Deprecated
@@ -63,7 +63,7 @@ public interface MigrationPlan {
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderStep2}
    */
   @Deprecated
@@ -96,7 +96,7 @@ public interface MigrationPlan {
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderFinalStep}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanBuilderImpl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.MigrationPlanBuilderImpl}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanImpl.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.command.MigrationPlanBuilderImpl.MappingInstr
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.MigrationPlanImpl}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1}
  */
 @Deprecated
@@ -63,7 +63,7 @@ public interface ModifyProcessInstanceCommandStep1
   ModifyProcessInstanceCommandStep2 terminateElement(final long elementInstanceKey);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2}
    */
   @Deprecated
@@ -80,7 +80,7 @@ public interface ModifyProcessInstanceCommandStep1
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ProblemException}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.PublishMessageCommandStep1}
  */
 @Deprecated
@@ -37,7 +37,7 @@ public interface PublishMessageCommandStep1
   PublishMessageCommandStep2 messageName(String messageName);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep2}
    */
   @Deprecated
@@ -67,7 +67,7 @@ public interface PublishMessageCommandStep1
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.ResolveIncidentResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ResolveIncidentCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.SetVariablesCommandStep1}
  */
 @Deprecated
@@ -63,7 +63,7 @@ public interface SetVariablesCommandStep1
   SetVariablesCommandStep2 variables(Object variables);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.SetVariablesCommandStep1.SetVariablesCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.StreamJobsCommandStep1}
  */
 @Deprecated
@@ -39,7 +39,7 @@ public interface StreamJobsCommandStep1 {
   StreamJobsCommandStep2 jobType(String jobType);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep2}
    */
   @Deprecated
@@ -57,7 +57,7 @@ public interface StreamJobsCommandStep1 {
   }
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
@@ -19,7 +19,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.ThrowErrorCommandStep1}
  */
 @Deprecated
@@ -38,7 +38,7 @@ public interface ThrowErrorCommandStep1
   ThrowErrorCommandStep2 errorCode(String errorCode);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.Topology;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.TopologyRequestStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.UnassignUserTaskCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateJobCommandStep1.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.protocol.rest.JobChangeset;
 import java.time.Duration;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.UpdateJobCommandStep1}
  */
 @Deprecated
@@ -95,7 +95,7 @@ public interface UpdateJobCommandStep1 {
   UpdateJobCommandStep2 updateTimeout(Duration timeout);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.UpdateJobCommandStep1.UpdateJobCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.UpdateRetriesJobResponse;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.UpdateRetriesJobCommandStep1}
  */
 @Deprecated
@@ -37,7 +37,7 @@ public interface UpdateRetriesJobCommandStep1
   UpdateRetriesJobCommandStep2 retries(int retries);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.UpdateRetriesJobCommandStep1.UpdateRetriesJobCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.response.UpdateTimeoutJobResponse;
 import java.time.Duration;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.UpdateTimeoutJobCommandStep1}
  */
 @Deprecated
@@ -51,7 +51,7 @@ public interface UpdateTimeoutJobCommandStep1
   UpdateTimeoutJobCommandStep2 timeout(Duration timeout);
 
   /**
-   * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+   * @deprecated since 8.8 for removal in 8.10, replaced by {@link
    *     io.camunda.client.api.command.UpdateTimeoutJobCommandStep1.UpdateTimeoutJobCommandStep2}
    */
   @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.command.UpdateUserTaskCommandStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DecisionDefinitionGetXmlRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DecisionDefinitionGetXmlRequest.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.fetch;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
  *
  * <p>The document content is returned as an {@link InputStream}.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.fetch.DocumentContentGetRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivateJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivateJobsResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ActivateJobsResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.command.ClientException;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ActivatedJob}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.AddPermissionsResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.AssignUserTaskResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.BroadcastSignalResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BrokerInfo.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BrokerInfo.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.BrokerInfo}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CancelProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CancelProcessInstanceResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.CancelProcessInstanceResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteJobResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.CompleteJobResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.CompleteUserTaskResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.CorrelateMessageResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.CreateUserResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.Decision}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DecisionRequirements}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteDocumentResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteDocumentResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DeleteDocumentResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteResourceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteResourceResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DeleteResourceResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DeploymentEvent}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentLinkResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentLinkResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.time.OffsetDateTime;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DocumentLinkResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentMetadata.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentMetadata.java
@@ -19,7 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DocumentMetadata}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceBatchResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceBatchResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DocumentReferenceBatchResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.DocumentReferenceResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.EvaluateDecisionResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.EvaluatedDecision}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.EvaluatedDecisionInput}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.EvaluatedDecisionOutput}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/FailJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/FailJobResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.FailJobResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.api.response.Form}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.api.response.Form}
  */
 @Deprecated
 public interface Form {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
@@ -16,7 +16,8 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.10, replaced by {@link io.camunda.client.api.response.Form}
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
+ *     io.camunda.client.api.response.Form}
  */
 @Deprecated
 public interface Form {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.MatchedDecisionRule}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MigrateProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MigrateProcessInstanceResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.MigrateProcessInstanceResponse}
  */
 @ExperimentalApi("https://github.com/camunda/camunda/issues/14907")

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ModifyProcessInstanceResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerHealth.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerHealth.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.PartitionBrokerHealth}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerRole.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerRole.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.PartitionBrokerRole}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionInfo.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionInfo.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.PartitionInfo}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PinClockResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PinClockResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.PinClockResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.Process}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ProcessInstanceEvent}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.command.ClientException;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ProcessInstanceResult}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.PublishMessageResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResetClockResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResetClockResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ResetClockResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResolveIncidentResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResolveIncidentResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.ResolveIncidentResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/SetVariablesResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/SetVariablesResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.SetVariablesResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.StreamJobsResponse}
  */
 @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Topology.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Topology.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.Topology}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.UnassignUserTaskResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateJobResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.UpdateJobResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateRetriesJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateRetriesJobResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.UpdateRetriesJobResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateTimeoutJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateTimeoutJobResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.UpdateTimeoutJobResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.response.UpdateUserTaskResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
@@ -31,7 +31,7 @@ import io.camunda.zeebe.client.api.search.sort.UserTaskSort;
 import java.util.function.Consumer;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.SearchRequestBuilders}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.SearchRequestPage}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.filter;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.DecisionDefinitionFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionRequirementsFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionRequirementsFilter.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 /**
  * Interface for defining Decision Requirmeent in search queries.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.DecisionRequirementsFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.filter;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.ElementInstanceFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/IncidentFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/IncidentFilter.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.filter;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.IncidentFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
@@ -19,7 +19,7 @@ import io.camunda.client.protocol.rest.VariableValueFilterProperty;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.ProcessInstanceFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.UserTaskFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/VariableValueFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/VariableValueFilter.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.filter;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.filter.VariableValueFilter}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionDefinitionQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionDefinitionQuery.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.response.DecisionDefinition;
 import io.camunda.zeebe.client.api.search.sort.DecisionDefinitionSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.DecisionDefinitionSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionRequirementsQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionRequirementsQuery.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.api.search.response.DecisionRequirements;
 import io.camunda.zeebe.client.api.search.sort.DecisionRequirementsSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.DecisionRequirementsSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FinalSearchQueryStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FinalSearchQueryStep.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
 import java.time.Duration;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.FinalSearchRequestStep}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FlownodeInstanceQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FlownodeInstanceQuery.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.response.FlowNodeInstance;
 import io.camunda.zeebe.client.api.search.sort.FlownodeInstanceSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.ElementInstanceSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/IncidentQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/IncidentQuery.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.response.Incident;
 import io.camunda.zeebe.client.api.search.sort.IncidentSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.IncidentSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/ProcessInstanceQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/ProcessInstanceQuery.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.client.api.search.response.ProcessInstance;
 import io.camunda.zeebe.client.api.search.sort.ProcessInstanceSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.ProcessInstanceSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/TypedSearchQueryRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/TypedSearchQueryRequest.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 import java.util.function.Consumer;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.TypedSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/UserTaskQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/UserTaskQuery.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.api.search.response.UserTask;
 import io.camunda.zeebe.client.api.search.sort.UserTaskSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.request.UserTaskSearchRequest}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionDefinition.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionDefinition.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.response;
 import io.camunda.zeebe.client.api.response.Decision;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.DecisionDefinition}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstanceReference.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.DecisionInstanceReference}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionRequirements.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionRequirements.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.DecisionRequirements}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.ElementInstance}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Incident.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Incident.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.Incident}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Operation.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Operation.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.Operation}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.ProcessInstance}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.client.api.search.response;
 
 /**
- * @deprecated this class will be removed with version 8.9.
+ * @deprecated this class will be removed with version 8.10.
  */
 @Deprecated
 public interface ProcessInstanceReference {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.SearchResponse}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.response;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.SearchResponsePage}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.response.UserTask}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.DecisionDefinitionSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionRequirementsSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionRequirementsSort.java
@@ -19,7 +19,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.DecisionRequirementsSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/FlownodeInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/FlownodeInstanceSort.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.ElementInstanceSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/IncidentSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/IncidentSort.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.IncidentSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/ProcessInstanceSort.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.ProcessInstanceSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/UserTaskSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/UserTaskSort.java
@@ -19,7 +19,7 @@ package io.camunda.zeebe.client.api.search.sort;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.search.sort.UserTaskSort}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java
@@ -28,7 +28,7 @@ import java.time.Duration;
  * <p>The supplier is called after a failed request. The worker will then await the supplied delay
  * before sending the next request.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.BackoffSupplier}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/ExponentialBackoffBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/ExponentialBackoffBuilder.java
@@ -18,7 +18,7 @@ package io.camunda.zeebe.client.api.worker;
 import java.util.Random;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.ExponentialBackoffBuilder}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
@@ -32,7 +32,7 @@ import java.time.Duration;
  * <li>mark a job as failed
  * <li>update the retries of a job
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.JobClient}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobHandler.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobHandler.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 /**
  * Implementations MUST be thread-safe.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.JobHandler}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
@@ -20,7 +20,7 @@ package io.camunda.zeebe.client.api.worker;
  * open, the client continuously receives jobs from the broker and hands them to a registered {@link
  * JobHandler}.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.JobWorker}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.util.List;
 
 /**
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.JobWorkerBuilderStep1}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.client.impl.worker.metrics.MicrometerJobWorkerMetricsBui
 /**
  * Worker metrics API. Allows basic instrumenting of job activation and handling.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.JobWorkerMetrics}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
@@ -40,7 +40,7 @@ import io.micrometer.core.instrument.Tag;
  * <p>NOTE: the names may be changed depending on the registry backing Micrometer (e.g. Prometheus
  * names will replace the periods with underscore, etc.)
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
  *     io.camunda.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder}
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -17,8 +17,6 @@
 package io.camunda.zeebe.client.impl;
 
 import com.google.protobuf.GeneratedMessageV3;
-import io.camunda.client.CamundaClient;
-import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
@@ -31,15 +29,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
     extends CompletableFuture<ClientResponse>
     implements ZeebeFuture<ClientResponse>,
         ClientResponseObserver<GeneratedMessageV3, BrokerResponse> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientFutureImpl.class);
 
   protected ClientCallStreamObserver<GeneratedMessageV3> clientCall;
   private final Function<BrokerResponse, ClientResponse> responseMapper;
@@ -55,10 +49,6 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join() {
     try {
-      LOG.warn(
-          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);
@@ -79,10 +69,6 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join(final long timeout, final TimeUnit unit) {
     try {
-      LOG.warn(
-          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
       return get(timeout, unit);
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -17,9 +17,13 @@
 package io.camunda.zeebe.client.impl;
 
 import com.google.protobuf.GeneratedMessageV3;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCallStreamObserver;
@@ -29,11 +33,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
     extends CompletableFuture<ClientResponse>
     implements ZeebeFuture<ClientResponse>,
         ClientResponseObserver<GeneratedMessageV3, BrokerResponse> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpZeebeFuture.class);
 
   protected ClientCallStreamObserver<GeneratedMessageV3> clientCall;
   private final Function<BrokerResponse, ClientResponse> responseMapper;
@@ -49,6 +57,9 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join() {
     try {
+      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);
@@ -69,6 +80,9 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join(final long timeout, final TimeUnit unit) {
     try {
+      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get(timeout, unit);
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -18,12 +18,10 @@ package io.camunda.zeebe.client.impl;
 
 import com.google.protobuf.GeneratedMessageV3;
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.CamundaFuture;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
-import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCallStreamObserver;
@@ -41,7 +39,7 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
     implements ZeebeFuture<ClientResponse>,
         ClientResponseObserver<GeneratedMessageV3, BrokerResponse> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HttpZeebeFuture.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientFutureImpl.class);
 
   protected ClientCallStreamObserver<GeneratedMessageV3> clientCall;
   private final Function<BrokerResponse, ClientResponse> responseMapper;
@@ -58,8 +56,7 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   public ClientResponse join() {
     try {
       LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
+          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);
@@ -81,8 +78,7 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   public ClientResponse join(final long timeout, final TimeUnit unit) {
     try {
       LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
+          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
       return get(timeout, unit);
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientFutureImpl.java
@@ -55,8 +55,10 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join() {
     try {
-      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
+      LOG.warn(
+          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);
@@ -77,8 +79,10 @@ public class ZeebeClientFutureImpl<ClientResponse, BrokerResponse>
   @Override
   public ClientResponse join(final long timeout, final TimeUnit unit) {
     try {
-      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
+      LOG.warn(
+          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get(timeout, unit);
     } catch (final ExecutionException e) {
       throw transformExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -189,7 +189,6 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final HttpClient httpClient) {
     LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
         ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
-
     this.config = config;
     jsonMapper = config.getJsonMapper();
     this.channel = channel;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -124,8 +124,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ZeebeClientImpl implements ZeebeClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientImpl.class);
 
   private static final String UNSUPPORTED_OPERATION_MSG =
       String.format(
@@ -183,6 +187,10 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final GatewayStub gatewayStub,
       final ExecutorResource executorResource,
       final HttpClient httpClient) {
+    LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+        ZeebeClient.class.getSimpleName(),
+        CamundaClient.class.getSimpleName());
+
     this.config = config;
     jsonMapper = config.getJsonMapper();
     this.channel = channel;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -188,8 +188,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final ExecutorResource executorResource,
       final HttpClient httpClient) {
     LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-        ZeebeClient.class.getSimpleName(),
-        CamundaClient.class.getSimpleName());
+        ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
 
     this.config = config;
     jsonMapper = config.getJsonMapper();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -187,8 +187,10 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final GatewayStub gatewayStub,
       final ExecutorResource executorResource,
       final HttpClient httpClient) {
-    LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-        ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
+    LOG.warn(
+        "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+        ZeebeClient.class.getSimpleName(),
+        CamundaClient.class.getSimpleName());
     this.config = config;
     jsonMapper = config.getJsonMapper();
     this.channel = channel;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -287,7 +287,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     final List<ClientInterceptor> defaultInterceptors = getDefaultInterceptors();
 
     if (!configInterceptors.isEmpty()) {
-      List<ClientInterceptor> allInterceptors = new ArrayList<>(configInterceptors);
+      final List<ClientInterceptor> allInterceptors = new ArrayList<>(configInterceptors);
       allInterceptors.addAll(defaultInterceptors);
       return gatewayStub.withInterceptors(allInterceptors.toArray(new ClientInterceptor[] {}));
     }
@@ -296,7 +296,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   private static List<ClientInterceptor> getDefaultInterceptors() {
-    List<ClientInterceptor> defaultInterceptors = new ArrayList<>();
+    final List<ClientInterceptor> defaultInterceptors = new ArrayList<>();
     defaultInterceptors.add(getZeebeGrpcDeprecationInterceptor());
     return defaultInterceptors;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -16,7 +16,9 @@
 package io.camunda.zeebe.client.impl.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ClientException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -227,6 +229,11 @@ public final class HttpClient implements AutoCloseable {
       final Class<HttpT> responseType,
       final JsonResponseTransformer<HttpT, RespT> transformer,
       final HttpZeebeFuture<RespT> result) {
+
+    LOGGER.warn(
+        "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+        ZeebeClient.class.getSimpleName(),
+        CamundaClient.class.getSimpleName());
 
     final URI target = buildRequestURI(path);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -16,7 +16,6 @@
 package io.camunda.zeebe.client.impl.http;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.CamundaFuture;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
@@ -44,8 +43,10 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   @Override
   public RespT join() {
     try {
-      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
+      LOG.warn(
+          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);
@@ -67,8 +68,10 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   @Override
   public RespT join(final long timeout, final TimeUnit unit) {
     try {
-      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
+      LOG.warn(
+          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return super.get(timeout, unit);
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -45,8 +45,7 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   public RespT join() {
     try {
       LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
+          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);
@@ -69,8 +68,7 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   public RespT join(final long timeout, final TimeUnit unit) {
     try {
       LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
+          ZeebeClient.class.getSimpleName(), CamundaClient.class.getSimpleName());
       return super.get(timeout, unit);
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
-import io.camunda.client.CamundaClient;
-import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ProblemException;
@@ -25,8 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implements a {@link ZeebeFuture} representing a HTTP call. Supports propagating cancellation of
@@ -36,17 +32,11 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements ZeebeFuture<RespT> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HttpZeebeFuture.class);
-
   private volatile Future<?> transportFuture;
 
   @Override
   public RespT join() {
     try {
-      LOG.warn(
-          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);
@@ -68,10 +58,6 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   @Override
   public RespT join(final long timeout, final TimeUnit unit) {
     try {
-      LOG.warn(
-          "{} is deprecated and will be removed in version 8.10. Please migrate to {}",
-          ZeebeClient.class.getSimpleName(),
-          CamundaClient.class.getSimpleName());
       return super.get(timeout, unit);
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -15,6 +15,9 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.ProblemException;
@@ -23,6 +26,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implements a {@link ZeebeFuture} representing a HTTP call. Supports propagating cancellation of
@@ -32,11 +37,16 @@ import java.util.concurrent.TimeoutException;
  */
 public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements ZeebeFuture<RespT> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(HttpZeebeFuture.class);
+
   private volatile Future<?> transportFuture;
 
   @Override
   public RespT join() {
     try {
+      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return get();
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);
@@ -58,6 +68,9 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
   @Override
   public RespT join(final long timeout, final TimeUnit unit) {
     try {
+      LOG.warn("{} is deprecated and will be removed in version 8.10. Please migrate to {}",
+          ZeebeClient.class.getSimpleName(),
+          CamundaClient.class.getSimpleName());
       return super.get(timeout, unit);
     } catch (final ExecutionException e) {
       throw unwrapExecutionException(e);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/JobChangeset.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/JobChangeset.java
@@ -21,7 +21,7 @@ import java.util.Objects;
  * Added to keep compatibility with the previous version of the client. Used in {@link
  * io.camunda.zeebe.client.api.command.UpdateJobCommandStep1#update(JobChangeset)}
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by #TODO
+ * @deprecated since 8.8 for removal in 8.10, replaced by #TODO
  *     https://github.com/camunda/camunda/issues/26851
  */
 @Deprecated

--- a/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/ProblemDetail.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/ProblemDetail.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  * Added to keep compatibility with the previous version of the client. Used in {@link
  * io.camunda.zeebe.client.api.command.ProblemException#details()}.
  *
- * @deprecated since 8.8 for removal in 8.9, replaced by #TODO
+ * @deprecated since 8.8 for removal in 8.10, replaced by #TODO
  *     https://github.com/camunda/camunda/issues/26851
  */
 @Deprecated


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Make sure client is aware that Zeebe Client is deprecated and that is going to be removed at 8.10 version.
- Refactor 8.9 removal to 8.10
- Add log warnings
  - run once on ZeebeClientImpl creation
  - spam mode, each time ZeebeClient call send

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/product-hub/issues/2794
related doc PR: https://github.com/camunda/camunda-docs/pull/6038
