### PR TITLE
fix: handle PathNotFoundException

### DIFF
--- a/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/auth/OidcGroupsLoaderTest.java
@@ -119,7 +119,7 @@ final class OidcGroupsLoaderTest {
     final var claims =
         Map.<String, Object>of("groups", List.of("g1", "g2"), "other_claim", "other_value");
 
-    final var loader = new OidcGroupsLoader("group_names");
+    final var loader = new OidcGroupsLoader("$.groups.names[*]");
 
     // when
     final var groups = loader.load(claims);


### PR DESCRIPTION
## Description

With some sort of expressions as groupsClaim, OidcGroupLoader throws PathNotFoundException when the claim is not available in the token. 
The expected behaviour is if for any reason the expression is not available with claims, it returns empty list for the groups.

## Related issues

closes #34292 