### PR TITLE
feat: Add startDate and endDate filtering criteria to element instance search API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -148,5 +148,4 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ElementInstanceFilter endDate(final Consumer<DateTimeProperty> endDate);
-
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -17,8 +17,10 @@ package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
+import java.time.OffsetDateTime;
 import java.util.function.Consumer;
 
 public interface ElementInstanceFilter extends SearchRequestFilter {
@@ -121,7 +123,15 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @param value the start date of the element instance
    * @return the updated filter
    */
-  ElementInstanceFilter startDate(final String value);
+  ElementInstanceFilter startDate(final OffsetDateTime value);
+
+  /**
+   * Filters element instances by the specified {@link DateTimeProperty} start date.
+   *
+   * @param startDate the start date of the element instance
+   * @return the updated filter
+   */
+  ElementInstanceFilter startDate(final Consumer<DateTimeProperty> startDate);
 
   /**
    * Filters element instances by end date.
@@ -129,5 +139,14 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @param value the end date of the element instance
    * @return the updated filter
    */
-  ElementInstanceFilter endDate(final String value);
+  ElementInstanceFilter endDate(final OffsetDateTime value);
+
+  /**
+   * Filters element instances by the specified {@link DateTimeProperty} end date.
+   *
+   * @param endDate the end date of the element instance
+   * @return the updated filter
+   */
+  ElementInstanceFilter endDate(final Consumer<DateTimeProperty> endDate);
+
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ElementInstanceFilter.java
@@ -114,4 +114,20 @@ public interface ElementInstanceFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ElementInstanceFilter tenantId(final String value);
+
+  /**
+   * Filters element instances by start date.
+   *
+   * @param value the start date of the element instance
+   * @return the updated filter
+   */
+  ElementInstanceFilter startDate(final String value);
+
+  /**
+   * Filters element instances by end date.
+   *
+   * @param value the end date of the element instance
+   * @return the updated filter
+   */
+  ElementInstanceFilter endDate(final String value);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
@@ -18,11 +18,14 @@ package io.camunda.client.impl.search.filter;
 import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.filter.ElementInstanceFilter;
+import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.ElementInstanceStateProperty;
+import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ElementInstanceStatePropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.impl.util.ParseUtil;
+import java.time.OffsetDateTime;
 import java.util.function.Consumer;
 
 public class ElementInstanceFilterImpl
@@ -112,14 +115,30 @@ public class ElementInstanceFilterImpl
   }
 
   @Override
-  public ElementInstanceFilter startDate(final String value) {
-    filter.setStartDate(value);
+  public ElementInstanceFilter startDate(final OffsetDateTime startDate) {
+    startDate(b -> b.eq(startDate));
     return this;
   }
 
   @Override
-  public ElementInstanceFilter endDate(final String value) {
-    filter.setEndDate(value);
+  public ElementInstanceFilter startDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setStartDate(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceFilter endDate(final OffsetDateTime endDate) {
+    endDate(b -> b.eq(endDate));
+    return this;
+  }
+
+  @Override
+  public ElementInstanceFilter endDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setEndDate(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ElementInstanceFilterImpl.java
@@ -112,6 +112,18 @@ public class ElementInstanceFilterImpl
   }
 
   @Override
+  public ElementInstanceFilter startDate(final String value) {
+    filter.setStartDate(value);
+    return this;
+  }
+
+  @Override
+  public ElementInstanceFilter endDate(final String value) {
+    filter.setEndDate(value);
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.ElementInstanceFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -25,6 +25,7 @@ import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.util.ClientRestTest;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
@@ -58,8 +59,8 @@ public class ElementInstanceTest extends ClientRestTest {
                     .hasIncident(true)
                     .incidentKey(4L)
                     .tenantId("<default>")
-                    .startDate("2024-05-23T23:05:00.000+000")
-                    .endDate("2024-05-23T23:06:00.000+000"))
+                    .startDate(b -> b.exists(true))
+                    .endDate(b -> b.exists(true)))
         .send()
         .join();
     // then
@@ -76,8 +77,232 @@ public class ElementInstanceTest extends ClientRestTest {
     assertThat(filter.getHasIncident()).isTrue();
     assertThat(filter.getIncidentKey()).isEqualTo("4");
     assertThat(filter.getTenantId()).isEqualTo("<default>");
-    assertThat(filter.getStartDate()).isEqualTo("2024-05-23T23:05:00.000+000");
-    assertThat(filter.getEndDate()).isEqualTo("2024-05-23T23:06:00.000+000");
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Exists()).isTrue();
+    assertThat(filter.getEndDate().get$Exists()).isTrue();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesNotExists() {
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.exists(false))
+                .endDate(b -> b.exists(false)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Exists()).isFalse();
+    assertThat(filter.getEndDate().get$Exists()).isFalse();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesGt() {
+    final OffsetDateTime now = OffsetDateTime.now();
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.gt(now))
+                .endDate(b -> b.gt(now)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Gt()).isNotNull();
+    assertThat(filter.getEndDate().get$Gt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesLt() {
+    final OffsetDateTime now = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.lt(now))
+                .endDate(b -> b.lt(now)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Lt()).isNotNull();
+    assertThat(filter.getEndDate().get$Lt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesGte() {
+    final OffsetDateTime now = OffsetDateTime.now();
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.gte(now))
+                .endDate(b -> b.gte(now)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Gte()).isNotNull();
+    assertThat(filter.getEndDate().get$Gte()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesLte() {
+    final OffsetDateTime now = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.lte(now))
+                .endDate(b -> b.lte(now)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Lte()).isNotNull();
+    assertThat(filter.getEndDate().get$Lte()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesGteLte() {
+    final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.gte(startDate))
+                .endDate(b -> b.lte(endDate)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Gte()).isNotNull();
+    assertThat(filter.getEndDate().get$Lte()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesGtLt() {
+    final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.gt(startDate))
+                .endDate(b -> b.lt(endDate)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Gt()).isNotNull();
+    assertThat(filter.getEndDate().get$Lt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesEq() {
+    final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.eq(startDate))
+                .endDate(b -> b.eq(endDate)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Eq()).isNotNull();
+    assertThat(filter.getEndDate().get$Eq()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesNeq() {
+    final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.neq(startDate))
+                .endDate(b -> b.neq(endDate)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$Neq()).isNotNull();
+    assertThat(filter.getEndDate().get$Neq()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnElementInstanceByDatesIn() {
+    final OffsetDateTime startDate = OffsetDateTime.now().minusDays(1);
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    // when
+    client
+        .newElementInstanceSearchRequest()
+        .filter(f ->
+            f.startDate(b -> b.in(startDate, endDate))
+                .endDate(b -> b.in(startDate, endDate)))
+        .send()
+        .join();
+
+    // then
+    final ElementInstanceSearchQuery request =
+        gatewayService.getLastRequest(ElementInstanceSearchQuery.class);
+    final ElementInstanceFilter filter = Objects.requireNonNull(request.getFilter());
+    assertThat(filter.getStartDate()).isNotNull();
+    assertThat(filter.getEndDate()).isNotNull();
+    assertThat(filter.getStartDate().get$In()).isNotNull();
+    assertThat(filter.getEndDate().get$In()).isNotNull();
   }
 
   @Test
@@ -105,6 +330,10 @@ public class ElementInstanceTest extends ClientRestTest {
                     .incidentKey()
                     .asc()
                     .tenantId()
+                    .asc()
+                    .startDate()
+                    .asc()
+                    .endDate()
                     .asc())
         .send()
         .join();
@@ -115,7 +344,7 @@ public class ElementInstanceTest extends ClientRestTest {
     final List<SearchRequestSort> sorts =
         SearchRequestSortMapper.fromElementInstanceSearchQuerySortRequest(
             Objects.requireNonNull(request.getSort()));
-    assertThat(sorts.size()).isEqualTo(9);
+    assertThat(sorts.size()).isEqualTo(11);
     assertSort(sorts.get(0), "processDefinitionKey", SortOrderEnum.ASC);
     assertSort(sorts.get(1), "processInstanceKey", SortOrderEnum.ASC);
     assertSort(sorts.get(2), "processDefinitionId", SortOrderEnum.ASC);
@@ -125,6 +354,8 @@ public class ElementInstanceTest extends ClientRestTest {
     assertSort(sorts.get(6), "endDate", SortOrderEnum.DESC);
     assertSort(sorts.get(7), "incidentKey", SortOrderEnum.ASC);
     assertSort(sorts.get(8), "tenantId", SortOrderEnum.ASC);
+    assertSort(sorts.get(9), "startDate", SortOrderEnum.ASC);
+    assertSort(sorts.get(10), "endDate", SortOrderEnum.ASC);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -57,7 +57,9 @@ public class ElementInstanceTest extends ClientRestTest {
                     .elementId("elementId")
                     .hasIncident(true)
                     .incidentKey(4L)
-                    .tenantId("<default>"))
+                    .tenantId("<default>")
+                    .startDate("2024-05-23T23:05:00.000+000")
+                    .endDate("2024-05-23T23:06:00.000+000"))
         .send()
         .join();
     // then
@@ -74,6 +76,8 @@ public class ElementInstanceTest extends ClientRestTest {
     assertThat(filter.getHasIncident()).isTrue();
     assertThat(filter.getIncidentKey()).isEqualTo("4");
     assertThat(filter.getTenantId()).isEqualTo("<default>");
+    assertThat(filter.getStartDate()).isEqualTo("2024-05-23T23:05:00.000+000");
+    assertThat(filter.getEndDate()).isEqualTo("2024-05-23T23:06:00.000+000");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/elementinstance/ElementInstanceTest.java
@@ -88,9 +88,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.exists(false))
-                .endDate(b -> b.exists(false)))
+        .filter(f -> f.startDate(b -> b.exists(false)).endDate(b -> b.exists(false)))
         .send()
         .join();
 
@@ -109,9 +107,7 @@ public class ElementInstanceTest extends ClientRestTest {
     final OffsetDateTime now = OffsetDateTime.now();
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.gt(now))
-                .endDate(b -> b.gt(now)))
+        .filter(f -> f.startDate(b -> b.gt(now)).endDate(b -> b.gt(now)))
         .send()
         .join();
 
@@ -131,9 +127,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.lt(now))
-                .endDate(b -> b.lt(now)))
+        .filter(f -> f.startDate(b -> b.lt(now)).endDate(b -> b.lt(now)))
         .send()
         .join();
 
@@ -152,9 +146,7 @@ public class ElementInstanceTest extends ClientRestTest {
     final OffsetDateTime now = OffsetDateTime.now();
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.gte(now))
-                .endDate(b -> b.gte(now)))
+        .filter(f -> f.startDate(b -> b.gte(now)).endDate(b -> b.gte(now)))
         .send()
         .join();
 
@@ -174,9 +166,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.lte(now))
-                .endDate(b -> b.lte(now)))
+        .filter(f -> f.startDate(b -> b.lte(now)).endDate(b -> b.lte(now)))
         .send()
         .join();
 
@@ -197,9 +187,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.gte(startDate))
-                .endDate(b -> b.lte(endDate)))
+        .filter(f -> f.startDate(b -> b.gte(startDate)).endDate(b -> b.lte(endDate)))
         .send()
         .join();
 
@@ -220,9 +208,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.gt(startDate))
-                .endDate(b -> b.lt(endDate)))
+        .filter(f -> f.startDate(b -> b.gt(startDate)).endDate(b -> b.lt(endDate)))
         .send()
         .join();
 
@@ -243,9 +229,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.eq(startDate))
-                .endDate(b -> b.eq(endDate)))
+        .filter(f -> f.startDate(b -> b.eq(startDate)).endDate(b -> b.eq(endDate)))
         .send()
         .join();
 
