### PR TITLE
fix: moved shutdown command to its own channel so we can see correct …

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,8 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha6
+CAMUNDA_VERSION=8.8.0-alpha7
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0-alpha6
+CONNECTORS_VERSION=8.8.0-alpha7
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -3,9 +3,9 @@
 printf "\nTest: Operate process instance api\n"
 
 curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
--H 'Content-Type: application/json' \
--H 'Accept: application/json' \
---data-raw '{
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json' \
+        --data-raw '{
   "filter": {
     "running": true,
     "active": true
@@ -15,48 +15,45 @@ curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
 returnCode=$?
 
 if [[ "$returnCode" != 0 ]]; then
-   echo "test failed"
-   exit 1
+        echo "test failed"
+        exit 1
 fi
 
 printf "\nTest: Tasklist user task\n"
 curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
--H 'Content-Type: application/json' \
--H 'Accept: application/json' \
---data-raw '{}'
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json' \
+        --data-raw '{}'
 
 returnCode=$?
 
 if [[ "$returnCode" != 0 ]]; then
-   echo "test failed"
-   exit 1
+        echo "test failed"
+        exit 1
 fi
-
 
 printf "\nTest: Zeebe topology endpoint\n"
 curl localhost:8080/v2/topology
 
 returnCode=$?
 if [[ "$returnCode" != 0 ]]; then
-   echo "test failed"
-   exit 1
+        echo "test failed"
+        exit 1
 fi
 printf "\nTest: test --config flag\n"
 
-PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.Camunda.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
+PREFIX="$(curl localhost:9600/actuator/configprops | jq '.contexts.camunda.beans.["camunda.tasklist-io.camunda.configuration.beanoverrides.LegacyTasklistProperties"].properties.zeebeElasticsearch.prefix')"
 echo $PREFIX
 if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
-   echo "test failed"
-   exit 1
+        echo "test failed"
+        exit 1
 fi
-
 
 printf "\nTest: connectors api \n"
 
-STATUS="$( curl localhost:8085/actuator/health | jq '.status' )"
+STATUS="$(curl localhost:8085/actuator/health | jq '.status')"
 echo $STATUS
 if [[ "$STATUS" != "\"UP\"" ]]; then
-   echo "test failed"
-   exit 1
+        echo "test failed"
+        exit 1
 fi
-


### PR DESCRIPTION
…shutdown log

## Description

Super small change so that when we call `c8run stop`, so also call `./shutdown.sh` the correct log message is printed out.

Resolves https://camunda.slack.com/archives/C074T8BTTM2/p1750865775116099

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
