### PR TITLE
Ensure we don't redirect on calls to /identity/setup and /identity/assets

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -43,7 +43,14 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
       final HttpServletResponse response,
       final FilterChain filterChain)
       throws ServletException, IOException {
-    if (!securityConfig.isApiProtected()) {
+    // Skip redirect logic for the setup page itself to prevent redirect loops
+    // Skip redirect logic for loading assets, e.g., CSS and JS files
+    // Skip redirect logic if the API is not protected
+    final var requestURI = request.getRequestURI();
+    final String setupPath = request.getContextPath() + REDIRECT_PATH;
+    if (requestURI.equals(setupPath)
+        || requestURI.contains(ASSETS_PATH)
+        || !securityConfig.isApiProtected()) {
       filterChain.doFilter(request, response);
       return;
     }

--- a/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/AdminUserCheckFilter.java
@@ -27,6 +27,7 @@ public class AdminUserCheckFilter extends OncePerRequestFilter {
   public static final String ADMIN_ROLE_ID = DefaultRole.ADMIN.getId();
   public static final String USER_MEMBERS = "users";
   public static final String REDIRECT_PATH = "/identity/setup";
+  public static final String ASSETS_PATH = "/identity/assets";
   private static final Logger LOG = LoggerFactory.getLogger(AdminUserCheckFilter.class);
   private final SecurityConfiguration securityConfig;
   private final RoleServices roleServices;

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -97,4 +97,20 @@ class AdminUserCheckFilterTest {
     // then
     verify(filterChain).doFilter(request, response);
   }
+
+  @Test
+  void shouldNotRedirectOIfRequestIsToSetupPath() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/setup");
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
 }

--- a/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/AdminUserCheckFilterTest.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -30,6 +31,11 @@ class AdminUserCheckFilterTest {
   @Mock private final HttpServletRequest request = mock(HttpServletRequest.class);
   @Mock private final HttpServletResponse response = mock(HttpServletResponse.class);
   @Mock private final FilterChain filterChain = mock(FilterChain.class);
+
+  @BeforeEach
+  void setup() {
+    when(request.getRequestURI()).thenReturn("/login");
+  }
 
   @Test
   void shouldRedirectIfNoAdminUserExistsOrIsConfigured() throws ServletException, IOException {
@@ -99,11 +105,27 @@ class AdminUserCheckFilterTest {
   }
 
   @Test
-  void shouldNotRedirectOIfRequestIsToSetupPath() throws ServletException, IOException {
+  void shouldNotRedirectIfRequestIsToSetupPath() throws ServletException, IOException {
     // given
     final var securityConfig = new SecurityConfiguration();
     when(request.getContextPath()).thenReturn("");
     when(request.getRequestURI()).thenReturn("/identity/setup");
+    final AdminUserCheckFilter adminUserCheckFilter =
+        new AdminUserCheckFilter(securityConfig, roleServices);
+
+    // when
+    adminUserCheckFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldNotRedirectIfRequestIsToAssetsPath() throws ServletException, IOException {
+    // given
+    final var securityConfig = new SecurityConfiguration();
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/identity/assets/some-asset.js");
     final AdminUserCheckFilter adminUserCheckFilter =
         new AdminUserCheckFilter(securityConfig, roleServices);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We had a redirect loop as a call to `/identity/setup` would redirect to itself.
We were redirecting when loading the assets, meaning the UI would not render anything.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to #33533
