### PR TITLE
fix: support graceful shutdown of schema initializer on SIGTERM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,7 +721,8 @@ jobs:
             maven-build-threads: 1
             maven-test-fork-count: 3
             runs-on: gcp-perf-core-8-default
-            docker-file: ''
+            docker-repository: localhost:5000/camunda/camunda
+            docker-file: camunda.Dockerfile
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
@@ -758,6 +759,7 @@ jobs:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
       TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
+      CAMUNDA_TEST_DOCKER_IMAGE: localhost:5000/camunda/camunda:current-test
       CAMUNDA_DOCKER_IMAGE_NAME: localhost:5000/camunda/camunda
       DOCKER_IMAGE_TAG: current-test
     services:

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -13,7 +13,9 @@ import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -22,6 +24,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
   private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
   private final SearchEngineConfiguration searchEngineConfiguration;
   private final SchemaManagerMetrics schemaManagerMetrics;
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   public SearchEngineSchemaInitializer(
       final SearchEngineConfiguration searchEngineConfiguration,
@@ -31,9 +34,10 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
   }
 
   @Override
-  public void afterPropertiesSet() throws IOException {
+  public void afterPropertiesSet() throws Exception {
     LOGGER.info("Initializing search engine schema...");
-    try (final var clientAdapter = ClientAdapter.of(searchEngineConfiguration.connect())) {
+    try (final var clientAdapter = ClientAdapter.of(searchEngineConfiguration.connect());
+        final var executor = Executors.newSingleThreadExecutor()) {
       final IndexDescriptors indexDescriptors =
           new IndexDescriptors(
               searchEngineConfiguration.connect().getIndexPrefix(),
@@ -46,8 +50,52 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
                   searchEngineConfiguration,
                   clientAdapter.objectMapper())
               .withMetrics(schemaManagerMetrics);
-      schemaManager.startup();
+      if (!addShutdownHook(executor)) {
+        LOGGER.info("skipping schema initialization, JVM is shutting down");
+        return;
+      }
+      executor.submit(schemaManager::startup).get();
+    } catch (final InterruptedException ie) {
+      LOGGER.warn("Schema initialization task was interrupted");
+      LOGGER.debug("Stack trace:", ie);
+      Thread.currentThread().interrupt();
+      return;
+    } catch (final Exception e) {
+      if (isShutdown.get()) {
+        LOGGER.warn("Schema initialization interrupted with shutdown. Message: {}", e.getMessage());
+        LOGGER.debug("Stack trace:", e);
+        Thread.currentThread().interrupt();
+        return;
+      }
+      throw e;
     }
     LOGGER.info("Search engine schema initialization complete.");
+  }
+
+  /**
+   * Adds a shutdown hook to the JVM that will be triggered when the application is shutting
+   *
+   * @return true if the shutdown hook was added successfully, false if the JVM is already shutting
+   *     down
+   */
+  private boolean addShutdownHook(final ExecutorService executor) {
+    try {
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    LOGGER.debug("Shutdown hook triggered");
+                    if (isShutdown.compareAndSet(false, true)) {
+                      executor.shutdownNow();
+                    }
+                  }));
+      return true;
+    } catch (final IllegalStateException e) {
+      // This can happen if the shutdown hook is added after the JVM has started shutting down.
+      // In this case, we just ignore the exception.
+      LOGGER.info("JVM is shutting down, cannot add shutdown hook: {}", e.getMessage());
+      LOGGER.debug("Stack trace:", e);
+      return false;
+    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -51,19 +51,17 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
                   clientAdapter.objectMapper())
               .withMetrics(schemaManagerMetrics);
       if (!addShutdownHook(executor)) {
-        LOGGER.info("skipping schema initialization, JVM is shutting down");
+        // skipping schema initialization as JVM is shutting down
         return;
       }
       executor.submit(schemaManager::startup).get();
     } catch (final InterruptedException ie) {
-      LOGGER.warn("Schema initialization task was interrupted");
-      LOGGER.debug("Stack trace:", ie);
+      LOGGER.debug("Schema initialization task was interrupted.", ie);
       Thread.currentThread().interrupt();
       return;
     } catch (final Exception e) {
       if (isShutdown.get()) {
-        LOGGER.warn("Schema initialization interrupted with shutdown. Message: {}", e.getMessage());
-        LOGGER.debug("Stack trace:", e);
+        LOGGER.debug("Schema initialization interrupted with shutdown.", e);
         Thread.currentThread().interrupt();
         return;
       }
@@ -84,7 +82,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
           .addShutdownHook(
               new Thread(
                   () -> {
-                    LOGGER.debug("Shutdown hook triggered");
+                    LOGGER.trace("Shutdown hook triggered");
                     if (isShutdown.compareAndSet(false, true)) {
                       executor.shutdownNow();
                     }
@@ -93,8 +91,7 @@ public class SearchEngineSchemaInitializer implements InitializingBean {
     } catch (final IllegalStateException e) {
       // This can happen if the shutdown hook is added after the JVM has started shutting down.
       // In this case, we just ignore the exception.
-      LOGGER.info("JVM is shutting down, cannot add shutdown hook: {}", e.getMessage());
-      LOGGER.debug("Stack trace:", e);
+      LOGGER.debug("JVM is shutting down, cannot add the schema initializer shutdown hook", e);
       return false;
     }
   }

--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -109,6 +109,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>elasticsearch</artifactId>
       <scope>test</scope>
@@ -159,6 +165,18 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerStartupIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema;
+
+import static io.camunda.zeebe.test.util.testcontainers.TestSearchContainers.createDefeaultElasticsearchContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.containers.ZeebeContainer;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class SchemaManagerStartupIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaManagerStartupIT.class);
+
+  private static final String CAMUNDA_TEST_IMAGE_NAME =
+      Optional.ofNullable(System.getenv("CAMUNDA_TEST_DOCKER_IMAGE"))
+          .orElse("camunda/camunda:SNAPSHOT");
+
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
+
+  @AutoClose
+  private final ZeebeContainer camunda =
+      new ZeebeContainer(DockerImageName.parse(CAMUNDA_TEST_IMAGE_NAME))
+          .withEnv("CAMUNDA_DATABASE_URL", "http://test-elasticsearch:9200")
+          .withEnv("SPRING_PROFILES_ACTIVE", "broker")
+          .withNetwork(Network.SHARED)
+          .waitingFor(
+              new WaitStrategy() {
+                @Override
+                public void waitUntilReady(final WaitStrategyTarget waitStrategyTarget) {
+                  // Wait until the application is shutdown
+                  Awaitility.await()
+                      .timeout(Duration.ofSeconds(60))
+                      .pollDelay(Duration.ofSeconds(1))
+                      .untilTrue(isShutdown);
+                }
+
+                @Override
+                public WaitStrategy withStartupTimeout(final Duration startupTimeout) {
+                  return this;
+                }
+              });
+
+  @Container
+  private final ElasticsearchContainer es =
+      createDefeaultElasticsearchContainer()
+          // Enable security in ES for to trigger the retry logic as application does not have
+          // credentials
+          .withEnv("xpack.security.enabled", "true")
+          .withNetwork(Network.SHARED)
+          .withNetworkAliases("test-elasticsearch");
+
+  @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  // false is to test the case when the shutdown is before the schema startup is started
+  // true is to test the case when the shutdown is when the schema startup is retrying
+  void shouldGracefullyShutdownWhenSchemaStartupStillRunning(final boolean waitForSchemaStartup)
+      throws InterruptedException {
+    // given
+    executor.submit(() -> camunda.start());
+
+    final var logToWaitFor =
+        waitForSchemaStartup
+            ? "Initializing search engine schema"
+            : "Root WebApplicationContext: initialization completed";
+
+    // just wait until the container is running (but not ready)
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .until(() -> camunda.isRunning() && camunda.getLogs().contains(logToWaitFor));
+    // Let the startup proceed a little
+    Thread.sleep(2_000);
+
+    // when
+    // Simulate external shutdown signal
+    LOG.info("Start graceful shutdown of the container");
+    camunda.shutdownGracefully(Duration.ofSeconds(30)); // as default Kubernetes shutdown timeout
+    isShutdown.set(true);
+
+    executor.awaitTermination(5, TimeUnit.SECONDS);
+
+    // then
+    final var logs = camunda.getLogs();
+    assertThat(logs)
+        .contains(
+            "org.springframework.boot.web.embedded.tomcat.GracefulShutdown - Graceful shutdown complete");
+    assertThat(logs).contains("io.camunda.zeebe.broker.system - Broker shut down");
+    assertThat(logs).doesNotContain("Failed to start application");
+    assertThat(logs).doesNotContain("BeanCreationException");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This change addresses an issue observed while trying to reproduce https://github.com/camunda/camunda/issues/33774  with Docker and Kubernetes.

**Reproduction steps with Kubernetes:**
- Scaled down Elasticsearch to zero.
- Restarted a Zeebe Pod.
- waited for the schema manager to enter backoff retry mode during schema initialization.
- Deleted the Zeebe Pod (also tested deleting the namespace and the entire cluster via Camunda Console).

**Observed behaviour:**
- The application continued running in bootstrapping mode for 30 seconds.
- Schema manager kept retrying during this time.
- After the 30-second timeout, the Pod was forcibly killed by Kubernetes (K8s uses `docker stop --timeout 30 --signal SIGTERM`).
- The graceful shutdown sequence of the broker was never triggered.

The schema startup was running on the main thread, which seems to not respond to `SIGTERM` by default. As a result, the app was stuck inside the schema initialization loop and missed the shutdown sequence.

In this pull request,
- Refactored schema startup to run on a dedicated single-threaded executor.
- Added a JVM shutdown hook to interrupt the schema initialization task during SIGTERM.
- Handled InterruptedException gracefully by preserving the thread’s interrupt status without propagating it as a startup failure, avoiding unnecessary BeanCreationException and ERROR logs in Spring, as this is considered a normal shutdown scenario.
- Integration test reproducing the issue 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

relates to #33774 
