### PR TITLE
fix: apply style fixes to enable scroll for long lists of listeners

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
@@ -72,33 +72,33 @@ const Listeners: React.FC = observer(() => {
 
   return (
     <Content>
-      <Stack as={Layer} $isUserTask={isUserTask}>
-        {isUserTask && (
-          <Dropdown
-            id="listenerTypeFilter"
-            data-testid="listener-type-filter"
-            titleText="Listener type"
-            label="All listeners"
-            hideLabel
-            onChange={async ({selectedItem}: SelectedItem) => {
-              if (selectedItem !== selectedOption) {
-                setSelectedOption(selectedItem);
+      {isUserTask && (
+        <Dropdown
+          id="listenerTypeFilter"
+          data-testid="listener-type-filter"
+          titleText="Listener type"
+          label="All listeners"
+          hideLabel
+          onChange={async ({selectedItem}: SelectedItem) => {
+            if (selectedItem !== selectedOption) {
+              setSelectedOption(selectedItem);
 
-                if (FilterLabelMapping[selectedItem] !== 'ALL_LISTENERS') {
-                  setListenerTypeFilter(FilterLabelMapping[selectedItem]);
-                } else {
-                  setListenerTypeFilter(undefined);
-                }
+              if (FilterLabelMapping[selectedItem] !== 'ALL_LISTENERS') {
+                setListenerTypeFilter(FilterLabelMapping[selectedItem]);
+              } else {
+                setListenerTypeFilter(undefined);
               }
-            }}
-            items={Object.keys(FilterLabelMapping)}
-            size="sm"
-            selectedItem={selectedOption}
-            disabled={
-              selectedOption === 'All listeners' && listeners?.length === 0
             }
-          />
-        )}
+          }}
+          items={Object.keys(FilterLabelMapping)}
+          size="sm"
+          selectedItem={selectedOption}
+          disabled={
+            selectedOption === 'All listeners' && listeners?.length === 0
+          }
+        />
+      )}
+      <Stack as={Layer}>
         {listeners?.length > 0 ? (
           <StructuredList
             dataTestId="listeners-list"

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/styled.ts
@@ -41,6 +41,7 @@ const WarningFilled = styled(BaseWarningFilled)`
 
 const Dropdown = styled(BaseDropdown)`
   width: 200px;
+  margin-bottom: ${spacing03};
 `;
 
 const EmptyMessageWrapper = styled.div`
@@ -55,11 +56,9 @@ const EmptyMessageWrapper = styled.div`
   }
 `;
 
-const dropdownHeight = '32px';
-
-const Stack = styled(BaseStack)<{$isUserTask: boolean}>`
-  height: ${({$isUserTask}) =>
-    $isUserTask ? `calc(100% - ${dropdownHeight})` : '100%'};
+const Stack = styled(BaseStack)`
+  height: 100%;
+  overflow-y: auto;
 `;
 
 export {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/Listeners/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/Listeners/index.tsx
@@ -84,33 +84,33 @@ const Listeners: React.FC<Props> = observer(
 
     return (
       <Content>
-        <Stack as={Layer} $isUserTask={isUserTask}>
-          {isUserTask && (
-            <Dropdown
-              id="listenerTypeFilter"
-              data-testid="listener-type-filter"
-              titleText="Listener type"
-              label="All listeners"
-              hideLabel
-              onChange={async ({selectedItem}: SelectedItem) => {
-                if (selectedItem !== selectedOption) {
-                  setSelectedOption(selectedItem);
+        {isUserTask && (
+          <Dropdown
+            id="listenerTypeFilter"
+            data-testid="listener-type-filter"
+            titleText="Listener type"
+            label="All listeners"
+            hideLabel
+            onChange={async ({selectedItem}: SelectedItem) => {
+              if (selectedItem !== selectedOption) {
+                setSelectedOption(selectedItem);
 
-                  if (FilterLabelMapping[selectedItem] !== 'ALL_LISTENERS') {
-                    setListenerTypeFilter(FilterLabelMapping[selectedItem]);
-                  } else {
-                    setListenerTypeFilter(undefined);
-                  }
+                if (FilterLabelMapping[selectedItem] !== 'ALL_LISTENERS') {
+                  setListenerTypeFilter(FilterLabelMapping[selectedItem]);
+                } else {
+                  setListenerTypeFilter(undefined);
                 }
-              }}
-              items={Object.keys(FilterLabelMapping)}
-              size="sm"
-              selectedItem={selectedOption}
-              disabled={
-                selectedOption === 'All listeners' && listeners?.length === 0
               }
-            />
-          )}
+            }}
+            items={Object.keys(FilterLabelMapping)}
+            size="sm"
+            selectedItem={selectedOption}
+            disabled={
+              selectedOption === 'All listeners' && listeners?.length === 0
+            }
+          />
+        )}
+        <Stack as={Layer}>
           {listeners?.length > 0 ? (
             <StructuredList
               dataTestId="listeners-list"

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/Listeners/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/v2/Listeners/styled.ts
@@ -41,6 +41,7 @@ const WarningFilled = styled(BaseWarningFilled)`
 
 const Dropdown = styled(BaseDropdown)`
   width: 200px;
+  margin-bottom: ${spacing03};
 `;
 
 const EmptyMessageWrapper = styled.div`
@@ -55,11 +56,9 @@ const EmptyMessageWrapper = styled.div`
   }
 `;
 
-const dropdownHeight = '32px';
-
-const Stack = styled(BaseStack)<{$isUserTask: boolean}>`
-  height: ${({$isUserTask}) =>
-    $isUserTask ? `calc(100% - ${dropdownHeight})` : '100%'};
+const Stack = styled(BaseStack)`
+  height: 100%;
+  overflow-y: auto;
 `;
 
 export {


### PR DESCRIPTION
## Description

- Fixes scrolling in long lists of listeners
- Move dropdown filter for listeners type to outside the container in order to remain fixed when long list is scrolled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26828

## Solution demo

Demo to show scrolling in long list of listeners working. The test was done by mocking the API's response so we can easily have dozens of listeners on the list. The solution was a matter of solving styling issues that were preventing the container from being scrollable. when the list exceeded the maximum space of the page.

https://github.com/user-attachments/assets/a0d32f9f-4f72-4aff-bb2d-4b344c5e5651

