### PR TITLE
Add SM + keycloak configuration setup

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConditionalOnCloud.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConditionalOnCloud.java
@@ -5,12 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migration.identity.config;
+package io.camunda.migration.identity.config.saas;
 
 import static io.camunda.migration.identity.config.IdentityMigrationProperties.PROP_CAMUNDA_MIGRATION_IDENTITY_MODE;
 
-import io.camunda.migration.identity.config.ConditionalOnCloud.ConditionalOnCloudCondition;
 import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
+import io.camunda.migration.identity.config.saas.ConditionalOnCloud.ConditionalOnCloudCondition;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConsoleConnectorConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/ConsoleConnectorConfig.java
@@ -5,8 +5,10 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migration.identity.config;
+package io.camunda.migration.identity.config.saas;
 
+import io.camunda.migration.identity.config.ConsoleProperties;
+import io.camunda.migration.identity.config.IdentityMigrationProperties;
 import io.camunda.migration.identity.console.ConsoleClient;
 import java.io.IOException;
 import java.util.Map;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/SaaSMigrationHandlerConfig.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migration.identity.config;
+package io.camunda.migration.identity.config.saas;
 
 import io.camunda.migration.identity.AuthorizationMigrationHandler;
 import io.camunda.migration.identity.ClientMigrationHandler;
@@ -23,7 +23,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConditionalOnCloud
-public class MigrationHandlerConfig {
+public class SaaSMigrationHandlerConfig {
   @Bean
   public GroupMigrationHandler groupMigrationHandler(
       final Authentication authentication,

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/saas/StaticEntities.java
@@ -22,17 +22,11 @@ public class StaticEntities {
   public static final String TASK_USER_ROLE_ID = "taskuser";
   public static final String VISITOR_ROLE_ID = "visitor";
 
-  public static final String ZEEBE_CLIENT_ID = "Zeebe";
-  public static final String OPERATE_CLIENT_ID = "Operate";
-  public static final String TASKLIST_CLIENT_ID = "Tasklist";
-
   public static final String IDENTITY_PROCESS_DEFINITION_RESOURCE_TYPE = "process-definition";
   public static final String IDENTITY_DECISION_DEFINITION_RESOURCE_TYPE = "decision-definition";
 
   public static final Set<String> ROLE_IDS =
       Set.of(DEVELOPER_ROLE_ID, OPERATIONS_ENGINEER_ROLE_ID, TASK_USER_ROLE_ID, VISITOR_ROLE_ID);
-  public static final Set<String> CLIENT_IDS =
-      Set.of(ZEEBE_CLIENT_ID, OPERATE_CLIENT_ID, TASKLIST_CLIENT_ID);
 
   public static final List<CreateRoleRequest> ROLES =
       List.of(
@@ -159,8 +153,7 @@ public class StaticEntities {
               AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION,
               Set.of(PermissionType.READ)));
 
-  public static final List<CreateAuthorizationRequest> getZeebeClientPermissions(
-      final String clientId) {
+  public static List<CreateAuthorizationRequest> getZeebeClientPermissions(final String clientId) {
     return List.of(
         new CreateAuthorizationRequest(
             clientId,
@@ -210,7 +203,7 @@ public class StaticEntities {
             Set.of(PermissionType.UPDATE, PermissionType.DELETE)));
   }
 
-  public static final List<CreateAuthorizationRequest> getOperateClientPermissions(
+  public static List<CreateAuthorizationRequest> getOperateClientPermissions(
       final String clientId) {
     return List.of(
         new CreateAuthorizationRequest(
@@ -254,7 +247,7 @@ public class StaticEntities {
             Set.of(PermissionType.READ)));
   }
 
-  public static final List<CreateAuthorizationRequest> getTasklistClientPermissions(
+  public static List<CreateAuthorizationRequest> getTasklistClientPermissions(
       final String ownerId) {
     return List.of(
         new CreateAuthorizationRequest(

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/ConditionalOnKeycloak.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/ConditionalOnKeycloak.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.sm;
+
+import static io.camunda.migration.identity.config.IdentityMigrationProperties.PROP_CAMUNDA_MIGRATION_IDENTITY_MODE;
+
+import io.camunda.migration.identity.config.IdentityMigrationProperties.Mode;
+import io.camunda.migration.identity.config.sm.ConditionalOnKeycloak.ConditionalOnKeycloakCondition;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(ConditionalOnKeycloakCondition.class)
+public @interface ConditionalOnKeycloak {
+
+  final class ConditionalOnKeycloakCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Mode mode =
+          Optional.ofNullable(
+                  context.getEnvironment().getProperty(PROP_CAMUNDA_MIGRATION_IDENTITY_MODE))
+              .map(Mode::valueOf)
+              .orElse(Mode.CLOUD);
+      return Mode.KEYCLOAK.equals(mode);
+    }
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/sm/SMKeycloakMigrationHandlerConfig.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity.config.sm;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnKeycloak
+public class SMKeycloakMigrationHandlerConfig {
+  // Add handlers bean here
+}

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/ConsoleClientIT.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/ConsoleClientIT.java
@@ -18,9 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import io.camunda.migration.identity.config.ConsoleConnectorConfig.TokenInterceptor;
 import io.camunda.migration.identity.config.ConsoleProperties;
 import io.camunda.migration.identity.config.IdentityMigrationProperties;
+import io.camunda.migration.identity.config.saas.ConsoleConnectorConfig.TokenInterceptor;
 import io.camunda.migration.identity.console.ConsoleClient;
 import io.camunda.migration.identity.console.ConsoleClient.Permission;
 import io.camunda.migration.identity.console.ConsoleClient.Role;


### PR DESCRIPTION
## Description

This PR adds:

- a new annotation `@ConditionalOnKeycloak` that allows us to inject beans based on the customer migration setup (KEYCLOAK in this case)
- a new configuration class where we can create beans used by the migration app on a SM + keycloak setup

## Related issues

closes #34435 
