### PR TITLE
Console Ping spike

### DIFF
--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -83,6 +83,15 @@ zeebe:
       ioThreadCount: 2
 
 camunda:
+  console:
+    ping:
+      enabled: true
+      endpoint: https://webhook.site/6480438f-a2ca-41c7-b71e-8a6f4c7fc942
+      clusterId: 123
+      clusterName: myCLuster
+      pingPeriod: 33
+      properties:
+
   database:
     # Controls which database must be used, possible values: elasticsearch, opensearch
     # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import java.util.Map;
+
+// @ConfigurationProperties(prefix = "camunda.console.ping")
+public class PingConfiguration {
+  private boolean enabled = false;
+  private String clusterId;
+  private String clusterName;
+  private String endpoint;
+  // number of minutes before the next ping
+  private int pingPeriod = 60;
+  private Map<String, String> properties;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public void setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(final String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(final String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public int getPingPeriod() {
+    return pingPeriod;
+  }
+
+  public void setPingPeriod(final int pingPeriod) {
+    this.pingPeriod = pingPeriod;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(final Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public int hashCode() {
+    return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  }
+
+  @Override
+  public String toString() {
+    return "PingConfiguration(enabled="
+        + isEnabled()
+        + ", CusterId="
+        + getClusterId()
+        + ", ClusterName="
+        + getClusterName()
+        + ", consoleEndpoint="
+        + getEndpoint()
+        + ", pingPeriod="
+        + getPingPeriod()
+        + ", properties="
+        + getProperties()
+        + ")";
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+// @EnableConfigurationProperties(PingConfiguration.class)
+public class PingConsoleConfiguration {
+  public static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleConfiguration.class);
+
+  private final PingConfiguration pingConfiguration;
+
+  private final ManagementServices managementServices;
+
+  public PingConsoleConfiguration(final ManagementServices managementServices) {
+    this.managementServices = managementServices;
+    pingConfiguration = new PingConfiguration();
+    // TODO: remove this hardcoded values.
+    pingConfiguration.setClusterId("123");
+    pingConfiguration.setClusterName("Mycluster");
+    pingConfiguration.setEnabled(true);
+    pingConfiguration.setPingPeriod(60);
+    pingConfiguration.setEndpoint("https://webhook.site/6480438f-a2ca-41c7-b71e-8a6f4c7fc94");
+  }
+
+  @PostConstruct
+  public void validate() {
+    // TODO: validate config here.
+    // should only try to validate if ping is enabled
+
+    // if endpoint is not set, should fail
+    // endpoint validity should be checked at runtime? throw warnings after
+    // several failed attempts?
+
+    // if clusterId is not set, should fail
+    // if period is not set, should fail
+
+    if (false) {
+      throw new IllegalStateException("Invalid Configuration.");
+    }
+  }
+
+  @Bean("persistentConsolePingTaskExecutor")
+  public ScheduledThreadPoolExecutor persistentConsolePingTaskExecutor() {
+    if (!pingConfiguration.isEnabled()) {
+      LOGGER.info("Console ping is disabled, skipping task creation.");
+      return null;
+    }
+    LOGGER.info(
+        "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+        pingConfiguration.getEndpoint(),
+        pingConfiguration.getPingPeriod());
+
+    final var executor = createTaskExecutor();
+    executor.schedule(
+        // TODO: use the config deleay period here.
+        new SelfSchedulingTask(
+            executor, new PingConsoleTask(managementServices, pingConfiguration), 1000),
+        1000,
+        TimeUnit.MILLISECONDS);
+    return executor;
+  }
+
+  public ScheduledThreadPoolExecutor createTaskExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("console-license-ping-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOGGER))
+            .factory();
+    final var executor = new ScheduledThreadPoolExecutor(0, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+    executor.allowCoreThreadTimeOut(true);
+    executor.setKeepAliveTime(1, TimeUnit.MINUTES);
+    executor.setCorePoolSize(1);
+    return executor;
+  }
+
+  // TODO: autowhire the configs.
+  //  @ConfigurationProperties("camunda.console.ping")
+  //  public record PingProps(
+  //      boolean enabled, String endpoint, String clusterId, String clusterName, int pingPeriod) {}
+
+  static final class SelfSchedulingTask implements Runnable {
+
+    private final ScheduledThreadPoolExecutor executor;
+    private final Runnable task;
+    private final long delay;
+
+    SelfSchedulingTask(
+        final ScheduledThreadPoolExecutor executor, final Runnable task, final long delay) {
+      this.executor = executor;
+      this.task = task;
+      this.delay = delay;
+    }
+
+    @Override
+    public void run() {
+      task.run();
+      executor.schedule(this, delay, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.service.ManagementServices;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PingConsoleTask implements Runnable {
+
+  public static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleTask.class);
+  private static final int NUMBER_OF_MAX_RETRIES = 10;
+  private static final int INITIAL_RETRY_DELAY_MS = 500;
+
+  private final ManagementServices managementServices;
+  private final PingConfiguration pingConfiguration;
+  private final HttpClient client;
+
+  public PingConsoleTask(
+      final ManagementServices managementServices, final PingConfiguration pingConfiguration) {
+    this.managementServices = managementServices;
+    this.pingConfiguration = pingConfiguration;
+    client = HttpClient.newHttpClient();
+  }
+
+  @Override
+  public void run() {
+
+    try {
+      final HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(pingConfiguration.getEndpoint()))
+              .POST(HttpRequest.BodyPublishers.ofString(getLicensePayload()))
+              .build();
+
+      RetryUtil.executeWithRetry(
+          () -> tryPingConsole(request), NUMBER_OF_MAX_RETRIES, INITIAL_RETRY_DELAY_MS);
+
+    } catch (final Exception e) {
+      if (e instanceof JsonProcessingException) {
+        LOGGER.warn("Failed to parse payload for Console ping task: {}", e.getMessage());
+      } else {
+        LOGGER.warn(
+            "Failed to execute Console ping task, after {} retries. Exception Message: {}. {}",
+            NUMBER_OF_MAX_RETRIES,
+            e.getMessage(),
+            e);
+      }
+
+      // TODO: later to remove this log also
+      LOGGER.info("Running the Console ping task.");
+    }
+  }
+
+  private HttpResponse<String> tryPingConsole(final HttpRequest request) {
+    // TODO: create custome exceptions for the ping task
+    try {
+      final HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString());
+      // We should retry on server errors, timeouts or too many request.
+      if (resp.statusCode() >= 500) {
+        throw new RuntimeException("Server error: " + resp.statusCode());
+      } else if (resp.statusCode() == 429 || resp.statusCode() == 408) {
+        throw new RuntimeException("Too many requests or timeout: " + resp.statusCode());
+      } else if (resp.statusCode() >= 400) {
+        // Should not retry for the remaining 4xx errors, but we log them.
+        LOGGER.warn(
+            "Received client error response: {}. No retry will be attempted.", resp.statusCode());
+      }
+      return resp;
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getLicensePayload() throws JsonProcessingException {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final LicensePayload.License license =
+        new LicensePayload.License(
+            managementServices.isCamundaLicenseValid(),
+            managementServices.getCamundaLicenseType().toString(),
+            managementServices.isCommercialCamundaLicense(),
+            managementServices.getCamundaLicenseExpiresAt() == null
+                ? null
+                : DATE_TIME_FORMATTER.format(managementServices.getCamundaLicenseExpiresAt()));
+    final LicensePayload payload =
+        new LicensePayload(
+            license,
+            pingConfiguration.getClusterId(),
+            pingConfiguration.getClusterName(),
+            pingConfiguration.getProperties());
+    return objectMapper.writeValueAsString(payload);
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record LicensePayload(
+      License license, String clusterId, String clusterName, Map<String, String> properties) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record License(
+        boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
+  }
+
+  public static class RetryUtil {
+    public static <T> T executeWithRetry(
+        final Supplier<T> action, final int maxRetries, final long initialDelayMillis)
+        throws Exception {
+      int attempt = 0;
+      while (true) {
+        try {
+          return action.get();
+        } catch (final Exception exception) {
+          attempt++;
+          if (attempt > maxRetries) {
+            throw exception;
+          }
+
+          // Exponential backoff with jitter
+          final long delay = (long) (initialDelayMillis * Math.pow(2, attempt - 1));
+          final long jitter = (long) (Math.random() * 100); // up to 100ms jitter
+          final long totalDelay = delay + jitter;
+
+          LOGGER.info(
+              "Failed to ping console. Will retry {}/{} after {} ms. Exception: {}",
+              attempt,
+              maxRetries,
+              totalDelay,
+              exception.getMessage());
+          TimeUnit.MILLISECONDS.sleep(totalDelay);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR is a prototype for the feature to ping the console with the license status with the use case 1 described in the epic.
What it implements: 

- gets the license status from `ManagementServices`.
- Schedules a recurring task to ping the console.
- This task has a retry exponential backoff mechanism depending on the type of failure.

What it does not implement:

- The configs are hard-coded.
- No config validation.
- No tests.

Will run benchmarks based on this branch to test it closer to a real scenario. 
What we expect to see:

- [x] The bean is run independently on each node.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to: https://github.com/camunda/camunda/issues/34192