### PR TITLE
feat: improve completeJob error message

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
@@ -47,6 +48,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.TerminalFailureException;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Decision;
@@ -236,26 +239,36 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final UserTaskSelector userTaskSelector, final Map<String, Object> variables) {
     final CamundaClient client = createClient();
     final AtomicReference<Long> userTaskKey = new AtomicReference<>();
-    Awaitility.await("until user task is active")
-        .ignoreExceptions()
-        .atMost(Duration.ofSeconds(2 * TIMEOUT))
-        .untilAsserted(
-            () -> {
-              final Future<SearchResponse<UserTask>> userTaskFuture =
-                  client.newUserTaskSearchRequest().send();
-              Assertions.assertThat(userTaskFuture)
-                  .succeedsWithin(Duration.ofSeconds(TIMEOUT))
-                  .extracting(SearchResponse::items)
-                  .satisfies(
-                      items -> {
-                        final List<UserTask> tasks =
-                            items.stream()
-                                .filter(userTaskSelector::test)
-                                .collect(Collectors.toList());
-                        Assertions.assertThat(tasks).isNotEmpty();
-                        userTaskKey.set(items.get(0).getUserTaskKey());
-                      });
-            });
+
+    try {
+      Awaitility.await("until user task is active")
+          .ignoreExceptions()
+          .atMost(Duration.ofSeconds(2 * TIMEOUT))
+          .untilAsserted(
+              () -> {
+                final Future<SearchResponse<UserTask>> userTaskFuture =
+                    client.newUserTaskSearchRequest().send();
+                Assertions.assertThat(userTaskFuture)
+                    .succeedsWithin(Duration.ofSeconds(TIMEOUT))
+                    .extracting(SearchResponse::items)
+                    .satisfies(
+                        items -> {
+                          final List<UserTask> tasks =
+                              items.stream()
+                                  .filter(userTaskSelector::test)
+                                  .collect(Collectors.toList());
+                          Assertions.assertThat(tasks).isNotEmpty();
+                          userTaskKey.set(items.get(0).getUserTaskKey());
+                        });
+              });
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+      final String failureMessage =
+          String.format(
+              "Expected to complete user task [%s] but no job is available.",
+              userTaskSelector.describe());
+
+      fail(failureMessage);
+    }
 
     LOGGER.debug(
         "Complete user task with variables {} [user-task-key: '{}']", variables, userTaskKey.get());
@@ -302,21 +315,33 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   private ActivatedJob getActivatedJob(final String jobType) {
     final CamundaClient client = createClient();
     final AtomicReference<ActivatedJob> activatedJob = new AtomicReference<>();
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
-        .untilAsserted(
-            () -> {
-              final List<ActivatedJob> jobs =
-                  client
-                      .newActivateJobsCommand()
-                      .jobType(jobType)
-                      .maxJobsToActivate(1)
-                      .send()
-                      .join()
-                      .getJobs();
-              assertThat(jobs).isNotEmpty();
-              activatedJob.set(jobs.get(0));
-            });
+
+    try {
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(10))
+          .untilAsserted(
+              () -> {
+                final List<ActivatedJob> jobs =
+                    client
+                        .newActivateJobsCommand()
+                        .jobType(jobType)
+                        .maxJobsToActivate(1)
+                        .send()
+                        .join()
+                        .getJobs();
+
+                assertThat(jobs).isNotEmpty();
+
+                activatedJob.set(jobs.get(0));
+              });
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+      final String failureMessage =
+          String.format(
+              "Expected to complete a job with the type '%s' but no job is available.", jobType);
+
+      fail(failureMessage);
+    }
+
     return activatedJob.get();
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -195,6 +195,19 @@ public class CamundaProcessTestContextIT {
   }
 
   @Test
+  void shouldGiveClearErrorMessageWhenJobIsMissing() {
+    // Given
+    final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // Then
+    Assertions.assertThatThrownBy(() -> processTestContext.completeJob("not-found"))
+        .hasMessage(
+            "Expected to complete a job with the type 'not-found' " + "but no job is available.");
+  }
+
+  @Test
   void shouldThrowBpmnErrorFromJob() {
     // Given
     final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
@@ -360,6 +373,20 @@ public class CamundaProcessTestContextIT {
     assertThat(processInstanceEvent).isCompleted();
     assertThat(processInstanceEvent).hasCompletedElements("success-end");
     assertThat(processInstanceEvent).hasVariables(variables);
+  }
+
+  @Test
+  void shouldGiveHelpfulErrorMessageWhenCompleteUserTaskFails() {
+    // Given
+    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client.newCreateInstanceCommand().processDefinitionKey(processDefinitionKey).send().join();
+
+    // When
+    Assertions.assertThatThrownBy(
+            () ->
+                processTestContext.completeUserTask(UserTaskSelectors.byElementId("unknown-task")))
+        .hasMessage("Expected to complete user task [unknown-task] but no job is available.");
   }
 
   @Test


### PR DESCRIPTION
## Description

In CPT, I can complete jobs and user tasks. The complete utility waits until the job/user task is available.
```
processTestContext.completeJob("not-existing", variables);
```
When no job/user task is available, the utility fails with a cryptic failure message.
```
org.awaitility.core.ConditionTimeoutException: Assertion condition defined as a Lambda expression in io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl null within 10 seconds.

	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1160)
	at org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:790)
	at io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl.getActivatedJob(CamundaProcessTestContextImpl.java:286)
	at io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl.completeJob(CamundaProcessTestContextImpl.java:219)
	at io.camunda.process.test.api.CamundaProcessTestExtensionIT.shouldCompleteJob(CamundaProcessTestExtensionIT.java:354)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:204)
	at org.awaitility.core.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:101)
	at org.awaitility.core.Uninterruptibles.getUninterruptibly(Uninterruptibles.java:81)
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:103)
	... 10 more
```
We should provide a clear failure message similar to the assertions. For example:
```
Expected to complete a job with the type 'non-existing' but no job is available. 
```

## Related issues

closes #[32214](https://github.com/camunda/camunda/issues/32214)