@@ -266,9 +250,7 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.neq(startDate))
-                .endDate(b -> b.neq(endDate)))
+        .filter(f -> f.startDate(b -> b.neq(startDate)).endDate(b -> b.neq(endDate)))
         .send()
         .join();
 
@@ -289,9 +271,8 @@ public class ElementInstanceTest extends ClientRestTest {
     // when
     client
         .newElementInstanceSearchRequest()
-        .filter(f ->
-            f.startDate(b -> b.in(startDate, endDate))
-                .endDate(b -> b.in(startDate, endDate)))
+        .filter(
+            f -> f.startDate(b -> b.in(startDate, endDate)).endDate(b -> b.in(startDate, endDate)))
         .send()
         .join();
 

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -100,6 +100,14 @@
       AND TENANT_ID IN
       <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
+    <if test="filter.startDates != null and !filter.startDates.isEmpty()">
+      AND START_DATE IN
+      <foreach collection="filter.startDates" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    </if>
+    <if test="filter.endDates != null and !filter.endDates.isEmpty()">
+      AND END_DATE IN
+      <foreach collection="filter.endDates" item="value" open="(" separator=", " close=")">#{value}</foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.FlowNodeInstanceEntity">

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -100,14 +100,23 @@
       AND TENANT_ID IN
       <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
-    <if test="filter.startDates != null and !filter.startDates.isEmpty()">
-      AND START_DATE IN
-      <foreach collection="filter.startDates" item="value" open="(" separator=", " close=")">#{value}</foreach>
+
+    <!-- Start Date Filters -->
+    <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">
+      <foreach collection="filter.startDateOperations" item="operation">
+        AND START_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
-    <if test="filter.endDates != null and !filter.endDates.isEmpty()">
-      AND END_DATE IN
-      <foreach collection="filter.endDates" item="value" open="(" separator=", " close=")">#{value}</foreach>
+
+    <!-- End Date Filters -->
+    <if test="filter.endDateOperations != null and !filter.endDateOperations.isEmpty()">
+      <foreach collection="filter.endDateOperations" item="operation">
+        AND END_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
     </if>
+
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.FlowNodeInstanceEntity">

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -1,0 +1,682 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.assertSorted;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilElementInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.enums.ElementInstanceType;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.random.RandomGenerator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class ElementInstanceSearchTest {
+
+  static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  static final List<ProcessInstanceEvent> PROCESS_INSTANCES = new ArrayList<>();
+  private static ElementInstance elementInstance;
+  private static ElementInstance elementInstanceWithIncident;
+  private static List<ElementInstance> allElementInstances;
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  public static void beforeAll() {
+    Objects.requireNonNull(camundaClient);
+    final List<String> processes =
+        List.of(
+            "service_tasks_v1.bpmn",
+            "service_tasks_v2.bpmn",
+            "incident_process_v1.bpmn",
+            "incident_process_v2.bpmn",
+            "manual_process.bpmn",
+            "parent_process_v1.bpmn",
+            "child_process_v1.bpmn");
+    processes.forEach(
+        process ->
+            DEPLOYED_PROCESSES.addAll(
+                deployResource(camundaClient, String.format("process/%s", process))
+                    .getProcesses()));
+
+    waitForProcessesToBeDeployed(camundaClient, DEPLOYED_PROCESSES.size());
+
+    PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"foo\"}"));
+    PROCESS_INSTANCES.add(
+        startProcessInstance(
+            camundaClient, "service_tasks_v1", "{\"xyz\": \"bar\",\"abc\": \"mnp\"}"));
+    PROCESS_INSTANCES.add(
+        startProcessInstance(camundaClient, "service_tasks_v2", "{\"path\":222}"));
+    PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "manual_process"));
+    final ProcessInstanceEvent processInstanceWithIncident =
+        startProcessInstance(camundaClient, "incident_process_v1");
+    PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "incident_process_v2"));
+    PROCESS_INSTANCES.add(processInstanceWithIncident);
+    PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "parent_process_v1"));
+
+    waitForProcessInstancesToStart(camundaClient, 8);
+    waitForElementInstances(camundaClient, 24);
+    waitUntilElementInstanceHasIncidents(camundaClient, 2);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 2);
+    // store element instances for querying
+    allElementInstances =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(100))
+            .sort(s -> s.elementId().asc())
+            .send()
+            .join()
+            .items();
+    elementInstance = allElementInstances.getFirst();
+    elementInstanceWithIncident =
+        allElementInstances.stream()
+            .filter(f -> f.getIncidentKey() != null)
+            .findFirst()
+            .orElseThrow();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+    PROCESS_INSTANCES.clear();
+  }
+
+  @Test
+  void shouldRetrieveElementInstanceByStartDateFilter() {
+    // given
+    final var ei =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    final var startDate = OffsetDateTime.parse(ei.getStartDate());
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            // also filtering by elementId to get a unique result since others may coincidentally
+            // have been started at the same time
+            .filter(f -> f.startDate(startDate).elementId(ei.getElementId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getStartDate()).isEqualTo(ei.getStartDate());
+  }
+
+  @Test
+  void shouldNotFindElementInstanceByStartDateFilter() {
+    // given
+    final var hourAgo = OffsetDateTime.now().minusHours(1);
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.startDate(hourAgo))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldRetrieveElementInstanceByEndDateFilter() {
+    // given
+    final var ei =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    final var endDate = OffsetDateTime.parse(ei.getEndDate());
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            // also filtering by elementId to get a unique result since others may coincidentally
+            // have ended at the same time
+            .filter(f -> f.endDate(endDate).elementId(ei.getElementId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getEndDate()).isEqualTo(ei.getEndDate());
+  }
+
+  @Test
+  void shouldNotFindElementInstanceByEndDateFilter() {
+    // given
+    final var hourAgo = OffsetDateTime.now().minusHours(1);
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.endDate(hourAgo))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  public void shouldValidateElementInstancePagination() {
+    final var result =
+        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2)).send().join();
+    assertThat(result.items().size()).isEqualTo(2);
+    final var key = result.items().getFirst().getElementInstanceKey();
+    // apply searchAfter
+    final var resultAfter =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.after(result.page().endCursor()))
+            .send()
+            .join();
+
+    assertThat(resultAfter.items().size()).isEqualTo(22);
+    final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
+    // apply searchBefore
+    final var resultBefore =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.before(resultAfter.page().startCursor()))
+            .send()
+            .join();
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(resultBefore.items().getFirst().getElementInstanceKey()).isEqualTo(key);
+  }
+
+  @Test
+  void shouldQueryElementInstanceByElementInstanceKey() {
+    // given
+    final var key = elementInstance.getElementInstanceKey();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementInstanceKey(key))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst()).isEqualTo(elementInstance);
+  }
+
+  @Test
+  void shouldSortElementInstanceByElementInstanceKey() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementInstanceKey().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementInstanceKey().desc())
+            .send()
+            .join();
+
+    assertSorted(resultAsc, resultDesc, ElementInstance::getElementInstanceKey);
+  }
+
+  @Test
+  void shouldQueryElementInstanceQueryByProcessInstanceKey() {
+    // given
+    final var processInstanceKey = elementInstance.getProcessInstanceKey();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items().getFirst().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(result.items().get(1).getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  void shouldSortElementInstanceByProcessInstanceKey() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.processInstanceKey().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.processInstanceKey().desc())
+            .send()
+            .join();
+
+    assertSorted(resultAsc, resultDesc, ElementInstance::getProcessInstanceKey);
+  }
+
+  @Test
+  void shouldGetElementInstanceByKey() {
+    // given
+    final var elementInstanceKey = elementInstance.getElementInstanceKey();
+
+    // when
+    final var result = camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result).isEqualTo(elementInstance);
+  }
+
+  @Test
+  void shouldQueryElementInstanceByElementId() {
+    // given
+    final var elementId = elementInstance.getElementId();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(elementId))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst().getElementId()).isEqualTo(elementId);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isNotNull();
+    assertThat(result.items().getFirst().getProcessDefinitionId())
+        .isEqualTo(elementInstance.getProcessDefinitionId());
+  }
+
+  @Test
+  void shouldQueryElementInstanceByElementName() {
+    // given
+    final var elementName = elementInstance.getElementName();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementName(elementName))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst().getElementName()).isEqualTo(elementName);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isNotNull();
+    assertThat(result.items().getFirst().getProcessDefinitionId())
+        .isEqualTo(elementInstance.getProcessDefinitionId());
+  }
+
+  @Test
+  void shouldSortElementInstanceByElementId() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementId().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementId().desc())
+            .send()
+            .join();
+    assertSorted(resultAsc, resultDesc, ElementInstance::getElementId);
+  }
+
+  @Test
+  void shouldSortElementInstanceByElementName() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementName().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.elementName().desc())
+            .send()
+            .join();
+    assertSorted(resultAsc, resultDesc, ElementInstance::getElementName);
+  }
+
+  @Test
+  void shouldHaveCorrectElementInstanceElementName() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId("noOpTask"))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementName()).isEqualTo("No Op");
+  }
+
+  @Test
+  void shouldUseElementInstanceElementIdIfNameNotSet() {
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId("Event_1p0nsc7"))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getElementName()).isEqualTo("Event_1p0nsc7");
+  }
+
+  @Test
+  void shouldQueryElementInstanceByProcessDefinitionKey() {
+    // given
+    final var processDefinitionKey = elementInstance.getProcessDefinitionKey();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items().getFirst().getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+  }
+
+  @Test
+  void shouldSortElementInstanceByProcessDefinitionKey() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.processDefinitionKey().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.processDefinitionKey().desc())
+            .send()
+            .join();
+    assertSorted(resultAsc, resultDesc, ElementInstance::getProcessDefinitionKey);
+  }
+
+  @Test
+  void shouldQueryElementInstanceByIncidentKey() {
+    // given
+    final var incidentKey = elementInstanceWithIncident.getIncidentKey();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.incidentKey(incidentKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst().getIncidentKey()).isEqualTo(incidentKey);
+    assertThat(result.items().getFirst().getState()).isEqualTo(ElementInstanceState.ACTIVE);
+    assertThat(result.items().getFirst().getIncident()).isEqualTo(true);
+  }
+
+  @Test
+  void shouldSortElementInstanceByIncidentKey() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.incidentKey().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .sort(s -> s.incidentKey().desc())
+            .send()
+            .join();
+
+    assertSorted(resultAsc, resultDesc, ElementInstance::getIncidentKey);
+  }
+
+  @Test
+  void shouldQueryElementInstanceByState() {
+    // given
+    final var state = elementInstance.getState();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.state(ElementInstanceState.valueOf(state.name())))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(19);
+    assertThat(result.items().getFirst().getState()).isEqualTo(state);
+  }
+
+  @Test
+  void shouldSortElementInstanceByState() {
+    // when
+    final var resultAsc =
+        camundaClient.newElementInstanceSearchRequest().sort(s -> s.state().asc()).send().join();
+    final var resultDesc =
+        camundaClient.newElementInstanceSearchRequest().sort(s -> s.state().desc()).send().join();
+
+    assertSorted(resultAsc, resultDesc, elementInstance -> elementInstance.getState().name());
+  }
+
+  @Test
+  void shouldQueryElementInstanceByIncident() {
+    // given
+    final var hasIncident = elementInstanceWithIncident.getIncident();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.hasIncident(hasIncident))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items().getFirst().getIncident()).isEqualTo(hasIncident);
+  }
+
+  @Test
+  void shouldQueryElementInstanceByType() {
+    // given
+    final var type = elementInstance.getType();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.type(ElementInstanceType.valueOf(type.name())))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(3);
+    assertThat(result.items().getFirst().getType()).isEqualTo(type);
+    assertThat(result.items().get(1).getType()).isEqualTo(type);
+    assertThat(result.items().get(2).getType()).isEqualTo(type);
+  }
+
+  @Test
+  void shouldSortElementInstanceByType() {
+    // when
+    final var resultAsc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(100))
+            .sort(s -> s.type().asc())
+            .send()
+            .join();
+    final var resultDesc =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(100))
+            .sort(s -> s.type().desc())
+            .send()
+            .join();
+
+    assertSorted(resultAsc, resultDesc, elementInstance -> elementInstance.getType().name());
+  }
+
+  @Test
+  void shouldQueryElementInstanceByTenantId() {
+    // given
+    final var tenantId = elementInstance.getTenantId();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.tenantId(tenantId))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(24);
+    assertThat(result.items()).allMatch(f -> f.getTenantId().equals(tenantId));
+  }
+
+  @Test
+  public void shouldQueryElementInstanceValidatePagination() {
+    final var result =
+        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2)).send().join();
+    assertThat(result.items().size()).isEqualTo(2);
+    final var key = result.items().getFirst().getElementInstanceKey();
+    // apply searchAfter
+    final var resultAfter =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.after(result.page().endCursor()))
+            .send()
+            .join();
+
+    assertThat(resultAfter.items().size()).isEqualTo(22);
+    final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
+    // apply searchBefore
+    final var resultBefore =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.before(resultAfter.page().startCursor()))
+            .send()
+            .join();
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(resultBefore.items().getFirst().getElementInstanceKey()).isEqualTo(key);
+  }
+
+  @Test
+  void shouldSearchByFromWithLimit() {
+    // when
+    final var resultAll = camundaClient.newElementInstanceSearchRequest().send().join();
+    final var thirdKey = resultAll.items().get(2).getElementInstanceKey();
+
+    final var resultSearchFrom =
+        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2).from(2)).send().join();
+
+    // then
+    assertThat(resultSearchFrom.items().size()).isEqualTo(2);
+    assertThat(resultSearchFrom.items().stream().findFirst().get().getElementInstanceKey())
+        .isEqualTo(thirdKey);
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByElementIdFilter() {
+    // given
+    final var random = RandomGenerator.getDefault();
+    final var elementInstance = allElementInstances.get(random.nextInt(allElementInstances.size()));
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processInstanceKey(elementInstance.getProcessInstanceKey())
+                        .elementId(elementInstance.getElementId()))
+            .send()
+            .join();
+
+    assertThat(result.items())
+        .extracting("processInstanceKey")
+        .containsExactly(elementInstance.getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByElementIdAndElementInstanceStateFilter() {
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.elementId("taskA").elementInstanceState(ElementInstanceState.ACTIVE))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
+        .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByElementIdAndElementInstanceIncidentFilter() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.elementId(elementInstanceWithIncident.getElementId())
+                        .hasElementInstanceIncident(true))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+  }
+
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ElementInstanceSearchTest.java
@@ -678,5 +678,4 @@ public class ElementInstanceSearchTest {
     // then
     assertThat(result.items().size()).isEqualTo(2);
   }
