### PR TITLE
ci: re-add optimize-ci for backwards compatibility with stable branches

### DIFF
--- a/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
+++ b/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
@@ -38,6 +38,10 @@ async function createHealthStatusConfig() {
           name: 'optimize-ci-data-layer',
           branches: ciBranches,
         },
+        {
+          name: 'optimize-ci',
+          branches: ciBranches,
+        },
         'optimize-zeebe-compatibility',
         'optimize-e2e-tests-sm',
       ],


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`optimize-ci` should be present in `createHealthStatusConfig.ts` so that it can properly run the health report on `stable` branches. The core features and data layer CI files do not exist on `stable`

This is re-adding `optimize-ci` which was removed in an earlier PR https://github.com/camunda/camunda/pull/34257

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
