### PR TITLE
ci: limit branches where spring minor updates are allowed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,9 +70,9 @@
       "enabled": false
     },
     {
-      "description": "Allow minor and patch updates for Spring and Spring-boot for our maintenance branches. Since Spring has a 1-year support cycle while C8 is supported for 18 months, we allow minor updates to help mitigate security risks.",
+      "description": "Allow minor updates for Spring and Spring-boot for stable branches where the Spring support window is not matching the Camunda support window yet. Right now these are 8.6+. Since Spring has a 1-year support cycle while C8 is supported for 18 months, we allow minor updates to help mitigate security risks.",
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/",
+        "/^stable\\/8\\.([6-9]|\\d\\d)/",
         "stable/operate-8.5"
       ],
       "matchManagers": [


### PR DESCRIPTION
## Description

For some stable branches like 8.5, the currently used spring version support windows match the support window of the stable branch. As spring minor updates can cause extra effort due to breaking changes, we only allow minor updates for branches where the currently used spring minor version has a shorter support window than Camunda 8.

Follow-up to https://github.com/camunda/camunda/pull/34433

Context see https://camunda.slack.com/archives/C08MRKHJ0CD/p1750700078922429

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
