### PR TITLE
deps: upgrade springboot to 3.3.13

### DIFF
--- a/benchmarks/project/pom.xml
+++ b/benchmarks/project/pom.xml
@@ -92,7 +92,7 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
 
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,7 +78,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.8</version.protobuf>
     <version.protobuf-common>2.29.0</version.protobuf-common>
-    <version.micrometer>1.12.13</version.micrometer>
+    <version.micrometer>1.13.15</version.micrometer>
     <version.rocksdbjni>8.11.4</version.rocksdbjni>
     <version.sbe>1.30.0</version.sbe>
     <version.scala>2.13.16</version.scala>
@@ -95,7 +95,7 @@
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.1.21</version.spring>
-    <version.spring-boot>3.2.12</version.spring-boot>
+    <version.spring-boot>3.3.13</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.5.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Springboot 3.3 and Spring 6.1 open-source support ends on June 30th. Upgrading to Springboot 3.4 and Spring 6.2 is not straightforward, and the value of doing it for 8.4 is limited given 8.4 EOL is in July.
Here I am upgrading 8.4 to Springboot 3.3.13 (3.2 support ended a while ago), we are still within 3.3 OSS for 5 days :) .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
