### PR TITLE
[Backport stable/8.7] perf: avoid copy of `ElementInstance`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -296,8 +296,7 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
-    final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);
-    return copyElementInstance(elementInstance);
+    return elementInstanceColumnFamily.get(elementInstanceKey, ElementInstance::new);
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.db;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Represents an column family, where it is possible to store keys of type {@link KeyType} and
@@ -43,6 +44,16 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * @return if the key was found in the column family then the value, otherwise null
    */
   ValueType get(KeyType key);
+
+  /**
+   * Returns the corresponding stored value in the column family to the given key. Returns null if
+   * the key does not exist. The difference to {@link #get(KeyType)} is that this method calls the
+   * {@code valueSupplier} to create a new instance of {@link ValueType} instead of a reference to
+   * the mutable internal value instance.
+   *
+   * <p>Use this method if you would otherwise immediately copy the returned value.
+   */
+  ValueType get(KeyType key, Supplier<ValueType> valueSupplier);
 
   /**
    * Visits the values, which are stored in the column family. The ordering depends on the key.

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -24,7 +24,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableReference;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksIterator;
 
@@ -153,6 +156,29 @@ class TransactionalColumnFamily<
         return valueInstance;
       }
       return null;
+    }
+  }
+
+  @Override
+  public ValueType get(final KeyType key, final Supplier<ValueType> valueSupplier) {
+    final var result = new MutableReference<ValueType>();
+    try (final var timer = metrics.measureGetLatency()) {
+      ensureInOpenTransaction(
+          transaction -> {
+            columnFamilyContext.writeKey(key);
+            final byte[] valueBytes =
+                transaction.get(
+                    transactionDb.getDefaultNativeHandle(),
+                    transactionDb.getReadOptionsNativeHandle(),
+                    columnFamilyContext.getKeyBufferArray(),
+                    columnFamilyContext.getKeyLength());
+            if (valueBytes != null) {
+              final var newValue = valueSupplier.get();
+              newValue.wrap(new UnsafeBuffer(valueBytes), 0, valueBytes.length);
+              result.set(newValue);
+            }
+          });
+      return result.get();
     }
   }
 

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/ColumnFamilyTest.java
@@ -466,6 +466,61 @@ public final class ColumnFamilyTest {
         .hasMessageContaining("Foreign key");
   }
 
+  @Test
+  public void shouldGetWithSupplierWhenKeyExists() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getValue()).isEqualTo(456);
+  }
+
+  @Test
+  public void shouldReturnNullWithSupplierWhenKeyDoesNotExist() {
+    // given
+    key.wrapLong(123);
+
+    // when
+    final var result = columnFamily.get(key, DbLong::new);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void shouldReturnIndependentValueWithSupplier() {
+    // given
+    upsertKeyValuePair(123, 456);
+
+    // when
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1).isNotSameAs(result2);
+  }
+
+  @Test
+  public void shouldReturnImmutableValueWithSupplier() {
+    // given
+    upsertKeyValuePair(1, 2);
+    upsertKeyValuePair(3, 4);
+
+    // when
+    key.wrapLong(1);
+    final DbLong result1 = columnFamily.get(key, DbLong::new);
+    key.wrapLong(3);
+    final DbLong result2 = columnFamily.get(key, DbLong::new);
+
+    // then -- verify they are different instances
+    assertThat(result1.getValue()).isEqualTo(2);
+    assertThat(result2.getValue()).isEqualTo(4);
+  }
+
   private void upsertKeyValuePair(final int key, final int value) {
     this.key.wrapLong(key);
     this.value.wrapLong(value);


### PR DESCRIPTION
# Description
Backport of #34431 to `stable/8.7`.

relates to 