### PR TITLE
Add console ping scheduler and task.

### DIFF
--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -96,7 +96,7 @@ camunda:
   # Operate configuration properties
   operate:
     # Set operate username and password.
-    # If user with <username> does not exists it will be created.
+    # If user with <username> does not exist it will be created.
     # Default: demo/demo
     #username:
     #password:
@@ -121,7 +121,7 @@ camunda:
   # Tasklist configuration properties
   tasklist:
     # Set Tasklist username and password.
-    # If user with <username> does not exists it will be created.
+    # If user with <username> does not exist it will be created.
     # Default: demo/demo
     #username:
     #password:

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.console.ping;
 
 import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
 import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -42,18 +43,7 @@ public class PingConsoleConfiguration implements ApplicationRunner {
   public void run(final ApplicationArguments args) {
     try {
       if (pingConfiguration.enabled) {
-        if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
-          throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
-        }
-        if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
-          throw new IllegalArgumentException("Cluster ID must not be null or empty.");
-        }
-        if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
-          throw new IllegalArgumentException("Cluster name must not be null or empty.");
-        }
-        if (pingConfiguration.pingPeriod() <= 0) {
-          throw new IllegalArgumentException("Ping period must be greater than zero.");
-        }
+        validateConfiguration();
 
         LOGGER.info(
             "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
@@ -71,6 +61,22 @@ public class PingConsoleConfiguration implements ApplicationRunner {
       }
     } catch (final Exception exception) {
       LOGGER.error("Failed to initialize PingConsoleTask: {}", exception.getMessage(), exception);
+    }
+  }
+
+  @VisibleForTesting
+  protected void validateConfiguration() {
+    if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+      throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+    }
+    if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+      throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+    }
+    if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+      throw new IllegalArgumentException("Cluster name must not be null or empty.");
+    }
+    if (pingConfiguration.pingPeriod() <= 0) {
+      throw new IllegalArgumentException("Ping period must be greater than zero.");
     }
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -39,34 +39,38 @@ public class PingConsoleConfiguration implements ApplicationRunner {
   }
 
   @Override
-  public void run(final ApplicationArguments args) throws Exception {
-    if (pingConfiguration.enabled) {
-      if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
-        throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
-      }
-      if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
-        throw new IllegalArgumentException("Cluster ID must not be null or empty.");
-      }
-      if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
-        throw new IllegalArgumentException("Cluster name must not be null or empty.");
-      }
-      if (pingConfiguration.pingPeriod() <= 0) {
-        throw new IllegalArgumentException("Ping period must be greater than zero.");
-      }
+  public void run(final ApplicationArguments args) {
+    try {
+      if (pingConfiguration.enabled) {
+        if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+          throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+        }
+        if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+          throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+        }
+        if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+          throw new IllegalArgumentException("Cluster name must not be null or empty.");
+        }
+        if (pingConfiguration.pingPeriod() <= 0) {
+          throw new IllegalArgumentException("Ping period must be greater than zero.");
+        }
 
