### PR TITLE
ci: update codeownerfile to set distro team to c8run

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 
 # C8Run by Distro team
 .github/workflows/c8run* @camunda/distribution
+/c8run/ @camunda/distribution
 
 # Camunda Ex Team Clients, SDK and CPT
 /clients/*        @camunda/camundaex


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Set distro team as owners for c8run in CODEOWNERS

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
