### PR TITLE
[Backport stable/8.4] perf: avoid copy of `ElementInstance`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -293,8 +293,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
-    final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);
-    return copyElementInstance(elementInstance);
+    return elementInstanceColumnFamily.get(elementInstanceKey, ElementInstance::new);
   }
 
   @Override

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.db;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Represents an column family, where it is possible to store keys of type {@link KeyType} and
@@ -43,6 +44,16 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * @return if the key was found in the column family then the value, otherwise null
    */
   ValueType get(KeyType key);
+
+  /**
+   * Returns the corresponding stored value in the column family to the given key. Returns null if
+   * the key does not exist. The difference to {@link #get(KeyType)} is that this method calls the
+   * {@code valueSupplier} to create a new instance of {@link ValueType} instead of a reference to
+   * the mutable internal value instance.
+   *
+   * <p>Use this method if you would otherwise immediately copy the returned value.
+   */
+  ValueType get(KeyType key, Supplier<ValueType> valueSupplier);
 
   /**
    * Visits the values, which are stored in the column family. The ordering depends on the key.

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -466,6 +466,61 @@ public final class ColumnFamilyTest {
         .hasMessageContaining("Foreign key");
   }
 
+  @Test
+  public void shouldGetWithSupplierWhenKeyExists() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getValue()).isEqualTo(456);
+  }
+
+  @Test
+  public void shouldReturnNullWithSupplierWhenKeyDoesNotExist() {
+    // given
+    key.wrapLong(123);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void shouldReturnIndependentValueWithSupplier() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1).isNotSameAs(result2);
+  }
+
+  @Test
+  public void shouldReturnImmutableValueWithSupplier() {
+    // given
+    upsertKeyValuePair(1, 2);
+    upsertKeyValuePair(3, 4);
+
+    // when
+    key.wrapLong(1);
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    key.wrapLong(3);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1.getValue()).isEqualTo(2);
+    assertThat(result2.getValue()).isEqualTo(4);
+  }
+
   private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);


### PR DESCRIPTION
# Description
Backport of #34431 to `stable/8.4`.

relates to 