### PR TITLE
perf: avoid copy of `ElementInstance`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -317,8 +317,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
-    final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);
-    return copyElementInstance(elementInstance);
+    return elementInstanceColumnFamily.get(elementInstanceKey, ElementInstance::new);
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.db;
 import io.camunda.zeebe.protocol.ScopedColumnFamily;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Represents a column family, where it is possible to store keys of type {@link KeyType} and
@@ -45,6 +46,16 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue>
    * @return if the key was found in the column family then the value, otherwise null
    */
   ValueType get(KeyType key);
+
+  /**
+   * Returns the corresponding stored value in the column family to the given key. Returns null if
+   * the key does not exist. The difference to {@link #get(KeyType)} is that this method calls the
+   * {@code valueSupplier} to create a new instance of {@link ValueType} instead of a reference to
+   * the mutable internal value instance.
+   *
+   * <p>Use this method if you would otherwise immediately copy the returned value.
+   */
+  ValueType get(KeyType key, Supplier<ValueType> valueSupplier);
 
   /**
    * Visits the values, which are stored in the column family. The ordering depends on the key.

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -26,7 +26,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableReference;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksIterator;
 
@@ -155,6 +158,29 @@ class TransactionalColumnFamily<
         return valueInstance;
       }
       return null;
+    }
+  }
+
+  @Override
+  public ValueType get(final KeyType key, final Supplier<ValueType> valueSupplier) {
+    final var result = new MutableReference<ValueType>();
+    try (final var timer = metrics.measureGetLatency()) {
+      ensureInOpenTransaction(
+          transaction -> {
+            columnFamilyContext.writeKey(key);
+            final byte[] valueBytes =
+                transaction.get(
+                    transactionDb.getDefaultNativeHandle(),
+                    transactionDb.getReadOptionsNativeHandle(),
+                    columnFamilyContext.getKeyBufferArray(),
+                    columnFamilyContext.getKeyLength());
+            if (valueBytes != null) {
+              final var newValue = valueSupplier.get();
+              newValue.wrap(new UnsafeBuffer(valueBytes), 0, valueBytes.length);
+              result.set(newValue);
+            }
+          });
+      return result.get();
     }
   }
 

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -466,6 +466,61 @@ public final class ColumnFamilyTest {
         .hasMessageContaining("Foreign key");
   }
 
+  @Test
+  public void shouldGetWithSupplierWhenKeyExists() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getValue()).isEqualTo(456);
+  }
+
+  @Test
+  public void shouldReturnNullWithSupplierWhenKeyDoesNotExist() {
+    // given
+    key.wrapLong(123);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void shouldReturnIndependentValueWithSupplier() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1).isNotSameAs(result2);
+  }
+
+  @Test
+  public void shouldReturnImmutableValueWithSupplier() {
+    // given
+    upsertKeyValuePair(1, 2);
+    upsertKeyValuePair(3, 4);
+
+    // when
+    key.wrapLong(1);
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    key.wrapLong(3);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1.getValue()).isEqualTo(2);
+    assertThat(result2.getValue()).isEqualTo(4);
+  }
+
   private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);


### PR DESCRIPTION
This adds another `get` variant on `ColumnFamily` that takes a `Supplier<ValueType>` and returns a fresh instance instead of the internally recycled value instance. This is much more efficient for callers that otherwise would have to immediately create a copy again.
First used for `ElementInstance`, one of the most prominent allocation sites seen during profiling.

Memory allocations before:
![image](https://github.com/user-attachments/assets/a3c9103a-07e5-4cea-8343-bf777fdbfe12)
95% in copying

CPU time before:
 ![image](https://github.com/user-attachments/assets/480c92bf-47e9-42cd-a593-a0d5f602e42e)
80% in copying

CPU time by caller before:
![image](https://github.com/user-attachments/assets/1b1c2686-b9df-4a15-962d-53ec9394f005)


Memory allocations after:
![image](https://github.com/user-attachments/assets/15c991b5-f438-4bf5-9574-ab34e8b6ff37)
100% on the returned bytes from RocksDB, instead of ~4%

CPU time after:
![image](https://github.com/user-attachments/assets/ab5fc7cc-74f0-4cc7-aa54-55cd5aafa58b)
100% on the call to RocksDB, instead of ~19%

CPU time by caller after:
![image](https://github.com/user-attachments/assets/bc97c821-9d36-4ece-b9de-57cfa1d22887)
