### PR TITLE
[Backport stable/optimize-8.6] fix: fix object variable modal on object variables disabled

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -540,6 +540,7 @@
     "runningEndedFlowNodeWarning": "Bei der Gruppierung nach Enddatum werden nur abgeschlossene Prozessknoten berücksichtigt. Daher zeigt das Setzen des Prozessknoten-Status Filters auf 'laufende Prozessknoten' keine Ergebnisse",
     "missingVariable": "Fehlende Variable",
     "nonExistingVariable": "Variable existiert nicht",
+    "disabledObjectVariables": "Keine Daten verfügbar. Die Konfiguration includeObjectVariableValue ist möglicherweise deaktiviert.",
     "nonExistingFlowNode": "Prozessknoten existiert nicht",
     "percentageOfInstances": "% der gesamten Instanzen, die dem Filter entsprechen",
     "addDescription": "Beschreibung hinzufügen"

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -540,6 +540,7 @@
     "runningEndedFlowNodeWarning": "Only completed flow nodes are considered when grouping by end date. Therefore, adding 'running' flow node status filter will show no results",
     "missingVariable": "Missing variable",
     "nonExistingVariable": "Variable does not exist",
+    "disabledObjectVariables": "No data available. The includeObjectVariableValue configuration setting might be disabled.",
     "nonExistingFlowNode": "Flow node(s) does not exist",
     "percentageOfInstances": "% of total instances that match the filter",
     "addDescription": "Add description"

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/ObjectVariableModal.tsx
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/ObjectVariableModal.tsx
@@ -36,10 +36,14 @@ export function ObjectVariableModal({
 }: ObjectVariableModalProps) {
   const [objectString, setObjectString] = useState<string>();
 
+  const updateObjectString = (objectString: string): void => {
+    setObjectString(objectString ? objectString : t('report.disabledObjectVariables').toString());
+  };
+
   useEffect(() => {
     mightFail(
       loadObjectValues(name, processInstanceId, processDefinitionKey, versions, tenantIds),
-      setObjectString,
+      updateObjectString,
       showError
     );
   }, [mightFail, name, processDefinitionKey, processInstanceId, tenantIds, versions]);


### PR DESCRIPTION
# Description
Backport of #34213 to `stable/optimize-8.6`.

relates to camunda/camunda-bpm-platform#4935