### PR TITLE
Feat/32608 implement batch operation lifecycle operations in camunda client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -2233,7 +2233,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newCancelBatchOperationCommand("123L")
+   *   .newCancelBatchOperationCommand("123")
    *   .send();
    * </pre>
    *

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -29,6 +29,7 @@ import io.camunda.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.client.api.command.AssignUserToGroupCommandStep1;
 import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
 import io.camunda.client.api.command.BroadcastSignalCommandStep1;
+import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ClockPinCommandStep1;
 import io.camunda.client.api.command.ClockResetCommandStep1;
@@ -60,7 +61,9 @@ import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
 import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
+import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
+import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.client.api.command.UnassignMappingFromGroupStep1;
@@ -2222,6 +2225,51 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the groups search request
    */
   BatchOperationSearchRequest newBatchOperationSearchRequest();
+
+  /**
+   * Command to cancel a batch operation
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * camundaClient
+   *   .newCancelBatchOperationCommand("123L")
+   *   .send();
+   * </pre>
+   *
+   * @return a builder to configure and send the cancel batch operation command
+   */
+  CancelBatchOperationStep1 newCancelBatchOperationCommand(String batchOperationId);
+
+  /**
+   * Command to suspend a batch operation
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * camundaClient
+   *   .newSuspendBatchOperationCommand("123L")
+   *   .send();
+   * </pre>
+   *
+   * @return a builder to configure and send the suspend batch operation command
+   */
+  SuspendBatchOperationStep1 newSuspendBatchOperationCommand(String batchOperationId);
+
+  /**
+   * Command to resume a batch operation
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * camundaClient
+   *   .newResumeBatchOperationCommand("123L")
+   *   .send();
+   * </pre>
+   *
+   * @return a builder to configure and send the resume batch operation command
+   */
+  ResumeBatchOperationStep1 newResumeBatchOperationCommand(String batchOperationId);
 
   /**
    * Executes a search request to query batch operation items.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CancelBatchOperationStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CancelBatchOperationStep1.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+public interface CancelBatchOperationStep1 extends FinalCommandStep<Void> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/ResumeBatchOperationStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ResumeBatchOperationStep1.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+public interface ResumeBatchOperationStep1 extends FinalCommandStep<Void> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/SuspendBatchOperationStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/SuspendBatchOperationStep1.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+public interface SuspendBatchOperationStep1 extends FinalCommandStep<Void> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -35,6 +35,7 @@ import io.camunda.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.client.api.command.AssignUserToGroupCommandStep1;
 import io.camunda.client.api.command.AssignUserToTenantCommandStep1;
 import io.camunda.client.api.command.BroadcastSignalCommandStep1;
+import io.camunda.client.api.command.CancelBatchOperationStep1;
 import io.camunda.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.ClockPinCommandStep1;
@@ -69,8 +70,10 @@ import io.camunda.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.client.api.command.PublishMessageCommandStep1;
 import io.camunda.client.api.command.RemoveUserFromTenantCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
+import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.StreamJobsCommandStep1;
+import io.camunda.client.api.command.SuspendBatchOperationStep1;
 import io.camunda.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.client.api.command.TopologyRequestStep1;
 import io.camunda.client.api.command.UnassignGroupFromTenantCommandStep1;
@@ -156,6 +159,7 @@ import io.camunda.client.impl.command.AssignUserTaskCommandImpl;
 import io.camunda.client.impl.command.AssignUserToGroupCommandImpl;
 import io.camunda.client.impl.command.AssignUserToTenantCommandImpl;
 import io.camunda.client.impl.command.BroadcastSignalCommandImpl;
+import io.camunda.client.impl.command.CancelBatchOperationCommandImpl;
 import io.camunda.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.ClockPinCommandImpl;
 import io.camunda.client.impl.command.ClockResetCommandImpl;
@@ -190,8 +194,10 @@ import io.camunda.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.PublishMessageCommandImpl;
 import io.camunda.client.impl.command.RemoveUserFromTenantCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
+import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.client.impl.command.StreamJobsCommandImpl;
+import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
 import io.camunda.client.impl.command.TopologyRequestImpl;
 import io.camunda.client.impl.command.UnassignGroupFromTenantCommandImpl;
 import io.camunda.client.impl.command.UnassignMappingFromGroupCommandImpl;
@@ -1154,6 +1160,21 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public BatchOperationSearchRequest newBatchOperationSearchRequest() {
     return new BatchOperationSearchRequestImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public CancelBatchOperationStep1 newCancelBatchOperationCommand(final String batchOperationId) {
+    return new CancelBatchOperationCommandImpl(httpClient, batchOperationId);
+  }
+
+  @Override
+  public SuspendBatchOperationStep1 newSuspendBatchOperationCommand(final String batchOperationId) {
+    return new SuspendBatchOperationCommandImpl(httpClient, batchOperationId);
+  }
+
+  @Override
+  public ResumeBatchOperationStep1 newResumeBatchOperationCommand(final String batchOperationId) {
+    return new ResumeBatchOperationCommandImpl(httpClient, batchOperationId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CancelBatchOperationCommandImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.CancelBatchOperationStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+/** Implementation of the command to cancel a batch operation. */
+public final class CancelBatchOperationCommandImpl implements CancelBatchOperationStep1 {
+
+  private final String batchOperationOd;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CancelBatchOperationCommandImpl(
+      final HttpClient httpClient, final String batchOperationId) {
+    this.batchOperationOd = batchOperationId;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Void> send() {
+    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+    httpClient.put(
+        "/batch-operations/" + batchOperationOd + "/cancellation",
+        null,
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResumeBatchOperationCommandImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.ResumeBatchOperationStep1;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+/** Implementation of the command to resume a batch operation. */
+public final class ResumeBatchOperationCommandImpl implements ResumeBatchOperationStep1 {
+
+  private final String batchOperationOd;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ResumeBatchOperationCommandImpl(
+      final HttpClient httpClient, final String batchOperationId) {
+    batchOperationOd = batchOperationId;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Void> send() {
+    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+    httpClient.put(
+        "/batch-operations/" + batchOperationOd + "/resumption",
+        null,
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SuspendBatchOperationCommandImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.SuspendBatchOperationStep1;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+/** Implementation of the command to suspend a batch operation. */
+public final class SuspendBatchOperationCommandImpl implements SuspendBatchOperationStep1 {
+
+  private final String batchOperationOd;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public SuspendBatchOperationCommandImpl(
+      final HttpClient httpClient, final String batchOperationId) {
+    batchOperationOd = batchOperationId;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<Void> send() {
+    final HttpCamundaFuture<Void> result = new HttpCamundaFuture<>();
+    httpClient.put(
+        "/batch-operations/" + batchOperationOd + "/suspension",
+        null,
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CancelBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CancelBatchOperationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class CancelBatchOperationTest extends ClientRestTest {
+
+  @Test
+  public void shouldSendCancelBatchOperationCommand() {
+    // when
+    client.newCancelBatchOperationCommand("batch-123").send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/cancellation");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/ResumeBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/ResumeBatchOperationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class ResumeBatchOperationTest extends ClientRestTest {
+
+  @Test
+  public void shouldSendCancelBatchOperationCommand() {
+    // when
+    client.newResumeBatchOperationCommand("batch-123").send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/resumption");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/SuspendBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/SuspendBatchOperationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class SuspendBatchOperationTest extends ClientRestTest {
+
+  @Test
+  public void shouldSendCancelBatchOperationCommand() {
+    // when
+    client.newSuspendBatchOperationCommand("batch-123").send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+    assertThat(request.getUrl()).isEqualTo("/v2/batch-operations/batch-123/suspension");
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.getScopedVariables;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForBatchOperationStatus;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.enums.BatchOperationState;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class BatchOperationLifecycleManagementTest {
+
+  private static CamundaClient camundaClient;
+
+  String testScopeId;
+
+  Process deployedProcess;
+  final List<ProcessInstanceEvent> activeProcessInstances = new ArrayList<>();
+
+  @BeforeEach
+  public void beforeEach(final TestInfo testInfo) {
+    Objects.requireNonNull(camundaClient);
+    testScopeId =
+        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
+
+    deployedProcess =
+        deployResource(camundaClient, "process/service_tasks_v1.bpmn").getProcesses().getFirst();
+
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    IntStream.range(0, 10)
+        .forEach(
+            i ->
+                activeProcessInstances.add(
+                    startScopedProcessInstance(
+                        camundaClient, "service_tasks_v1", testScopeId, Map.of("xyz", "bar"))));
+
+    waitForScopedProcessInstancesToStart(camundaClient, testScopeId, activeProcessInstances.size());
+  }
+
+  @AfterEach
+  void afterEach() {
+    activeProcessInstances.clear();
+  }
+
+  @Test
+  void shouldCancelBatchOperation() {
+    // given a batch operation
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+    final var batchOperationId = result.getBatchOperationId();
+    assertThat(result).isNotNull();
+
+    // when we cancel the batch operation
+    camundaClient.newCancelBatchOperationCommand(batchOperationId).send().join();
+
+    // and
+    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.CANCELED);
+  }
+
+  @Test
+  void shouldSuspendBatchOperation() {
+    // given a batch operation
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+    final var batchOperationId = result.getBatchOperationId();
+    assertThat(result).isNotNull();
+
+    // when we suspend the batch operation
+    camundaClient.newSuspendBatchOperationCommand(batchOperationId).send().join();
+
+    // and
+    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.SUSPENDED);
+  }
+
+  @Test
+  void shouldResumeBatchOperation() {
+    // given a batch operation
+    final var result =
+        camundaClient
+            .newCreateBatchOperationCommand()
+            .processInstanceCancel()
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
+            .send()
+            .join();
+    final var batchOperationId = result.getBatchOperationId();
+    assertThat(result).isNotNull();
+
+    // and it is suspended
+    camundaClient.newSuspendBatchOperationCommand(batchOperationId).send().join();
+
+    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.SUSPENDED);
+
+    // when we resume the batch operation
+    camundaClient.newResumeBatchOperationCommand(batchOperationId).send().join();
+
+    // then it's again active and can complete
+    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.COMPLETED);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationLifecycleManagementTest.java
@@ -20,7 +20,11 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.BatchOperationState;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +42,18 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class BatchOperationLifecycleManagementTest {
 
   private static CamundaClient camundaClient;
+
+  @MultiDbTestApplication
+  private static final TestStandaloneApplication<?> APPLICATION =
+      new TestStandaloneBroker()
+          .withUnauthenticatedAccess()
+          .withBrokerConfig(
+              b -> {
+                b.getExperimental()
+                    .getEngine()
+                    .getBatchOperations()
+                    .setSchedulerInterval(Duration.ofSeconds(3));
+              });
 
   String testScopeId;
 
@@ -132,6 +148,6 @@ public class BatchOperationLifecycleManagementTest {
     camundaClient.newResumeBatchOperationCommand(batchOperationId).send().join();
 
     // then it's again active and can complete
-    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.COMPLETED);
+    waitForBatchOperationStatus(camundaClient, batchOperationId, BatchOperationState.ACTIVE);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -398,6 +398,23 @@ public final class TestHelper {
             });
   }
 
+  public static void waitForBatchOperationStatus(
+      final CamundaClient camundaClient,
+      final String batchOperationId,
+      final BatchOperationState expectedStatus) {
+    Awaitility.await("batch operation should have state " + expectedStatus)
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              // and
+              final var batch =
+                  camundaClient.newBatchOperationGetRequest(batchOperationId).send().join();
+              assertThat(batch).isNotNull();
+              assertThat(batch.getStatus()).isEqualTo(expectedStatus);
+            });
+  }
+
   public static void waitForProcessInstanceToBeTerminated(
       final CamundaClient camundaClient, final Long processInstanceKey) {
     Awaitility.await("should wait until process is terminated")

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationResumeProcessor.java
@@ -114,6 +114,8 @@ public final class BatchOperationResumeProcessor
     }
 
     resumeBatchOperation(resumeKey, batchOperation.get(), command.getValue());
+    responseWriter.writeEventOnCommand(
+        resumeKey, BatchOperationIntent.RESUMED, command.getValue(), command);
     commandDistributionBehavior
         .withKey(resumeKey)
         .inQueue(DistributionQueue.BATCH_OPERATION)


### PR DESCRIPTION
## Description

* Adds new commands to camunda client to cancel, suspend and resume batch operations
* Fixes a bug in the BatchOperationResumeProcessor which causes the client to wait forever (no response writer was used)
* Added unit and acceptance tests for the new batch operation lifecycle management client commands

## Related issues

closes #32608 
