### PR TITLE
Fix user task restrictions filter

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskRestrictionsIT.java
@@ -17,9 +17,13 @@ import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.application.Profile;
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.GroupDefinition;
+import io.camunda.qa.util.auth.Membership;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
@@ -29,12 +33,11 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
-import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -49,23 +52,45 @@ public class UserTaskRestrictionsIT {
       new TestCamundaApplication()
           .withAuthorizationsEnabled()
           .withBasicAuth()
+          .withAdditionalProfile(Profile.TASKLIST)
           .withProperty("camunda.tasklist.identity.userAccessRestrictionsEnabled", true);
 
   private static final String ADMIN = "admin";
   private static final String USER1 = "user1";
   private static final String USER2 = "user2";
+  private static final String USER3 = "user3";
+  private static final String USER4 = "user4";
+  private static final String GROUP1 = "group1";
+  private static final String GROUP2 = "group2";
 
-  private static final String PROCESS_ID_3 = "processWithCandidateUsers";
-  private static final BpmnModelInstance PROCESS_3 =
-      Bpmn.createExecutableProcess(PROCESS_ID_3)
+  private static final String PROCESS_ID_1 = "processWithCandidateUsers";
+  private static final BpmnModelInstance PROCESS_1 =
+      Bpmn.createExecutableProcess(PROCESS_ID_1)
           .startEvent()
           .parallelGateway("startParallel")
           .userTask("user1Task")
+          .zeebeUserTask()
           .zeebeCandidateUsers(USER1)
           .parallelGateway("endParallel")
           .moveToNode("startParallel")
           .userTask("user2Task")
+          .zeebeUserTask()
           .zeebeCandidateUsers(USER2)
+          .done();
+
+  private static final String PROCESS_ID_2 = "processWithCandidateGroups";
+  private static final BpmnModelInstance PROCESS_2 =
+      Bpmn.createExecutableProcess(PROCESS_ID_2)
+          .startEvent()
+          .parallelGateway("startParallel")
+          .userTask("group1Task")
+          .zeebeUserTask()
+          .zeebeCandidateGroups(GROUP1)
+          .parallelGateway("endParallel")
+          .moveToNode("startParallel")
+          .userTask("group2Task")
+          .zeebeUserTask()
+          .zeebeCandidateGroups(GROUP2)
           .done();
 
   @UserDefinition
@@ -83,55 +108,55 @@ public class UserTaskRestrictionsIT {
       new TestUser(
           USER1,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_3))));
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_1))));
 
   @UserDefinition
   private static final TestUser USER2_USER =
       new TestUser(
           USER2,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_3))));
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_1))));
 
-  private static long processInstanceKey;
+  @UserDefinition
+  private static final TestUser USER3_USER = new TestUser(USER3, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser USER4_USER = new TestUser(USER4, "password", List.of());
+
+  @GroupDefinition
+  private static final TestGroup GROUP1_GROUP =
+      new TestGroup(
+          GROUP1,
+          GROUP1,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_2))),
+          List.of(new Membership(USER3, EntityType.USER)));
+
+  @GroupDefinition
+  private static final TestGroup GROUP2_GROUP =
+      new TestGroup(
+          GROUP2,
+          GROUP2,
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_2))),
+          List.of(new Membership(USER4, EntityType.USER)));
+
+  private static long processInstanceKeyCandidateUsers;
+  private static long processInstanceKeyCandidateGroups;
 
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    deployResource(adminClient, PROCESS_3, PROCESS_ID_3 + ".bpmn");
-    final var startEvent = startProcessInstance(adminClient, PROCESS_ID_3);
-    processInstanceKey = startEvent.getProcessInstanceKey();
+    deployResource(adminClient, PROCESS_1, PROCESS_ID_1 + ".bpmn");
+    deployResource(adminClient, PROCESS_2, PROCESS_ID_2 + ".bpmn");
+    final var startEvent1 = startProcessInstance(adminClient, PROCESS_ID_1);
+    final var startEvent2 = startProcessInstance(adminClient, PROCESS_ID_2);
+    processInstanceKeyCandidateUsers = startEvent1.getProcessInstanceKey();
+    processInstanceKeyCandidateGroups = startEvent2.getProcessInstanceKey();
 
