### PR TITLE
feat: allow custom startup URL

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -163,7 +164,12 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet.BoolVar(&settings.Docker, "docker", false, "Run Camunda from docker-compose.")
 	startFlagSet.StringVar(&settings.Username, "username", "demo", "Change the first users username (default: demo)")
 	startFlagSet.StringVar(&settings.Password, "password", "demo", "Change the first users password (default: demo)")
+	startFlagSet.StringVar(&settings.StartupUrl, "startup-url", createOperateUrl(settings), "The URL to open after startup.")
 	return startFlagSet
+}
+
+func createOperateUrl(settings *types.C8RunSettings) string {
+	return fmt.Sprintf("%s://localhost:%s/operate", settings.GetProtocol(), strconv.Itoa(settings.Port))
 }
 
 func createStopFlagSet(settings *types.C8RunSettings) *flag.FlagSet {

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"text/template"
 	"time"
 
@@ -33,15 +32,10 @@ type Ports struct {
 }
 
 func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8RunSettings, retries int) error {
-	protocol := "http"
-	if settings.HasKeyStore() {
-		protocol = "https"
-	}
-	healthEndpoint := fmt.Sprintf("%s://localhost:9600/actuator/health", protocol)
-	browserUrl := fmt.Sprintf("%s://localhost:%s/operate", protocol, strconv.Itoa(settings.Port))
+	healthEndpoint := fmt.Sprintf("%s://localhost:9600/actuator/health", settings.GetProtocol())
 	if isRunning(ctx, name, healthEndpoint, retries, 14*time.Second) {
 		log.Info().Str("name", name).Msg("has successfully been started.")
-		if err := c8.OpenBrowser(ctx, browserUrl); err != nil {
+		if err := c8.OpenBrowser(ctx, settings.StartupUrl); err != nil {
 			log.Err(err).Msg("Failed to open browser")
 			return nil
 		}

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"text/template"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 )
 
 type opener interface {
-	OpenBrowser(ctx context.Context, protocol string, port int) error
+	OpenBrowser(ctx context.Context, url string) error
 }
 
 type Ports struct {
@@ -37,9 +38,10 @@ func QueryCamunda(ctx context.Context, c8 opener, name string, settings types.C8
 		protocol = "https"
 	}
 	healthEndpoint := fmt.Sprintf("%s://localhost:9600/actuator/health", protocol)
+	browserUrl := fmt.Sprintf("%s://localhost:%s/operate", protocol, strconv.Itoa(settings.Port))
 	if isRunning(ctx, name, healthEndpoint, retries, 14*time.Second) {
 		log.Info().Str("name", name).Msg("has successfully been started.")
-		if err := c8.OpenBrowser(ctx, protocol, settings.Port); err != nil {
+		if err := c8.OpenBrowser(ctx, browserUrl); err != nil {
 			log.Err(err).Msg("Failed to open browser")
 			return nil
 		}

--- a/c8run/internal/processmanagement/processhandler_test.go
+++ b/c8run/internal/processmanagement/processhandler_test.go
@@ -14,7 +14,7 @@ type mockC8 struct {
 	ProcessTreeFunc func(pid int) []*os.Process
 }
 
-func (m *mockC8) OpenBrowser(ctx context.Context, protocol string, port int) error { return nil }
+func (m *mockC8) OpenBrowser(ctx context.Context, url string) error { return nil }
 func (m *mockC8) ProcessTree(pid int) []*os.Process {
 	if m.ProcessTreeFunc != nil {
 		return m.ProcessTreeFunc(pid)

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 type C8Run interface {
-	OpenBrowser(ctx context.Context, protocol string, port int) error
+	OpenBrowser(ctx context.Context, url string) error
 	ProcessTree(commandPid int) []*os.Process
 	VersionCmd(ctx context.Context, javaBinaryPath string) *exec.Cmd
 	ElasticsearchCmd(ctx context.Context, elasticsearchVersion string, parentDir string) *exec.Cmd

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -26,11 +26,21 @@ type C8RunSettings struct {
 	Username             string
 	Password             string
 	Docker               bool
+	StartupUrl           string
 }
 
 // HasKeyStore returns true when the keystore and password are set
 func (c C8RunSettings) HasKeyStore() bool {
 	return c.Keystore != "" && c.KeystorePassword != ""
+}
+
+// GetProtocol resolves the protocol to use for accessing Camunda endpoints
+func (c C8RunSettings) GetProtocol() string {
+	protocol := "http"
+	if c.HasKeyStore() {
+		protocol = "https"
+	}
+	return protocol
 }
 
 type Processes struct {

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func (w *UnixC8Run) OpenBrowser(ctx context.Context, protocol string, port int) error {
+func (w *UnixC8Run) OpenBrowser(ctx context.Context, url string) error {
 	panic("Platform was not built for unix")
 }
 

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -10,12 +10,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"syscall"
 )
 
-func (w *UnixC8Run) OpenBrowser(ctx context.Context, protocol string, port int) error {
-	operateUrl := protocol + "://localhost:" + strconv.Itoa(port) + "/operate"
+func (w *UnixC8Run) OpenBrowser(ctx context.Context, url string) error {
 	var openBrowserCmdString string
 	if runtime.GOOS == "darwin" {
 		openBrowserCmdString = "open"
@@ -24,7 +22,7 @@ func (w *UnixC8Run) OpenBrowser(ctx context.Context, protocol string, port int) 
 	} else {
 		return fmt.Errorf("OpenBrowser: platform %s is not supported", runtime.GOOS)
 	}
-	openBrowserCmd := exec.CommandContext(ctx, openBrowserCmdString, operateUrl)
+	openBrowserCmd := exec.CommandContext(ctx, openBrowserCmdString, url)
 	err := openBrowserCmd.Run()
 	if err != nil {
 		return fmt.Errorf("OpenBrowser: failed to open browser %w\n%s", err, debug.Stack())

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 )
 
-func (w *WindowsC8Run) OpenBrowser(ctx context.Context, protocol string, port int) error {
+func (w *WindowsC8Run) OpenBrowser(ctx context.Context, url string) error {
 	panic("Platform was not built for windows")
 }
 

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -9,13 +9,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime/debug"
-	"strconv"
 	"syscall"
 )
 
-func (w *WindowsC8Run) OpenBrowser(ctx context.Context, protocol string, port int) error {
-	operateUrl := protocol + "://localhost:" + strconv.Itoa(port) + "/operate"
-	openBrowserCmdString := "start " + operateUrl
+func (w *WindowsC8Run) OpenBrowser(ctx context.Context, url string) error {
+	openBrowserCmdString := "start " + url
 	openBrowserCmd := exec.CommandContext(ctx, "cmd", "/C", openBrowserCmdString)
 	openBrowserCmd.SysProcAttr = &syscall.SysProcAttr{
 		// CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags


### PR DESCRIPTION
## Description

First commit `refactor: change c8.OpenBrowser parameters to take a full URL` gives more flexibility in passing potential custom URLs to the function.

The second commit `feat: allow custom startup URL` is adding command flag being `--startup-url` that allows to customize the page to open after startup.

Main use case for now is a customized Getting Started experience, where we want to direct users to certain guides.
Context: https://github.com/camunda/product-hub/issues/2752

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates #https://github.com/camunda/product-hub/issues/2752
