### PR TITLE
fix: SnapshotCopy opens the source db in read only mode

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.db;
 
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
-import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -18,19 +16,6 @@ import java.util.Set;
  * also method to compare two snapshots that can be useful when testing.
  */
 public interface SnapshotCopy {
-
-  /**
-   * Helper function that can be used to compare or copy two snapshots. Particularly useful for
-   * testing.
-   *
-   * @param fromPath path of the readonly snapshot that will be associated to "from" arguments in
-   *     {@link CopyContextConsumer}
-   * @param toDBPath path of the snapshot that will be associated to "to" arguments in {@link
-   *     CopyContextConsumer}
-   * @param consumer that can access both DB instances.
-   */
-  void withContexts(final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer);
-
   /**
    * Copies the content of a snapshot from a path to another path, copying only the columns with a
    * certain scope
@@ -40,22 +25,4 @@ public interface SnapshotCopy {
    * @param scope the scope of the columns to copy
    */
   void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope);
-
-  interface CopyContextConsumer {
-
-    /**
-     * Callback that will be invoked when the two DBs are opened. The arguments of this function
-     * cannot escape this method, as they will be closed once this method returns.
-     *
-     * @param fromDB DB located at fromPath
-     * @param fromCtx transaction context at fromPath
-     * @param toDB DB located at toPath
-     * @param toCtx transaction context at toPath
-     */
-    void accept(
-        ZeebeTransactionDb<ZbColumnFamilies> fromDB,
-        TransactionContext fromCtx,
-        ZeebeTransactionDb<ZbColumnFamilies> toDB,
-        TransactionContext toCtx);
-  }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
@@ -5,18 +5,18 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.db.impl.rocksdb.transaction;
+package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.DbKey;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /** This class is used only internally by #isEmpty to search for same column family prefix. */
-final class DbNullKey implements DbKey {
+public final class DbNullKey implements DbKey {
 
   public static final DbNullKey INSTANCE = new DbNullKey();
 
-  DbNullKey() {}
+  public DbNullKey() {}
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -24,12 +24,12 @@ final class DbNullKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    // do nothing
+  public int getLength() {
+    return 0;
   }
 
   @Override
-  public int getLength() {
-    return 0;
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    // do nothing
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/PrefixReadOptions.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/PrefixReadOptions.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import org.rocksdb.ReadOptions;
+
+public class PrefixReadOptions {
+  public static ReadOptions readOptions() {
+    return new ReadOptions()
+        .setPrefixSameAsStart(true)
+        .setTotalOrderSeek(false)
+        // setting a positive value to read-ahead is only useful when using network storage with
+        // high latency, at the cost of making iterators more expensive (memory and computation
+        // wise)
+        .setReadaheadSize(0);
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -8,19 +8,13 @@
 package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.SnapshotCopy;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.RawTransactionalColumnFamily;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RocksDBSnapshotCopy implements SnapshotCopy {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotCopy.class);
   private final ZeebeRocksDbFactory<ZbColumnFamilies> factory;
 
   public RocksDBSnapshotCopy(final ZeebeRocksDbFactory<ZbColumnFamilies> factory) {
@@ -28,58 +22,12 @@ public class RocksDBSnapshotCopy implements SnapshotCopy {
   }
 
   @Override
-  public void withContexts(
-      final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer) {
-    try (final var toDB = factory.createDb(toDBPath.toFile());
-        final var fromDB = factory.createDb(fromPath.toFile())) {
-      final var fromCtx = fromDB.createContext();
-      final var toCtx = toDB.createContext();
-      consumer.accept(fromDB, fromCtx, toDB, toCtx);
-    }
-  }
-
-  @Override
   public void copySnapshot(
-      final Path fromPath, final Path toDBPath, final Set<ColumnFamilyScope> scopes) {
-    withContexts(fromPath, toDBPath, scoped(scopes));
-  }
-
-  private CopyContextConsumer scoped(final Set<ColumnFamilyScope> scopes) {
-    return (fromDB, fromCtx, toDB, toCtx) -> {
-      final var abort = new AtomicBoolean(false);
-      toCtx.runInTransaction(
-          () -> {
-            final var toTransaction = (ZeebeTransaction) toCtx.getCurrentTransaction();
-            for (final var cf : ZbColumnFamilies.values()) {
-              if (abort.get()) {
-                break;
-              }
-              if (!scopes.contains(cf.partitionScope())) {
-                continue;
-              }
-              LOG.debug("Copying column family '{}'", cf);
-              final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
-              final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
-              fromCf.forEach(
-                  (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
-                    try {
-                      toCf.rawPut(
-                          toTransaction, key, keyOffset, keyLen, value, valueOffset, valueLen);
-                      return true;
-                    } catch (final Exception e) {
-                      LOG.error(
-                          "Failed to copy column family '{}' on key {} and value with length {} terminating.",
-                          cf,
-                          new String(key),
-                          value.length);
-                      LOG.error("Exception", e);
-                      abort.set(true);
-                      return false;
-                    }
-                  });
-            }
-            toTransaction.commit();
-          });
-    };
+      final Path fromPath, final Path toPath, final Set<ColumnFamilyScope> scopes) {
+    try (final var fromDB =
+            (SnapshotOnlyDb<ZbColumnFamilies>) factory.openSnapshotOnlyDb(fromPath.toFile());
+        final var toDB = factory.createDb(toPath.toFile())) {
+      fromDB.copySnapshot(toDB, scopes);
+    }
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -30,12 +30,11 @@ public class RocksDBSnapshotCopy implements SnapshotCopy {
   @Override
   public void withContexts(
       final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer) {
-    try (final var toDB = factory.createDb(toDBPath.toFile())) {
-      try (final var fromDB = factory.createDb(fromPath.toFile())) {
-        final var fromCtx = fromDB.createContext();
-        final var toCtx = toDB.createContext();
-        consumer.accept(fromDB, fromCtx, toDB, toCtx);
-      }
+    try (final var toDB = factory.createDb(toDBPath.toFile());
+        final var fromDB = factory.createDb(fromPath.toFile())) {
+      final var fromCtx = fromDB.createContext();
+      final var toCtx = toDB.createContext();
+      consumer.accept(fromDB, fromCtx, toDB, toCtx);
     }
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -26,8 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.agrona.CloseHelper;
+import org.agrona.collections.MutableBoolean;
 import org.rocksdb.Checkpoint;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
@@ -117,7 +117,7 @@ final class SnapshotOnlyDb<ColumnFamilyType extends Enum<? extends EnumValue> & 
       final ZeebeTransactionDb<ZbColumnFamilies> toDB, final Set<ColumnFamilyScope> scopes) {
     try (final var readOptions = PrefixReadOptions.readOptions()) {
       final var toCtx = toDB.createContext();
-      final var abort = new AtomicBoolean(false);
+      final var abort = new MutableBoolean(false);
       for (final var cf : ZbColumnFamilies.values()) {
         if (abort.get()) {
           break;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -149,9 +149,9 @@ final class SnapshotOnlyDb<ColumnFamilyType extends Enum<? extends EnumValue> & 
                               LOG.error(
                                   "Failed to copy column family '{}' on key {} and value with length {} terminating.",
                                   cf,
-                                  new String(key),
-                                  value.length);
-                              LOG.error("Exception", e);
+                                  new String(key, 0, keyLen),
+                                  value.length,
+                                  e);
                               abort.set(true);
                               return false;
                             }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -135,7 +135,7 @@ final class SnapshotOnlyDb<ColumnFamilyType extends Enum<? extends EnumValue> & 
                   new DbNullKey(),
                   (prefixKey, prefixLength) -> {
                     try (final RocksIterator iterator = db.newIterator(readOptions)) {
-                      RawTransactionalColumnFamily.forEach(
+                      RawTransactionalColumnFamily.forEachPreallocated(
                           iterator,
                           cf,
                           prefixKey,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
@@ -33,7 +33,7 @@ public class ColumnFamilyContext {
   private int keyLength;
   private final long columnFamilyPrefix;
 
-  ColumnFamilyContext(final long columnFamilyPrefix) {
+  public ColumnFamilyContext(final long columnFamilyPrefix) {
     this.columnFamilyPrefix = columnFamilyPrefix;
     prefixKeyBuffers = new ArrayDeque<>();
     prefixKeyBuffers.add(new ExpandableArrayBuffer());
@@ -115,7 +115,7 @@ public class ColumnFamilyContext {
     }
   }
 
-  ByteBuffer keyWithColumnFamily(DbKey key) {
+  ByteBuffer keyWithColumnFamily(final DbKey key) {
     final var bytes = ByteBuffer.allocate(Long.BYTES + key.getLength());
     final var buffer = new UnsafeBuffer(bytes);
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -109,6 +109,15 @@ public class RawTransactionalColumnFamily {
         keyLen);
   }
 
+  /**
+   * Iterates over the column family with prefix {@param prefixKey}
+   *
+   * @param iterator the underlying rocksDB iterator
+   * @param prefixKey the prefix key to filter the iteration
+   * @param prefixOffset the offset in the prefix key array
+   * @param prefixLength the length of the prefix key
+   * @param visitor the visitor to apply to each key-value pair
+   */
   public static void forEach(
       final RocksIterator iterator,
       final ZbColumnFamilies columnFamily,
@@ -139,6 +148,12 @@ public class RawTransactionalColumnFamily {
     }
   }
 
+  /**
+   * Similar to {@link foreach(RocksIterator, ZbColumnFamilies, byte[], int, int, Visitor)} but
+   * avoids allocating a new byte[] for each key & value. This reduces the allocations almost
+   * entirely. Use this method if you don't need to use the byte[] after the visitor returns. If
+   * that's not the case, use the other method, as you would avoid a copy.
+   */
   public static void forEachPreallocated(
       final RocksIterator iterator,
       final ZbColumnFamilies columnFamily,
@@ -189,6 +204,18 @@ public class RawTransactionalColumnFamily {
   }
 
   public interface Visitor {
+
+    /**
+     * Visits a key-value pair in the column family during iteration.
+     *
+     * @param key the key byte array
+     * @param keyOffset the offset in the key array
+     * @param keyLen the length of the key
+     * @param value the value byte array
+     * @param valueOffset the offset in the value array
+     * @param valueLen the length of the value
+     * @return true if iteration should continue, false otherwise
+     */
     boolean visit(
         byte[] key, int keyOffset, int keyLen, byte[] value, int valueOffset, int valueLen);
   }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -174,7 +174,10 @@ public class RawTransactionalColumnFamily {
         shouldVisitNext = visitor.visit(keyBytes, 0, keyLen, valueBytes, 0, valueLen);
       } catch (final Exception e) {
         LOG.error(
-            "Error visiting key {} in column family {}", new String(keyBytes), columnFamily, e);
+            "Error visiting key {} in column family {}",
+            new String(keyBytes, 0, keyLen),
+            columnFamily,
+            e);
         shouldVisitNext = false;
       }
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.protocol.ScopedColumnFamily;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics;
 import io.camunda.zeebe.db.impl.NoopColumnFamilyMetrics;
+import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
 import io.camunda.zeebe.db.impl.rocksdb.Loggers;
+import io.camunda.zeebe.db.impl.rocksdb.PrefixReadOptions;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDBMetricExporter;
 import io.camunda.zeebe.protocol.EnumValue;
@@ -80,14 +82,7 @@ public class ZeebeTransactionDb<
     this.meterRegistry = meterRegistry;
     metricExporter = new RocksDBMetricExporter(meterRegistry);
 
-    prefixReadOptions =
-        new ReadOptions()
-            .setPrefixSameAsStart(true)
-            .setTotalOrderSeek(false)
-            // setting a positive value to read-ahead is only useful when using network storage with
-            // high latency, at the cost of making iterators more expensive (memory and computation
-            // wise)
-            .setReadaheadSize(0);
+    prefixReadOptions = PrefixReadOptions.readOptions();
     closables.add(prefixReadOptions);
     defaultReadOptions = new ReadOptions();
     closables.add(defaultReadOptions);

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
@@ -144,7 +144,7 @@ public class RocksDBSnapshotCopyTest {
                     if (channel.read(bb) < 0) {
                       break;
                     }
-                    crc.update(bb.array());
+                    crc.update(bb);
                   }
                   return Map.entry(path.toString(), crc.getValue());
                 } catch (final IOException e) {

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
@@ -47,7 +47,7 @@ public class RawTransactionalColumnFamilyTest {
     context = db.createContext();
 
     for (final var cf : ZbColumnFamilies.values()) {
-      final var rawCF = new RawTransactionalColumnFamily(db, cf, context);
+      final var rawCF = new RawTransactionalColumnFamily(db, cf);
       columnFamilies.put(cf, rawCF);
     }
   }
@@ -80,6 +80,7 @@ public class RawTransactionalColumnFamilyTest {
     // when
     final var i = new MutableReference<>(0);
     rawCF.forEach(
+        context,
         ((rawKey, keyOffset, keyLen, value, valueOffset, valueLen) -> {
           final var cfContext = new ColumnFamilyContext(cf.getValue());
           assertThat(keyOffset).isZero();


### PR DESCRIPTION
## Description
The db opened at the source snapshot location is a `SnapshotOnlyDb`, which opens RocksDB in readOnly mode.
This should avoid having rocksDB changing the files on disk while performing get operations.

The `forEach` method from `RawTransactionalColumnFamily` has been defined as static as well, in order to be used from `SnapshotOnlyDb` as well, as it does not have an open transaction. 

A new `forEachPreallocated` method preallocates `byte [] key, byte[] value` in order to avoid allocating altogether when iterating. 
To avoid introducing new bugs, a new method has been created, so that the caller knows that the `byte[]` received cannot be used outside the invoked callback.

## Integration tests:
- this fix is tested by PR #34495 (stacked on this branch)
## Related issues

closes #34430