-
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndElementInstanceSearchTest.java
@@ -1014,6 +1014,90 @@ public class ProcessInstanceAndElementInstanceSearchTest {
   }
 
   @Test
+  void shouldRetrieveElementInstaneceByStartDateFilter() {
+    // given
+    final var ei =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            // also filtering by elementId to get a unique result since others may coincidentally
+            // have been started at the same time
+            .filter(f -> f.startDate(ei.getStartDate()).elementId(ei.getElementId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getStartDate()).isEqualTo(ei.getStartDate());
+  }
+
+  @Test
+  void shouldNotFindElementInstanceByStartDateFilter() {
+    // given
+    final String hourAgo = OffsetDateTime.now().minusHours(1).toString();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.startDate(hourAgo))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldRetrieveElementInstaneceByEndDateFilter() {
+    // given
+    final var ei =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .page(p -> p.limit(1))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            // also filtering by elementId to get a unique result since others may coincidentally
+            // have ended at the same time
+            .filter(f -> f.startDate(ei.getEndDate()).elementId(ei.getElementId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getStartDate()).isEqualTo(ei.getStartDate());
+  }
+
+  @Test
+  void shouldNotFindElementInstanceByEndDateFilter() {
+    // given
+    final String hourAgo = OffsetDateTime.now().minusHours(1).toString();
+    // when
+    final var result =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.endDate(hourAgo))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
   void shouldSortProcessInstancesByState() {
     // when
     final var resultAsc =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchTest.java
@@ -13,10 +13,8 @@ import static io.camunda.client.api.search.enums.ProcessInstanceState.TERMINATED
 import static io.camunda.it.util.TestHelper.assertSorted;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
-import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
-import static io.camunda.it.util.TestHelper.waitUntilElementInstanceHasIncidents;
 import static io.camunda.it.util.TestHelper.waitUntilJobWorkerHasFailedJob;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,24 +26,26 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
-import io.camunda.client.api.search.enums.ElementInstanceState;
-import io.camunda.client.api.search.enums.ElementInstanceType;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
-import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.random.RandomGenerator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
-public class ProcessInstanceAndElementInstanceSearchTest {
+public class ProcessInstanceSearchTest {
 
   public static final String INCIDENT_ERROR_MESSAGE_V1 =
       "Expected result of the expression 'retriesA' to be 'NUMBER', but was 'STRING'.";
@@ -53,9 +53,6 @@ public class ProcessInstanceAndElementInstanceSearchTest {
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   static final List<ProcessInstanceEvent> PROCESS_INSTANCES = new ArrayList<>();
   private static long processInstanceWithIncidentKey;
-  private static ElementInstance elementInstance;
-  private static ElementInstance elementInstanceWithIncident;
-  private static List<ElementInstance> allElementInstances;
   private static CamundaClient camundaClient;
 
   @BeforeAll
@@ -94,24 +91,7 @@ public class ProcessInstanceAndElementInstanceSearchTest {
     PROCESS_INSTANCES.add(startProcessInstance(camundaClient, "parent_process_v1"));
 
     waitForProcessInstancesToStart(camundaClient, 8);
-    waitForElementInstances(camundaClient, 24);
-    waitUntilElementInstanceHasIncidents(camundaClient, 2);
     waitUntilProcessInstanceHasIncidents(camundaClient, 2);
-    // store element instances for querying
-    allElementInstances =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.limit(100))
-            .sort(s -> s.elementId().asc())
-            .send()
-            .join()
-            .items();
-    elementInstance = allElementInstances.getFirst();
-    elementInstanceWithIncident =
-        allElementInstances.stream()
-            .filter(f -> f.getIncidentKey() != null)
-            .findFirst()
-            .orElseThrow();
   }
 
   @AfterAll
@@ -1014,90 +994,6 @@ public class ProcessInstanceAndElementInstanceSearchTest {
   }
 
   @Test
-  void shouldRetrieveElementInstaneceByStartDateFilter() {
-    // given
-    final var ei =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.limit(1))
-            .send()
-            .join()
-            .items()
-            .getFirst();
-
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            // also filtering by elementId to get a unique result since others may coincidentally
-            // have been started at the same time
-            .filter(f -> f.startDate(ei.getStartDate()).elementId(ei.getElementId()))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getStartDate()).isEqualTo(ei.getStartDate());
-  }
-
-  @Test
-  void shouldNotFindElementInstanceByStartDateFilter() {
-    // given
-    final String hourAgo = OffsetDateTime.now().minusHours(1).toString();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.startDate(hourAgo))
-            .send()
-            .join();
-    // then
-    assertThat(result.items()).isEmpty();
-  }
-
-  @Test
-  void shouldRetrieveElementInstaneceByEndDateFilter() {
-    // given
-    final var ei =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.limit(1))
-            .send()
-            .join()
-            .items()
-            .getFirst();
-
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            // also filtering by elementId to get a unique result since others may coincidentally
-            // have ended at the same time
-            .filter(f -> f.startDate(ei.getEndDate()).elementId(ei.getElementId()))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getStartDate()).isEqualTo(ei.getStartDate());
-  }
-
-  @Test
-  void shouldNotFindElementInstanceByEndDateFilter() {
-    // given
-    final String hourAgo = OffsetDateTime.now().minusHours(1).toString();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.endDate(hourAgo))
-            .send()
-            .join();
-    // then
-    assertThat(result.items()).isEmpty();
-  }
-
-  @Test
   void shouldSortProcessInstancesByState() {
     // when
     final var resultAsc =
@@ -1133,440 +1029,6 @@ public class ProcessInstanceAndElementInstanceSearchTest {
             .join();
     assertThat(result.items().size()).isEqualTo(2);
     assertThat(resultBefore.items().getFirst().getProcessInstanceKey()).isEqualTo(key);
-  }
-
-  @Test
-  public void shouldValidateElementInstancePagination() {
-    final var result =
-        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2)).send().join();
-    assertThat(result.items().size()).isEqualTo(2);
-    final var key = result.items().getFirst().getElementInstanceKey();
-    // apply searchAfter
-    final var resultAfter =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.after(result.page().endCursor()))
-            .send()
-            .join();
-
-    assertThat(resultAfter.items().size()).isEqualTo(22);
-    final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
-    // apply searchBefore
-    final var resultBefore =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.before(resultAfter.page().startCursor()))
-            .send()
-            .join();
-    assertThat(result.items().size()).isEqualTo(2);
-    assertThat(resultBefore.items().getFirst().getElementInstanceKey()).isEqualTo(key);
-  }
-
-  @Test
-  void shouldQueryElementInstanceByElementInstanceKey() {
-    // given
-    final var key = elementInstance.getElementInstanceKey();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementInstanceKey(key))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().getFirst()).isEqualTo(elementInstance);
-  }
-
-  @Test
-  void shouldSortElementInstanceByElementInstanceKey() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementInstanceKey().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementInstanceKey().desc())
-            .send()
-            .join();
-
-    assertSorted(resultAsc, resultDesc, ElementInstance::getElementInstanceKey);
-  }
-
-  @Test
-  void shouldQueryElementInstanceQueryByProcessInstanceKey() {
-    // given
-    final var processInstanceKey = elementInstance.getProcessInstanceKey();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.processInstanceKey(processInstanceKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(5);
-    assertThat(result.items().getFirst().getProcessInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(result.items().get(1).getProcessInstanceKey()).isEqualTo(processInstanceKey);
-  }
-
-  @Test
-  void shouldSortElementInstanceByProcessInstanceKey() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.processInstanceKey().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.processInstanceKey().desc())
-            .send()
-            .join();
-
-    assertSorted(resultAsc, resultDesc, ElementInstance::getProcessInstanceKey);
-  }
-
-  @Test
-  void shouldGetElementInstanceByKey() {
-    // given
-    final var elementInstanceKey = elementInstance.getElementInstanceKey();
-
-    // when
-    final var result = camundaClient.newElementInstanceGetRequest(elementInstanceKey).send().join();
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result).isEqualTo(elementInstance);
-  }
-
-  @Test
-  void shouldQueryElementInstanceByElementId() {
-    // given
-    final var elementId = elementInstance.getElementId();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementId(elementId))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().getFirst().getElementId()).isEqualTo(elementId);
-    assertThat(result.items().getFirst().getProcessDefinitionId()).isNotNull();
-    assertThat(result.items().getFirst().getProcessDefinitionId())
-        .isEqualTo(elementInstance.getProcessDefinitionId());
-  }
-
-  @Test
-  void shouldQueryElementInstanceByElementName() {
-    // given
-    final var elementName = elementInstance.getElementName();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementName(elementName))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().getFirst().getElementName()).isEqualTo(elementName);
-    assertThat(result.items().getFirst().getProcessDefinitionId()).isNotNull();
-    assertThat(result.items().getFirst().getProcessDefinitionId())
-        .isEqualTo(elementInstance.getProcessDefinitionId());
-  }
-
-  @Test
-  void shouldSortElementInstanceByElementId() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementId().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementId().desc())
-            .send()
-            .join();
-    assertSorted(resultAsc, resultDesc, ElementInstance::getElementId);
-  }
-
-  @Test
-  void shouldSortElementInstanceByElementName() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementName().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.elementName().desc())
-            .send()
-            .join();
-    assertSorted(resultAsc, resultDesc, ElementInstance::getElementName);
-  }
-
-  @Test
-  void shouldHaveCorrectElementInstanceElementName() {
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementId("noOpTask"))
-            .send()
-            .join();
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getElementName()).isEqualTo("No Op");
-  }
-
-  @Test
-  void shouldUseElementInstanceElementIdIfNameNotSet() {
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementId("Event_1p0nsc7"))
-            .send()
-            .join();
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getElementName()).isEqualTo("Event_1p0nsc7");
-  }
-
-  @Test
-  void shouldQueryElementInstanceByProcessDefinitionKey() {
-    // given
-    final var processDefinitionKey = elementInstance.getProcessDefinitionKey();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.processDefinitionKey(processDefinitionKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(5);
-    assertThat(result.items().getFirst().getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
-  }
-
-  @Test
-  void shouldSortElementInstanceByProcessDefinitionKey() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.processDefinitionKey().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.processDefinitionKey().desc())
-            .send()
-            .join();
-    assertSorted(resultAsc, resultDesc, ElementInstance::getProcessDefinitionKey);
-  }
-
-  @Test
-  void shouldQueryElementInstanceByIncidentKey() {
-    // given
-    final var incidentKey = elementInstanceWithIncident.getIncidentKey();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.incidentKey(incidentKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().getFirst().getIncidentKey()).isEqualTo(incidentKey);
-    assertThat(result.items().getFirst().getState()).isEqualTo(ElementInstanceState.ACTIVE);
-    assertThat(result.items().getFirst().getIncident()).isEqualTo(true);
-  }
-
-  @Test
-  void shouldSortElementInstanceByIncidentKey() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.incidentKey().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .sort(s -> s.incidentKey().desc())
-            .send()
-            .join();
-
-    assertSorted(resultAsc, resultDesc, ElementInstance::getIncidentKey);
-  }
-
-  @Test
-  void shouldQueryElementInstanceByState() {
-    // given
-    final var state = elementInstance.getState();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.state(ElementInstanceState.valueOf(state.name())))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(19);
-    assertThat(result.items().getFirst().getState()).isEqualTo(state);
-  }
-
-  @Test
-  void shouldSortElementInstanceByState() {
-    // when
-    final var resultAsc =
-        camundaClient.newElementInstanceSearchRequest().sort(s -> s.state().asc()).send().join();
-    final var resultDesc =
-        camundaClient.newElementInstanceSearchRequest().sort(s -> s.state().desc()).send().join();
-
-    assertSorted(resultAsc, resultDesc, elementInstance -> elementInstance.getState().name());
-  }
-
-  @Test
-  void shouldQueryElementInstanceByIncident() {
-    // given
-    final var hasIncident = elementInstanceWithIncident.getIncident();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.hasIncident(hasIncident))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(2);
-    assertThat(result.items().getFirst().getIncident()).isEqualTo(hasIncident);
-  }
-
-  @Test
-  void shouldQueryElementInstanceByType() {
-    // given
-    final var type = elementInstance.getType();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.type(ElementInstanceType.valueOf(type.name())))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(3);
-    assertThat(result.items().getFirst().getType()).isEqualTo(type);
-    assertThat(result.items().get(1).getType()).isEqualTo(type);
-    assertThat(result.items().get(2).getType()).isEqualTo(type);
-  }
-
-  @Test
-  void shouldSortElementInstanceByType() {
-    // when
-    final var resultAsc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.limit(100))
-            .sort(s -> s.type().asc())
-            .send()
-            .join();
-    final var resultDesc =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.limit(100))
-            .sort(s -> s.type().desc())
-            .send()
-            .join();
-
-    assertSorted(resultAsc, resultDesc, elementInstance -> elementInstance.getType().name());
-  }
-
-  @Test
-  void shouldQueryElementInstanceByTenantId() {
-    // given
-    final var tenantId = elementInstance.getTenantId();
-    // when
-    final var result =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.tenantId(tenantId))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.page().totalItems()).isEqualTo(24);
-    assertThat(result.items()).allMatch(f -> f.getTenantId().equals(tenantId));
-  }
-
-  @Test
-  public void shouldQueryElementInstanceValidatePagination() {
-    final var result =
-        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2)).send().join();
-    assertThat(result.items().size()).isEqualTo(2);
-    final var key = result.items().getFirst().getElementInstanceKey();
-    // apply searchAfter
-    final var resultAfter =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.after(result.page().endCursor()))
-            .send()
-            .join();
-
-    assertThat(resultAfter.items().size()).isEqualTo(22);
-    final var keyAfter = resultAfter.items().getFirst().getElementInstanceKey();
-    // apply searchBefore
-    final var resultBefore =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .page(p -> p.before(resultAfter.page().startCursor()))
-            .send()
-            .join();
-    assertThat(result.items().size()).isEqualTo(2);
-    assertThat(resultBefore.items().getFirst().getElementInstanceKey()).isEqualTo(key);
-  }
-
-  @Test
-  void shouldSearchByFromWithLimit() {
-    // when
-    final var resultAll = camundaClient.newElementInstanceSearchRequest().send().join();
-    final var thirdKey = resultAll.items().get(2).getElementInstanceKey();
-
-    final var resultSearchFrom =
-        camundaClient.newElementInstanceSearchRequest().page(p -> p.limit(2).from(2)).send().join();
-
-    // then
-    assertThat(resultSearchFrom.items().size()).isEqualTo(2);
-    assertThat(resultSearchFrom.items().stream().findFirst().get().getElementInstanceKey())
-        .isEqualTo(thirdKey);
   }
 
   @Test
