### PR TITLE
Unable to deploy process with boundary event without outgoing flows

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -65,9 +65,10 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
       validationResultCollector.addError(0, "Cannot have incoming sequence flows");
     }
 
-    if (element.getOutgoing().isEmpty() && !isValidCompensationBoundaryEvent(element)) {
+    if (hasCompensationDefinition(element) && !isValidCompensationBoundaryEvent(element)) {
       validationResultCollector.addError(
-          0, "Must have at least one outgoing sequence flow or association");
+          0,
+          "Compensation boundary events must have a compensation association and no outgoing sequence flows");
     }
 
     validateEventDefinition(element, validationResultCollector);
@@ -100,6 +101,11 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
         });
   }
 
+  private boolean hasCompensationDefinition(final BoundaryEvent element) {
+    return element.getEventDefinitions().stream()
+        .anyMatch(CompensateEventDefinition.class::isInstance);
+  }
+
   private boolean isValidCompensationBoundaryEvent(final BoundaryEvent element) {
     // A compensation boundary event should have no outgoing sequence flows. The compensation
     // handler is connected by an association.
@@ -107,10 +113,7 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
         element.getModelInstance().getModelElementsByType(Association.class).stream()
             .filter(a -> a.getSource().getId().equals(element.getId()))
             .findFirst();
-    return element.getOutgoing().isEmpty()
-        && association.isPresent()
-        && element.getEventDefinitions().stream()
-            .anyMatch(CompensateEventDefinition.class::isInstance);
+    return element.getOutgoing().isEmpty() && association.isPresent();
   }
 
   private void validateEventDefinition(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTest {
@@ -65,11 +66,14 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .serviceTask("task", b -> b.zeebeJobType("type"))
             .boundaryEvent("boundary")
             .cancelActivity(true)
-            .timerWithDuration("PT0.5S")
+            .compensation(AbstractBpmnModelElementBuilder::done)
             .moveToActivity("task")
             .endEvent("end")
             .done(),
-        singletonList(expect("boundary", "Must have at least one outgoing sequence flow"))
+        singletonList(
+            expect(
+                "boundary",
+                "Compensation boundary events must have a compensation association and no outgoing sequence flows"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventWithoutOutgoingSequenceFlowTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventWithoutOutgoingSequenceFlowTest.java
@@ -62,20 +62,20 @@ public final class BoundaryEventWithoutOutgoingSequenceFlowTest {
     return Arrays.asList(
         new Object[][] {
           {
-            "message-int",
+            "message-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
                         .boundaryEvent(
                             "boundary",
-                            bb ->
-                                bb.message(m -> m.name("MSG").zeebeCorrelationKeyExpression("k"))),
+                            bb -> bb.message(m -> m.name("MSG").zeebeCorrelationKeyExpression("k")))
+                        .moveToActivity("element"),
             (BoundaryTrigger)
                 (engine, key) -> engine.message().withName("MSG").withCorrelationKey("v").publish(),
             true
           },
           {
-            "message-non-int",
+            "message-non-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
@@ -83,51 +83,55 @@ public final class BoundaryEventWithoutOutgoingSequenceFlowTest {
                             "boundary",
                             bb ->
                                 bb.cancelActivity(false)
-                                    .message(
-                                        m -> m.name("MSG").zeebeCorrelationKeyExpression("k"))),
+                                    .message(m -> m.name("MSG").zeebeCorrelationKeyExpression("k")))
+                        .moveToActivity("element"),
             (BoundaryTrigger)
                 (engine, key) -> engine.message().withName("MSG").withCorrelationKey("v").publish(),
             false
           },
           {
-            "timer-int",
+            "timer-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
-                        .boundaryEvent("boundary", bb -> bb.timerWithDuration("PT1S")),
+                        .boundaryEvent("boundary", bb -> bb.timerWithDuration("PT1S"))
+                        .moveToActivity("element"),
             (BoundaryTrigger) (engine, key) -> engine.increaseTime(Duration.ofSeconds(2)),
             true
           },
           {
-            "timer-non-int",
+            "timer-non-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
                         .boundaryEvent(
-                            "boundary", bb -> bb.cancelActivity(false).timerWithDuration("PT1S")),
+                            "boundary", bb -> bb.cancelActivity(false).timerWithDuration("PT1S"))
+                        .moveToActivity("element"),
             (BoundaryTrigger) (engine, key) -> engine.increaseTime(Duration.ofSeconds(2)),
             false
           },
           {
-            "signal-int",
+            "signal-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
-                        .boundaryEvent("boundary", bb -> bb.signal("SIG")),
+                        .boundaryEvent("boundary", bb -> bb.signal("SIG"))
+                        .moveToActivity("element"),
             (BoundaryTrigger) (engine, key) -> engine.signal().withSignalName("SIG").broadcast(),
             true
           },
           {
-            "signal-non-int",
+            "signal-non-interrupting",
             (BoundaryScenario)
                 b ->
                     b.serviceTask("element", t -> t.zeebeJobType("type"))
-                        .boundaryEvent("boundary", bb -> bb.cancelActivity(false).signal("SIG")),
+                        .boundaryEvent("boundary", bb -> bb.cancelActivity(false).signal("SIG"))
+                        .moveToActivity("element"),
             (BoundaryTrigger) (engine, key) -> engine.signal().withSignalName("SIG").broadcast(),
             false
           },
           {
-            "escalation-int",
+            "escalation-interrupting",
             (BoundaryScenario)
                 b ->
                     b.subProcess(
@@ -146,7 +150,7 @@ public final class BoundaryEventWithoutOutgoingSequenceFlowTest {
             true
           },
           {
-            "escalation-non-int",
+            "escalation-non-interrupting",
             (BoundaryScenario)
                 b ->
                     b.subProcess(
@@ -166,7 +170,7 @@ public final class BoundaryEventWithoutOutgoingSequenceFlowTest {
             false
           },
           {
-            "error-int",
+            "error-interrupting",
             (BoundaryScenario)
                 b ->
                     b.subProcess(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventWithoutOutgoingSequenceFlowTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/boundary/BoundaryEventWithoutOutgoingSequenceFlowTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.boundary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Parameterized runtime tests for boundary events without outgoing sequence flows. Interrupting
+ * boundary event terminates the attached activity. Non-interrupting boundary events leave it
+ * running, and we complete the job created by the service task to verify that the process instance
+ * completes.
+ */
+@RunWith(Parameterized.class)
+public final class BoundaryEventWithoutOutgoingSequenceFlowTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+  private final String name;
+  private final BoundaryScenario builder;
+  private final BoundaryTrigger trigger;
+  private final boolean shouldTerminate;
+  private long instanceKey;
+
+  public BoundaryEventWithoutOutgoingSequenceFlowTest(
+      final String name,
+      final BoundaryScenario builder,
+      final BoundaryTrigger trigger,
+      final boolean shouldTerminate) {
+    this.name = name;
+    this.builder = builder;
+    this.trigger = trigger;
+    this.shouldTerminate = shouldTerminate;
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {
+            "message-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent(
+                            "boundary",
+                            bb ->
+                                bb.message(m -> m.name("MSG").zeebeCorrelationKeyExpression("k"))),
+            (BoundaryTrigger)
+                (engine, key) -> engine.message().withName("MSG").withCorrelationKey("v").publish(),
+            true
+          },
+          {
+            "message-non-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent(
+                            "boundary",
+                            bb ->
+                                bb.cancelActivity(false)
+                                    .message(
+                                        m -> m.name("MSG").zeebeCorrelationKeyExpression("k"))),
+            (BoundaryTrigger)
+                (engine, key) -> engine.message().withName("MSG").withCorrelationKey("v").publish(),
+            false
+          },
+          {
+            "timer-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent("boundary", bb -> bb.timerWithDuration("PT1S")),
+            (BoundaryTrigger) (engine, key) -> engine.increaseTime(Duration.ofSeconds(2)),
+            true
+          },
+          {
+            "timer-non-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent(
+                            "boundary", bb -> bb.cancelActivity(false).timerWithDuration("PT1S")),
+            (BoundaryTrigger) (engine, key) -> engine.increaseTime(Duration.ofSeconds(2)),
+            false
+          },
+          {
+            "signal-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent("boundary", bb -> bb.signal("SIG")),
+            (BoundaryTrigger) (engine, key) -> engine.signal().withSignalName("SIG").broadcast(),
+            true
+          },
+          {
+            "signal-non-int",
+            (BoundaryScenario)
+                b ->
+                    b.serviceTask("element", t -> t.zeebeJobType("type"))
+                        .boundaryEvent("boundary", bb -> bb.cancelActivity(false).signal("SIG")),
+            (BoundaryTrigger) (engine, key) -> engine.signal().withSignalName("SIG").broadcast(),
+            false
+          },
+          {
+            "escalation-int",
+            (BoundaryScenario)
+                b ->
+                    b.subProcess(
+                            "element",
+                            sub ->
+                                sub.embeddedSubProcess()
+                                    .startEvent()
+                                    .serviceTask("triggerTask", t -> t.zeebeJobType("triggerType"))
+                                    .intermediateThrowEvent(
+                                        "escalationThrow", e -> e.escalation("ESC"))
+                                    .endEvent())
+                        .boundaryEvent("boundary", bb -> bb.escalation("ESC"))
+                        .moveToActivity("element"),
+            (BoundaryTrigger)
+                (engine, key) -> engine.job().ofInstance(key).withType("triggerType").complete(),
+            true
+          },
+          {
+            "escalation-non-int",
+            (BoundaryScenario)
+                b ->
+                    b.subProcess(
+                            "element",
+                            sub ->
+                                sub.embeddedSubProcess()
+                                    .startEvent()
+                                    .serviceTask("triggerTask", t -> t.zeebeJobType("triggerType"))
+                                    .intermediateThrowEvent(
+                                        "escalationThrow", e -> e.escalation("ESC"))
+                                    .serviceTask("task", t -> t.zeebeJobType("type"))
+                                    .endEvent())
+                        .boundaryEvent("boundary", bb -> bb.cancelActivity(false).escalation("ESC"))
+                        .moveToActivity("element"),
+            (BoundaryTrigger)
+                (engine, key) -> engine.job().ofInstance(key).withType("triggerType").complete(),
+            false
+          },
+          {
+            "error-int",
+            (BoundaryScenario)
+                b ->
+                    b.subProcess(
+                            "element",
+                            sub ->
+                                sub.embeddedSubProcess()
+                                    .startEvent()
+                                    .serviceTask("triggerTask", t -> t.zeebeJobType("triggerType"))
+                                    .endEvent("end", e -> e.error("ERR")))
+                        .boundaryEvent("boundary", bb -> bb.error("ERR"))
+                        .moveToActivity("element"),
+            (BoundaryTrigger)
+                (engine, key) -> engine.job().ofInstance(key).withType("triggerType").complete(),
+            true
+          }
+        });
+  }
+
+  @Before
+  public void deployAndCreateInstance() {
+    final BpmnModelInstance model = betweenStartAndEnd("process-" + name, builder);
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    instanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process-" + name).withVariable("k", "v").create();
+  }
+
+  @Test
+  public void shouldTerminateOrKeepElementWithBoundaryAttached() {
+    trigger.trigger(ENGINE, instanceKey);
+
+    if (shouldTerminate) {
+      final boolean terminated =
+          RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+              .withProcessInstanceKey(instanceKey)
+              .withElementId("element")
+              .exists();
+      assertThat(terminated).isTrue();
+    } else {
+      final boolean jobCreated =
+          RecordingExporter.jobRecords(JobIntent.CREATED)
+              .withProcessInstanceKey(instanceKey)
+              .withType("type")
+              .exists();
+      assertThat(jobCreated).isTrue();
+
+      // to verify completing the job and the process
+      ENGINE.job().ofInstance(instanceKey).withType("type").complete();
+    }
+
+    final boolean instanceCompleted =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withElementType(BpmnElementType.PROCESS)
+            .withProcessInstanceKey(instanceKey)
+            .withElementId("process-" + name)
+            .exists();
+
+    assertThat(instanceCompleted).isTrue();
+  }
+
+  /** Builds the process between startEvent() → ... → endEvent().done() */
+  private static BpmnModelInstance betweenStartAndEnd(
+      final String processId, final BoundaryScenario between) {
+
+    final AbstractFlowNodeBuilder<?, ?> start =
+        Bpmn.createExecutableProcess(processId).startEvent();
+    final AbstractFlowNodeBuilder<?, ?> afterActivity = between.apply(start);
+    return afterActivity.endEvent().done();
+  }
+
+  /** Inserts serviceTask + boundaryEvent without outgoing flows. */
+  @FunctionalInterface
+  private interface BoundaryScenario {
+    AbstractFlowNodeBuilder<?, ?> apply(AbstractFlowNodeBuilder<?, ?> builder);
+  }
+
+  /** Triggers the boundary event at runtime. */
+  @FunctionalInterface
+  private interface BoundaryTrigger {
+    void trigger(EngineRule engine, long instanceKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
@@ -39,7 +39,8 @@ public class CompensationEventTest {
     ProcessValidationUtil.validateProcess(
         process,
         ExpectedValidationResult.expect(
-            BoundaryEvent.class, "Must have at least one outgoing sequence flow or association"));
+            BoundaryEvent.class,
+            "Compensation boundary events must have a compensation association and no outgoing sequence flows"));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Relax the boundary‐event outgoing‐flow rule so non-compensation events can be sink, while still enforcing “no outgoing + association” for compensation boundaries; update the validator messages and existing BPMN validation tests, and add a concise parameterized runtime test covering interrupting vs. non-interrupting behavior for all boundary event types.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #33589 