-    assertThat(
-            RecordingExporter.processRecords(ProcessIntent.CREATED)
-                .withBpmnProcessId(PROCESS_ID_3)
-                .limit(1L)
-                .count())
-        .isOne();
-    assertThat(
-            RecordingExporter.processInstanceCreationRecords()
-                .withIntent(ProcessInstanceCreationIntent.CREATED)
-                .withBpmnProcessId(PROCESS_ID_3)
-                .limit(1L)
-                .count())
-        .isOne();
-    //    assertThat(
-    //            RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
-    //                .withProcessInstanceKey(processInstanceKey)
-    //                .limit(2L)
-    //                .count())
-    //        .isEqualTo(2);
-    assertThat(
-            RecordingExporter.jobRecords(JobIntent.CREATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(2L)
-                .count())
-        .isEqualTo(2);
+    awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateUsers, 2);
+    awaitUserTaskBeingAvailable(adminClient, processInstanceKeyCandidateGroups, 2);
   }
 
   @Test
-  public void searchShouldReturnCandidateUserTasks(
-      @Authenticated(USER1) final CamundaClient user1Client,
-      @Authenticated(USER2) final CamundaClient user2Client)
-      throws JsonProcessingException {
+  public void searchShouldReturnCandidateUserTasks() throws JsonProcessingException {
     // given
     try (final var tasklistUser1RestClient =
             STANDALONE_CAMUNDA
@@ -143,10 +168,9 @@ public class UserTaskRestrictionsIT {
                 .withAuthentication(USER2_USER.username(), USER2_USER.password()); ) {
 
       // when
-      final HttpResponse<String> user1Response =
-          tasklistUser1RestClient.searchTasks(processInstanceKey);
-      final HttpResponse<String> user2Response =
-          tasklistUser2RestClient.searchTasks(processInstanceKey);
+      // searching for tasks available to user1 and user2 (no process instance key provided)
+      final HttpResponse<String> user1Response = tasklistUser1RestClient.searchTasks(null);
+      final HttpResponse<String> user2Response = tasklistUser2RestClient.searchTasks(null);
 
       // then
       assertThat(user1Response).isNotNull();
@@ -154,14 +178,69 @@ public class UserTaskRestrictionsIT {
       assertThat(user1Response.statusCode()).isEqualTo(200);
       assertThat(user2Response.statusCode()).isEqualTo(200);
 
-      final var tasksUser1 =
+      final TaskSearchResponse[] tasksUser1 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
               user1Response.body(), TaskSearchResponse[].class);
-      assertThat(tasksUser1).hasSize(1);
+      assertThat(tasksUser1.length).isEqualTo(1);
+      assertThat(tasksUser1[0].getCandidateUsers()).containsExactly(USER1);
       final var tasksUser2 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
               user2Response.body(), TaskSearchResponse[].class);
       assertThat(tasksUser2).hasSize(1);
+      assertThat(tasksUser2[0].getCandidateUsers()).containsExactly(USER2);
     }
+  }
+
+  @Test
+  public void searchShouldReturnCandidateGroupTasks() throws JsonProcessingException {
+    // given
+    try (final var tasklistUser3RestClient =
+            STANDALONE_CAMUNDA
+                .newTasklistClient()
+                .withAuthentication(USER3_USER.username(), USER3_USER.password());
+        final var tasklistUser4RestClient =
+            STANDALONE_CAMUNDA
+                .newTasklistClient()
+                .withAuthentication(USER4_USER.username(), USER4_USER.password()); ) {
+
+      // when
+      // searching for tasks available to user1 and user2 (no process instance key provided)
+      final HttpResponse<String> user3Response = tasklistUser3RestClient.searchTasks(null);
+      final HttpResponse<String> user4Response = tasklistUser4RestClient.searchTasks(null);
+
+      // then
+      assertThat(user3Response).isNotNull();
+      assertThat(user4Response).isNotNull();
+      assertThat(user3Response.statusCode()).isEqualTo(200);
+      assertThat(user4Response.statusCode()).isEqualTo(200);
+
+      final TaskSearchResponse[] tasksUser3 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user3Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser3.length).isEqualTo(1);
+      assertThat(tasksUser3[0].getCandidateGroups()).containsExactly(GROUP1);
+      final var tasksUser4 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user4Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser4).hasSize(1);
+      assertThat(tasksUser4[0].getCandidateGroups()).containsExactly(GROUP2);
+    }
+  }
+
+  public static void awaitUserTaskBeingAvailable(
+      final CamundaClient camundaClient, final long processInstanceKey, final int count) {
+    Awaitility.await("should create user tasks")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newUserTaskSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
+              assertThat(result.items()).hasSize(count);
+            });
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UserTaskRestrictionsIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_USER_TASK;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestRestTasklistClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.net.http.HttpResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class UserTaskRestrictionsIT {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication STANDALONE_CAMUNDA =
+      new TestCamundaApplication()
+          .withAuthorizationsEnabled()
+          .withBasicAuth()
+          .withProperty("camunda.tasklist.identity.userAccessRestrictionsEnabled", true);
+
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+
+  private static final String PROCESS_ID_3 = "processWithCandidateUsers";
+  private static final BpmnModelInstance PROCESS_3 =
+      Bpmn.createExecutableProcess(PROCESS_ID_3)
+          .startEvent()
+          .parallelGateway("startParallel")
+          .userTask("user1Task")
+          .zeebeCandidateUsers(USER1)
+          .parallelGateway("endParallel")
+          .moveToNode("startParallel")
+          .userTask("user2Task")
+          .zeebeCandidateUsers(USER2)
+          .done();
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER =
+      new TestUser(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser USER1_USER =
+      new TestUser(
+          USER1,
+          "password",
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_3))));
+
+  @UserDefinition
+  private static final TestUser USER2_USER =
+      new TestUser(
+          USER2,
+          "password",
+          List.of(new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of(PROCESS_ID_3))));
+
+  private static long processInstanceKey;
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    deployResource(adminClient, PROCESS_3, PROCESS_ID_3 + ".bpmn");
+    final var startEvent = startProcessInstance(adminClient, PROCESS_ID_3);
+    processInstanceKey = startEvent.getProcessInstanceKey();
+
+    assertThat(
+            RecordingExporter.processRecords(ProcessIntent.CREATED)
+                .withBpmnProcessId(PROCESS_ID_3)
+                .limit(1L)
+                .count())
+        .isOne();
+    assertThat(
+            RecordingExporter.processInstanceCreationRecords()
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withBpmnProcessId(PROCESS_ID_3)
+                .limit(1L)
+                .count())
+        .isOne();
+    //    assertThat(
+    //            RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+    //                .withProcessInstanceKey(processInstanceKey)
+    //                .limit(2L)
+    //                .count())
+    //        .isEqualTo(2);
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2L)
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void searchShouldReturnCandidateUserTasks(
+      @Authenticated(USER1) final CamundaClient user1Client,
+      @Authenticated(USER2) final CamundaClient user2Client)
+      throws JsonProcessingException {
+    // given
+    try (final var tasklistUser1RestClient =
+            STANDALONE_CAMUNDA
+                .newTasklistClient()
+                .withAuthentication(USER1_USER.username(), USER1_USER.password());
+        final var tasklistUser2RestClient =
+            STANDALONE_CAMUNDA
+                .newTasklistClient()
+                .withAuthentication(USER2_USER.username(), USER2_USER.password()); ) {
+
+      // when
+      final HttpResponse<String> user1Response =
+          tasklistUser1RestClient.searchTasks(processInstanceKey);
+      final HttpResponse<String> user2Response =
+          tasklistUser2RestClient.searchTasks(processInstanceKey);
+
+      // then
+      assertThat(user1Response).isNotNull();
+      assertThat(user2Response).isNotNull();
+      assertThat(user1Response.statusCode()).isEqualTo(200);
+      assertThat(user2Response.statusCode()).isEqualTo(200);
+
+      final var tasksUser1 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user1Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser1).hasSize(1);
+      final var tasksUser2 =
+          TestRestTasklistClient.OBJECT_MAPPER.readValue(
+              user2Response.body(), TaskSearchResponse[].class);
+      assertThat(tasksUser2).hasSize(1);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/task/UserTaskRestrictionsIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.auth;
+package io.camunda.it.task;
 
 import static io.camunda.client.api.search.enums.PermissionType.CREATE;
 import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
@@ -181,7 +181,7 @@ public class UserTaskRestrictionsIT {
       final TaskSearchResponse[] tasksUser1 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
               user1Response.body(), TaskSearchResponse[].class);
-      assertThat(tasksUser1.length).isEqualTo(1);
+      assertThat(tasksUser1).hasSize(1);
       assertThat(tasksUser1[0].getCandidateUsers()).containsExactly(USER1);
       final var tasksUser2 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
@@ -217,7 +217,7 @@ public class UserTaskRestrictionsIT {
       final TaskSearchResponse[] tasksUser3 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(
               user3Response.body(), TaskSearchResponse[].class);
-      assertThat(tasksUser3.length).isEqualTo(1);
+      assertThat(tasksUser3).hasSize(1);
       assertThat(tasksUser3[0].getCandidateGroups()).containsExactly(GROUP1);
       final var tasksUser4 =
           TestRestTasklistClient.OBJECT_MAPPER.readValue(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Reproduce and fix a bug report where users can see user tasks that they are not assigned to as candidate users, or part of the assigned candidate groups.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #28976