@@ -1722,62 +1184,6 @@ public class ProcessInstanceAndElementInstanceSearchTest {
           .extracting("processDefinitionId")
           .containsExactlyInAnyOrder("service_tasks_v2");
     }
-  }
-
-  @Test
-  void shouldQueryProcessInstancesByElementIdFilter() {
-    // given
-    final var random = RandomGenerator.getDefault();
-    final var elementInstance = allElementInstances.get(random.nextInt(allElementInstances.size()));
-
-    // when
-    final var result =
-        camundaClient
-            .newProcessInstanceSearchRequest()
-            .filter(
-                f ->
-                    f.processInstanceKey(elementInstance.getProcessInstanceKey())
-                        .elementId(elementInstance.getElementId()))
-            .send()
-            .join();
-
-    assertThat(result.items())
-        .extracting("processInstanceKey")
-        .containsExactly(elementInstance.getProcessInstanceKey());
-  }
-
-  @Test
-  void shouldQueryProcessInstancesByElementIdAndElementInstanceStateFilter() {
-
-    // when
-    final var result =
-        camundaClient
-            .newProcessInstanceSearchRequest()
-            .filter(f -> f.elementId("taskA").elementInstanceState(ElementInstanceState.ACTIVE))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(2);
-    assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
-        .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v1");
-  }
-
-  @Test
-  void shouldQueryProcessInstancesByElementIdAndElementInstanceIncidentFilter() {
-    // when
-    final var result =
-        camundaClient
-            .newProcessInstanceSearchRequest()
-            .filter(
-                f ->
-                    f.elementId(elementInstanceWithIncident.getElementId())
-                        .hasElementInstanceIncident(true))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(2);
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
@@ -47,8 +48,8 @@ public class FlownodeInstanceFilterTransformer
     ofNullable(stringTerms(TREE_PATH, filter.treePaths())).ifPresent(queries::add);
     ofNullable(filter.hasIncident()).ifPresent(f -> queries.add(term(INCIDENT, f)));
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
-    ofNullable(stringTerms(START_DATE, filter.startDates())).ifPresent(queries::add);
-    ofNullable(stringTerms(END_DATE, filter.endDates())).ifPresent(queries::add);
+    queries.addAll(dateTimeOperations(START_DATE, filter.startDateOperations()));
+    queries.addAll(dateTimeOperations(END_DATE, filter.endDateOperations()));
     return and(queries);
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -47,6 +47,8 @@ public class FlownodeInstanceFilterTransformer
     ofNullable(stringTerms(TREE_PATH, filter.treePaths())).ifPresent(queries::add);
     ofNullable(filter.hasIncident()).ifPresent(f -> queries.add(term(INCIDENT, f)));
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
+    ofNullable(stringTerms(START_DATE, filter.startDates())).ifPresent(queries::add);
+    ofNullable(stringTerms(END_DATE, filter.endDates())).ifPresent(queries::add);
     return and(queries);
   }
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
@@ -257,5 +257,4 @@ public final class FlowNodeInstanceFilterTest extends AbstractTransformerTest {
               assertThat(searchRangeQuery.format()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
             });
   }
