### PR TITLE
Fix tenant loading for simple mappings

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOAuthPrincipalServiceImpl.java
@@ -17,7 +17,6 @@ import io.camunda.authentication.entity.OAuthContext;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.query.RoleQuery;
 import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -128,19 +127,14 @@ public class CamundaOAuthPrincipalServiceImpl implements CamundaOAuthPrincipalSe
       ownerTypeToIds.put(GROUP, groups);
     }
 
-    final var roles =
-        roleServices.findAll(
-            RoleQuery.of(
-                roleQuery ->
-                    roleQuery.filter(roleFilter -> roleFilter.memberIdsByType(ownerTypeToIds))));
+    final var roles = roleServices.getRolesByMemberTypeAndMemberIds(ownerTypeToIds);
     final var roleIds = roles.stream().map(RoleEntity::roleId).collect(Collectors.toSet());
     if (!roleIds.isEmpty()) {
       ownerTypeToIds.put(EntityType.ROLE, roleIds);
     }
 
-    // TODO: Get tenants for username and clientId https://github.com/camunda/camunda/issues/26572
     final var tenants =
-        tenantServices.getTenantsByMappingsAndGroupsAndRoles(mappingIds, groups, roleIds).stream()
+        tenantServices.getTenantsByMemberTypeAndMemberIds(ownerTypeToIds).stream()
             .map(TenantDTO::fromEntity)
             .toList();
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -209,9 +209,7 @@ public class CamundaOAuthPrincipalServiceTest {
                   new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
                   new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
-      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
       final var groupRole = new RoleEntity(3L, "roleGroup", "Role Group", "description");
-
       when(groupServices.getGroupsByMemberTypeAndMemberIds(
               Map.of(
                   EntityType.MAPPING,
@@ -220,6 +218,7 @@ public class CamundaOAuthPrincipalServiceTest {
                   Set.of("foo@camunda.test"))))
           .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
 
+      final var roleR1 = new RoleEntity(8L, "roleR1", "Role R1", "R1 description");
       when(roleServices.getRolesByMemberTypeAndMemberIds(
               Map.of(
                   EntityType.MAPPING,
@@ -232,8 +231,16 @@ public class CamundaOAuthPrincipalServiceTest {
 
       final var tenantT1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
       final var groupTenant = new TenantEntity(200L, "tenant1", "Tenant One", "First Tenant");
-      when(tenantServices.getTenantsByMappingsAndGroupsAndRoles(
-              Set.of("test-id", "test-id-2"), Set.of("group-g1"), Set.of("roleR1", "roleGroup")))
+      when(tenantServices.getTenantsByMemberTypeAndMemberIds(
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("test-id", "test-id-2"),
+                  EntityType.USER,
+                  Set.of("foo@camunda.test"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"),
+                  EntityType.ROLE,
+                  Set.of("roleR1", "roleGroup"))))
           .thenReturn(List.of(tenantT1, groupTenant));
 
       when(authorizationServices.getAuthorizedApplications(
@@ -281,13 +288,6 @@ public class CamundaOAuthPrincipalServiceTest {
                   Set.of("scooby-doo"))))
           .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
 
-      final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
-      final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
-
-      when(tenantServices.getTenantsByMappingsAndGroupsAndRoles(
-              Set.of("map-1", "map-2"), Set.of("group-g1"), Set.of("roleR1")))
-          .thenReturn(List.of(tenantEntity1, tenantEntity2));
-
       final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
       when(roleServices.getRolesByMemberTypeAndMemberIds(
               Map.of(
@@ -298,6 +298,21 @@ public class CamundaOAuthPrincipalServiceTest {
                   EntityType.USER,
                   Set.of("scooby-doo"))))
           .thenReturn(List.of(roleR1));
+
+      final var tenantEntity1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
+      final var tenantEntity2 = new TenantEntity(200L, "t2", "Tenant Two", "Second Tenant");
+
+      when(tenantServices.getTenantsByMemberTypeAndMemberIds(
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("map-1", "map-2"),
+                  EntityType.USER,
+                  Set.of("scooby-doo"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"),
+                  EntityType.ROLE,
+                  Set.of("roleR1"))))
+          .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
       when(authorizationServices.getAuthorizedApplications(
               Map.of(

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOAuthPrincipalServiceTest.java
@@ -18,7 +18,6 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.search.query.RoleQuery;
 import io.camunda.security.configuration.AuthenticationConfiguration;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -221,20 +220,15 @@ public class CamundaOAuthPrincipalServiceTest {
                   Set.of("foo@camunda.test"))))
           .thenReturn(List.of(new GroupEntity(1L, "group-g1", "G1", "Group G1")));
 
-      final var expectedRoleQuery =
-          RoleQuery.of(
-              roleQuery ->
-                  roleQuery.filter(
-                      roleFilter ->
-                          roleFilter.memberIdsByType(
-                              Map.of(
-                                  EntityType.MAPPING,
-                                  Set.of("test-id", "test-id-2"),
-                                  EntityType.USER,
-                                  Set.of("foo@camunda.test"),
-                                  EntityType.GROUP,
-                                  Set.of("group-g1")))));
-      when(roleServices.findAll(expectedRoleQuery)).thenReturn(List.of(roleR1, groupRole));
+      when(roleServices.getRolesByMemberTypeAndMemberIds(
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("test-id", "test-id-2"),
+                  EntityType.USER,
+                  Set.of("foo@camunda.test"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"))))
+          .thenReturn(List.of(roleR1, groupRole));
 
       final var tenantT1 = new TenantEntity(100L, "t1", "Tenant One", "First Tenant");
       final var groupTenant = new TenantEntity(200L, "tenant1", "Tenant One", "First Tenant");
@@ -295,20 +289,15 @@ public class CamundaOAuthPrincipalServiceTest {
           .thenReturn(List.of(tenantEntity1, tenantEntity2));
 
       final var roleR1 = new RoleEntity(10L, "roleR1", "Role R1", "R1 description");
-      final var expectedQuery =
-          RoleQuery.of(
-              roleQuery ->
-                  roleQuery.filter(
-                      roleFilter ->
-                          roleFilter.memberIdsByType(
-                              Map.of(
-                                  EntityType.MAPPING,
-                                  Set.of("map-1", "map-2"),
-                                  EntityType.GROUP,
-                                  Set.of("group-g1"),
-                                  EntityType.USER,
-                                  Set.of("scooby-doo")))));
-      when(roleServices.findAll(expectedQuery)).thenReturn(List.of(roleR1));
+      when(roleServices.getRolesByMemberTypeAndMemberIds(
+              Map.of(
+                  EntityType.MAPPING,
+                  Set.of("map-1", "map-2"),
+                  EntityType.GROUP,
+                  Set.of("group-g1"),
+                  EntityType.USER,
+                  Set.of("scooby-doo"))))
+          .thenReturn(List.of(roleR1));
 
       when(authorizationServices.getAuthorizedApplications(
               Map.of(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -163,8 +163,6 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                     b.must(
                         List.of(
                             SearchQuery.of(
-                                q1 -> q1.term(t -> t.field("memberType").value(memberType))),
-                            SearchQuery.of(
                                 q1 ->
                                     q1.hasParent(
                                         p ->
@@ -175,6 +173,8 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                                                             q2.term(
                                                                 t ->
                                                                     t.field("tenantId")
-                                                                        .value(parentId))))))))));
+                                                                        .value(parentId)))))),
+                            SearchQuery.of(
+                                q1 -> q1.term(t -> t.field("memberType").value(memberType)))))));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -9,6 +9,7 @@ package io.camunda.search.filter;
 
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -19,7 +20,8 @@ public record TenantFilter(
     String joinParentId,
     EntityType entityType,
     Set<String> memberIds,
-    EntityType childMemberType)
+    EntityType childMemberType,
+    Map<EntityType, Set<String>> memberIdsByType)
     implements FilterBase {
 
   public static TenantFilter of(final Function<Builder, Builder> builderFunction) {
@@ -34,7 +36,8 @@ public record TenantFilter(
         .joinParentId(joinParentId)
         .memberType(entityType)
         .memberIds(memberIds)
-        .childMemberType(childMemberType);
+        .childMemberType(childMemberType)
+        .memberIdsByType(memberIdsByType);
   }
 
   public static final class Builder implements ObjectBuilder<TenantFilter> {
@@ -46,6 +49,7 @@ public record TenantFilter(
     private EntityType entityType;
     private Set<String> memberIds;
     private EntityType childMemberType;
+    private Map<EntityType, Set<String>> memberIdsByType;
 
     public Builder key(final Long value) {
       key = value;
@@ -82,10 +86,22 @@ public record TenantFilter(
       return this;
     }
 
+    public Builder memberIdsByType(final Map<EntityType, Set<String>> value) {
+      memberIdsByType = value;
+      return this;
+    }
+
     @Override
     public TenantFilter build() {
       return new TenantFilter(
-          key, tenantId, name, joinParentId, entityType, memberIds, childMemberType);
+          key,
+          tenantId,
+          name,
+          joinParentId,
+          entityType,
+          memberIds,
+          childMemberType,
+          memberIdsByType);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.DefaultRole;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -85,6 +86,15 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   public List<RoleEntity> getRolesByMemberId(final String memberId, final EntityType entityType) {
     return findAll(
         RoleQuery.of(q -> q.filter(f -> f.memberId(memberId).childMemberType(entityType))));
+  }
+
+  public List<RoleEntity> getRolesByMemberTypeAndMemberIds(
+      final Map<EntityType, Set<String>> memberTypesToMemberIds) {
+    return findAll(
+        RoleQuery.of(
+            roleQuery ->
+                roleQuery.filter(
+                    roleFilter -> roleFilter.memberIdsByType(memberTypesToMemberIds))));
   }
 
   public List<RoleEntity> getRolesByUserAndGroups(

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -135,6 +136,11 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     tenants.addAll(groupTenants);
     tenants.addAll(roleTenants);
     return tenants.stream().distinct().toList();
+  }
+
+  public List<TenantEntity> getTenantsByMemberTypeAndMemberIds(
+      final Map<EntityType, Set<String>> memberTypesToMemberIds) {
+    return findAll(TenantQuery.of(q -> q.filter(f -> f.memberIdsByType(memberTypesToMemberIds))));
   }
 
   public TenantEntity getById(final String tenantId) {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR is the last in a chain of fixes for the loading of the entities in the authentiation context (roles: https://github.com/camunda/camunda/pull/33877 groups: https://github.com/camunda/camunda/issues/26572 authorized applications https://github.com/camunda/camunda/pull/33973. In this PR I: 
- Add in the support for loading tenants based on simple mappings
- Refactor the role code slightly to use a method in the service class for clarity

## Related issues

closes https://github.com/camunda/camunda/issues/26572
