### PR TITLE
fix: revert renaming newUserCreateCommand in ZeebeClient to keep consistency

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -863,7 +863,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    *
    * zeebeClient
-   *  .newCreateUserCommand()
+   *  .newUserCreateCommand()
    *  .username(username)
    *  .email(email)
    *  .name(name)
@@ -875,7 +875,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    * @return a builder for the command
    */
-  CreateUserCommandStep1 newCreateUserCommand();
+  CreateUserCommandStep1 newUserCreateCommand();
 
   /**
    * Command to create a document.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -637,7 +637,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public CreateUserCommandStep1 newCreateUserCommand() {
+  public CreateUserCommandStep1 newUserCreateCommand() {
     return new CreateUserCommandImpl(httpClient, jsonMapper);
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
@@ -36,7 +36,7 @@ public class CreateUserTest extends ClientRestTest {
   void shouldCreateUser() {
     // when
     client
-        .newCreateUserCommand()
+        .newUserCreateCommand()
         .username(USERNAME)
         .name(NAME)
         .email(EMAIL)
@@ -58,7 +58,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newCreateUserCommand()
+                    .newUserCreateCommand()
                     .name(NAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -74,7 +74,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newCreateUserCommand()
+                    .newUserCreateCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .password(PASSWORD)
@@ -90,7 +90,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newCreateUserCommand()
+                    .newUserCreateCommand()
                     .username(USERNAME)
                     .email(EMAIL)
                     .password(PASSWORD)
@@ -106,7 +106,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newCreateUserCommand()
+                    .newUserCreateCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)
@@ -126,7 +126,7 @@ public class CreateUserTest extends ClientRestTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newCreateUserCommand()
+                    .newUserCreateCommand()
                     .username(USERNAME)
                     .name(NAME)
                     .email(EMAIL)


### PR DESCRIPTION
See discussion https://github.com/camunda/camunda-docs/pull/6049#discussion_r2168962065

closes #33838