-
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
@@ -189,4 +189,40 @@ public final class FlowNodeInstanceFilterTest extends AbstractTransformerTest {
               assertThat(t.value().stringValue()).isEqualTo("<default>");
             });
   }
+
+  @Test
+  public void shouldQueryByStartDate() {
+    final var filter =
+        FilterBuilders.flowNodeInstance(f -> f.startDates("2024-05-23T23:05:00.000+000"));
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("startDate");
+              assertThat(t.value().stringValue()).isEqualTo("2024-05-23T23:05:00.000+000");
+            });
+  }
+
+  @Test
+  public void shouldQueryByEndDate() {
+    final var filter =
+        FilterBuilders.flowNodeInstance(f -> f.endDates("2024-05-23T23:05:00.000+000"));
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("endDate");
+              assertThat(t.value().stringValue()).isEqualTo("2024-05-23T23:05:00.000+000");
+            });
+  }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
@@ -9,13 +9,42 @@ package io.camunda.search.clients.transformers.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.Operation;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public final class FlowNodeInstanceFilterTest extends AbstractTransformerTest {
+
+  @Test
+  public void shouldCreateDefaultFilter() {
+    // when
+    final var flowNodeInstanceFilter = (new FlowNodeInstanceFilter.Builder()).build();
+
+    // then
+    assertThat(flowNodeInstanceFilter.flowNodeInstanceKeys()).isEmpty();
+    assertThat(flowNodeInstanceFilter.processInstanceKeys()).isEmpty();
+    assertThat(flowNodeInstanceFilter.processDefinitionKeys()).isEmpty();
+    assertThat(flowNodeInstanceFilter.processDefinitionIds()).isEmpty();
+    assertThat(flowNodeInstanceFilter.stateOperations()).isEmpty();
+    assertThat(flowNodeInstanceFilter.types()).isEmpty();
+    assertThat(flowNodeInstanceFilter.flowNodeIds()).isEmpty();
+    assertThat(flowNodeInstanceFilter.flowNodeNames()).isEmpty();
+    assertThat(flowNodeInstanceFilter.treePaths()).isEmpty();
+    assertThat(flowNodeInstanceFilter.hasIncident()).isNull();
+    assertThat(flowNodeInstanceFilter.incidentKeys()).isEmpty();
+    assertThat(flowNodeInstanceFilter.tenantIds()).isEmpty();
+    assertThat(flowNodeInstanceFilter.startDateOperations()).isEmpty();
+    assertThat(flowNodeInstanceFilter.endDateOperations()).isEmpty();
+  }
 
   @Test
   public void shouldQueryByFlowNodeInstanceKey() {
@@ -191,38 +220,42 @@ public final class FlowNodeInstanceFilterTest extends AbstractTransformerTest {
   }
 
   @Test
-  public void shouldQueryByStartDate() {
+  public void shouldQueryByStartDateAndEndDate() {
+    // given
+    final var dateAfter = OffsetDateTime.of(2024, 3, 12, 10, 30, 15, 0, ZoneOffset.UTC);
+    final var dateBefore = OffsetDateTime.of(2024, 7, 15, 10, 30, 15, 0, ZoneOffset.UTC);
+    final var dateFilter = List.of(Operation.gte(dateAfter), Operation.lt(dateBefore));
     final var filter =
-        FilterBuilders.flowNodeInstance(f -> f.startDates("2024-05-23T23:05:00.000+000"));
+        FilterBuilders.flowNodeInstance(
+            f -> f.startDateOperations(dateFilter).endDateOperations(dateFilter));
+
     // when
     final var searchRequest = transformQuery(filter);
 
     // then
     final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(2);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
         .isInstanceOfSatisfying(
-            SearchTermQuery.class,
-            t -> {
-              assertThat(t.field()).isEqualTo("startDate");
-              assertThat(t.value().stringValue()).isEqualTo("2024-05-23T23:05:00.000+000");
+            SearchRangeQuery.class,
+            (searchRangeQuery) -> {
+              assertThat(searchRangeQuery.field()).isEqualTo("startDate");
+              assertThat(searchRangeQuery.gte()).isEqualTo("2024-03-12T10:30:15.000+0000");
+              assertThat(searchRangeQuery.lt()).isEqualTo("2024-07-15T10:30:15.000+0000");
+              assertThat(searchRangeQuery.format()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchRangeQuery.class,
+            (searchRangeQuery) -> {
+              assertThat(searchRangeQuery.field()).isEqualTo("endDate");
+              assertThat(searchRangeQuery.gte()).isEqualTo("2024-03-12T10:30:15.000+0000");
+              assertThat(searchRangeQuery.lt()).isEqualTo("2024-07-15T10:30:15.000+0000");
+              assertThat(searchRangeQuery.format()).isEqualTo("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
             });
   }
 
-  @Test
-  public void shouldQueryByEndDate() {
-    final var filter =
-        FilterBuilders.flowNodeInstance(f -> f.endDates("2024-05-23T23:05:00.000+000"));
-    // when
-    final var searchRequest = transformQuery(filter);
-
-    // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
-        .isInstanceOfSatisfying(
-            SearchTermQuery.class,
-            t -> {
-              assertThat(t.field()).isEqualTo("endDate");
-              assertThat(t.value().stringValue()).isEqualTo("2024-05-23T23:05:00.000+000");
-            });
-  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
@@ -14,6 +14,7 @@ import static io.camunda.util.CollectionUtil.collectValuesAsList;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -32,8 +33,8 @@ public record FlowNodeInstanceFilter(
     Boolean hasIncident,
     List<Long> incidentKeys,
     List<String> tenantIds,
-    List<String> startDates,
-    List<String> endDates)
+    List<Operation<OffsetDateTime>> startDateOperations,
+    List<Operation<OffsetDateTime>> endDateOperations)
     implements FilterBase {
 
   public static FlowNodeInstanceFilter of(
@@ -55,8 +56,8 @@ public record FlowNodeInstanceFilter(
     private Boolean hasIncident;
     private List<Long> incidentKeys;
     private List<String> tenantIds;
-    private List<String> startDates;
-    private List<String> endDates;
+    private List<Operation<OffsetDateTime>> startDateOperations;
+    private List<Operation<OffsetDateTime>> endDateOperations;
 
     public FlowNodeInstanceFilter.Builder flowNodeInstanceKeys(final List<Long> values) {
       flowNodeInstanceKeys = addValuesToList(flowNodeInstanceKeys, values);
@@ -169,22 +170,28 @@ public record FlowNodeInstanceFilter(
       return tenantIds(collectValuesAsList(values));
     }
 
-    public FlowNodeInstanceFilter.Builder startDates(final List<String> values) {
-      startDates = addValuesToList(startDates, values);
+    public FlowNodeInstanceFilter.Builder startDateOperations(
+        final List<Operation<OffsetDateTime>> operations) {
+      startDateOperations = addValuesToList(startDateOperations, operations);
       return this;
     }
 
-    public FlowNodeInstanceFilter.Builder startDates(final String... values) {
-      return startDates(collectValuesAsList(values));
+    @SafeVarargs
+    public final FlowNodeInstanceFilter.Builder startDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return startDateOperations(collectValues(operation, operations));
     }
 
-    public FlowNodeInstanceFilter.Builder endDates(final List<String> values) {
-      endDates = addValuesToList(endDates, values);
+    public FlowNodeInstanceFilter.Builder endDateOperations(
+        final List<Operation<OffsetDateTime>> operations) {
+      endDateOperations = addValuesToList(endDateOperations, operations);
       return this;
     }
 
-    public FlowNodeInstanceFilter.Builder endDates(final String... values) {
-      return endDates(collectValuesAsList(values));
+    @SafeVarargs
+    public final FlowNodeInstanceFilter.Builder endDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return endDateOperations(collectValues(operation, operations));
     }
 
     @Override
@@ -202,8 +209,8 @@ public record FlowNodeInstanceFilter(
           hasIncident,
           Objects.requireNonNullElse(incidentKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
-          Objects.requireNonNullElse(startDates, Collections.emptyList()),
-          Objects.requireNonNullElse(endDates, Collections.emptyList()));
+          Objects.requireNonNullElse(startDateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(endDateOperations, Collections.emptyList()));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
@@ -31,7 +31,9 @@ public record FlowNodeInstanceFilter(
     List<String> treePaths,
     Boolean hasIncident,
     List<Long> incidentKeys,
-    List<String> tenantIds)
+    List<String> tenantIds,
+    List<String> startDates,
+    List<String> endDates)
     implements FilterBase {
 
   public static FlowNodeInstanceFilter of(
@@ -53,6 +55,8 @@ public record FlowNodeInstanceFilter(
     private Boolean hasIncident;
     private List<Long> incidentKeys;
     private List<String> tenantIds;
+    private List<String> startDates;
+    private List<String> endDates;
 
     public FlowNodeInstanceFilter.Builder flowNodeInstanceKeys(final List<Long> values) {
       flowNodeInstanceKeys = addValuesToList(flowNodeInstanceKeys, values);
@@ -165,6 +169,24 @@ public record FlowNodeInstanceFilter(
       return tenantIds(collectValuesAsList(values));
     }
 
+    public FlowNodeInstanceFilter.Builder startDates(final List<String> values) {
+      startDates = addValuesToList(startDates, values);
+      return this;
+    }
+
+    public FlowNodeInstanceFilter.Builder startDates(final String... values) {
+      return startDates(collectValuesAsList(values));
+    }
+
+    public FlowNodeInstanceFilter.Builder endDates(final List<String> values) {
+      endDates = addValuesToList(endDates, values);
+      return this;
+    }
+
+    public FlowNodeInstanceFilter.Builder endDates(final String... values) {
+      return endDates(collectValuesAsList(values));
+    }
+
     @Override
     public FlowNodeInstanceFilter build() {
       return new FlowNodeInstanceFilter(
@@ -179,7 +201,9 @@ public record FlowNodeInstanceFilter(
           Objects.requireNonNullElse(treePaths, Collections.emptyList()),
           hasIncident,
           Objects.requireNonNullElse(incidentKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
+          Objects.requireNonNullElse(startDates, Collections.emptyList()),
+          Objects.requireNonNullElse(endDates, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6567,11 +6567,13 @@ components:
           type: string
           description: The key of incident if field incident is true.
         startDate:
-          type: string
           description: The start date of this element instance.
+          allOf:
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
         endDate:
-          type: string
-          description: The end date of this element instance.
+          description: The start date of this element instance.
+          allOf:
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
     ElementInstanceSearchQueryResult:
       type: object
       allOf:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6566,6 +6566,12 @@ components:
         incidentKey:
           type: string
           description: The key of incident if field incident is true.
+        startDate:
+          type: string
+          description: The start date of this element instance.
+        endDate:
+          type: string
+          description: The end date of this element instance.
     ElementInstanceSearchQueryResult:
       type: object
       allOf:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6571,7 +6571,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/DateTimeFilterProperty"
         endDate:
-          description: The start date of this element instance.
+          description: The end date of this element instance.
           allOf:
             - $ref: "#/components/schemas/DateTimeFilterProperty"
     ElementInstanceSearchQueryResult:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1028,8 +1028,12 @@ public final class SearchQueryRequestMapper {
                   .map(KeyUtil::keyToLong)
                   .ifPresent(builder::incidentKeys);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
-              Optional.ofNullable(f.getStartDate()).ifPresent(builder::startDates);
-              Optional.ofNullable(f.getEndDate()).ifPresent(builder::endDates);
+              Optional.ofNullable(filter.getStartDate())
+                  .map(mapToOperations(OffsetDateTime.class))
+                  .ifPresent(builder::startDateOperations);
+              Optional.ofNullable(filter.getEndDate())
+                  .map(mapToOperations(OffsetDateTime.class))
+                  .ifPresent(builder::endDateOperations);
             });
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1028,6 +1028,8 @@ public final class SearchQueryRequestMapper {
                   .map(KeyUtil::keyToLong)
                   .ifPresent(builder::incidentKeys);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
+              Optional.ofNullable(f.getStartDate()).ifPresent(builder::startDates);
+              Optional.ofNullable(f.getEndDate()).ifPresent(builder::endDates);
             });
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -255,10 +255,12 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                         .hasIncident(true)
                         .incidentKeys(2251799813685320L)
                         .tenantIds("default")
-                        .startDateOperations(Operation.eq(OffsetDateTime.parse("2023-05-17T10:10:10Z")))
-                        .endDateOperations(Operation.eq(OffsetDateTime.parse("2023-05-23T10:10:10.000Z")))
-                .build())
-        .build());
+                        .startDateOperations(
+                            Operation.eq(OffsetDateTime.parse("2023-05-17T10:10:10Z")))
+                        .endDateOperations(
+                            Operation.eq(OffsetDateTime.parse("2023-05-23T10:10:10.000Z")))
+                        .build())
+                .build());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -210,7 +210,9 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                 "elementName": "name",
                 "hasIncident": true,
                 "incidentKey": "2251799813685320",
-                "tenantId": "default"
+                "tenantId": "default",
+                "startDate": "2023-05-17T10:10:10Z",
+                "endDate": "2023-05-23T10:10:10.000Z"
               }
             }
             """;
@@ -244,6 +246,8 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                         .hasIncident(true)
                         .incidentKeys(2251799813685320L)
                         .tenantIds("default")
+                        .startDates("2023-05-17T10:10:10Z")
+                        .endDates("2023-05-23T10:10:10.000Z")
                         .build())
                 .build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -18,12 +18,14 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.ElementInstanceServices;
+import io.camunda.zeebe.gateway.protocol.rest.ElementInstanceStateEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCacheItem;
@@ -31,8 +33,14 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -131,6 +139,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
 
   @MockBean ElementInstanceServices elementInstanceServices;
   @MockBean ProcessCache processCache;
+  @Captor ArgumentCaptor<FlowNodeInstanceQuery> queryCaptor;
 
   @BeforeEach
   void setupServices() {
@@ -246,10 +255,10 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                         .hasIncident(true)
                         .incidentKeys(2251799813685320L)
                         .tenantIds("default")
-                        .startDates("2023-05-17T10:10:10Z")
-                        .endDates("2023-05-23T10:10:10.000Z")
-                        .build())
-                .build());
+                        .startDateOperations(Operation.eq(OffsetDateTime.parse("2023-05-17T10:10:10Z")))
+                        .endDateOperations(Operation.eq(OffsetDateTime.parse("2023-05-23T10:10:10.000Z")))
+                .build())
+        .build());
   }
 
   @Test
@@ -364,5 +373,65 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
 
     verify(elementInstanceServices).getByKey(5L);
     verify(processCache, never()).getElementName(any());
+  }
+
+  private static Stream<Arguments> provideAdvancedSearchParameters() {
+    final var streamBuilder = Stream.<Arguments>builder();
+
+    customOperationTestCases(
+        streamBuilder,
+        "state",
+        ops -> new FlowNodeInstanceFilter.Builder().stateOperations(ops).build(),
+        List.of(
+            List.of(Operation.eq(String.valueOf(ElementInstanceStateEnum.ACTIVE))),
+            List.of(Operation.neq(String.valueOf(ElementInstanceStateEnum.COMPLETED))),
+            List.of(
+                Operation.in(
+                    String.valueOf(ElementInstanceStateEnum.COMPLETED),
+                    String.valueOf(ElementInstanceStateEnum.ACTIVE)),
+                Operation.like("act"))),
+        true);
+    dateTimeOperationTestCases(
+        streamBuilder,
+        "startDate",
+        ops -> new FlowNodeInstanceFilter.Builder().startDateOperations(ops).build());
+    dateTimeOperationTestCases(
+        streamBuilder,
+        "endDate",
+        ops -> new FlowNodeInstanceFilter.Builder().endDateOperations(ops).build());
+    return streamBuilder.build();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAdvancedSearchParameters")
+  void shouldSearchFlowNodeInstancesWithAdvancedFilter(
+      final String filterString, final FlowNodeInstanceFilter filter) {
+    // given
+    final var request =
+        """
+            {
+                "filter": %s
+            }"""
+            .formatted(filterString);
+    System.out.println("request = " + request);
+    when(elementInstanceServices.search(queryCaptor.capture())).thenReturn(SEARCH_QUERY_RESULT);
+
+    // when / then
+    webClient
+        .post()
+        .uri(ELEMENT_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(elementInstanceServices)
+        .search(new FlowNodeInstanceQuery.Builder().filter(filter).build());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added startDate and endDate attributes as filter criteria to OpenAPI, REST controller, Search Layer, and Java client.

- Change `startDate`/`endDate` from `String` type to `DateTimeFilterProperty` and align code.
- Aligned Tests.
 
**Note**: `ProcessInstanceAndElementInstanceSearchTest` separated to `ProcessInstanceSearchTest` and `ElementInstanceSearchTest`. 
There is a BeforeAll annotation in a method that deploy a process and start Instances. This is mandatory for both test classes,  for ProcessInstance and ElementInstance search. This separation adds a little more overhead but should be acceptable since there is a profit on readability and maintainability.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/33281
