### PR TITLE
ci: align optimize CI files with new team structure

### DIFF
--- a/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
+++ b/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
@@ -20,11 +20,9 @@ async function createHealthStatusConfig() {
   const githubService = new GitHubService(GITHUB_TOKEN, GITHUB_ORG, GITHUB_REPO);
   const releaseBranches = await githubService.getBranchesWithPrefix('release/optimize-');
   const optimizeStableBranches = await githubService.getBranchesWithPrefix('stable/optimize-');
-  const ciBranches = [
-    MAIN_BRANCH,
-    ...releaseBranches,
-    ...optimizeStableBranches,
-  ].sort(githubService.sortBranches);
+  const ciBranches = [MAIN_BRANCH, ...releaseBranches, ...optimizeStableBranches].sort(
+    githubService.sortBranches,
+  );
 
   const config: Partial<Config> = {
     github: {
@@ -33,7 +31,11 @@ async function createHealthStatusConfig() {
       defaultBranch: MAIN_BRANCH,
       workflows: [
         {
-          name: 'optimize-ci',
+          name: 'optimize-ci-core-features',
+          branches: ciBranches,
+        },
+        {
+          name: 'optimize-ci-data-layer',
           branches: ciBranches,
         },
         'optimize-zeebe-compatibility',

--- a/.github/workflows/optimize-ci-core-features.yml
+++ b/.github/workflows/optimize-ci-core-features.yml
@@ -1,0 +1,247 @@
+name: "[Legacy] Optimize / Core Features"
+on:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/optimize-*"
+      - "bom/*"
+      - "parent/*"
+      - "pom.xml"
+      - "optimize/**"
+      - "optimize.Dockerfile"
+  push:
+    branches:
+      - main
+      - stable/**
+      - release/**
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/optimize-*"
+      - "bom/*"
+      - "parent/*"
+      - "pom.xml"
+      - "optimize/**"
+      - "optimize.Dockerfile"
+  workflow_dispatch:
+
+# Will limit the workflow to 1 concurrent run per ref (branch / PR)
+# If a new commits occurs, the current run will be canceled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# set permissions to allow to publish test results
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    name: "Get changed directories"
+    runs-on: ubuntu-latest
+    outputs:
+      backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Get list of changed directories
+        id: filter
+        uses: ./.github/actions/paths-filter
+
+  docker:
+    name: "Docker Build"
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/optimize-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref }}
+
+  integration-tests:
+    name: "[IT] Run on Elasticsearch"
+    runs-on: gcp-core-32-default
+    timeout-minutes: 120
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        includedGroups: [ 'ccsm-test' ]
+        include:
+          - includedGroups: 'ccsm-test'
+            excludedGroups: ''
+            profiles: 'ccsm-it'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remote/origin/main
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-build
+        with:
+          harbor: true
+          maven-cache-key-modifier: optimize-tests
+          maven-version: 3.8.6
+          time-zone: Europe/Berlin
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: "Read Java / Version Info"
+        id: "pom-info"
+        uses: YunaBraska/java-info-action@main
+        with:
+          work-dir: ./optimize
+
+      - name: Expose Parsed Elastic Version
+        run: |
+          echo "ELASTIC_VERSION=${{ steps.pom-info.outputs.x_elasticsearch_test_version }}" >> "$GITHUB_ENV"
+
+      - name: Start Elasticsearch
+        uses: ./.github/actions/compose
+        with:
+          compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
+          project_name: elasticsearch
+        env:
+          ELASTIC_VERSION: ${{ env.ELASTIC_VERSION }}
+          ELASTIC_JVM_MEMORY: 16
+          ELASTIC_HTTP_PORT: 9200
+
+      - name: Verify integration
+        uses: ./.github/actions/run-maven
+        env:
+          LIMITS_CPU: 8
+        with:
+          threads: 8
+          parameters: >
+            verify -Dit.test.excludedGroups=${{ matrix.excludedGroups }}
+            -Dit.test.includedGroups=${{ matrix.includedGroups }}
+            -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
+            -Dfailsafe.rerunFailingTestsCount=2
+            -Ddatabase.type=elasticsearch -f optimize/pom.xml -pl backend -am
+
+      - name: Upload Test Results
+        if: always()
+        uses: ./.github/actions/collect-test-artifacts
+        with:
+          name: integration-test-elasticsearch-${{ matrix.includedGroups }}-junit
+          path: |
+            **/failsafe-reports/**/*.xml
+
+      - name: Docker log dump
+        uses: ./.github/actions/docker-logs
+        if: always()
+        with:
+          archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-docker
+
+  integration-tests-os:
+    name: "[IT] Run on OpenSearch"
+    runs-on: gcp-core-32-default
+    timeout-minutes: 120
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        includedGroups: [ 'ccsm-test' ]
+        include:
+          - includedGroups: 'ccsm-test'
+            excludedGroups: 'openSearchSingleTestFailOK'
+            profiles: 'ccsm-it'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remote/origin/main
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-build
+        with:
+          harbor: true
+          maven-cache-key-modifier: optimize-tests
+          maven-version: 3.8.6
+          time-zone: Europe/Berlin
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: "Read Java / Version Info"
+        id: "pom-info"
+        uses: YunaBraska/java-info-action@main
+        with:
+          work-dir: ./optimize
+
+      - name: Expose Parsed OpenSearch Version
+        run: echo "OPENSEARCH_VERSION=${{ steps.pom-info.outputs.x_opensearch_test_version }}" >> "$GITHUB_ENV"
+
+      - name: Start OpenSearch
+        uses: ./.github/actions/compose
+        with:
+          compose_file: .github/actions/compose/docker-compose.opensearch.yml
+          project_name: opensearch
+        env:
+          OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
+          OPENSEARCH_JVM_MEMORY: 16
+          OPENSEARCH_HTTP_PORT: 9200
+
+      - name: Verify integration
+        uses: ./.github/actions/run-maven
+        env:
+          LIMITS_CPU: 8
+        with:
+          threads: 8
+          parameters: >
+            verify -Dit.test.excludedGroups=${{ matrix.excludedGroups }}
+            -Dit.test.includedGroups=${{ matrix.includedGroups }}
+            -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
+            -Dfailsafe.rerunFailingTestsCount=2
+            -Ddatabase.type=opensearch -f optimize/pom.xml -pl backend -am
+
+      - name: Upload Test Results
+        if: always()
+        uses: ./.github/actions/collect-test-artifacts
+        with:
+          name: integration-test-opensearch-${{ matrix.includedGroups }}-junit
+          path: |
+            **/failsafe-reports/**/*.xml
+
+      - name: Docker log dump
+        uses: ./.github/actions/docker-logs
+        if: always()
+        with:
+          archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-docker
+
+  # Only deploy artifacts on push event, which in this case can only be triggered by main and stable
+  deploy-artifacts:
+    if: github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'stable/'))
+    name: "Deploy Artifacts"
+    needs: [ integration-tests ]
+    uses: ./.github/workflows/optimize-deploy-artifacts.yml
+    secrets: inherit
+
+  # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
+  rerun-failed-jobs:
+    needs:
+      - integration-tests
+      - integration-tests-os
+      - deploy-artifacts
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrigger job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            lost communication with the server
+            The runner has received a shutdown signal
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/optimize-ci-data-layer.yml
+++ b/.github/workflows/optimize-ci-data-layer.yml
@@ -2,7 +2,7 @@
 # test location: /optimize/qa/schema-integrity-tests, /optimize/backend/src/it/java, optimize/upgrade/src/test/java/io/camunda/optimize/upgrade
 # type: CI
 # owner: @camunda/core-features
-name: Optimize CI
+name: "[Legacy] Optimize / Data Layer"
 on:
   pull_request:
     paths:
@@ -54,16 +54,9 @@ jobs:
         id: filter
         uses: ./.github/actions/paths-filter
 
-  docker:
-    name: Optimize Build
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/optimize-ci-build-reusable.yml
-    secrets: inherit
-    with:
-      branch: ${{ github.head_ref }}
-
+  # TODO - re-enable this test. It fails when enabled
   es-schema-integrity-test:
-    name: Elasticsearch Schema Integrity Test
+    name: "Elasticsearch Schema Integrity"
     if: false
     runs-on: gcp-core-8-default
     timeout-minutes: 30
@@ -134,8 +127,9 @@ jobs:
         with:
           archive_name: es-schema-integrity-test-docker
 
+  # TODO - re-enable this test. It fails when enabled
   os-schema-integrity-test:
-    name: OpenSearch Schema Integrity Test
+    name: "OpenSearch Schema Integrity"
     if: false
     runs-on: gcp-core-8-default
     timeout-minutes: 30
@@ -203,167 +197,8 @@ jobs:
         with:
           archive_name: os-schema-integrity-test-docker
 
-  integration-tests:
-    name: Integration Tests
-    runs-on: gcp-core-32-default
-    timeout-minutes: 120
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        includedGroups: [ 'ccsm-test' ]
-        include:
-          - includedGroups: 'ccsm-test'
-            excludedGroups: ''
-            profiles: 'ccsm-it'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Fetch main branch
-        run: git fetch origin main:refs/remote/origin/main
-
-      - name: Setup Maven
-        uses: ./.github/actions/setup-build
-        with:
-          harbor: true
-          maven-cache-key-modifier: optimize-tests
-          maven-version: 3.8.6
-          time-zone: Europe/Berlin
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-      - name: "Read Java / Version Info"
-        id: "pom-info"
-        uses: YunaBraska/java-info-action@main
-        with:
-          work-dir: ./optimize
-
-      - name: Expose Parsed Elastic Version
-        run: |
-          echo "ELASTIC_VERSION=${{ steps.pom-info.outputs.x_elasticsearch_test_version }}" >> "$GITHUB_ENV"
-
-      - name: Start Elasticsearch
-        uses: ./.github/actions/compose
-        with:
-          compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
-          project_name: elasticsearch
-        env:
-          ELASTIC_VERSION: ${{ env.ELASTIC_VERSION }}
-          ELASTIC_JVM_MEMORY: 16
-          ELASTIC_HTTP_PORT: 9200
-
-      - name: Verify integration
-        uses: ./.github/actions/run-maven
-        env:
-          LIMITS_CPU: 8
-        with:
-          threads: 8
-          parameters: >
-            verify -Dit.test.excludedGroups=${{ matrix.excludedGroups }}
-            -Dit.test.includedGroups=${{ matrix.includedGroups }}
-            -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
-            -Dfailsafe.rerunFailingTestsCount=2
-            -Ddatabase.type=elasticsearch -f optimize/pom.xml -pl backend -am
-
-      - name: Upload Test Results
-        if: always()
-        uses: ./.github/actions/collect-test-artifacts
-        with:
-          name: integration-test-elasticsearch-${{ matrix.includedGroups }}-junit
-          path: |
-            **/failsafe-reports/**/*.xml
-
-      - name: Docker log dump
-        uses: ./.github/actions/docker-logs
-        if: always()
-        with:
-          archive_name: integration-tests-elasticsearch-${{ matrix.includedGroups }}-docker
-
-  integration-tests-os:
-    name: Integration Tests OpenSearch
-    runs-on: gcp-core-32-default
-    timeout-minutes: 120
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        includedGroups: [ 'ccsm-test' ]
-        include:
-          - includedGroups: 'ccsm-test'
-            excludedGroups: 'openSearchSingleTestFailOK'
-            profiles: 'ccsm-it'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Fetch main branch
-        run: git fetch origin main:refs/remote/origin/main
-
-      - name: Setup Maven
-        uses: ./.github/actions/setup-build
-        with:
-          harbor: true
-          maven-cache-key-modifier: optimize-tests
-          maven-version: 3.8.6
-          time-zone: Europe/Berlin
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-      - name: "Read Java / Version Info"
-        id: "pom-info"
-        uses: YunaBraska/java-info-action@main
-        with:
-          work-dir: ./optimize
-
-      - name: Expose Parsed OpenSearch Version
-        run: echo "OPENSEARCH_VERSION=${{ steps.pom-info.outputs.x_opensearch_test_version }}" >> "$GITHUB_ENV"
-
-      - name: Start OpenSearch
-        uses: ./.github/actions/compose
-        with:
-          compose_file: .github/actions/compose/docker-compose.opensearch.yml
-          project_name: opensearch
-        env:
-          OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
-          OPENSEARCH_JVM_MEMORY: 16
-          OPENSEARCH_HTTP_PORT: 9200
-
-      - name: Verify integration
-        uses: ./.github/actions/run-maven
-        env:
-          LIMITS_CPU: 8
-        with:
-          threads: 8
-          parameters: >
-            verify -Dit.test.excludedGroups=${{ matrix.excludedGroups }}
-            -Dit.test.includedGroups=${{ matrix.includedGroups }}
-            -Dskip.docker -Dskip.fe.build -P${{ matrix.profiles }}
-            -Dfailsafe.rerunFailingTestsCount=2
-            -Ddatabase.type=opensearch -f optimize/pom.xml -pl backend -am
-
-      - name: Upload Test Results
-        if: always()
-        uses: ./.github/actions/collect-test-artifacts
-        with:
-          name: integration-test-opensearch-${{ matrix.includedGroups }}-junit
-          path: |
-            **/failsafe-reports/**/*.xml
-
-      - name: Docker log dump
-        uses: ./.github/actions/docker-logs
-        if: always()
-        with:
-          archive_name: integration-tests-opensearch-${{ matrix.includedGroups }}-docker
-
   upgrade-tests:
-    name: Upgrade
+    name: "Database Upgrade"
     runs-on: gcp-core-8-default
     timeout-minutes: 20
     strategy:
@@ -429,23 +264,13 @@ jobs:
         with:
           archive_name: upgrade-docker-${{ matrix.database }}
 
-  # Only deploy artifacts on push event, which in this case can only be triggered by main and stable
-  deploy-artifacts:
-    if: github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'stable/'))
-    name: Deploy Artifacts
-    needs: [ integration-tests, upgrade-tests ]
-    uses: ./.github/workflows/optimize-deploy-artifacts.yml
-    secrets: inherit
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:
     needs:
-      - integration-tests
-      - integration-tests-os
       - upgrade-tests
       - os-schema-integrity-test
       - es-schema-integrity-test
-      - deploy-artifacts
     if: failure() && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Split apart Optimize CI so that each CI file has a dedicated team as an owner, rather than having mixed ownership of one file

The daily update status script was changed to use the new names of the CI files

This closes https://github.com/camunda/product-hub/issues/2817 as Optimize is the only component that needs a split of its CI files. The CI files of Zeebe and Tasklist did not need splitting apart. Operate was already completed with https://github.com/camunda/product-hub/issues/2853

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/product-hub/issues/2817