-      LOGGER.info(
-          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
-          pingConfiguration.endpoint(),
-          pingConfiguration.pingPeriod());
-      final var executor = createTaskExecutor();
-      executor.schedule(
-          new SelfSchedulingTask(
-              executor,
-              new PingConsoleTask(managementServices, pingConfiguration),
-              // pingPeriod is given in minutes.
-              pingConfiguration.pingPeriod * 60 * 1000L),
-          1000,
-          TimeUnit.MILLISECONDS);
+        LOGGER.info(
+            "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+            pingConfiguration.endpoint(),
+            pingConfiguration.pingPeriod());
+        final var executor = createTaskExecutor();
+        executor.schedule(
+            new SelfSchedulingTask(
+                executor,
+                new PingConsoleTask(managementServices, pingConfiguration),
+                // pingPeriod is given in minutes.
+                pingConfiguration.pingPeriod * 60 * 1000L),
+            1000,
+            TimeUnit.MILLISECONDS);
+      }
+    } catch (final Exception exception) {
+      LOGGER.error("Failed to initialize PingConsoleTask: {}", exception.getMessage(), exception);
     }
   }
 

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({ConsolePingConfiguration.class})
+public class PingConsoleConfiguration implements ApplicationRunner {
+  public static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleConfiguration.class);
+
+  private final ConsolePingConfiguration pingConfiguration;
+  private final ManagementServices managementServices;
+
+  @Autowired
+  public PingConsoleConfiguration(
+      final ConsolePingConfiguration pingConfigurationProperties,
+      final ManagementServices managementServices) {
+    pingConfiguration = pingConfigurationProperties;
+    this.managementServices = managementServices;
+  }
+
+  @Override
+  public void run(final ApplicationArguments args) throws Exception {
+    if (pingConfiguration.enabled) {
+      if (pingConfiguration.endpoint() == null || pingConfiguration.endpoint().isBlank()) {
+        throw new IllegalArgumentException("Ping endpoint must not be null or empty.");
+      }
+      if (pingConfiguration.clusterId() == null || pingConfiguration.clusterId().isBlank()) {
+        throw new IllegalArgumentException("Cluster ID must not be null or empty.");
+      }
+      if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+        throw new IllegalArgumentException("Cluster name must not be null or empty.");
+      }
+      if (pingConfiguration.pingPeriod() <= 0) {
+        throw new IllegalArgumentException("Ping period must be greater than zero.");
+      }
+
+      LOGGER.info(
+          "Console ping is enabled with endpoint: {}, and delay: {} " + "minutes",
+          pingConfiguration.endpoint(),
+          pingConfiguration.pingPeriod());
+      final var executor = createTaskExecutor();
+      executor.schedule(
+          new SelfSchedulingTask(
+              executor,
+              new PingConsoleTask(managementServices, pingConfiguration),
+              // pingPeriod is given in minutes.
+              pingConfiguration.pingPeriod * 60 * 1000L),
+          1000,
+          TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public ScheduledThreadPoolExecutor createTaskExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("console-license-ping-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOGGER))
+            .factory();
+    final var executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+    return executor;
+  }
+
+  @ConfigurationProperties("camunda.console.ping")
+  public record ConsolePingConfiguration(
+      boolean enabled,
+      String endpoint,
+      String clusterId,
+      String clusterName,
+      int pingPeriod,
+      Map<String, String> properties) {}
+
+  static final class SelfSchedulingTask implements Runnable {
+
+    private final ScheduledThreadPoolExecutor executor;
+    private final Runnable task;
+    private final long delay;
+
+    SelfSchedulingTask(
+        final ScheduledThreadPoolExecutor executor, final Runnable task, final long delay) {
+      this.executor = executor;
+      this.task = task;
+      this.delay = delay;
+    }
+
+    @Override
+    public void run() {
+      task.run();
+      executor.schedule(this, delay, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.console.ping.PingConsoleConfiguration.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PingConsoleConfigurationTest {
+
+  @Mock private ManagementServices managementServices;
+  @Mock private ConsolePingConfiguration pingConfiguration;
+  @Mock private HttpClient mockClient;
+
+  @Test
+  void shouldFailToStartConsolePing() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(true, null, "clusterId", "clusterName", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Ping endpoint must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http://localhost:8080", null, "clusterName", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Cluster ID must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http://localhost:8080", "clusterId", "", 5, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Cluster name must not be null or empty.", exception.getMessage());
+
+    exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            new PingConsoleConfiguration(
+                    new ConsolePingConfiguration(
+                        true, "http" + "://localhost:8080", "clusterId", "clusterName", 0, null),
+                    managementServices)
+                ::validateConfiguration);
+    assertEquals("Ping period must be greater than zero.", exception.getMessage());
+  }
+
+  @Test
+  void shouldSucceedToStartConsolePing() {
+    assertDoesNotThrow(
+        () ->
+            new PingConsoleConfiguration(
+                new ConsolePingConfiguration(
+                    true, "http://localhost:8080", "clusterId", "clusterName", 1, null),
+                managementServices));
+
+    // does not throw if the feature is disabled
+    assertDoesNotThrow(
+        () ->
+            new PingConsoleConfiguration(
+                new ConsolePingConfiguration(false, "", "", null, -32, null), managementServices));
+  }
+
+  @Test
+  void doesNotRetryOnSuccess() throws Exception {
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    // Simulate a successful response
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(mockResponse);
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    verify(spyTask, times(1)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSendException() throws Exception {
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    // when we simulate 2 failures and 1 success
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new IOException("IO error"))
+        .thenThrow(new InterruptedException("Interrupted connection error"))
+        .thenReturn(mockResponse); // 3rd try succeeds
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSpecificStatusCodes() throws Exception {
+    final HttpResponse<String> firstMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> secondMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> thirdMockResponse = mock(HttpResponse.class);
+
+    when(firstMockResponse.statusCode()).thenReturn(500); // server error
+    when(secondMockResponse.statusCode()).thenReturn(429); // timeout
+    when(thirdMockResponse.statusCode()).thenReturn(200); // successful request
+
+    when(pingConfiguration.endpoint()).thenReturn("http://fake-endpoint.com");
+
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
+
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(firstMockResponse)
+        .thenReturn(secondMockResponse)
+        .thenReturn(thirdMockResponse);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(managementServices, pingConfiguration, mockClient);
+
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the first use case for the Ping console task. 

- This task is a bean that runs on application commons which is present in in the broker, operate, tasklist, and gateway pods.
- Before running, the config is validated; if this fails, the feature does not run. It is also disabled by default.
- The task is retried if the request fails (it does not attempt to rerun for 4xx except for 429 and 408).
- The PR also adds testing.

We ran manual tests locally with a webhook just to make sure it runs on all the pods referred above.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/34258, https://github.com/camunda/camunda/issues/34259
