### PR TITLE
fix: downgrade to spring-boot 3.4.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,7 +97,7 @@
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.2.8</version.spring>
     <version.spring-security>6.5.1</version.spring-security>
-    <version.spring-boot>3.5.3</version.spring-boot>
+    <version.spring-boot>3.4.7</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

Newer Camunda releases are not yet on spring boot 3.5, does downgrading to not have a version drop after 8.5. Furthermore, Spring-Boot 3.4 still fits the maintenance cycle of 8.5. Spring-Boot 3.4.x is supported till 31st of December 2025. Camunda 8.5 is supported till 14th of October 2025.

Context see https://camunda.slack.com/archives/C08MRKHJ0CD/p1750700078922429

Will create a follow-up change on main to lock the boot version to 3.4.x for stable/8.5.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
