### PR TITLE
fix: add the command position to the SCALING_UP event 

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleUpProcessor.java
@@ -61,7 +61,7 @@ public class ScaleUpProcessor implements DistributedTypedRecordProcessor<ScaleRe
       return;
     }
     final var scalingKey = keyGenerator.nextKey();
-    scaleUp.setBootstrappedAt(command.getKey());
+    scaleUp.setScalingPosition(command.getPosition());
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
     responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScalingUpApplier.java
@@ -26,6 +26,6 @@ public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRec
     final var partitionCount = value.getDesiredPartitionCount();
     final var partitions = PartitionUtil.allPartitions(partitionCount);
 
-    routingState.setDesiredPartitions(new TreeSet<>(partitions), key);
+    routingState.setDesiredPartitions(new TreeSet<>(partitions), value.getScalingPosition());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -37,7 +37,7 @@ public class ScaleUpTest {
   public void beforeEach() {
     RecordingExporter.reset();
     clearInvocations(engine.getCommandResponseWriter());
-    index = 100;
+    index = 10012093;
   }
 
   @Test
@@ -219,7 +219,8 @@ public class ScaleUpTest {
             .getLast();
     assertThat(record.getValue().getDesiredPartitionCount()).isEqualTo(4);
     assertThat(record.getValue().getRedistributedPartitions()).containsExactly(1, 2);
-    assertThat(record.getValue().getBootstrappedAt()).isGreaterThanOrEqualTo(key);
+    // SCALE_UP command is the first command
+    assertThat(record.getValue().getBootstrappedAt()).isEqualTo(1);
 
     // when the partitions are marked as bootstrapped
     final var bootstrapPartition3 =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -33,6 +33,7 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
       new ArrayProperty<>("relocatedPartitions", IntegerValue::new);
 
   private final LongProperty bootstrappedAt = new LongProperty("bootstrappedAt", -1L);
+  private final LongProperty scalingPosition = new LongProperty("scalingPosition", -1L);
 
   public ScaleRecord() {
     super(4);
@@ -79,6 +80,16 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
 
   public ScaleRecord setBootstrappedAt(final long bootstrappedAt) {
     this.bootstrappedAt.setValue(bootstrappedAt);
+    return this;
+  }
+
+  @Override
+  public long getScalingPosition() {
+    return scalingPosition.getValue();
+  }
+
+  public ScaleRecord setScalingPosition(final long position) {
+    scalingPosition.setValue(position);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2932,7 +2932,8 @@ final class JsonSerializableToJsonTest {
           "desiredPartitionCount": -1,
           "redistributedPartitions": [],
           "relocatedPartitions": [],
-          "bootstrappedAt": -1
+          "bootstrappedAt": -1,
+          "scalingPosition": -1
         }
         """
       },
@@ -2944,7 +2945,8 @@ final class JsonSerializableToJsonTest {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [],
           "relocatedPartitions": [],
-          "bootstrappedAt": -1
+          "bootstrappedAt": -1,
+          "scalingPosition": -1
         }
         """
       },
@@ -2956,13 +2958,15 @@ final class JsonSerializableToJsonTest {
                     .setDesiredPartitionCount(5)
                     .setRelocatedPartitions(List.of(4, 5))
                     .setRedistributedPartitions(List.of(4, 5))
-                    .setBootstrappedAt(123L),
+                    .setBootstrappedAt(123L)
+                    .setScalingPosition(199L),
         """
         {
          "desiredPartitionCount": 5,
           "redistributedPartitions": [4,5],
           "relocatedPartitions": [4,5],
-          "bootstrappedAt": 123
+          "bootstrappedAt": 123,
+          "scalingPosition": 199
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -30,4 +30,6 @@ public interface ScaleRecordValue extends RecordValue {
   Collection<Integer> getRelocatedPartitions();
 
   long getBootstrappedAt();
+
+  long getScalingPosition();
 }


### PR DESCRIPTION

## Description
Even though we need the position of the SCALING_UP event, it's a followup event so if the command is persisted, then also the corresponding event is persisted as well.
Unfortunately having the position of the records for events is a bit tricky

## Related issues

closes #34343
