### PR TITLE
feat: use cancel process instance endpoint in Operate UI

### DIFF
--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.setup.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/index.setup.tsx
@@ -8,8 +8,11 @@
 
 import {authenticationStore} from 'modules/stores/authentication';
 import {operationsStore} from 'modules/stores/operations';
-import {variablesStore} from 'modules/stores/variables';
-import {createBatchOperation, createInstance} from 'modules/testUtils';
+import {
+  createBatchOperation,
+  createInstance,
+  createProcessInstance,
+} from 'modules/testUtils';
 import {useEffect} from 'react';
 import {Paths} from 'modules/Routes';
 import {LocationLog} from 'modules/utils/LocationLog';
@@ -17,34 +20,19 @@ import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
-import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 
 const mockOperationCreated = createBatchOperation();
 
-const mockInstanceWithActiveOperation = createInstance({
-  operations: [
-    {
-      id: '8292773a-4cc5-4129-be11-eafe3e39a052',
-      batchOperationId: 'a8104a2d-642d-46f2-ad5d-d4447b85e378',
-      type: 'RESOLVE_INCIDENT',
-      state: 'SENT',
-      errorMessage: null,
-      completedDate: null,
-    },
-  ],
-  hasActiveOperation: true,
+const mockInstanceDeprecated = createInstance();
+
+const mockInstance = createProcessInstance();
+
+const mockInstanceWithParentInstance = createProcessInstance({
+  parentProcessInstanceKey: '8724390842390124',
 });
 
-const mockCanceledInstance = createInstance({
-  state: 'CANCELED',
-});
-
-const mockInstanceWithParentInstance = createInstance({
-  parentInstanceId: '8724390842390124',
-});
-
-const mockInstanceWithoutOperations = createInstance({
-  operations: [],
+const mockInstanceWithIncident = createProcessInstance({
+  hasIncident: true,
 });
 
 const mockProcess = {
@@ -55,24 +43,10 @@ const mockProcess = {
   versionTag: 'myVersionTag',
 };
 
-const mockProcessInstance: ProcessInstance = {
-  processInstanceKey: '123',
-  processDefinitionName: 'someProcessName',
-  state: 'ACTIVE',
-  processDefinitionVersion: 1,
-  processDefinitionVersionTag: 'myVersionTag',
-  processDefinitionId: 'someKey',
-  processDefinitionKey: '',
-  tenantId: '<default>',
-  startDate: '2018-06-21',
-  hasIncident: false,
-};
-
 const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   useEffect(() => {
     return () => {
       operationsStore.reset();
-      variablesStore.reset();
       authenticationStore.reset();
     };
   }, []);
@@ -93,12 +67,11 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 export {
-  mockOperationCreated,
-  mockInstanceWithActiveOperation,
-  mockCanceledInstance,
+  mockInstance,
   mockInstanceWithParentInstance,
-  mockInstanceWithoutOperations,
+  mockInstanceWithIncident,
+  mockInstanceDeprecated,
+  mockOperationCreated,
   mockProcess,
-  mockProcessInstance,
   Wrapper,
 };

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/multiTenancy.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/multiTenancy.test.tsx
@@ -14,10 +14,7 @@ import {
 import {ProcessInstanceHeader} from './index';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
 import {operationsStore} from 'modules/stores/operations';
-import {
-  mockInstanceWithoutOperations,
-  mockProcessInstance,
-} from './index.setup';
+import {mockInstanceDeprecated, mockInstance} from './index.setup';
 import {MemoryRouter} from 'react-router-dom';
 import {createUser, mockProcessXML} from 'modules/testUtils';
 import {authenticationStore} from 'modules/stores/authentication';
@@ -66,7 +63,7 @@ describe('InstanceHeader', () => {
       multiTenancyEnabled: true,
     };
 
-    mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
+    mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockMe().withSuccess(
       createUser({
@@ -77,12 +74,12 @@ describe('InstanceHeader', () => {
       }),
     );
 
-    render(<ProcessInstanceHeader processInstance={mockProcessInstance} />, {
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
       wrapper: Wrapper,
     });
 
     processInstanceDetailsStore.init({
-      id: mockInstanceWithoutOperations.id,
+      id: mockInstanceDeprecated.id,
     });
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),
@@ -107,7 +104,7 @@ describe('InstanceHeader', () => {
   });
 
   it('should hide multi tenancy column and exclude tenant from version link', async () => {
-    mockFetchProcessInstance().withSuccess(mockInstanceWithoutOperations);
+    mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
     mockMe().withSuccess(
       createUser({
@@ -118,12 +115,12 @@ describe('InstanceHeader', () => {
       }),
     );
 
-    render(<ProcessInstanceHeader processInstance={mockProcessInstance} />, {
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
       wrapper: Wrapper,
     });
 
     processInstanceDetailsStore.init({
-      id: mockInstanceWithoutOperations.id,
+      id: mockInstanceDeprecated.id,
     });
     await waitForElementToBeRemoved(
       screen.getByTestId('instance-header-skeleton'),

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/versionTag.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/v2/versionTag.test.tsx
@@ -13,9 +13,9 @@ import {
 } from 'modules/testing-library';
 import {ProcessInstanceHeader} from './index';
 import {
-  mockInstanceWithActiveOperation,
+  mockInstanceDeprecated,
   mockProcess,
-  mockProcessInstance,
+  mockInstance,
   Wrapper,
 } from './index.setup';
 import {mockProcessXML} from 'modules/testUtils';
@@ -26,7 +26,7 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 
 describe('InstanceHeader', () => {
   beforeEach(() => {
-    mockFetchProcessInstance().withSuccess(mockInstanceWithActiveOperation);
+    mockFetchProcessInstance().withSuccess(mockInstanceDeprecated);
     mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
   });
   afterEach(() => {
@@ -36,12 +36,12 @@ describe('InstanceHeader', () => {
   it('should render version tag', async () => {
     mockFetchProcess().withSuccess(mockProcess);
 
-    render(<ProcessInstanceHeader processInstance={mockProcessInstance} />, {
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
       wrapper: Wrapper,
     });
 
     processInstanceDetailsStore.init({
-      id: mockInstanceWithActiveOperation.id,
+      id: mockInstanceDeprecated.id,
     });
 
     await waitForElementToBeRemoved(
@@ -58,7 +58,7 @@ describe('InstanceHeader', () => {
     render(
       <ProcessInstanceHeader
         processInstance={{
-          ...mockProcessInstance,
+          ...mockInstance,
           processDefinitionVersionTag: undefined,
         }}
       />,
@@ -68,7 +68,7 @@ describe('InstanceHeader', () => {
     );
 
     processInstanceDetailsStore.init({
-      id: mockInstanceWithActiveOperation.id,
+      id: mockInstanceDeprecated.id,
     });
 
     await waitForElementToBeRemoved(
@@ -85,7 +85,7 @@ describe('InstanceHeader', () => {
     render(
       <ProcessInstanceHeader
         processInstance={{
-          ...mockProcessInstance,
+          ...mockInstance,
           processDefinitionVersionTag: undefined,
         }}
       />,
@@ -95,7 +95,7 @@ describe('InstanceHeader', () => {
     );
 
     processInstanceDetailsStore.init({
-      id: mockInstanceWithActiveOperation.id,
+      id: mockInstanceDeprecated.id,
     });
 
     await waitForElementToBeRemoved(

--- a/operate/client/src/modules/api/v2/processInstances/cancelProcessInstance.ts
+++ b/operate/client/src/modules/api/v2/processInstances/cancelProcessInstance.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints, ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {request} from 'modules/request';
+
+const cancelProcessInstance = async (
+  processInstanceKey: ProcessInstance['processInstanceKey'],
+) => {
+  return request({
+    url: endpoints.cancelProcessInstance.getUrl({processInstanceKey}),
+    method: endpoints.cancelProcessInstance.method,
+    responseType: 'none',
+  });
+};
+
+export {cancelProcessInstance};

--- a/operate/client/src/modules/components/Operations/v2/Cancel.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.tsx
@@ -12,17 +12,15 @@ import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {Paths} from 'modules/Routes';
 import {useCancelProcessInstance} from 'modules/mutations/processInstance/useCancelProcessInstance';
 import {OperationItem} from 'modules/components/OperationItem';
-import {Restricted} from 'modules/components/Restricted';
 import {Link} from 'modules/components/Link';
 import {useRootInstanceId} from 'modules/queries/callHierarchy/useRootInstanceId';
 import {notificationsStore} from 'modules/stores/notifications';
 
 type Props = {
   processInstanceKey: ProcessInstance['processInstanceKey'];
-  permissions?: ResourceBasedPermissionDto[] | null;
 };
 
-const Cancel: React.FC<Props> = ({processInstanceKey, permissions}) => {
+const Cancel: React.FC<Props> = ({processInstanceKey}) => {
   const [isCancellationModalVisible, setIsCancellationModalVisible] =
     useState(false);
 
@@ -43,20 +41,13 @@ const Cancel: React.FC<Props> = ({processInstanceKey, permissions}) => {
 
   return (
     <>
-      <Restricted
-        resourceBasedRestrictions={{
-          scopes: ['UPDATE_PROCESS_INSTANCE'],
-          permissions,
-        }}
-      >
-        <OperationItem
-          type="CANCEL_PROCESS_INSTANCE"
-          onClick={() => setIsCancellationModalVisible(true)}
-          title={`Cancel Instance ${processInstanceKey}`}
-          disabled={cancelProcessInstanceMutation.isPending}
-          size="sm"
-        />
-      </Restricted>
+      <OperationItem
+        type="CANCEL_PROCESS_INSTANCE"
+        onClick={() => setIsCancellationModalVisible(true)}
+        title={`Cancel Instance ${processInstanceKey}`}
+        disabled={cancelProcessInstanceMutation.isPending}
+        size="sm"
+      />
 
       {isCancellationModalVisible && (
         <>

--- a/operate/client/src/modules/components/Operations/v2/Cancel.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {Modal} from '@carbon/react';
 import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {Paths} from 'modules/Routes';

--- a/operate/client/src/modules/components/Operations/v2/Cancel.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Cancel.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useState} from 'react';
+import {Modal} from '@carbon/react';
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {Paths} from 'modules/Routes';
+import {useCancelProcessInstance} from 'modules/mutations/processInstance/useCancelProcessInstance';
+import {OperationItem} from 'modules/components/OperationItem';
+import {Restricted} from 'modules/components/Restricted';
+import {Link} from 'modules/components/Link';
+import {useRootInstanceId} from 'modules/queries/callHierarchy/useRootInstanceId';
+import {notificationsStore} from 'modules/stores/notifications';
+
+type Props = {
+  processInstanceKey: ProcessInstance['processInstanceKey'];
+  permissions?: ResourceBasedPermissionDto[] | null;
+};
+
+const Cancel: React.FC<Props> = ({processInstanceKey, permissions}) => {
+  const [isCancellationModalVisible, setIsCancellationModalVisible] =
+    useState(false);
+
+  const {data: rootInstanceId} = useRootInstanceId({
+    enabled: isCancellationModalVisible,
+  });
+
+  const cancelProcessInstanceMutation = useCancelProcessInstance(
+    processInstanceKey,
+    (error) =>
+      notificationsStore.displayNotification({
+        kind: 'error',
+        title: 'Failed to cancel process instance',
+        subtitle: error.message,
+        isDismissable: true,
+      }),
+  );
+
+  return (
+    <>
+      <Restricted
+        resourceBasedRestrictions={{
+          scopes: ['UPDATE_PROCESS_INSTANCE'],
+          permissions,
+        }}
+      >
+        <OperationItem
+          type="CANCEL_PROCESS_INSTANCE"
+          onClick={() => setIsCancellationModalVisible(true)}
+          title={`Cancel Instance ${processInstanceKey}`}
+          disabled={cancelProcessInstanceMutation.isPending}
+          size="sm"
+        />
+      </Restricted>
+
+      {isCancellationModalVisible && (
+        <>
+          {!rootInstanceId ? (
+            <Modal
+              open={isCancellationModalVisible}
+              preventCloseOnClickOutside
+              modalHeading="Apply Operation"
+              primaryButtonText="Apply"
+              secondaryButtonText="Cancel"
+              onRequestSubmit={() => {
+                setIsCancellationModalVisible(false);
+                cancelProcessInstanceMutation.mutate();
+              }}
+              onRequestClose={() => setIsCancellationModalVisible(false)}
+              size="md"
+              data-testid="confirm-cancellation-modal"
+            >
+              <p>{`About to cancel Instance ${processInstanceKey}. In case there are called instances, these will be canceled too.`}</p>
+              <p>Click "Apply" to proceed.</p>
+            </Modal>
+          ) : (
+            <Modal
+              open={isCancellationModalVisible}
+              preventCloseOnClickOutside
+              modalHeading="Cancel Instance"
+              passiveModal
+              onRequestClose={() => setIsCancellationModalVisible(false)}
+              size="md"
+              data-testid="passive-cancellation-modal"
+            >
+              <p>
+                To cancel this instance, the root instance{' '}
+                <Link
+                  to={Paths.processInstance(rootInstanceId)}
+                  title={`View root instance ${rootInstanceId}`}
+                >
+                  {rootInstanceId}
+                </Link>{' '}
+                needs to be canceled. When the root instance is canceled all the
+                called instances will be canceled automatically.
+              </p>
+            </Modal>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export {Cancel};

--- a/operate/client/src/modules/components/Operations/v2/Delete.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Delete.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {Modal} from '@carbon/react';
 import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {Restricted} from 'modules/components/Restricted';

--- a/operate/client/src/modules/components/Operations/v2/Delete.tsx
+++ b/operate/client/src/modules/components/Operations/v2/Delete.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useState} from 'react';
+import {Modal} from '@carbon/react';
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {Restricted} from 'modules/components/Restricted';
+import {useOperations} from 'modules/queries/operations/useOperations';
+import {ACTIVE_OPERATION_STATES} from 'modules/constants';
+import {DangerButton} from 'modules/components/OperationItem/DangerButton';
+
+type Props = {
+  processInstanceKey: ProcessInstance['processInstanceKey'];
+  permissions?: ResourceBasedPermissionDto[] | null;
+  applyOperation: (operationType: OperationEntityType) => Promise<void>;
+};
+
+const Delete: React.FC<Props> = ({
+  processInstanceKey,
+  applyOperation,
+  permissions,
+}) => {
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+  const {data: operations} = useOperations();
+
+  const isOperationActive = (operationType: OperationEntityType) => {
+    return operations?.some(
+      (operation) =>
+        operation.type === operationType &&
+        ACTIVE_OPERATION_STATES.includes(operation.state),
+    );
+  };
+
+  return (
+    <>
+      <Restricted
+        resourceBasedRestrictions={{
+          scopes: ['DELETE_PROCESS_INSTANCE'],
+          permissions,
+        }}
+      >
+        <DangerButton
+          type="DELETE"
+          onClick={() => setIsDeleteModalVisible(true)}
+          title={`Delete Instance ${processInstanceKey}`}
+          disabled={isOperationActive('DELETE_PROCESS_INSTANCE')}
+          size="sm"
+        />
+      </Restricted>
+
+      {isDeleteModalVisible && (
+        <Modal
+          open={isDeleteModalVisible}
+          danger
+          preventCloseOnClickOutside
+          modalHeading="Delete Instance"
+          primaryButtonText="Delete"
+          secondaryButtonText="Cancel"
+          onRequestSubmit={() => {
+            applyOperation('DELETE_PROCESS_INSTANCE');
+            setIsDeleteModalVisible(false);
+          }}
+          onRequestClose={() => setIsDeleteModalVisible(false)}
+          size="md"
+          data-testid="confirm-deletion-modal"
+        >
+          <p>About to delete Instance {processInstanceKey}.</p>
+          <p>Click "Delete" to proceed.</p>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export {Delete};

--- a/operate/client/src/modules/components/Operations/v2/ResolveIncident.tsx
+++ b/operate/client/src/modules/components/Operations/v2/ResolveIncident.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import React from 'react';
 import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 import {Restricted} from 'modules/components/Restricted';
 import {useOperations} from 'modules/queries/operations/useOperations';

--- a/operate/client/src/modules/components/Operations/v2/ResolveIncident.tsx
+++ b/operate/client/src/modules/components/Operations/v2/ResolveIncident.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
+import {Restricted} from 'modules/components/Restricted';
+import {useOperations} from 'modules/queries/operations/useOperations';
+import {ACTIVE_OPERATION_STATES} from 'modules/constants';
+import {OperationItem} from 'modules/components/OperationItem';
+
+type Props = {
+  processInstanceKey: ProcessInstance['processInstanceKey'];
+  permissions?: ResourceBasedPermissionDto[] | null;
+  applyOperation: (operationType: OperationEntityType) => Promise<void>;
+};
+
+const ResolveIncident: React.FC<Props> = ({
+  processInstanceKey,
+  permissions,
+  applyOperation,
+}) => {
+  const {data: operations} = useOperations();
+
+  const isOperationActive = (operationType: OperationEntityType) => {
+    return operations?.some(
+      (operation) =>
+        operation.type === operationType &&
+        ACTIVE_OPERATION_STATES.includes(operation.state),
+    );
+  };
+
+  return (
+    <>
+      <Restricted
+        resourceBasedRestrictions={{
+          scopes: ['UPDATE_PROCESS_INSTANCE'],
+          permissions,
+        }}
+      >
+        <OperationItem
+          type="RESOLVE_INCIDENT"
+          onClick={() => applyOperation('RESOLVE_INCIDENT')}
+          title={`Retry Instance ${processInstanceKey}`}
+          disabled={isOperationActive('RESOLVE_INCIDENT')}
+          size="sm"
+        />
+      </Restricted>
+    </>
+  );
+};
+
+export {ResolveIncident};

--- a/operate/client/src/modules/components/Operations/v2/index.tsx
+++ b/operate/client/src/modules/components/Operations/v2/index.tsx
@@ -8,25 +8,22 @@
 
 import React, {useState} from 'react';
 
-import {ACTIVE_OPERATION_STATES} from 'modules/constants';
 import {ErrorHandler, operationsStore} from 'modules/stores/operations';
 import {observer} from 'mobx-react';
 
 import {OperationItems} from 'modules/components/OperationItems';
 import {OperationItem} from 'modules/components/OperationItem';
-import {DangerButton} from 'modules/components/OperationItem/DangerButton';
 import {modificationsStore} from 'modules/stores/modifications';
 import {Restricted} from 'modules/components/Restricted';
-import {Modal, InlineLoading} from '@carbon/react';
-import {Paths} from 'modules/Routes';
-import {Link} from 'modules/components/Link';
+import {InlineLoading} from '@carbon/react';
 import {OperationsContainer} from '../styled';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {getStateLocally} from 'modules/utils/localStorage';
 import {ModificationHelperModal} from '../ModificationHelperModal';
 import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
-import {useOperations} from 'modules/queries/operations/useOperations';
-import {useRootInstanceId} from 'modules/queries/callHierarchy/useRootInstanceId';
+import {Cancel} from './Cancel';
+import {Delete} from './Delete';
+import {ResolveIncident} from './ResolveIncident';
 
 type Props = {
   instance: ProcessInstance;
@@ -48,16 +45,10 @@ const Operations: React.FC<Props> = observer(
     isInstanceModificationVisible = false,
     permissions,
   }) => {
-    const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
-    const [isCancellationModalVisible, setIsCancellationModalVisible] =
-      useState(false);
     const [
       isModificationModeHelperModalVisible,
       setIsModificationModeHelperModalVisible,
     ] = useState(false);
-
-    const {data: operations} = useOperations();
-    const {data: rootInstanceId} = useRootInstanceId();
 
     const {isModificationModeEnabled} = modificationsStore;
 
@@ -76,15 +67,7 @@ const Operations: React.FC<Props> = observer(
       onOperation?.(operationType);
     };
 
-    const isOperationActive = (operationType: OperationEntityType) => {
-      return operations?.some(
-        (operation) =>
-          operation.type === operationType &&
-          ACTIVE_OPERATION_STATES.includes(operation.state),
-      );
-    };
-
-    const isRunning = instance.state === 'ACTIVE';
+    const isInstanceActive = instance.state === 'ACTIVE';
 
     return (
       <OperationsContainer orientation="horizontal">
@@ -99,56 +82,28 @@ const Operations: React.FC<Props> = observer(
         )}
         <OperationItems>
           {instance.hasIncident && !isModificationModeEnabled && (
-            <Restricted
-              resourceBasedRestrictions={{
-                scopes: ['UPDATE_PROCESS_INSTANCE'],
-                permissions,
-              }}
-            >
-              <OperationItem
-                type="RESOLVE_INCIDENT"
-                onClick={() => applyOperation('RESOLVE_INCIDENT')}
-                title={`Retry Instance ${instance.processInstanceKey}`}
-                disabled={isOperationActive('RESOLVE_INCIDENT')}
-                size="sm"
-              />
-            </Restricted>
+            <ResolveIncident
+              processInstanceKey={instance.processInstanceKey}
+              permissions={permissions}
+              applyOperation={applyOperation}
+            />
           )}
-          {isRunning && !isModificationModeEnabled && (
-            <Restricted
-              resourceBasedRestrictions={{
-                scopes: ['UPDATE_PROCESS_INSTANCE'],
-                permissions,
-              }}
-            >
-              <OperationItem
-                type="CANCEL_PROCESS_INSTANCE"
-                onClick={() => setIsCancellationModalVisible(true)}
-                title={`Cancel Instance ${instance.processInstanceKey}`}
-                disabled={isOperationActive('CANCEL_PROCESS_INSTANCE')}
-                size="sm"
-              />
-            </Restricted>
+          {isInstanceActive && !isModificationModeEnabled && (
+            <Cancel
+              processInstanceKey={instance.processInstanceKey}
+              permissions={permissions}
+            />
           )}
-          {!isRunning && (
-            <Restricted
-              resourceBasedRestrictions={{
-                scopes: ['DELETE_PROCESS_INSTANCE'],
-                permissions,
-              }}
-            >
-              <DangerButton
-                type="DELETE"
-                onClick={() => setIsDeleteModalVisible(true)}
-                title={`Delete Instance ${instance.processInstanceKey}`}
-                disabled={isOperationActive('DELETE_PROCESS_INSTANCE')}
-                size="sm"
-              />
-            </Restricted>
+          {!isInstanceActive && (
+            <Delete
+              processInstanceKey={instance.processInstanceKey}
+              permissions={permissions}
+              applyOperation={applyOperation}
+            />
           )}
 
           {isInstanceModificationVisible &&
-            isRunning &&
+            isInstanceActive &&
             !isModificationModeEnabled && (
               <Restricted
                 resourceBasedRestrictions={{
@@ -171,72 +126,6 @@ const Operations: React.FC<Props> = observer(
               </Restricted>
             )}
         </OperationItems>
-
-        {isCancellationModalVisible && (
-          <>
-            {!rootInstanceId ? (
-              <Modal
-                open={isCancellationModalVisible}
-                preventCloseOnClickOutside
-                modalHeading="Apply Operation"
-                primaryButtonText="Apply"
-                secondaryButtonText="Cancel"
-                onRequestSubmit={() => {
-                  setIsCancellationModalVisible(false);
-                  applyOperation('CANCEL_PROCESS_INSTANCE');
-                }}
-                onRequestClose={() => setIsCancellationModalVisible(false)}
-                size="md"
-                data-testid="confirm-cancellation-modal"
-              >
-                <p>{`About to cancel Instance ${instance.processInstanceKey}. In case there are called instances, these will be canceled too.`}</p>
-                <p>Click "Apply" to proceed.</p>
-              </Modal>
-            ) : (
-              <Modal
-                open={isCancellationModalVisible}
-                preventCloseOnClickOutside
-                modalHeading="Cancel Instance"
-                passiveModal
-                onRequestClose={() => setIsCancellationModalVisible(false)}
-                size="md"
-                data-testid="passive-cancellation-modal"
-              >
-                <p>
-                  To cancel this instance, the root instance{' '}
-                  <Link
-                    to={Paths.processInstance(rootInstanceId)}
-                    title={`View root instance ${rootInstanceId}`}
-                  >
-                    {rootInstanceId}
-                  </Link>{' '}
-                  needs to be canceled. When the root instance is canceled all
-                  the called instances will be canceled automatically.
-                </p>
-              </Modal>
-            )}
-          </>
-        )}
-        {isDeleteModalVisible && (
-          <Modal
-            open={isDeleteModalVisible}
-            danger
-            preventCloseOnClickOutside
-            modalHeading="Delete Instance"
-            primaryButtonText="Delete"
-            secondaryButtonText="Cancel"
-            onRequestSubmit={() => {
-              applyOperation('DELETE_PROCESS_INSTANCE');
-              setIsDeleteModalVisible(false);
-            }}
-            onRequestClose={() => setIsDeleteModalVisible(false)}
-            size="md"
-            data-testid="confirm-deletion-modal"
-          >
-            <p>About to delete Instance {instance.processInstanceKey}.</p>
-            <p>Click "Delete" to proceed.</p>
-          </Modal>
-        )}
 
         {isModificationModeHelperModalVisible && (
           <ModificationHelperModal

--- a/operate/client/src/modules/components/Operations/v2/index.tsx
+++ b/operate/client/src/modules/components/Operations/v2/index.tsx
@@ -89,10 +89,7 @@ const Operations: React.FC<Props> = observer(
             />
           )}
           {isInstanceActive && !isModificationModeEnabled && (
-            <Cancel
-              processInstanceKey={instance.processInstanceKey}
-              permissions={permissions}
-            />
+            <Cancel processInstanceKey={instance.processInstanceKey} />
           )}
           {!isInstanceActive && (
             <Delete

--- a/operate/client/src/modules/mocks/api/v2/processInstances/cancelProcessInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/cancelProcessInstance.ts
@@ -6,19 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
- */
-
+import {endpoints} from '@vzeta/camunda-api-zod-schemas';
 import {mockPostRequest} from '../../mockRequest';
 
 const mockCancelProcessInstance = (contextPath = '') =>
   mockPostRequest(
-    `${contextPath}/v2/process-instances/:processInstanceKey/cancellation`,
+    `${contextPath}${endpoints.cancelProcessInstance.getUrl({processInstanceKey: ':processInstanceKey'})}`,
   );
 
 export {mockCancelProcessInstance};

--- a/operate/client/src/modules/mocks/api/v2/processInstances/cancelProcessInstance.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/cancelProcessInstance.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+
+const mockCancelProcessInstance = (contextPath = '') =>
+  mockPostRequest(
+    `${contextPath}/v2/process-instances/:processInstanceKey/cancellation`,
+  );
+
+export {mockCancelProcessInstance};

--- a/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation} from '@tanstack/react-query';
+import {cancelProcessInstance} from 'modules/api/v2/processInstances/cancelProcessInstance';
+
+function useCancelProcessInstance(
+  processInstanceKey: string,
+  onError?: (error: Error) => void,
+) {
+  return useMutation({
+    mutationFn: () => cancelProcessInstance(processInstanceKey),
+    onSuccess: (response) => {
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+    },
+    onError,
+  });
+}
+
+export {useCancelProcessInstance};

--- a/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
+++ b/operate/client/src/modules/mutations/processInstance/useCancelProcessInstance.tsx
@@ -14,11 +14,12 @@ function useCancelProcessInstance(
   onError?: (error: Error) => void,
 ) {
   return useMutation({
-    mutationFn: () => cancelProcessInstance(processInstanceKey),
-    onSuccess: (response) => {
+    mutationFn: async () => {
+      const response = await cancelProcessInstance(processInstanceKey);
       if (!response.ok) {
         throw new Error(response.statusText);
       }
+      return response;
     },
     onError,
   });

--- a/operate/client/src/modules/queries/callHierarchy/useCallHierarchy.ts
+++ b/operate/client/src/modules/queries/callHierarchy/useCallHierarchy.ts
@@ -20,6 +20,7 @@ function getQueryKey(processInstanceKey?: string) {
 
 const useCallHierarchy = <T = GetProcessInstanceCallHierarchyResponseBody>(
   select?: (data: GetProcessInstanceCallHierarchyResponseBody) => T,
+  enabled: boolean = true,
 ): UseQueryResult<T, RequestError> => {
   const {processInstanceId} = useProcessInstancePageParams();
 
@@ -37,6 +38,7 @@ const useCallHierarchy = <T = GetProcessInstanceCallHierarchyResponseBody>(
         }
       : skipToken,
     select,
+    enabled,
   });
 };
 

--- a/operate/client/src/modules/queries/callHierarchy/useRootInstanceId.ts
+++ b/operate/client/src/modules/queries/callHierarchy/useRootInstanceId.ts
@@ -15,7 +15,11 @@ const rootInstanceIdParser = (
   return data[0]?.processInstanceKey;
 };
 
-const useRootInstanceId = () =>
-  useCallHierarchy<string | undefined>(rootInstanceIdParser);
+type useRootInstanceIdOptions = {
+  enabled?: boolean;
+};
+
+const useRootInstanceId = (options?: useRootInstanceIdOptions) =>
+  useCallHierarchy<string | undefined>(rootInstanceIdParser, options?.enabled);
 
 export {useRootInstanceId};

--- a/operate/client/src/modules/queries/operations/useOperations.ts
+++ b/operate/client/src/modules/queries/operations/useOperations.ts
@@ -12,7 +12,15 @@ const operationsParser = (data: ProcessInstanceEntity) => {
   return data.operations;
 };
 
-const useOperations = () =>
-  useProcessInstanceDeprecated<InstanceOperationEntity[]>(operationsParser);
+type Options = {
+  enabled?: boolean;
+};
+
+const useOperations = (options?: Options) => {
+  return useProcessInstanceDeprecated<InstanceOperationEntity[]>(
+    operationsParser,
+    options?.enabled,
+  );
+};
 
 export {useOperations};

--- a/operate/client/src/modules/queries/processInstance/deprecated/useProcessInstanceDeprecated.ts
+++ b/operate/client/src/modules/queries/processInstance/deprecated/useProcessInstanceDeprecated.ts
@@ -19,6 +19,7 @@ function getQueryKey(processInstanceKey?: string) {
 
 const useProcessInstanceDeprecated = <T = ProcessInstanceEntity>(
   select?: (data: ProcessInstanceEntity) => T,
+  enabled: boolean = true,
 ): UseQueryResult<T, RequestError> => {
   const {processInstanceId} = useProcessInstancePageParams();
 
@@ -38,6 +39,7 @@ const useProcessInstanceDeprecated = <T = ProcessInstanceEntity>(
       : skipToken,
     select,
     refetchInterval: 5000,
+    enabled,
   });
 };
 

--- a/operate/client/src/modules/request/index.ts
+++ b/operate/client/src/modules/request/index.ts
@@ -39,7 +39,7 @@ type RequestParams = {
   headers?: RequestInit['headers'];
   body?: string | unknown;
   signal?: RequestInit['signal'];
-  responseType?: 'json' | 'text';
+  responseType?: 'json' | 'text' | 'none';
 };
 
 async function requestWithThrow<T>({
@@ -54,12 +54,17 @@ async function requestWithThrow<T>({
     const response = await request({url, method, body, headers, signal});
 
     if (response.ok) {
-      return {
-        response: (await (responseType === 'text'
-          ? response.text()
-          : response.json())) as T,
-        error: null,
-      };
+      if (responseType === 'none') {
+        return {response: null as T, error: null};
+      }
+
+      if (responseType === 'text') {
+        return {response: (await response.text()) as T, error: null};
+      }
+
+      if (responseType === 'json') {
+        return {response: (await response.json()) as T, error: null};
+      }
     }
 
     return {

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -13,6 +13,7 @@ import {ProcessInstanceByNameDto} from './api/incidents/fetchProcessInstancesByN
 import {ProcessDto} from './api/processes/fetchGroupedProcesses';
 import {IncidentDto} from './api/processInstances/fetchProcessInstanceIncidents';
 import {BatchOperationDto} from './api/sharedTypes';
+import {ProcessInstance} from '@vzeta/camunda-api-zod-schemas';
 
 /**
  * @returns a jest mock function that resolves with given value
@@ -98,6 +99,7 @@ const createBatchOperation = (
 /**
  * @returns a mocked instance Object with a unique id
  * @param {*} customProps Obj with any type of custom property
+ * @deprecated this function is used to create data in the format of internal API responses.
  */
 export const createInstance = (
   options: Partial<ProcessInstanceEntity> = {},
@@ -118,6 +120,24 @@ export const createInstance = (
     rootInstanceId: null,
     callHierarchy: [],
     tenantId: '<default>',
+    ...options,
+  };
+};
+
+const createProcessInstance = (
+  options: Partial<ProcessInstance> = {},
+): ProcessInstance => {
+  return {
+    processInstanceKey: '2251799813685294',
+    processDefinitionName: 'someProcessName',
+    state: 'ACTIVE',
+    processDefinitionVersion: 1,
+    processDefinitionVersionTag: 'myVersionTag',
+    processDefinitionId: 'someKey',
+    processDefinitionKey: '2223894723423800',
+    tenantId: '<default>',
+    startDate: '2018-06-21',
+    hasIncident: false,
     ...options,
   };
 };
@@ -1193,4 +1213,9 @@ export const createEventSubProcessFlowNodeInstances = (
   };
 };
 
-export {createVariable, createBatchOperation, createUser};
+export {
+  createVariable,
+  createBatchOperation,
+  createUser,
+  createProcessInstance,
+};

--- a/operate/client/src/modules/utils/instance/index.ts
+++ b/operate/client/src/modules/utils/instance/index.ts
@@ -28,6 +28,10 @@ const isInstanceRunning = (processInstance: ProcessInstance): boolean => {
   return processInstance.state === 'ACTIVE' || processInstance.hasIncident;
 };
 
+/**
+ * @deprecated this function is used for data from internal API responses.
+ * Prefer to use getProcessDefinitionName to get the name from v2 API data.
+ */
 const getProcessName = (instance: ProcessInstanceEntity | null) => {
   if (instance === null) {
     return '';


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Add tanstack mutation for instance cancellation
  - The existing [single operation endpoint](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/cancel-process-instance/) is used instead of a batch operation endpoint ([see decision](https://docs.google.com/document/d/1WoqNKGF-GuZrpmcEkykAWZ5P63Ul4LZkI8Z9kFYC3TU/edit?tab=t.q83f4pggqnit#heading=h.6pt1zwv30xau))
- Split up `Operations` v2 component:
  - `Cancel` -> migrated to v2 in this PR
  - `Delete` -> will be migrated to v2 in a following PR
  - `ResolveIncidents`  -> will be migrated to v2 in a following PR
- Remove proactive permission checks for instance cancellation ([see decision](https://docs.google.com/document/d/1WoqNKGF-GuZrpmcEkykAWZ5P63Ul4LZkI8Z9kFYC3TU/edit?tab=t.q83f4pggqnit#heading=h.666dlrh8e9nl))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33049 
