### PR TITLE
feat: generify mockDmnDecision decision output

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -193,7 +193,7 @@ public interface CamundaProcessTestContext {
    * Mocks a DMN decision with the specified decision ID and sets the provided variables.
    *
    * @param decisionId the ID of the DMN decision to mock
-   * @param variables a map of variables to set for the mocked DMN decision
+   * @param decisionOutput the decision's output which may be a value, list or map.
    */
-  void mockDmnDecision(final String decisionId, final Map<String, Object> variables);
+  void mockDmnDecision(final String decisionId, final Object decisionOutput);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -263,9 +263,9 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
-  public void mockDmnDecision(final String decisionId, final Map<String, Object> variables) {
+  public void mockDmnDecision(final String decisionId, final Object decisionOutput) {
     final CamundaClient client = createClient();
-    final String jsonVariables = client.getConfiguration().getJsonMapper().toJson(variables);
+    final String jsonVariables = client.getConfiguration().getJsonMapper().toJson(decisionOutput);
 
     // Create an empty DMN model
     final DmnModelInstance modelInstance = Dmn.createEmptyModel();
@@ -288,7 +288,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     literalExpression.setText(text);
     decision.addChildElement(literalExpression);
 
-    LOGGER.debug("Mock: Deploy a DMN '{}' with result variables {}", decisionId, variables);
+    LOGGER.debug("Mock: Deploy a DMN '{}' with decision output {}", decisionId, decisionOutput);
 
     final String resourceName = decisionId + ".dmn";
     client


### PR DESCRIPTION
## Description

The result of a DMN decision can be of different types depending on the structure of the decision (e.g. single value, list, map).

In CPT, I can mock a DMN decision and define the decision output as a map:
```
void mockDmnDecision(final String decisionId, final Map<String, Object> variables);
```
To support an arbitrary result type, we should change the signature to:
```
void mockDmnDecision(final String decisionId, final Object decisionOutput);
```

## Related issues

closes https://github.com/camunda/camunda/issues/32209
