### PR TITLE
Fix pom mc requirements optimize 8.7

### DIFF
--- a/optimize/qa/pom.xml
+++ b/optimize/qa/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
   <artifactId>optimize-qa</artifactId>
+  <name>Optimize QA</name>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -9,6 +9,7 @@
   </parent>
 
   <artifactId>optimize-schema-integrity-tests</artifactId>
+  <name>Optimize Schema Integrity Test</name>
 
   <properties>
     <old.database.port>9250</old.database.port>


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C01H4NG9XDY/p1750855909298959?thread_ts=1750357865.227679&cid=C01H4NG9XDY.

This PR adds the missing `<name>` property to the relevant pom.xml files, to comply with Sonatype Central Portal requirements.

EDIT: same changes must be backported to stabe/optimize-8.6 (manually checked)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
