### PR TITLE
33885 add has more property to v2 responses

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -61,6 +61,7 @@ public class CamundaUserDetailsServiceTest {
         .thenReturn(
             new SearchQueryResult<>(
                 1,
+                false,
                 List.of(new UserEntity(100L, TEST_USER_ID, "Foo Bar", "email@tested", "password1")),
                 null,
                 null));
@@ -110,7 +111,7 @@ public class CamundaUserDetailsServiceTest {
   public void testUserDetailsNotFound() {
     // given
     when(userService.search(any()))
-        .thenReturn(new SearchQueryResult<>(0, Collections.emptyList(), null, null));
+        .thenReturn(new SearchQueryResult<>(0, false, Collections.emptyList(), null, null));
     // when/then
     assertThatThrownBy(() -> userDetailsService.loadUserByUsername(TEST_USER_ID))
         .isInstanceOf(UsernameNotFoundException.class);

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -33,7 +33,9 @@ public interface SearchResponsePage {
    *
    * @return {@code true} if more than 10,000 items exist in ES or OS; {@code false} otherwise.
    */
-  Boolean hasMoreTotalItems();
+  default Boolean hasMoreTotalItems() {
+    return false;
+  }
 
   /** The cursor to the first item in the returned page. */
   String startCursor();

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -34,7 +34,7 @@ public interface SearchResponsePage {
    *
    * @return {@code true} if more results exist than the default ES/OS maximum of 10_000 items; {@code false} otherwise.
    */
-  boolean hasMoreTotalItems();
+  Boolean hasMoreTotalItems();
 
   /** The cursor to the first item in the returned page. */
   String startCursor();

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -20,6 +20,22 @@ public interface SearchResponsePage {
   /** Total number of items that matches the query */
   Long totalItems();
 
+  /**
+   * Indicates whether there are more results available beyond the default maximum threshold
+   * of 10_000 items in search responses from Elasticsearch or OpenSearch (ES/OS).
+   * <p>
+   * In ES/OS-backed searches, the {@code totalItems} value is capped at 10_000 for performance reasons.
+   * If the underlying ES/OS response returns {@code hits.total.relation = "gte"}, meaning the actual
+   * number of results is greater than or equal to 10_000, this method returns {@code true}.
+   * Otherwise, it returns {@code false}.
+   * <p>
+   * This helps API consumers detect when the reported {@code totalItems} count is not the full count,
+   * and more items may be available than are indicated.
+   *
+   * @return {@code true} if more results exist than the default ES/OS maximum of 10_000 items; {@code false} otherwise.
+   */
+  boolean hasMore();
+
   /** The cursor to the first item in the returned page. */
   String startCursor();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -34,7 +34,7 @@ public interface SearchResponsePage {
    *
    * @return {@code true} if more results exist than the default ES/OS maximum of 10_000 items; {@code false} otherwise.
    */
-  boolean hasMore();
+  boolean hasMoreTotalItems();
 
   /** The cursor to the first item in the returned page. */
   String startCursor();

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -21,18 +21,17 @@ public interface SearchResponsePage {
   Long totalItems();
 
   /**
-   * Indicates whether there are more results available beyond the default maximum threshold
-   * of 10_000 items in search responses from Elasticsearch or OpenSearch (ES/OS).
-   * <p>
-   * In ES/OS-backed searches, the {@code totalItems} value is capped at 10_000 for performance reasons.
-   * If the underlying ES/OS response returns {@code hits.total.relation = "gte"}, meaning the actual
-   * number of results is greater than or equal to 10_000, this method returns {@code true}.
-   * Otherwise, it returns {@code false}.
-   * <p>
-   * This helps API consumers detect when the reported {@code totalItems} count is not the full count,
-   * and more items may be available than are indicated.
+   * Whether more than 10,000 results exist in Elasticsearch (ES) or OpenSearch (OS) searches.
    *
-   * @return {@code true} if more results exist than the default ES/OS maximum of 10_000 items; {@code false} otherwise.
+   * <p>In ES or OS, total hits are capped at 10,000. If the result set is greater than or equal to
+   * this, this method returns {@code true}; otherwise, it returns {@code false}.
+   *
+   * <p>For RDBMS-backed searches, this is always {@code false} because there is no such limitation.
+   *
+   * <p>This helps clients understand when total item counts may be incomplete due to ES or OS
+   * limits.
+   *
+   * @return {@code true} if more than 10,000 items exist in ES or OS; {@code false} otherwise.
    */
   Boolean hasMoreTotalItems();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -149,7 +149,10 @@ public final class SearchResponseMapper {
   private static SearchResponsePage toSearchResponsePage(
       final SearchQueryPageResponse pageResponse) {
     return new SearchResponsePageImpl(
-        pageResponse.getTotalItems(), pageResponse.getStartCursor(), pageResponse.getEndCursor());
+        pageResponse.getTotalItems(),
+        Boolean.TRUE.equals(pageResponse.getHasMore()),
+        pageResponse.getStartCursor(),
+        pageResponse.getEndCursor());
   }
 
   public static SearchResponse<DecisionRequirements> toDecisionRequirementsSearchResponse(
@@ -311,8 +314,8 @@ public final class SearchResponseMapper {
   }
 
   public static List<ProcessInstanceCallHierarchyEntryResponse>
-      toProcessInstanceCallHierarchyEntryResponse(
-          final ProcessInstanceCallHierarchyEntry[] entries) {
+  toProcessInstanceCallHierarchyEntryResponse(
+      final ProcessInstanceCallHierarchyEntry[] entries) {
     return toSearchResponseInstances(
         Arrays.asList(entries), ProcessInstanceCallHierarchyEntryResponseImpl::new);
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -150,7 +150,7 @@ public final class SearchResponseMapper {
       final SearchQueryPageResponse pageResponse) {
     return new SearchResponsePageImpl(
         pageResponse.getTotalItems(),
-        Boolean.TRUE.equals(pageResponse.getHasMore()),
+        Boolean.TRUE.equals(pageResponse.getHasMoreTotalItems()),
         pageResponse.getStartCursor(),
         pageResponse.getEndCursor());
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -314,8 +314,8 @@ public final class SearchResponseMapper {
   }
 
   public static List<ProcessInstanceCallHierarchyEntryResponse>
-  toProcessInstanceCallHierarchyEntryResponse(
-      final ProcessInstanceCallHierarchyEntry[] entries) {
+      toProcessInstanceCallHierarchyEntryResponse(
+          final ProcessInstanceCallHierarchyEntry[] entries) {
     return toSearchResponseInstances(
         Arrays.asList(entries), ProcessInstanceCallHierarchyEntryResponseImpl::new);
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -25,6 +25,14 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   private final String endCursor;
 
   public SearchResponsePageImpl(
+      final long totalItems, final String startCursor, final String endCursor) {
+    this.totalItems = totalItems;
+    this.startCursor = startCursor;
+    this.endCursor = endCursor;
+    this.hasMoreTotalItems = false;
+  }
+
+  public SearchResponsePageImpl(
       final long totalItems,
       final boolean hasMoreTotalItems,
       final String startCursor,

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -20,14 +20,14 @@ import io.camunda.client.api.search.response.SearchResponsePage;
 public class SearchResponsePageImpl implements SearchResponsePage {
 
   private final long totalItems;
-  private final boolean hasMore;
+  private final boolean hasMoreTotalItems;
   private final String startCursor;
   private final String endCursor;
 
   public SearchResponsePageImpl(
-      final long totalItems, final boolean hasMore, final String startCursor, final String endCursor) {
+      final long totalItems, final boolean hasMoreTotalItems, final String startCursor, final String endCursor) {
     this.totalItems = totalItems;
-    this.hasMore = hasMore;
+    this.hasMoreTotalItems = hasMoreTotalItems;
     this.startCursor = startCursor;
     this.endCursor = endCursor;
   }
@@ -38,8 +38,8 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   }
 
   @Override
-  public boolean hasMore() {
-    return hasMore;
+  public boolean hasMoreTotalItems() {
+    return hasMoreTotalItems;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -20,12 +20,14 @@ import io.camunda.client.api.search.response.SearchResponsePage;
 public class SearchResponsePageImpl implements SearchResponsePage {
 
   private final long totalItems;
+  private final boolean hasMore;
   private final String startCursor;
   private final String endCursor;
 
   public SearchResponsePageImpl(
-      final long totalItems, final String startCursor, final String endCursor) {
+      final long totalItems, final boolean hasMore, final String startCursor, final String endCursor) {
     this.totalItems = totalItems;
+    this.hasMore = hasMore;
     this.startCursor = startCursor;
     this.endCursor = endCursor;
   }
@@ -33,6 +35,11 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   @Override
   public Long totalItems() {
     return totalItems;
+  }
+
+  @Override
+  public boolean hasMore() {
+    return hasMore;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -38,7 +38,7 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   }
 
   @Override
-  public boolean hasMoreTotalItems() {
+  public Boolean hasMoreTotalItems() {
     return hasMoreTotalItems;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -25,7 +25,10 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   private final String endCursor;
 
   public SearchResponsePageImpl(
-      final long totalItems, final boolean hasMoreTotalItems, final String startCursor, final String endCursor) {
+      final long totalItems,
+      final boolean hasMoreTotalItems,
+      final String startCursor,
+      final String endCursor) {
     this.totalItems = totalItems;
     this.hasMoreTotalItems = hasMoreTotalItems;
     this.startCursor = startCursor;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -26,10 +26,7 @@ public class SearchResponsePageImpl implements SearchResponsePage {
 
   public SearchResponsePageImpl(
       final long totalItems, final String startCursor, final String endCursor) {
-    this.totalItems = totalItems;
-    this.startCursor = startCursor;
-    this.endCursor = endCursor;
-    this.hasMoreTotalItems = false;
+    this(totalItems, false, startCursor, endCursor);
   }
 
   public SearchResponsePageImpl(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -74,7 +74,7 @@ public class ProcessDefinitionSearchTest {
   }
 
   @Test
-  void shouldNotifyIfHasMoreItems() {
+  void shouldHaveMoreTotalItemsField() {
     // given
     final var resultAll =
         camundaClient
@@ -84,8 +84,8 @@ public class ProcessDefinitionSearchTest {
             .join();
 
     // then
-    assertThat(resultAll.page().hasMore()).isNotNull();
-    assertThat(resultAll.page().hasMore()).isFalse();
+    assertThat(resultAll.page().hasMoreTotalItems()).isNotNull();
+    assertThat(resultAll.page().hasMoreTotalItems()).isFalse();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -74,6 +74,21 @@ public class ProcessDefinitionSearchTest {
   }
 
   @Test
+  void shouldNotifyIfHasMoreItems() {
+    // given
+    final var resultAll =
+        camundaClient
+            .newProcessDefinitionSearchRequest()
+            .sort(s -> s.processDefinitionKey().desc())
+            .send()
+            .join();
+
+    // then
+    assertThat(resultAll.page().hasMore()).isNotNull();
+    assertThat(resultAll.page().hasMore()).isFalse();
+  }
+
+  @Test
   void shouldPaginateWithSortingByProcessDefinitionKey() {
     // given
     final var resultAll =

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -20,6 +21,7 @@ import io.camunda.search.es.transformers.aggregator.SearchAggregationResultTrans
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class SearchResponseTransformer<T>
@@ -37,13 +39,14 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
+    final var hasMore = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);
     final var transformedAggregations = of(aggregations);
 
     return new SearchQueryResponse.Builder<T>()
-        .totalHits(totalHits)
+        .totalHits(totalHits, hasMore)
         .scrollId(scrollId)
         .hits(transformedHits)
         .aggregations(transformedAggregations)

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
@@ -39,14 +39,14 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
-    final var hasMore = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
+    final var hasMoreTotalItems = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);
     final var transformedAggregations = of(aggregations);
 
     return new SearchQueryResponse.Builder<T>()
-        .totalHits(totalHits, hasMore)
+        .totalHits(totalHits, hasMoreTotalItems)
         .scrollId(scrollId)
         .hits(transformedHits)
         .aggregations(transformedAggregations)

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
@@ -39,7 +39,8 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
-    final var hasMoreTotalItems = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
+    final var hasMoreTotalItems =
+        Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -181,8 +181,8 @@ public class ElasticsearchDataStoreClientTest {
         SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
 
     // when
-    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
-        TestDocument.class);
+    final SearchQueryResponse<TestDocument> response =
+        searchClient.search(request, TestDocument.class);
 
     // then
     assertThat(response).isNotNull();
@@ -199,16 +199,16 @@ public class ElasticsearchDataStoreClientTest {
         SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
 
     // when
-    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
-        TestDocument.class);
+    final SearchQueryResponse<TestDocument> response =
+        searchClient.search(request, TestDocument.class);
 
     // then
     assertThat(response).isNotNull();
     assertThat(response.hasMoreTotalItems()).isTrue();
   }
 
-  private SearchResponse<TestDocument> createDefaultSearchResponse(long totalHits,
-      TotalHitsRelation totalHitsRelation) {
+  private SearchResponse<TestDocument> createDefaultSearchResponse(
+      long totalHits, TotalHitsRelation totalHitsRelation) {
     return SearchResponse.of(
         (f) ->
             f.took(122)
@@ -238,7 +238,5 @@ public class ElasticsearchDataStoreClientTest {
                 .shards(s -> s.total(1).successful(1).failed(0)));
   }
 
-  record TestDocument(String id) {
-
-  }
+  record TestDocument(String id) {}
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -84,7 +84,7 @@ public class ElasticsearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.totalHits()).isEqualTo(789);
+    assertThat(response.totalHits()).isEqualTo(TEST_HITS);
   }
 
   @Test

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -170,7 +170,7 @@ public class ElasticsearchDataStoreClientTest {
   }
 
   @Test
-  public void shouldHasMoreFieldFalse() throws IOException {
+  public void shouldHaveMoreTotalItemsFalse() throws IOException {
     // given
     final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
     final var searchResponse = createDefaultSearchResponse(TEST_HITS, HITS_RELATION);
@@ -186,11 +186,11 @@ public class ElasticsearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.hasMore()).isFalse();
+    assertThat(response.hasMoreTotalItems()).isFalse();
   }
 
   @Test
-  public void shouldHasMoreFieldTrue() throws IOException {
+  public void shouldHaveMoreTotalItemsTrue() throws IOException {
     // given
     final var searchResponse = createDefaultSearchResponse(CAPPED_HITS, CAPPED_HITS_RELATION);
     when(client.search((SearchRequest) any(), eq(TestDocument.class))).thenReturn(searchResponse);
@@ -204,7 +204,7 @@ public class ElasticsearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.hasMore()).isTrue();
+    assertThat(response.hasMoreTotalItems()).isTrue();
   }
 
   private SearchResponse<TestDocument> createDefaultSearchResponse(long totalHits,

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -8,6 +8,7 @@
 package io.camunda.search.es.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,7 @@ import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import io.camunda.search.clients.core.SearchGetRequest;
 import io.camunda.search.clients.core.SearchIndexRequest;
 import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.core.SearchWriteResponse;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import java.io.IOException;
@@ -35,6 +37,10 @@ import org.mockito.ArgumentCaptor;
 
 public class ElasticsearchDataStoreClientTest {
 
+  private final static long TEST_HITS = 789;
+  private final static TotalHitsRelation HITS_RELATION = TotalHitsRelation.Eq;
+  private final static long CAPPED_HITS = 10_000;
+  private final static TotalHitsRelation CAPPED_HITS_RELATION = TotalHitsRelation.Gte;
   private ElasticsearchClient client;
   private ElasticsearchSearchClient searchClient;
 
@@ -48,7 +54,7 @@ public class ElasticsearchDataStoreClientTest {
   public void shouldTransformSearchRequest() throws IOException {
     // given
     final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-    final var searchResponse = createDefaultSearchResponse();
+    final var searchResponse = createDefaultSearchResponse(TEST_HITS, HITS_RELATION);
     when(client.search(searchRequestCaptor.capture(), eq(TestDocument.class)))
         .thenReturn(searchResponse);
 
@@ -66,7 +72,7 @@ public class ElasticsearchDataStoreClientTest {
   public void shouldTransformSearchResponse() throws IOException {
     // given
     final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-    final var searchResponse = createDefaultSearchResponse();
+    final var searchResponse = createDefaultSearchResponse(TEST_HITS, HITS_RELATION);
     when(client.search(searchRequestCaptor.capture(), eq(TestDocument.class)))
         .thenReturn(searchResponse);
 
@@ -163,7 +169,46 @@ public class ElasticsearchDataStoreClientTest {
     assertThat(response.result()).isEqualTo(SearchWriteResponse.Result.CREATED);
   }
 
-  private SearchResponse<TestDocument> createDefaultSearchResponse() {
+  @Test
+  public void shouldHasMoreFieldFalse() throws IOException {
+    // given
+    final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+    final var searchResponse = createDefaultSearchResponse(TEST_HITS, HITS_RELATION);
+    when(client.search(searchRequestCaptor.capture(), eq(TestDocument.class)))
+        .thenReturn(searchResponse);
+
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
+
+    // when
+    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
+        TestDocument.class);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.hasMore()).isFalse();
+  }
+
+  @Test
+  public void shouldHasMoreFieldTrue() throws IOException {
+    // given
+    final var searchResponse = createDefaultSearchResponse(CAPPED_HITS, CAPPED_HITS_RELATION);
+    when(client.search((SearchRequest) any(), eq(TestDocument.class))).thenReturn(searchResponse);
+
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
+
+    // when
+    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
+        TestDocument.class);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.hasMore()).isTrue();
+  }
+
+  private SearchResponse<TestDocument> createDefaultSearchResponse(long totalHits,
+      TotalHitsRelation totalHitsRelation) {
     return SearchResponse.of(
         (f) ->
             f.took(122)
@@ -171,7 +216,7 @@ public class ElasticsearchDataStoreClientTest {
                     HitsMetadata.of(
                         (m) ->
                             m.hits(new ArrayList<>())
-                                .total((t) -> t.value(789).relation(TotalHitsRelation.Eq))))
+                                .total((t) -> t.value(totalHits).relation(totalHitsRelation))))
                 .shards((s) -> s.failed(0).successful(100).total(100))
                 .timedOut(false));
   }
@@ -193,5 +238,7 @@ public class ElasticsearchDataStoreClientTest {
                 .shards(s -> s.total(1).successful(1).failed(0)));
   }
 
-  record TestDocument(String id) {}
+  record TestDocument(String id) {
+
+  }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -37,10 +37,10 @@ import org.mockito.ArgumentCaptor;
 
 public class ElasticsearchDataStoreClientTest {
 
-  private final static long TEST_HITS = 789;
-  private final static TotalHitsRelation HITS_RELATION = TotalHitsRelation.Eq;
-  private final static long CAPPED_HITS = 10_000;
-  private final static TotalHitsRelation CAPPED_HITS_RELATION = TotalHitsRelation.Gte;
+  private static final long TEST_HITS = 789;
+  private static final TotalHitsRelation HITS_RELATION = TotalHitsRelation.Eq;
+  private static final long CAPPED_HITS = 10_000;
+  private static final TotalHitsRelation CAPPED_HITS_RELATION = TotalHitsRelation.Gte;
   private ElasticsearchClient client;
   private ElasticsearchSearchClient searchClient;
 

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
@@ -39,14 +39,14 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
-    final var hasMore = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
+    final var hasMoreTotalItems = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);
     final var transformedAggregations = of(aggregations);
 
     return new SearchQueryResponse.Builder<T>()
-        .totalHits(totalHits, hasMore)
+        .totalHits(totalHits, hasMoreTotalItems)
         .scrollId(scrollId)
         .hits(transformedHits)
         .aggregations(transformedAggregations)

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
@@ -16,11 +16,13 @@ import io.camunda.search.os.transformers.aggregator.SearchAggregationResultTrans
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
 public final class SearchResponseTransformer<T>
     extends OpensearchTransformer<SearchResponse<T>, SearchQueryResponse<T>> {
@@ -37,13 +39,14 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
+    final var hasMore = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);
     final var transformedAggregations = of(aggregations);
 
     return new SearchQueryResponse.Builder<T>()
-        .totalHits(totalHits)
+        .totalHits(totalHits, hasMore)
         .scrollId(scrollId)
         .hits(transformedHits)
         .aggregations(transformedAggregations)

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchResponseTransformer.java
@@ -39,7 +39,8 @@ public final class SearchResponseTransformer<T>
 
     final var total = hits.total();
     final var totalHits = of(total);
-    final var hasMoreTotalItems = Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
+    final var hasMoreTotalItems =
+        Objects.nonNull(total) && total.relation() == TotalHitsRelation.Gte;
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
@@ -181,8 +181,8 @@ public class OpensearchDataStoreClientTest {
         SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
 
     // when
-    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
-        TestDocument.class);
+    final SearchQueryResponse<TestDocument> response =
+        searchClient.search(request, TestDocument.class);
 
     // then
     assertThat(response).isNotNull();
@@ -199,16 +199,16 @@ public class OpensearchDataStoreClientTest {
         SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
 
     // when
-    final SearchQueryResponse<TestDocument> response = searchClient.search(request,
-        TestDocument.class);
+    final SearchQueryResponse<TestDocument> response =
+        searchClient.search(request, TestDocument.class);
 
     // then
     assertThat(response).isNotNull();
     assertThat(response.hasMoreTotalItems()).isTrue();
   }
 
-  private SearchResponse<TestDocument> createDefaultSearchResponse(long totalHits,
-      TotalHitsRelation totalHitsRelation) {
+  private SearchResponse<TestDocument> createDefaultSearchResponse(
+      long totalHits, TotalHitsRelation totalHitsRelation) {
     return SearchResponse.searchResponseOf(
         (f) ->
             f.took(122)

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
@@ -84,7 +84,7 @@ public class OpensearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.totalHits()).isEqualTo(789);
+    assertThat(response.totalHits()).isEqualTo(TEST_HITS);
   }
 
   @Test

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
@@ -170,7 +170,7 @@ public class OpensearchDataStoreClientTest {
   }
 
   @Test
-  public void shouldHasMoreFieldFalse() throws IOException {
+  public void shouldHaveMoreTotalItemsFalse() throws IOException {
     // given
     final var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
     final var searchResponse = createDefaultSearchResponse(TEST_HITS, HITS_RELATION);
@@ -186,11 +186,11 @@ public class OpensearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.hasMore()).isFalse();
+    assertThat(response.hasMoreTotalItems()).isFalse();
   }
 
   @Test
-  public void shouldHasMoreFieldTrue() throws IOException {
+  public void shouldHaveMoreTotalItemsTrue() throws IOException {
     // given
     final var searchResponse = createDefaultSearchResponse(CAPPED_HITS, CAPPED_HITS_RELATION);
     when(client.search((SearchRequest) any(), eq(TestDocument.class))).thenReturn(searchResponse);
@@ -204,7 +204,7 @@ public class OpensearchDataStoreClientTest {
 
     // then
     assertThat(response).isNotNull();
-    assertThat(response.hasMore()).isTrue();
+    assertThat(response.hasMoreTotalItems()).isTrue();
   }
 
   private SearchResponse<TestDocument> createDefaultSearchResponse(long totalHits,

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
@@ -37,10 +37,10 @@ import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
 public class OpensearchDataStoreClientTest {
 
-  private final static long TEST_HITS = 789;
-  private final static TotalHitsRelation HITS_RELATION = TotalHitsRelation.Eq;
-  private final static long CAPPED_HITS = 10_000;
-  private final static TotalHitsRelation CAPPED_HITS_RELATION = TotalHitsRelation.Gte;
+  private static final long TEST_HITS = 789;
+  private static final TotalHitsRelation HITS_RELATION = TotalHitsRelation.Eq;
+  private static final long CAPPED_HITS = 10_000;
+  private static final TotalHitsRelation CAPPED_HITS_RELATION = TotalHitsRelation.Gte;
   private OpenSearchClient client;
   private OpensearchSearchClient searchClient;
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
@@ -16,6 +16,7 @@ import java.util.function.Function;
 
 public record SearchQueryResponse<T>(
     long totalHits,
+    boolean hasMore,
     String scrollId,
     List<SearchQueryHit<T>> hits,
     Map<String, AggregationResult> aggregations) {
@@ -28,12 +29,19 @@ public record SearchQueryResponse<T>(
   public static final class Builder<T> implements ObjectBuilder<SearchQueryResponse<T>> {
 
     private long totalHits;
+    private boolean hasMore = false;
     private String scrollId;
     private List<SearchQueryHit<T>> hits;
     private Map<String, AggregationResult> aggregations;
 
     public Builder<T> totalHits(final long value) {
       totalHits = value;
+      return this;
+    }
+
+    public Builder<T> totalHits(final long value, final boolean hasMore) {
+      totalHits = value;
+      this.hasMore = hasMore;
       return this;
     }
 
@@ -56,6 +64,7 @@ public record SearchQueryResponse<T>(
     public SearchQueryResponse<T> build() {
       return new SearchQueryResponse<T>(
           totalHits,
+          hasMore,
           scrollId,
           Objects.requireNonNullElse(hits, Collections.emptyList()),
           aggregations);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
 
 public record SearchQueryResponse<T>(
     long totalHits,
-    boolean hasMore,
+    boolean hasMoreTotalItems,
     String scrollId,
     List<SearchQueryHit<T>> hits,
     Map<String, AggregationResult> aggregations) {
@@ -29,7 +29,7 @@ public record SearchQueryResponse<T>(
   public static final class Builder<T> implements ObjectBuilder<SearchQueryResponse<T>> {
 
     private long totalHits;
-    private boolean hasMore = false;
+    private boolean hasMoreTotalItems = false;
     private String scrollId;
     private List<SearchQueryHit<T>> hits;
     private Map<String, AggregationResult> aggregations;
@@ -39,9 +39,9 @@ public record SearchQueryResponse<T>(
       return this;
     }
 
-    public Builder<T> totalHits(final long value, final boolean hasMore) {
+    public Builder<T> totalHits(final long value, final boolean hasMoreTotalItems) {
       totalHits = value;
-      this.hasMore = hasMore;
+      this.hasMoreTotalItems = hasMoreTotalItems;
       return this;
     }
 
@@ -64,7 +64,7 @@ public record SearchQueryResponse<T>(
     public SearchQueryResponse<T> build() {
       return new SearchQueryResponse<T>(
           totalHits,
-          hasMore,
+          hasMoreTotalItems,
           scrollId,
           Objects.requireNonNullElse(hits, Collections.emptyList()),
           aggregations);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
@@ -50,7 +50,7 @@ public final class SearchQueryResultTransformer<T, R> {
     }
 
     return new Builder<R>()
-        .total(value.totalHits())
+        .total(value.totalHits(), value.hasMore())
         .startCursor(Cursor.encode(firstSortValues))
         .endCursor(Cursor.encode(lastSortValues))
         .items(items.stream().map(documentToEntityMapper::apply).toList())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
@@ -50,7 +50,7 @@ public final class SearchQueryResultTransformer<T, R> {
     }
 
     return new Builder<R>()
-        .total(value.totalHits(), value.hasMore())
+        .total(value.totalHits(), value.hasMoreTotalItems())
         .startCursor(Cursor.encode(firstSortValues))
         .endCursor(Cursor.encode(lastSortValues))
         .items(items.stream().map(documentToEntityMapper::apply).toList())

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
@@ -114,10 +114,10 @@ class SearchClientBasedQueryExecutorTest {
         createProcessInstanceEntityResponse(demoProcessInstance, 1, false);
 
     when(searchClient.search(
-        any(SearchQueryRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+            any(SearchQueryRequest.class), eq(ProcessInstanceForListViewEntity.class)))
         .thenReturn(processInstanceEntityResponse);
     when(authorizationQueryStrategy.applyAuthorizationToQuery(
-        any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
         .thenAnswer(i -> i.getArgument(0));
 
     // When we search
@@ -138,10 +138,10 @@ class SearchClientBasedQueryExecutorTest {
         createProcessInstanceEntityResponse(demoProcessInstance, 10000, true);
 
     when(searchClient.search(
-        any(SearchQueryRequest.class), eq(ProcessInstanceForListViewEntity.class)))
+            any(SearchQueryRequest.class), eq(ProcessInstanceForListViewEntity.class)))
         .thenReturn(processInstanceEntityResponse);
     when(authorizationQueryStrategy.applyAuthorizationToQuery(
-        any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
         .thenAnswer(i -> i.getArgument(0));
 
     // When we search
@@ -249,7 +249,8 @@ class SearchClientBasedQueryExecutorTest {
   }
 
   private SearchQueryResponse<ProcessInstanceForListViewEntity> createProcessInstanceEntityResponse(
-      final ProcessInstanceForListViewEntity demoProcessInstance, final long totalHits,
+      final ProcessInstanceForListViewEntity demoProcessInstance,
+      final long totalHits,
       final boolean hasMoreFields) {
     final SearchQueryHit<ProcessInstanceForListViewEntity> hit =
         new SearchQueryHit.Builder<ProcessInstanceForListViewEntity>()

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
@@ -13,21 +13,28 @@ import java.util.List;
 import java.util.Objects;
 
 public record SearchQueryResult<T>(
-    long total, List<T> items, String startCursor, String endCursor) {
+    long total, boolean hasMore, List<T> items, String startCursor, String endCursor) {
 
   public static <T> SearchQueryResult<T> empty() {
-    return new SearchQueryResult<>(0, Collections.emptyList(), null, null);
+    return new SearchQueryResult<>(0, false, Collections.emptyList(), null, null);
   }
 
   public static final class Builder<T> implements ObjectBuilder<SearchQueryResult<T>> {
 
     private long total;
+    private boolean hasMore = false;
     private List<T> items;
     private String startCursor;
     private String endCursor;
 
     public Builder<T> total(final long value) {
       total = value;
+      return this;
+    }
+
+    public Builder<T> total(final long value, final boolean hasMore) {
+      total = value;
+      this.hasMore = hasMore;
       return this;
     }
 
@@ -50,6 +57,7 @@ public record SearchQueryResult<T>(
     public SearchQueryResult<T> build() {
       return new SearchQueryResult<T>(
           total,
+          hasMore,
           Objects.requireNonNullElse(items, Collections.emptyList()),
           startCursor,
           endCursor);

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record SearchQueryResult<T>(
-    long total, boolean hasMore, List<T> items, String startCursor, String endCursor) {
+    long total, boolean hasMoreTotalItems, List<T> items, String startCursor, String endCursor) {
 
   public static <T> SearchQueryResult<T> empty() {
     return new SearchQueryResult<>(0, false, Collections.emptyList(), null, null);
@@ -22,7 +22,7 @@ public record SearchQueryResult<T>(
   public static final class Builder<T> implements ObjectBuilder<SearchQueryResult<T>> {
 
     private long total;
-    private boolean hasMore = false;
+    private boolean hasMoreTotalItems = false;
     private List<T> items;
     private String startCursor;
     private String endCursor;
@@ -32,9 +32,9 @@ public record SearchQueryResult<T>(
       return this;
     }
 
-    public Builder<T> total(final long value, final boolean hasMore) {
+    public Builder<T> total(final long value, final boolean hasMoreTotalItems) {
       total = value;
-      this.hasMore = hasMore;
+      this.hasMoreTotalItems = hasMoreTotalItems;
       return this;
     }
 
@@ -57,7 +57,7 @@ public record SearchQueryResult<T>(
     public SearchQueryResult<T> build() {
       return new SearchQueryResult<T>(
           total,
-          hasMore,
+          hasMoreTotalItems,
           Objects.requireNonNullElse(items, Collections.emptyList()),
           startCursor,
           endCursor);

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -113,7 +113,7 @@ public class AuthorizationServiceTest {
   public void shouldReturnSingleAuthorizationForGet() {
     // given
     final var entity = mock(AuthorizationEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchAuthorizations(any())).thenReturn(result);
 
     // when
@@ -128,7 +128,7 @@ public class AuthorizationServiceTest {
     // given
     final var authorizationKey = 100L;
     when(client.searchAuthorizations(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findAuthorization(authorizationKey)).isEmpty();

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -83,12 +83,12 @@ public final class DecisionDefinitionServiceTest {
     when(definitionEntity.decisionRequirementsKey()).thenReturn(42L);
     when(definitionEntity.decisionDefinitionId()).thenReturn("decId");
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(definitionEntity), null, null));
 
     final var requirementEntity = mock(DecisionRequirementsEntity.class);
     when(requirementEntity.xml()).thenReturn("<foo>bar</foo>");
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(requirementEntity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(requirementEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId",
             authentication,
@@ -106,7 +106,7 @@ public final class DecisionDefinitionServiceTest {
   public void shouldThrowNotFoundExceptionOnUnmatchedDecisionKey() {
     // given
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // then
     final var exception =
@@ -127,9 +127,9 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(definitionEntity), null, null));
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
     when(securityContextProvider.isAuthorized(
             "decId",
             authentication,
@@ -152,7 +152,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId",
             authentication,
@@ -174,7 +174,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId",
             authentication,
@@ -199,7 +199,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId",
             authentication,

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -67,7 +67,8 @@ public final class DecisionRequirementsServiceTest {
     when(decisionRequirementEntity.decisionRequirementsKey()).thenReturn(124L);
     when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
     when(client.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(decisionRequirementEntity), null, null));
+        .thenReturn(
+            new SearchQueryResult<>(1, false, List.of(decisionRequirementEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decReqId",
             authentication,

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -67,7 +67,7 @@ public final class DecisionRequirementsServiceTest {
     when(decisionRequirementEntity.decisionRequirementsKey()).thenReturn(124L);
     when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
     when(client.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(decisionRequirementEntity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(decisionRequirementEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decReqId",
             authentication,

--- a/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ElementInstanceServiceTest.java
@@ -67,7 +67,7 @@ public final class ElementInstanceServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchFlowNodeInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,
@@ -87,7 +87,7 @@ public final class ElementInstanceServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchFlowNodeInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -121,7 +121,7 @@ public class GroupServiceTest {
   public void shouldThrowExceptionIfGroupNotFoundById() {
     // given
     final var id = "groupId";
-    when(client.searchGroups(any())).thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+    when(client.searchGroups(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findGroup(id)).isEmpty();
@@ -216,7 +216,7 @@ public class GroupServiceTest {
     final var groupName = "testGroup";
     final var entity = mock(GroupEntity.class);
     when(entity.name()).thenReturn(groupName);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchGroups(any())).thenReturn(result);
 
     // when

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -121,7 +121,8 @@ public class GroupServiceTest {
   public void shouldThrowExceptionIfGroupNotFoundById() {
     // given
     final var id = "groupId";
-    when(client.searchGroups(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
+    when(client.searchGroups(any()))
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findGroup(id)).isEmpty();

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -67,7 +67,7 @@ public final class IncidentServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchIncidents(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,
@@ -87,7 +87,7 @@ public final class IncidentServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchIncidents(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -102,7 +102,7 @@ public class MappingServicesTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(MappingEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchMappings(any())).thenReturn(result);
   }
 
@@ -110,7 +110,7 @@ public class MappingServicesTest {
   public void shouldReturnSingleVariableForFind() {
     // given
     final var entity = mock(MappingEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchMappings(any())).thenReturn(result);
 
     // when
@@ -123,7 +123,7 @@ public class MappingServicesTest {
   @Test
   public void shouldReturnEmptyWhenNotFoundByFind() {
     // given
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
+    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findMapping("mappingId")).isEmpty();
@@ -132,7 +132,7 @@ public class MappingServicesTest {
   @Test
   public void shouldThrowExceptionWhenNotFoundByGet() {
     // given
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
+    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     final var exception =

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -123,7 +123,8 @@ public class MappingServicesTest {
   @Test
   public void shouldReturnEmptyWhenNotFoundByFind() {
     // given
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
+    when(client.searchMappings(any()))
+        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findMapping("mappingId")).isEmpty();
@@ -132,7 +133,8 @@ public class MappingServicesTest {
   @Test
   public void shouldThrowExceptionWhenNotFoundByGet() {
     // given
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
+    when(client.searchMappings(any()))
+        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     final var exception =

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -126,7 +126,7 @@ public final class ProcessInstanceServiceTest {
     when(entity.processInstanceKey()).thenReturn(key);
     when(entity.processDefinitionId()).thenReturn("processId");
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(entity), null, null));
     authorizeProcessReadInstance(true, "processId");
 
     // when
@@ -141,7 +141,7 @@ public final class ProcessInstanceServiceTest {
     // given
     final var key = 100L;
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     final var exception =
@@ -157,7 +157,7 @@ public final class ProcessInstanceServiceTest {
     final var entity1 = mock(ProcessInstanceEntity.class);
     final var entity2 = mock(ProcessInstanceEntity.class);
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(2, List.of(entity1, entity2), null, null));
+        .thenReturn(new SearchQueryResult<>(2, false, List.of(entity1, entity2), null, null));
 
     // when / then
     final var exception =
@@ -172,7 +172,7 @@ public final class ProcessInstanceServiceTest {
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processDefinitionId()).thenReturn("processId");
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     authorizeProcessReadInstance(false, "processId");
     // when
     final Executable executeGetByKey = () -> services.getByKey(1L);
@@ -230,7 +230,7 @@ public final class ProcessInstanceServiceTest {
     authorizeProcessReadInstance(true, "parent_process_id");
 
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(childProcess, parentProcess), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
 
     // when
     final var result = services.callHierarchy(childProcess.processInstanceKey());
@@ -251,7 +251,7 @@ public final class ProcessInstanceServiceTest {
     when(rootInstance.treePath()).thenReturn(null); // No treePath
 
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(rootInstance), null, null));
 
     // when
     final var result = services.callHierarchy(123L);
@@ -270,7 +270,7 @@ public final class ProcessInstanceServiceTest {
     when(rootInstance.treePath()).thenReturn("PI_123"); // Root treePath
 
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(rootInstance), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(rootInstance), null, null));
 
     // when
     final var result = services.callHierarchy(123L);
@@ -431,7 +431,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstance.processInstanceKey()).thenReturn(processInstanceKey);
     when(processInstance.processDefinitionId()).thenReturn("processId");
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(processInstance), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(processInstance), null, null));
     authorizeProcessReadInstance(true, processInstance.processDefinitionId());
 
     when(incidentSearchClient.searchIncidents(any())).thenReturn(queryResult);
@@ -464,7 +464,7 @@ public final class ProcessInstanceServiceTest {
     final var processInstance = mock(ProcessInstanceEntity.class);
     when(processInstance.processDefinitionId()).thenReturn("processId");
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(processInstance), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(processInstance), null, null));
     authorizeProcessReadInstance(false, processInstance.processDefinitionId());
 
     final var query = new IncidentQuery.Builder().build();

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -230,7 +230,8 @@ public final class ProcessInstanceServiceTest {
     authorizeProcessReadInstance(true, "parent_process_id");
 
     when(processInstanceSearchClient.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
+        .thenReturn(
+            new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
 
     // when
     final var result = services.callHierarchy(childProcess.processInstanceKey());

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -118,7 +118,8 @@ public class RoleServicesTest {
   public void shouldThrownExceptionIfNotFoundById() {
     // given
     final var roleId = "roleId";
-    when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
+    when(client.searchRoles(any()))
+        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findRole(roleId)).isEmpty();

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -96,7 +96,7 @@ public class RoleServicesTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(RoleEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchRoles(any())).thenReturn(result);
   }
 
@@ -104,7 +104,7 @@ public class RoleServicesTest {
   public void shouldReturnSingleVariableForGet() {
     // given
     final var entity = mock(RoleEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchRoles(any())).thenReturn(result);
 
     // when
@@ -118,7 +118,7 @@ public class RoleServicesTest {
   public void shouldThrownExceptionIfNotFoundById() {
     // given
     final var roleId = "roleId";
-    when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
+    when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findRole(roleId)).isEmpty();

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -108,7 +108,8 @@ public class TenantServiceTest {
   @Test
   public void shouldThrowExceptionIfNotFoundByKey() {
     // given
-    when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
+    when(client.searchTenants(any()))
+        .thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
 

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -82,7 +82,7 @@ public class TenantServiceTest {
   @Test
   public void shouldReturnSingleTenant() {
     // given
-    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(tenantEntity), null, null);
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
@@ -95,7 +95,7 @@ public class TenantServiceTest {
   @Test
   public void shouldReturnSingleVariableForGet() {
     // given
-    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(tenantEntity), null, null);
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
@@ -108,7 +108,7 @@ public class TenantServiceTest {
   @Test
   public void shouldThrowExceptionIfNotFoundByKey() {
     // given
-    when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
+    when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, false, List.of(), null, null));
 
     // when / then
 
@@ -244,7 +244,7 @@ public class TenantServiceTest {
     final var service = new TenantServices(stubbedBrokerClient, contextProvider, client, auth);
     when(client.withSecurityContext(any())).thenReturn(client);
     when(client.searchTenants(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(tenantEntity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(tenantEntity), null, null));
 
     assertThatCode(() -> service.getById("tenant-id")).isInstanceOf(ForbiddenException.class);
   }

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -95,7 +95,7 @@ public class UserServiceTest {
   public void shouldReturnUserForGet() {
     // given
     final var entity = mock(UserEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchUsers(any())).thenReturn(result);
 
     // when
@@ -109,7 +109,7 @@ public class UserServiceTest {
   public void shouldThrownExceptionIfUserNotFoundByUsername() {
     // given
     final var username = "username";
-    when(client.searchUsers(any())).thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+    when(client.searchUsers(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findUser(username)).isEmpty();

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -109,7 +109,8 @@ public class UserServiceTest {
   public void shouldThrownExceptionIfUserNotFoundByUsername() {
     // given
     final var username = "username";
-    when(client.searchUsers(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
+    when(client.searchUsers(any()))
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
 
     // when / then
     assertThat(services.findUser(username)).isEmpty();

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -147,7 +147,7 @@ public class UserTaskServiceTest {
     // given
     final var entity = mock(UserTaskEntity.class);
     when(entity.processDefinitionId()).thenReturn("bpid");
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchUserTasks(any())).thenReturn(result);
     authorizeReadUserTasksForProcess(false, "bpid");
 
@@ -167,7 +167,7 @@ public class UserTaskServiceTest {
     // given
     final var entity = mock(UserTaskEntity.class);
     when(entity.processDefinitionId()).thenReturn("bpid");
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchUserTasks(any())).thenReturn(result);
     authorizeReadUserTasksForProcess(false, "bpid");
 
@@ -220,6 +220,6 @@ public class UserTaskServiceTest {
   }
 
   private <T> SearchQueryResult<T> wrapWithSearchQueryResult(final T... entities) {
-    return new SearchQueryResult<>(entities.length, List.of(entities), null, null);
+    return new SearchQueryResult<>(entities.length, false, List.of(entities), null, null);
   }
 }

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -80,9 +80,9 @@ public class VariableServiceTest {
     final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchVariables(any())).thenReturn(result);
     when(securityContextProvider.isAuthorized(
-        processId,
-        authentication,
-        Authorization.of(a -> a.processDefinition().readProcessInstance())))
+            processId,
+            authentication,
+            Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .thenReturn(true);
 
     // when
@@ -101,9 +101,9 @@ public class VariableServiceTest {
     when(client.searchVariables(any()))
         .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
-        processId,
-        authentication,
-        Authorization.of(a -> a.processDefinition().readProcessInstance())))
+            processId,
+            authentication,
+            Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .thenReturn(false);
     // when
     final Executable executeGetByKey = () -> services.getByKey(1L);

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -67,7 +67,7 @@ public class VariableServiceTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(VariableEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchVariables(any())).thenReturn(result);
   }
 
@@ -77,12 +77,12 @@ public class VariableServiceTest {
     final var entity = mock(VariableEntity.class);
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
-    final var result = new SearchQueryResult<>(1, List.of(entity), null, null);
+    final var result = new SearchQueryResult<>(1, false, List.of(entity), null, null);
     when(client.searchVariables(any())).thenReturn(result);
     when(securityContextProvider.isAuthorized(
-            processId,
-            authentication,
-            Authorization.of(a -> a.processDefinition().readProcessInstance())))
+        processId,
+        authentication,
+        Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .thenReturn(true);
 
     // when
@@ -99,11 +99,11 @@ public class VariableServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchVariables(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
-            processId,
-            authentication,
-            Authorization.of(a -> a.processDefinition().readProcessInstance())))
+        processId,
+        authentication,
+        Authorization.of(a -> a.processDefinition().readProcessInstance())))
         .thenReturn(false);
     // when
     final Executable executeGetByKey = () -> services.getByKey(1L);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -73,7 +73,7 @@ public class AuthenticationInterceptorTest {
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
     when(userServices.search(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(createUserEntity()), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
     new AuthenticationInterceptor(new BasicAuth(userServices, passwordEncoder))
@@ -99,7 +99,7 @@ public class AuthenticationInterceptorTest {
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
     when(userServices.search(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(createUserEntity()), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))
         .interceptCall(
             closeStatusCapturingServerCall,
@@ -121,7 +121,7 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any())).thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
+    when(userServices.search(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))
         .interceptCall(closeStatusCapturingServerCall, metadata, failingNextHandler());
 
@@ -144,7 +144,7 @@ public class AuthenticationInterceptorTest {
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
     when(userServices.search(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(createUserEntity()), null, null));
+        .thenReturn(new SearchQueryResult<>(1, false, List.of(createUserEntity()), null, null));
     final var passwordEncoder = mock(PasswordEncoder.class);
     when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -121,7 +121,8 @@ public class AuthenticationInterceptorTest {
     // demo:demo
     metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Basic ZGVtbzpkZW1v");
     final var userServices = mock(UserServices.class);
-    when(userServices.search(any())).thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
+    when(userServices.search(any()))
+        .thenReturn(new SearchQueryResult<>(0, false, List.of(), null, null));
     new AuthenticationInterceptor(new BasicAuth(userServices, mock(PasswordEncoder.class)))
         .interceptCall(closeStatusCapturingServerCall, metadata, failingNextHandler());
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9031,7 +9031,7 @@ components:
           format: int64
         hasMoreTotalItems:
           description: |
-            Indicates if more results exist beyond the reported totalItems value. The totalItems value is capped at 10,000 due to ElasticSearch and OpenSearch search limitations. This field is true if additional results exist beyond this cap; otherwise, it is false.
+            Indicates if more results exist beyond the reported totalItems value. If ElasticSearch or OpenSearch is used, the totalItems value is capped at 10,000 due to search limitations. This field is true if additional results exist beyond this cap; otherwise, it is false.
           type: boolean
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9029,6 +9029,9 @@ components:
           description: Total items matching the criteria.
           type: integer
           format: int64
+        hasMore:
+          description: Has more items than default maximum total items ES/OS return.
+          type: boolean
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9030,7 +9030,8 @@ components:
           type: integer
           format: int64
         hasMoreTotalItems:
-          description: Has more items than default maximum total items ES/OS return.
+          description: |
+            Indicates if more results exist beyond the reported totalItems value. The totalItems value is capped at 10,000 due to ElasticSearch and OpenSearch search limitations. This field is true if additional results exist beyond this cap; otherwise, it is false.
           type: boolean
         startCursor:
           description: The cursor value for getting the previous page of results. Use this in the `before` field of an ensuing request.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -9029,7 +9029,7 @@ components:
           description: Total items matching the criteria.
           type: integer
           format: int64
-        hasMore:
+        hasMoreTotalItems:
           description: Has more items than default maximum total items ES/OS return.
           type: boolean
         startCursor:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -449,6 +449,7 @@ public final class SearchQueryResponseMapper {
 
     return new SearchQueryPageResponse()
         .totalItems(result.total())
+        .hasMore(result.hasMore())
         .startCursor(result.startCursor())
         .endCursor(result.endCursor());
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -449,7 +449,7 @@ public final class SearchQueryResponseMapper {
 
     return new SearchQueryPageResponse()
         .totalItems(result.total())
-        .hasMore(result.hasMore())
+        .hasMoreTotalItems(result.hasMoreTotalItems())
         .startCursor(result.startCursor())
         .endCursor(result.endCursor());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationControllerTest.java
@@ -139,7 +139,7 @@ class BatchOperationControllerTest extends RestControllerTest {
 
     // when / then
     when(batchOperationServices.search(any(BatchOperationQuery.class)))
-        .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(entity), null, null));
 
     webClient
         .post()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationItemControllerTest.java
@@ -106,7 +106,7 @@ class BatchOperationItemControllerTest extends RestControllerTest {
 
     // when / then
     when(batchOperationServices.searchItems(any(BatchOperationItemQuery.class)))
-        .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
+        .thenReturn(new SearchQueryResult(1, false, List.of(entity), null, null));
 
     webClient
         .post()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
### Background
In Elasticsearch/OpenSearch (ES/OS), the `totalItems` field in a search response is capped at 10,000 for performance reasons. However, the actual number of matching items may exceed this limit. When this occurs, ES/OS sets `hits.total.relation` to `"gte"` (greater than or equal to), indicating that the true number of results is at least 10,000, but possibly more.

Currently, clients receive a `totalItems` value of 10,000 in such cases, with no indication that additional results may exist. This lack of visibility can lead to incorrect assumptions about the completeness of search results.

## Goal
Provide clients with a clear indication when more than totalItems may exist in a search response.

## Solution
Introduce a new field in the `SearchQueryPageResponse` response object:
`boolean hasMoreTotalItems`

### Behavior
- Default value: `false`
- For ES/OS-based searches:
  - If hits.total.relation == "gte" → set hasMoreTotalItems = true
  - Else → hasMoreTotalItems = false
- For RDBMS-based searches:
  - Always set hasMoreTotalItems = false (no change to current behavior)

### Changes Introduced in this PR
- `rest-api.yaml`, add **hasMoreTotalItems** field at **SearchQueryPageResponse**
- `SearchQueryResponse` Records, hasMoreTotalItems field addition
- `SearchResponseTransformer` ES/OS, to pass-through ES/OS `SearchResponse` and fill **SearchQueryResponse**.hasMoreTotalItems 
- `SearchQueryResult` Record, hasMoreTotalItems field addition (sync all constructor methods)
- `SearchQueryResultTransformer`, to pass-through ES/OS response and fill **SearchQueryResult**.hasMoreTotalItems 
- `SearchQueryResponseMapper` to map SearchQueryResult to SearchQueryPageResponse

### Coverage
- `ElasticsearchDataStoreClientTest`/`OpensearchDataStoreClientTest`: test SearchResponseTransformer, ES/OS SearchResponse to SearchQueryResponse
  - shouldHaveMoreTotalItemsFalse
  - shouldHaveMoreTotalItemsTrue
- `SearchClientBasedQueryExecutorTest`
  - shouldSearchQueryResultHaveMoreTotalItemsFalse
  - shouldSearchQueryResultHaveMoreTotalItemsTrue
- `ProcessDefinitionSearchTest`.shouldHaveMoreTotalItemsField, e2e test checking hasMoreTotalItems field exist and has default value false as a @MultiDbTest

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/33885
