### PR TITLE
Fix bug where wrong start event got activated

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -105,10 +105,13 @@ public final class BpmnEventSubscriptionBehavior {
         eventTrigger.getVariables());
   }
 
-  public Optional<EventTrigger> getEventTriggerForProcessDefinition(
-      final long processDefinitionKey) {
-    final var eventTrigger = eventScopeInstanceState.peekEventTrigger(processDefinitionKey);
-    return Optional.ofNullable(eventTrigger);
+  public Optional<EventTrigger> findEventTriggerForStartEvent(
+      final long processDefinitionKey, final long processInstanceKey) {
+    return eventScopeInstanceState.findEventTrigger(
+        processDefinitionKey,
+        eventTrigger ->
+            eventTrigger.getProcessInstanceKey() == processInstanceKey
+                || eventTrigger.getProcessInstanceKey() == -1L);
   }
 
   public void activateTriggeredStartEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -136,11 +136,8 @@ public final class ProcessProcessor
         || element.hasTimerStartEvent()
         || element.hasSignalStartEvent()) {
       eventSubscriptionBehavior
-          .getEventTriggerForProcessDefinition(activated.getProcessDefinitionKey())
-          .filter(
-              eventTrigger ->
-                  eventTrigger.getProcessInstanceKey() == activated.getProcessInstanceKey()
-                      || eventTrigger.getProcessInstanceKey() == -1L)
+          .findEventTriggerForStartEvent(
+              activated.getProcessDefinitionKey(), activated.getProcessInstanceKey())
           .ifPresentOrElse(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredStartEvent(activated, eventTrigger),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/EventScopeInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/EventScopeInstanceState.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.instance.EventScopeInstance;
 import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import java.util.Optional;
+import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 
 public interface EventScopeInstanceState {
@@ -29,6 +31,18 @@ public interface EventScopeInstanceState {
    * @return the next event trigger or null if none exist
    */
   EventTrigger peekEventTrigger(long eventScopeKey);
+
+  /**
+   * Returns the first event trigger that matches the provided predicate. If none were found,
+   * returns an empty optional.
+   *
+   * @param eventScopeKey the scope of the event trigger
+   * @param predicate the predicate to match the event trigger against
+   * @return the first event trigger that matches the predicate, or an empty optional if none were
+   *     found
+   */
+  Optional<EventTrigger> findEventTrigger(
+      final long eventScopeKey, final Predicate<EventTrigger> predicate);
 
   /**
    * Checks if the event scope can be triggered for the given event.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalStartEventTest.java
@@ -29,6 +29,11 @@ public class SignalStartEventTest {
   private static final String SIGNAL_NAME_1 = "a";
   private static final String SIGNAL_NAME_2 = "b";
 
+  /**
+   * We set the maximum commands in a batch to 21. It doesn't impact other tests, but it is
+   * necessary for the regression test {@link
+   * #shouldTriggerOnlySignalStartEventWhenCommandProcessingOrderIsSkewedByCommandBatching()}
+   */
   @Rule public final EngineRule engine = EngineRule.singlePartition().maxCommandsInBatch(21);
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/EventScopeInstanceStateTest.java
@@ -426,6 +426,32 @@ public final class EventScopeInstanceStateTest {
   }
 
   @Test
+  void shouldFindFirstEventTriggerWithPredicate() {
+    // given
+    final var processInstanceKey = 456L;
+    final EventTrigger eventTrigger1 = createEventTrigger();
+    final EventTrigger eventTrigger2 = createEventTrigger();
+
+    state.createInstance(SCOPE_KEY, NO_INTERRUPTING_ELEMENT_IDS, NO_BOUNDARY_ELEMENT_IDS);
+
+    // when
+    triggerEvent(SCOPE_KEY, 1, eventTrigger1, processInstanceKey);
+    triggerEvent(SCOPE_KEY, 2, eventTrigger2, processInstanceKey);
+
+    // then
+    assertThat(
+            state.findEventTrigger(
+                SCOPE_KEY, (trigger) -> trigger.getProcessInstanceKey() == processInstanceKey))
+        .isPresent()
+        .get()
+        .isEqualTo(eventTrigger1);
+    assertThat(
+            state.findEventTrigger(
+                SCOPE_KEY, (trigger) -> trigger.getProcessInstanceKey() != processInstanceKey))
+        .isEmpty();
+  }
+
+  @Test
   void shouldPollEventTrigger() {
     // given
     final EventTrigger eventTrigger1 = createEventTrigger();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

On activation of a start event we try to find the first event trigger for this process definition. If this event triggers its process instance key doesn't match the process instance key of the process that gets activated, we activate the none start event.

This code contains the assumption that there is only one event trigger for this process definitions. That doesn't have to be to true. Instead of fetching the first event trigger we should look for one that matches our process instance key. Only if we, after iterating through the state, do not find a matching event trigger we should activate the none start event.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #33952 
closes #7669 
