### PR TITLE
feat: Simplify user task data access for TL jobs

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -105,6 +105,13 @@ public interface ActivatedJob {
   Object getVariable(String name);
 
   /**
+   * @return user task properties associated with this job. Present only if the job is of kind
+   *     {@code TASK_LISTENER}; returns {@code null} for other job kinds such as {@code
+   *     BPMN_ELEMENT} or {@code EXECUTION_LISTENER}.
+   */
+  UserTaskProperties getUserTask();
+
+  /**
    * @return the record encoded as JSON
    */
   String toJson();

--- a/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
@@ -58,7 +58,7 @@ public interface UserTaskProperties {
   /**
    * @return the key of the form associated with the user task.
    */
-  String getFormKey();
+  Long getFormKey();
 
   /**
    * @return the priority of the user task (0-100).
@@ -68,5 +68,5 @@ public interface UserTaskProperties {
   /**
    * @return the unique key identifying the user task.
    */
-  String getUserTaskKey();
+  Long getUserTaskKey();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UserTaskProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+import java.util.List;
+
+/** Represents the properties of a user task associated with a job. */
+public interface UserTaskProperties {
+
+  /**
+   * @return the action performed on the user task (e.g., "claim", "update", "complete").
+   */
+  String getAction();
+
+  /**
+   * @return the user assigned to the task.
+   */
+  String getAssignee();
+
+  /**
+   * @return the list of candidate groups for the user task.
+   */
+  List<String> getCandidateGroups();
+
+  /**
+   * @return the list of candidate users for the user task.
+   */
+  List<String> getCandidateUsers();
+
+  /**
+   * @return the list of attributes that were changed in the user task.
+   */
+  List<String> getChangedAttributes();
+
+  /**
+   * @return the due date of the user task in ISO 8601 format.
+   */
+  String getDueDate();
+
+  /**
+   * @return the follow-up date of the user task in ISO 8601 format.
+   */
+  String getFollowUpDate();
+
+  /**
+   * @return the key of the form associated with the user task.
+   */
+  String getFormKey();
+
+  /**
+   * @return the priority of the user task (0-100).
+   */
+  Integer getPriority();
+
+  /**
+   * @return the unique key identifying the user task.
+   */
+  String getUserTaskKey();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.UserTaskProperties;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,6 +44,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final int retries;
   private final long deadline;
   private final String variables;
+  private final UserTaskProperties userTask;
 
   private Map<String, Object> variablesAsMap;
 
@@ -68,6 +70,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = job.getElementId();
     elementInstanceKey = job.getElementInstanceKey();
     tenantId = job.getTenantId();
+    userTask = job.hasUserTask() ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
   }
 
   public ActivatedJobImpl(
@@ -99,6 +102,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = getOrEmpty(job.getElementId());
     elementInstanceKey = parseLongOrEmpty(job.getElementInstanceKey());
     tenantId = getOrEmpty(job.getTenantId());
+    userTask = job.getUserTask() != null ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
   }
 
   @Override
@@ -186,6 +190,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
       throw new ClientException(String.format("The variable %s is not available", name));
     }
     return getVariablesAsMap().get(name);
+  }
+
+  @Override
+  public UserTaskProperties getUserTask() {
+    return userTask;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UserTaskProperties;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.List;
 import java.util.function.BooleanSupplier;
@@ -30,9 +31,9 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   private final List<String> changedAttributes;
   private final String dueDate;
   private final String followUpDate;
-  private final String formKey;
+  private final Long formKey;
   private final Integer priority;
-  private final String userTaskKey;
+  private final Long userTaskKey;
 
   public UserTaskPropertiesImpl(final GatewayOuterClass.UserTaskProperties props) {
     action = orNull(props::hasAction, props::getAction);
@@ -55,9 +56,9 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
     changedAttributes = props.getChangedAttributes();
     dueDate = props.getDueDate();
     followUpDate = props.getFollowUpDate();
-    formKey = props.getFormKey();
+    formKey = ParseUtil.parseLongOrNull(props.getFormKey());
     priority = props.getPriority();
-    userTaskKey = props.getUserTaskKey();
+    userTaskKey = ParseUtil.parseLongOrNull(props.getUserTaskKey());
   }
 
   @Override
@@ -96,7 +97,7 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   }
 
   @Override
-  public String getFormKey() {
+  public Long getFormKey() {
     return formKey;
   }
 
@@ -106,7 +107,7 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   }
 
   @Override
-  public String getUserTaskKey() {
+  public Long getUserTaskKey() {
     return userTaskKey;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UserTaskPropertiesImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.UserTaskProperties;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public final class UserTaskPropertiesImpl implements UserTaskProperties {
+
+  private final String action;
+  private final String assignee;
+  private final List<String> candidateGroups;
+  private final List<String> candidateUsers;
+  private final List<String> changedAttributes;
+  private final String dueDate;
+  private final String followUpDate;
+  private final String formKey;
+  private final Integer priority;
+  private final String userTaskKey;
+
+  public UserTaskPropertiesImpl(final GatewayOuterClass.UserTaskProperties props) {
+    action = orNull(props::hasAction, props::getAction);
+    assignee = orNull(props::hasAssignee, props::getAssignee);
+    candidateGroups = props.getCandidateGroupsList();
+    candidateUsers = props.getCandidateUsersList();
+    changedAttributes = props.getChangedAttributesList();
+    dueDate = orNull(props::hasDueDate, props::getDueDate);
+    followUpDate = orNull(props::hasFollowUpDate, props::getFollowUpDate);
+    formKey = orNull(props::hasFormKey, props::getFormKey);
+    priority = orNull(props::hasPriority, props::getPriority);
+    userTaskKey = orNull(props::hasUserTaskKey, props::getUserTaskKey);
+  }
+
+  public UserTaskPropertiesImpl(final io.camunda.client.protocol.rest.UserTaskProperties props) {
+    action = props.getAction();
+    assignee = props.getAssignee();
+    candidateGroups = props.getCandidateGroups();
+    candidateUsers = props.getCandidateUsers();
+    changedAttributes = props.getChangedAttributes();
+    dueDate = props.getDueDate();
+    followUpDate = props.getFollowUpDate();
+    formKey = props.getFormKey();
+    priority = props.getPriority();
+    userTaskKey = props.getUserTaskKey();
+  }
+
+  @Override
+  public String getAction() {
+    return action;
+  }
+
+  @Override
+  public String getAssignee() {
+    return assignee;
+  }
+
+  @Override
+  public List<String> getCandidateGroups() {
+    return candidateGroups;
+  }
+
+  @Override
+  public List<String> getCandidateUsers() {
+    return candidateUsers;
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return changedAttributes;
+  }
+
+  @Override
+  public String getDueDate() {
+    return dueDate;
+  }
+
+  @Override
+  public String getFollowUpDate() {
+    return followUpDate;
+  }
+
+  @Override
+  public String getFormKey() {
+    return formKey;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
+  }
+
+  @Override
+  public String getUserTaskKey() {
+    return userTaskKey;
+  }
+
+  /**
+   * Returns the value from the supplier if the condition is true; otherwise, returns {@code null}.
+   *
+   * @param hasValue a BooleanSupplier, typically referencing a {@code hasXxx()} method
+   * @param getter a Supplier, typically referencing a {@code getXxx()} method
+   * @param <T> the type of the value
+   * @return the value from {@code getter} if {@code hasValue} returns {@code true}; otherwise
+   *     {@code null}
+   */
+  private static <T> T orNull(final BooleanSupplier hasValue, final Supplier<T> getter) {
+    return hasValue.getAsBoolean() ? getter.get() : null;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -110,6 +110,13 @@ public interface ActivatedJob {
   Object getVariable(String name);
 
   /**
+   * @return user task properties associated with this job. Present only if the job is of kind
+   *     {@code TASK_LISTENER}; returns {@code null} for other job kinds such as {@code
+   *     BPMN_ELEMENT} or {@code EXECUTION_LISTENER}.
+   */
+  UserTaskProperties getUserTask();
+
+  /**
    * @return the record encoded as JSON
    */
   String toJson();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskProperties.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+import java.util.List;
+
+/**
+ * Represents the properties of a user task associated with a job.
+ *
+ * @deprecated since 8.8 for removal in 8.10, replaced by {@link
+ *     io.camunda.client.api.response.UserTaskProperties}
+ */
+@Deprecated
+public interface UserTaskProperties {
+
+  /**
+   * @return the action performed on the user task (e.g., "claim", "update", "complete").
+   */
+  String getAction();
+
+  /**
+   * @return the user assigned to the task.
+   */
+  String getAssignee();
+
+  /**
+   * @return the list of candidate groups for the user task.
+   */
+  List<String> getCandidateGroups();
+
+  /**
+   * @return the list of candidate users for the user task.
+   */
+  List<String> getCandidateUsers();
+
+  /**
+   * @return the list of attributes that were changed in the user task.
+   */
+  List<String> getChangedAttributes();
+
+  /**
+   * @return the due date of the user task in ISO 8601 format.
+   */
+  String getDueDate();
+
+  /**
+   * @return the follow-up date of the user task in ISO 8601 format.
+   */
+  String getFollowUpDate();
+
+  /**
+   * @return the key of the form associated with the user task.
+   */
+  String getFormKey();
+
+  /**
+   * @return the priority of the user task (0-100).
+   */
+  Integer getPriority();
+
+  /**
+   * @return the unique key identifying the user task.
+   */
+  String getUserTaskKey();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskProperties.java
@@ -64,7 +64,7 @@ public interface UserTaskProperties {
   /**
    * @return the key of the form associated with the user task.
    */
-  String getFormKey();
+  Long getFormKey();
 
   /**
    * @return the priority of the user task (0-100).
@@ -74,5 +74,5 @@ public interface UserTaskProperties {
   /**
    * @return the unique key identifying the user task.
    */
-  String getUserTaskKey();
+  Long getUserTaskKey();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -20,6 +20,7 @@ import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.UserTaskProperties;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +45,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final int retries;
   private final long deadline;
   private final String variables;
+  private final UserTaskProperties userTask;
 
   private Map<String, Object> variablesAsMap;
 
@@ -69,6 +71,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = job.getElementId();
     elementInstanceKey = job.getElementInstanceKey();
     tenantId = job.getTenantId();
+    userTask = job.hasUserTask() ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
   }
 
   public ActivatedJobImpl(
@@ -100,6 +103,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = getOrEmpty(job.getElementId());
     elementInstanceKey = ParseUtil.parseLongOrEmpty(job.getElementInstanceKey());
     tenantId = getOrEmpty(job.getTenantId());
+    userTask = job.getUserTask() != null ? new UserTaskPropertiesImpl(job.getUserTask()) : null;
   }
 
   @Override
@@ -187,6 +191,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
       throw new ClientException(String.format("The variable %s is not available", name));
     }
     return getVariablesAsMap().get(name);
+  }
+
+  @Override
+  public UserTaskProperties getUserTask() {
+    return userTask;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskPropertiesImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskPropertiesImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.client.api.response.UserTaskProperties;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.List;
@@ -30,9 +31,9 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   private final List<String> changedAttributes;
   private final String dueDate;
   private final String followUpDate;
-  private final String formKey;
+  private final Long formKey;
   private final Integer priority;
-  private final String userTaskKey;
+  private final Long userTaskKey;
 
   public UserTaskPropertiesImpl(final GatewayOuterClass.UserTaskProperties props) {
     action = orNull(props::hasAction, props::getAction);
@@ -55,9 +56,9 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
     changedAttributes = props.getChangedAttributes();
     dueDate = props.getDueDate();
     followUpDate = props.getFollowUpDate();
-    formKey = props.getFormKey();
+    formKey = ParseUtil.parseLongOrNull(props.getFormKey());
     priority = props.getPriority();
-    userTaskKey = props.getUserTaskKey();
+    userTaskKey = ParseUtil.parseLongOrNull(props.getUserTaskKey());
   }
 
   @Override
@@ -96,7 +97,7 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   }
 
   @Override
-  public String getFormKey() {
+  public Long getFormKey() {
     return formKey;
   }
 
@@ -106,7 +107,7 @@ public final class UserTaskPropertiesImpl implements UserTaskProperties {
   }
 
   @Override
-  public String getUserTaskKey() {
+  public Long getUserTaskKey() {
     return userTaskKey;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskPropertiesImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskPropertiesImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.UserTaskProperties;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public final class UserTaskPropertiesImpl implements UserTaskProperties {
+
+  private final String action;
+  private final String assignee;
+  private final List<String> candidateGroups;
+  private final List<String> candidateUsers;
+  private final List<String> changedAttributes;
+  private final String dueDate;
+  private final String followUpDate;
+  private final String formKey;
+  private final Integer priority;
+  private final String userTaskKey;
+
+  public UserTaskPropertiesImpl(final GatewayOuterClass.UserTaskProperties props) {
+    action = orNull(props::hasAction, props::getAction);
+    assignee = orNull(props::hasAssignee, props::getAssignee);
+    candidateGroups = props.getCandidateGroupsList();
+    candidateUsers = props.getCandidateUsersList();
+    changedAttributes = props.getChangedAttributesList();
+    dueDate = orNull(props::hasDueDate, props::getDueDate);
+    followUpDate = orNull(props::hasFollowUpDate, props::getFollowUpDate);
+    formKey = orNull(props::hasFormKey, props::getFormKey);
+    priority = orNull(props::hasPriority, props::getPriority);
+    userTaskKey = orNull(props::hasUserTaskKey, props::getUserTaskKey);
+  }
+
+  public UserTaskPropertiesImpl(final io.camunda.client.protocol.rest.UserTaskProperties props) {
+    action = props.getAction();
+    assignee = props.getAssignee();
+    candidateGroups = props.getCandidateGroups();
+    candidateUsers = props.getCandidateUsers();
+    changedAttributes = props.getChangedAttributes();
+    dueDate = props.getDueDate();
+    followUpDate = props.getFollowUpDate();
+    formKey = props.getFormKey();
+    priority = props.getPriority();
+    userTaskKey = props.getUserTaskKey();
+  }
+
+  @Override
+  public String getAction() {
+    return action;
+  }
+
+  @Override
+  public String getAssignee() {
+    return assignee;
+  }
+
+  @Override
+  public List<String> getCandidateGroups() {
+    return candidateGroups;
+  }
+
+  @Override
+  public List<String> getCandidateUsers() {
+    return candidateUsers;
+  }
+
+  @Override
+  public List<String> getChangedAttributes() {
+    return changedAttributes;
+  }
+
+  @Override
+  public String getDueDate() {
+    return dueDate;
+  }
+
+  @Override
+  public String getFollowUpDate() {
+    return followUpDate;
+  }
+
+  @Override
+  public String getFormKey() {
+    return formKey;
+  }
+
+  @Override
+  public Integer getPriority() {
+    return priority;
+  }
+
+  @Override
+  public String getUserTaskKey() {
+    return userTaskKey;
+  }
+
+  /**
+   * Returns the value from the supplier if the condition is true; otherwise, returns {@code null}.
+   *
+   * @param hasValue a BooleanSupplier, typically referencing a {@code hasXxx()} method
+   * @param getter a Supplier, typically referencing a {@code getXxx()} method
+   * @param <T> the type of the value
+   * @return the value from {@code getter} if {@code hasValue} returns {@code true}; otherwise
+   *     {@code null}
+   */
+  private static <T> T orNull(final BooleanSupplier hasValue, final Supplier<T> getter) {
+    return hasValue.getAsBoolean() ? getter.get() : null;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -28,6 +28,7 @@ import io.camunda.client.impl.response.ActivatedJobImpl;
 import io.camunda.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UserTaskProperties;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -106,6 +107,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
 
     job = response.getJobs().get(1);
@@ -123,6 +125,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
@@ -130,6 +133,94 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(request.getMaxJobsToActivate()).isEqualTo(3);
     assertThat(request.getTimeout()).isEqualTo(1000);
     assertThat(request.getWorker()).isEqualTo("worker1");
+  }
+
+  @Test
+  public void shouldActivateJobsWithUserTaskProperties() {
+    // given
+    final ActivatedJob activatedJob1 =
+        ActivatedJob.newBuilder()
+            // with all user task properties set
+            .setUserTask(
+                UserTaskProperties.newBuilder()
+                    .setAction("update")
+                    .setAssignee("tony")
+                    .addCandidateGroups("assistants")
+                    .addCandidateUsers("jarvis")
+                    .addCandidateUsers("friday")
+                    .addChangedAttributes("assignee")
+                    .setDueDate("2019-04-22T00:00:00Z")
+                    .setFollowUpDate("2018-04-23T00:00:00Z")
+                    .setFormKey("formKey_007")
+                    .setPriority(10)
+                    .setUserTaskKey("userTaskKey_123")
+                    .build())
+            .build();
+
+    final ActivatedJob activatedJob2 =
+        ActivatedJob.newBuilder()
+            // with empty user task properties
+            .setUserTask(UserTaskProperties.newBuilder().build())
+            .build();
+
+    final ActivatedJob activatedJob3 =
+        ActivatedJob.newBuilder()
+            // with not set user task properties
+            .build();
+
+    gatewayService.onActivateJobsRequest(activatedJob1, activatedJob2, activatedJob3);
+
+    // when
+    final ActivateJobsResponse response =
+        client
+            .newActivateJobsCommand()
+            .jobType("payment")
+            .maxJobsToActivate(10)
+            .workerName("paymentWorker")
+            .timeout(Duration.ofMillis(1000))
+            .execute();
+
+    // then
+    assertThat(response.getJobs()).hasSize(3);
+
+    io.camunda.client.api.response.ActivatedJob job = response.getJobs().get(0);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with all user task properties set")
+        .satisfies(
+            props -> {
+              assertThat(props.getAction()).isEqualTo("update");
+              assertThat(props.getAssignee()).isEqualTo("tony");
+              assertThat(props.getCandidateGroups()).containsExactly("assistants");
+              assertThat(props.getCandidateUsers()).containsExactly("jarvis", "friday");
+              assertThat(props.getChangedAttributes()).containsExactly("assignee");
+              assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
+              assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
+              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getPriority()).isEqualTo(10);
+              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+            });
+
+    job = response.getJobs().get(1);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with empty user task properties")
+        .satisfies(
+            props -> {
+              assertThat(props.getAction()).isNull();
+              assertThat(props.getAssignee()).isNull();
+              assertThat(props.getCandidateGroups()).isEmpty();
+              assertThat(props.getCandidateUsers()).isEmpty();
+              assertThat(props.getChangedAttributes()).isEmpty();
+              assertThat(props.getDueDate()).isNull();
+              assertThat(props.getFollowUpDate()).isNull();
+              assertThat(props.getFormKey()).isNull();
+              assertThat(props.getPriority()).isNull();
+              assertThat(props.getUserTaskKey()).isNull();
+            });
+
+    job = response.getJobs().get(2);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with null user task properties")
+        .isNull();
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -151,9 +151,9 @@ public final class ActivateJobsTest extends ClientTest {
                     .addChangedAttributes("assignee")
                     .setDueDate("2019-04-22T00:00:00Z")
                     .setFollowUpDate("2018-04-23T00:00:00Z")
-                    .setFormKey("formKey_007")
+                    .setFormKey(123)
                     .setPriority(10)
-                    .setUserTaskKey("userTaskKey_123")
+                    .setUserTaskKey(456)
                     .build())
             .build();
 
@@ -195,9 +195,9 @@ public final class ActivateJobsTest extends ClientTest {
               assertThat(props.getChangedAttributes()).containsExactly("assignee");
               assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
               assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
-              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getFormKey()).isEqualTo(123);
               assertThat(props.getPriority()).isEqualTo(10);
-              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+              assertThat(props.getUserTaskKey()).isEqualTo(456);
             });
 
     job = response.getJobs().get(1);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -163,9 +163,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
                 .addChangedAttributesItem("assignee")
                 .dueDate("2019-04-22T00:00:00Z")
                 .followUpDate("2018-04-23T00:00:00Z")
-                .formKey("formKey_007")
+                .formKey("1")
                 .priority(10)
-                .userTaskKey("userTaskKey_123"),
+                .userTaskKey("123"),
             props -> {
               assertThat(props.getAction()).isEqualTo("update");
               assertThat(props.getAssignee()).isEqualTo("tony");
@@ -174,9 +174,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
               assertThat(props.getChangedAttributes()).containsExactly("assignee");
               assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
               assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
-              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getFormKey()).isEqualTo(1);
               assertThat(props.getPriority()).isEqualTo(10);
-              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+              assertThat(props.getUserTaskKey()).isEqualTo(123);
             }),
         new ActivateJobWithUserTaskPropsTestCase(
             "should activate job with empty user task properties",

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -30,6 +30,7 @@ import io.camunda.client.protocol.rest.ActivatedJobResult;
 import io.camunda.client.protocol.rest.JobActivationRequest;
 import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.UserTaskProperties;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import java.time.Duration;
@@ -37,7 +38,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public final class ActivateJobsRestTest extends ClientRestTest {
 
@@ -114,6 +119,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob1.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
 
     job = response.getJobs().get(1);
@@ -134,6 +140,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob2.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
 
     final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
@@ -141,6 +148,83 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(request.getMaxJobsToActivate()).isEqualTo(3);
     assertThat(request.getTimeout()).isEqualTo(1000);
     assertThat(request.getWorker()).isEqualTo("worker1");
+  }
+
+  private static Stream<ActivateJobWithUserTaskPropsTestCase> userTaskPropertiesProvider() {
+    return Stream.of(
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with all user task properties set",
+            new UserTaskProperties()
+                .action("update")
+                .assignee("tony")
+                .addCandidateGroupsItem("assistants")
+                .addCandidateUsersItem("jarvis")
+                .addCandidateUsersItem("friday")
+                .addChangedAttributesItem("assignee")
+                .dueDate("2019-04-22T00:00:00Z")
+                .followUpDate("2018-04-23T00:00:00Z")
+                .formKey("formKey_007")
+                .priority(10)
+                .userTaskKey("userTaskKey_123"),
+            props -> {
+              assertThat(props.getAction()).isEqualTo("update");
+              assertThat(props.getAssignee()).isEqualTo("tony");
+              assertThat(props.getCandidateGroups()).containsExactly("assistants");
+              assertThat(props.getCandidateUsers()).containsExactly("jarvis", "friday");
+              assertThat(props.getChangedAttributes()).containsExactly("assignee");
+              assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
+              assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
+              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getPriority()).isEqualTo(10);
+              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+            }),
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with empty user task properties",
+            new UserTaskProperties(),
+            props -> {
+              assertThat(props.getAction()).isNull();
+              assertThat(props.getAssignee()).isNull();
+              assertThat(props.getCandidateGroups()).isEmpty();
+              assertThat(props.getCandidateUsers()).isEmpty();
+              assertThat(props.getChangedAttributes()).isEmpty();
+              assertThat(props.getDueDate()).isNull();
+              assertThat(props.getFollowUpDate()).isNull();
+              assertThat(props.getFormKey()).isNull();
+              assertThat(props.getPriority()).isNull();
+              assertThat(props.getUserTaskKey()).isNull();
+            }),
+        new ActivateJobWithUserTaskPropsTestCase(
+            "should activate job with null user task properties",
+            null,
+            props -> assertThat(props).isNull()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("userTaskPropertiesProvider")
+  public void shouldActivateJobsWithUserTaskProperties(
+      final ActivateJobWithUserTaskPropsTestCase testCase) {
+
+    // given
+    final ActivatedJobResult activatedJob =
+        new ActivatedJobResult().userTask(testCase.providedProperties);
+
+    gatewayService.onActivateJobsRequest(new JobActivationResult().addJobsItem(activatedJob));
+
+    // when
+    final ActivateJobsResponse response =
+        client
+            .newActivateJobsCommand()
+            .jobType("payment")
+            .maxJobsToActivate(10)
+            .workerName("paymentWorker")
+            .timeout(Duration.ofMillis(1000))
+            .execute();
+
+    // then
+    assertThat(response.getJobs())
+        .singleElement()
+        .extracting(io.camunda.client.api.response.ActivatedJob::getUserTask)
+        .satisfies(testCase.assertions);
   }
 
   @Test
@@ -439,6 +523,27 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     public VariablesPojo setA(final int a) {
       this.a = a;
       return this;
+    }
+  }
+
+  private static final class ActivateJobWithUserTaskPropsTestCase {
+
+    public final String testDescription;
+    public final UserTaskProperties providedProperties;
+    public final Consumer<io.camunda.client.api.response.UserTaskProperties> assertions;
+
+    public ActivateJobWithUserTaskPropsTestCase(
+        final String testDescription,
+        final UserTaskProperties providedProperties,
+        final Consumer<io.camunda.client.api.response.UserTaskProperties> assertions) {
+      this.testDescription = testDescription;
+      this.providedProperties = providedProperties;
+      this.assertions = assertions;
+    }
+
+    @Override
+    public String toString() {
+      return testDescription;
     }
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.client.impl.response.ActivatedJobImpl;
 import io.camunda.zeebe.client.util.ClientTest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UserTaskProperties;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -106,6 +107,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob1.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
 
     job = response.getJobs().get(1);
@@ -123,6 +125,7 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
     assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
     assertThat(job.getVariables()).isEqualTo(activatedJob2.getVariables());
+    assertThat(job.getUserTask()).isNull();
     assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
@@ -130,6 +133,95 @@ public final class ActivateJobsTest extends ClientTest {
     assertThat(request.getMaxJobsToActivate()).isEqualTo(3);
     assertThat(request.getTimeout()).isEqualTo(1000);
     assertThat(request.getWorker()).isEqualTo("worker1");
+  }
+
+  @Test
+  public void shouldActivateJobsWithUserTaskProperties() {
+    // given
+    final ActivatedJob activatedJob1 =
+        ActivatedJob.newBuilder()
+            // with all user task properties set
+            .setUserTask(
+                UserTaskProperties.newBuilder()
+                    .setAction("update")
+                    .setAssignee("tony")
+                    .addCandidateGroups("assistants")
+                    .addCandidateUsers("jarvis")
+                    .addCandidateUsers("friday")
+                    .addChangedAttributes("assignee")
+                    .setDueDate("2019-04-22T00:00:00Z")
+                    .setFollowUpDate("2018-04-23T00:00:00Z")
+                    .setFormKey("formKey_007")
+                    .setPriority(10)
+                    .setUserTaskKey("userTaskKey_123")
+                    .build())
+            .build();
+
+    final ActivatedJob activatedJob2 =
+        ActivatedJob.newBuilder()
+            // with empty user task properties
+            .setUserTask(UserTaskProperties.newBuilder().build())
+            .build();
+
+    final ActivatedJob activatedJob3 =
+        ActivatedJob.newBuilder()
+            // with not set user task properties
+            .build();
+
+    gatewayService.onActivateJobsRequest(activatedJob1, activatedJob2, activatedJob3);
+
+    // when
+    final ActivateJobsResponse response =
+        client
+            .newActivateJobsCommand()
+            .jobType("payment")
+            .maxJobsToActivate(10)
+            .workerName("paymentWorker")
+            .timeout(Duration.ofMillis(1000))
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs()).hasSize(3);
+
+    io.camunda.zeebe.client.api.response.ActivatedJob job = response.getJobs().get(0);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with all user task properties set")
+        .satisfies(
+            props -> {
+              assertThat(props.getAction()).isEqualTo("update");
+              assertThat(props.getAssignee()).isEqualTo("tony");
+              assertThat(props.getCandidateGroups()).containsExactly("assistants");
+              assertThat(props.getCandidateUsers()).containsExactly("jarvis", "friday");
+              assertThat(props.getChangedAttributes()).containsExactly("assignee");
+              assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
+              assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
+              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getPriority()).isEqualTo(10);
+              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+            });
+
+    job = response.getJobs().get(1);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with empty user task properties")
+        .satisfies(
+            props -> {
+              assertThat(props.getAction()).isNull();
+              assertThat(props.getAssignee()).isNull();
+              assertThat(props.getCandidateGroups()).isEmpty();
+              assertThat(props.getCandidateUsers()).isEmpty();
+              assertThat(props.getChangedAttributes()).isEmpty();
+              assertThat(props.getDueDate()).isNull();
+              assertThat(props.getFollowUpDate()).isNull();
+              assertThat(props.getFormKey()).isNull();
+              assertThat(props.getPriority()).isNull();
+              assertThat(props.getUserTaskKey()).isNull();
+            });
+
+    job = response.getJobs().get(2);
+    assertThat(job.getUserTask())
+        .describedAs("Should activate job with null user task properties")
+        .isNull();
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsTest.java
@@ -151,9 +151,9 @@ public final class ActivateJobsTest extends ClientTest {
                     .addChangedAttributes("assignee")
                     .setDueDate("2019-04-22T00:00:00Z")
                     .setFollowUpDate("2018-04-23T00:00:00Z")
-                    .setFormKey("formKey_007")
+                    .setFormKey(123)
                     .setPriority(10)
-                    .setUserTaskKey("userTaskKey_123")
+                    .setUserTaskKey(456)
                     .build())
             .build();
 
@@ -196,9 +196,9 @@ public final class ActivateJobsTest extends ClientTest {
               assertThat(props.getChangedAttributes()).containsExactly("assignee");
               assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
               assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
-              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getFormKey()).isEqualTo(123);
               assertThat(props.getPriority()).isEqualTo(10);
-              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+              assertThat(props.getUserTaskKey()).isEqualTo(456);
             });
 
     job = response.getJobs().get(1);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
@@ -162,9 +162,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
                 .addChangedAttributesItem("assignee")
                 .dueDate("2019-04-22T00:00:00Z")
                 .followUpDate("2018-04-23T00:00:00Z")
-                .formKey("formKey_007")
+                .formKey("1")
                 .priority(10)
-                .userTaskKey("userTaskKey_123"),
+                .userTaskKey("100"),
             props -> {
               assertThat(props.getAction()).isEqualTo("update");
               assertThat(props.getAssignee()).isEqualTo("tony");
@@ -173,9 +173,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
               assertThat(props.getChangedAttributes()).containsExactly("assignee");
               assertThat(props.getDueDate()).isEqualTo("2019-04-22T00:00:00Z");
               assertThat(props.getFollowUpDate()).isEqualTo("2018-04-23T00:00:00Z");
-              assertThat(props.getFormKey()).isEqualTo("formKey_007");
+              assertThat(props.getFormKey()).isEqualTo(1);
               assertThat(props.getPriority()).isEqualTo(10);
-              assertThat(props.getUserTaskKey()).isEqualTo("userTaskKey_123");
+              assertThat(props.getUserTaskKey()).isEqualTo(100);
             }),
         new ActivateJobWithUserTaskPropsTestCase(
             "should activate job with empty user task properties",

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
@@ -17,6 +17,7 @@ package io.camunda.spring.client.jobhandling.parameter;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
+import java.util.List;
 import java.util.Map;
 
 public class CompatActivatedJobParameterResolver implements ParameterResolver {
@@ -112,6 +113,65 @@ public class CompatActivatedJobParameterResolver implements ParameterResolver {
     @Override
     public Object getVariable(final String name) {
       return job.getVariable(name);
+    }
+
+    @Override
+    public io.camunda.zeebe.client.api.response.UserTaskProperties getUserTask() {
+      if (job.getUserTask() == null) {
+        return null;
+      }
+
+      return new io.camunda.zeebe.client.api.response.UserTaskProperties() {
+        @Override
+        public String getAction() {
+          return job.getUserTask().getAction();
+        }
+
+        @Override
+        public String getAssignee() {
+          return job.getUserTask().getAssignee();
+        }
+
+        @Override
+        public List<String> getCandidateGroups() {
+          return job.getUserTask().getCandidateGroups();
+        }
+
+        @Override
+        public List<String> getCandidateUsers() {
+          return job.getUserTask().getCandidateUsers();
+        }
+
+        @Override
+        public List<String> getChangedAttributes() {
+          return job.getUserTask().getChangedAttributes();
+        }
+
+        @Override
+        public String getDueDate() {
+          return job.getUserTask().getDueDate();
+        }
+
+        @Override
+        public String getFollowUpDate() {
+          return job.getUserTask().getFollowUpDate();
+        }
+
+        @Override
+        public String getFormKey() {
+          return job.getUserTask().getFormKey();
+        }
+
+        @Override
+        public Integer getPriority() {
+          return job.getUserTask().getPriority();
+        }
+
+        @Override
+        public String getUserTaskKey() {
+          return job.getUserTask().getUserTaskKey();
+        }
+      };
     }
 
     @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/CompatActivatedJobParameterResolver.java
@@ -17,6 +17,7 @@ package io.camunda.spring.client.jobhandling.parameter;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.response.UserTaskProperties;
 import java.util.List;
 import java.util.Map;
 
@@ -116,12 +117,12 @@ public class CompatActivatedJobParameterResolver implements ParameterResolver {
     }
 
     @Override
-    public io.camunda.zeebe.client.api.response.UserTaskProperties getUserTask() {
+    public UserTaskProperties getUserTask() {
       if (job.getUserTask() == null) {
         return null;
       }
 
-      return new io.camunda.zeebe.client.api.response.UserTaskProperties() {
+      return new UserTaskProperties() {
         @Override
         public String getAction() {
           return job.getUserTask().getAction();
@@ -158,7 +159,7 @@ public class CompatActivatedJobParameterResolver implements ParameterResolver {
         }
 
         @Override
-        public String getFormKey() {
+        public Long getFormKey() {
           return job.getUserTask().getFormKey();
         }
 
@@ -168,7 +169,7 @@ public class CompatActivatedJobParameterResolver implements ParameterResolver {
         }
 
         @Override
-        public String getUserTaskKey() {
+        public Long getUserTaskKey() {
           return job.getUserTask().getUserTaskKey();
         }
       };

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -190,6 +190,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-cluster-config</artifactId>
     </dependency>

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -25,174 +25,184 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ResponseMapperTest {
 
-  static Stream<TestCase> testCasesProvider() {
-    return Stream.of(
-        new TestCase(
-            "TASK_LISTENER job with valid user task properties in headers",
-            JobKind.TASK_LISTENER,
-            Map.of(
-                Protocol.USER_TASK_ACTION_HEADER_NAME, "complete",
-                Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "john",
-                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"group1\",\"group2\"]",
-                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"user1\"]",
-                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
-                Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
-                Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
-                Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
-                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
-                Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
-            job -> {
-              assertThat(job.hasUserTask())
-                  .as("User task properties should be set for TASK_LISTENER job")
-                  .isTrue();
-              assertThat(job.getUserTask())
-                  .satisfies(
-                      props -> {
-                        // Verify all user task properties are correctly mapped
-                        assertThat(props.getAction()).isEqualTo("complete");
-                        assertThat(props.getAssignee()).isEqualTo("john");
-                        assertThat(props.getCandidateGroupsList())
-                            .containsExactly("group1", "group2");
-                        assertThat(props.getCandidateUsersList()).containsExactly("user1");
-                        assertThat(props.getChangedAttributesList()).containsExactly("assignee");
-                        assertThat(props.getDueDate()).isEqualTo("2024-07-01");
-                        assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
-                        assertThat(props.getFormKey()).isEqualTo("formKey");
-                        assertThat(props.getPriority()).isEqualTo(10);
-                        assertThat(props.getUserTaskKey()).isEqualTo("utKey");
-                      });
-            }),
-        new TestCase(
-            "TASK_LISTENER job with invalid or empty header values",
-            JobKind.TASK_LISTENER,
-            Map.of(
-                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "",
-                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "invalid_string",
-                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "132",
-                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "<not_a_number>"),
-            job -> {
-              assertThat(job.hasUserTask())
-                  .as("User task properties should be set for TASK_LISTENER job")
-                  .isTrue();
-              assertThat(job.getUserTask())
-                  .satisfies(
-                      props -> {
-                        assertThat(props.hasAction()).as("Action should not be set").isFalse();
-                        assertThat(props.hasAssignee()).as("Assignee should not be set").isFalse();
-                        assertThat(props.getCandidateGroupsList())
-                            .as("Candidate groups should be empty for invalid input")
-                            .isEmpty();
-                        assertThat(props.getCandidateUsersList())
-                            .as("Candidate users should be empty for invalid input")
-                            .isEmpty();
-                        assertThat(props.getChangedAttributesList())
-                            .as("Changed attributes should be empty for invalid input")
-                            .isEmpty();
-                        assertThat(props.hasDueDate()).as("Due date should not be set").isFalse();
-                        assertThat(props.hasFollowUpDate())
-                            .as("Follow-up date should not be set")
-                            .isFalse();
-                        assertThat(props.hasFormKey()).as("Form key should not be set").isFalse();
-                        assertThat(props.hasPriority()).as("Priority should not be set").isFalse();
-                        assertThat(props.hasUserTaskKey())
-                            .as("User task key should not be set")
-                            .isFalse();
-                      });
-            }),
-        new TestCase(
-            "TASK_LISTENER job with no headers",
-            JobKind.TASK_LISTENER,
-            Collections.emptyMap(),
-            job ->
+  @Nested
+  class ActivatedJobMappingTest {
+
+    static Stream<ActivatedJobWithUserTaskPropsCase> activatedJobWithUserTaskPropsCases() {
+      return Stream.of(
+          new ActivatedJobWithUserTaskPropsCase(
+              "TASK_LISTENER job with valid user task properties in headers",
+              JobKind.TASK_LISTENER,
+              Map.of(
+                  Protocol.USER_TASK_ACTION_HEADER_NAME, "complete",
+                  Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "john",
+                  Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"group1\",\"group2\"]",
+                  Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"user1\"]",
+                  Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
+                  Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
+                  Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
+                  Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
+                  Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
+                  Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
+              job -> {
                 assertThat(job.hasUserTask())
-                    .as(
-                        "User task properties should not be set for TASK_LISTENER job with no headers")
-                    .isFalse()),
-        new TestCase(
-            "BPMN_ELEMENT with no user task properties",
-            JobKind.BPMN_ELEMENT,
-            Collections.singletonMap("someHeader", "someValue"),
-            job ->
+                    .as("User task properties should be set for TASK_LISTENER job")
+                    .isTrue();
+                assertThat(job.getUserTask())
+                    .satisfies(
+                        props -> {
+                          // Verify all user task properties are correctly mapped
+                          assertThat(props.getAction()).isEqualTo("complete");
+                          assertThat(props.getAssignee()).isEqualTo("john");
+                          assertThat(props.getCandidateGroupsList())
+                              .containsExactly("group1", "group2");
+                          assertThat(props.getCandidateUsersList()).containsExactly("user1");
+                          assertThat(props.getChangedAttributesList()).containsExactly("assignee");
+                          assertThat(props.getDueDate()).isEqualTo("2024-07-01");
+                          assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
+                          assertThat(props.getFormKey()).isEqualTo("formKey");
+                          assertThat(props.getPriority()).isEqualTo(10);
+                          assertThat(props.getUserTaskKey()).isEqualTo("utKey");
+                        });
+              }),
+          new ActivatedJobWithUserTaskPropsCase(
+              "TASK_LISTENER job with invalid or empty header values",
+              JobKind.TASK_LISTENER,
+              Map.of(
+                  Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "",
+                  Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "invalid_string",
+                  Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "132",
+                  Protocol.USER_TASK_PRIORITY_HEADER_NAME, "<not_a_number>"),
+              job -> {
                 assertThat(job.hasUserTask())
-                    .as("User task properties should not be set for BPMN_ELEMENT job")
-                    .isFalse()),
-        new TestCase(
-            "EXECUTION_LISTENER with no user task properties",
-            JobKind.EXECUTION_LISTENER,
-            Collections.emptyMap(),
-            job ->
-                assertThat(job.hasUserTask())
-                    .as("User task properties should not be set for EXECUTION_LISTENER job")
-                    .isFalse()));
-  }
+                    .as("User task properties should be set for TASK_LISTENER job")
+                    .isTrue();
+                assertThat(job.getUserTask())
+                    .satisfies(
+                        props -> {
+                          assertThat(props.hasAction()).as("Action should not be set").isFalse();
+                          assertThat(props.hasAssignee())
+                              .as("Assignee should not be set")
+                              .isFalse();
+                          assertThat(props.getCandidateGroupsList())
+                              .as("Candidate groups should be empty for invalid input")
+                              .isEmpty();
+                          assertThat(props.getCandidateUsersList())
+                              .as("Candidate users should be empty for invalid input")
+                              .isEmpty();
+                          assertThat(props.getChangedAttributesList())
+                              .as("Changed attributes should be empty for invalid input")
+                              .isEmpty();
+                          assertThat(props.hasDueDate()).as("Due date should not be set").isFalse();
+                          assertThat(props.hasFollowUpDate())
+                              .as("Follow-up date should not be set")
+                              .isFalse();
+                          assertThat(props.hasFormKey()).as("Form key should not be set").isFalse();
+                          assertThat(props.hasPriority())
+                              .as("Priority should not be set")
+                              .isFalse();
+                          assertThat(props.hasUserTaskKey())
+                              .as("User task key should not be set")
+                              .isFalse();
+                        });
+              }),
+          new ActivatedJobWithUserTaskPropsCase(
+              "TASK_LISTENER job with no headers",
+              JobKind.TASK_LISTENER,
+              Collections.emptyMap(),
+              job ->
+                  assertThat(job.hasUserTask())
+                      .as(
+                          "User task properties should not be set for TASK_LISTENER job with no headers")
+                      .isFalse()),
+          new ActivatedJobWithUserTaskPropsCase(
+              "BPMN_ELEMENT with no user task properties",
+              JobKind.BPMN_ELEMENT,
+              Collections.singletonMap("someHeader", "someValue"),
+              job ->
+                  assertThat(job.hasUserTask())
+                      .as("User task properties should not be set for BPMN_ELEMENT job")
+                      .isFalse()),
+          new ActivatedJobWithUserTaskPropsCase(
+              "EXECUTION_LISTENER with no user task properties",
+              JobKind.EXECUTION_LISTENER,
+              Collections.emptyMap(),
+              job ->
+                  assertThat(job.hasUserTask())
+                      .as("User task properties should not be set for EXECUTION_LISTENER job")
+                      .isFalse()));
+    }
 
-  @ParameterizedTest
-  @MethodSource("testCasesProvider")
-  void shouldMapActivatedJobWithUserTaskPropertiesBasedOnJobKind(final TestCase testCase) {
-    // given
-    final JobRecord jobRecord = mockJobRecord(testCase);
+    @ParameterizedTest
+    @MethodSource("activatedJobWithUserTaskPropsCases")
+    void shouldMapActivatedJobWithUserTaskPropertiesBasedOnJobKind(
+        final ActivatedJobWithUserTaskPropsCase testCase) {
+      // given
+      final JobRecord jobRecord = mockJobRecord(testCase);
 
-    final JobBatchRecord batchRecordMock = mock(JobBatchRecord.class);
-    final ValueArray<JobRecord> jobsValueArrayMock = mockValueArray(jobRecord);
-    when(batchRecordMock.jobs()).thenReturn(jobsValueArrayMock);
-    final LongValue jobKey = mock(LongValue.class);
-    when(jobKey.getValue()).thenReturn(123L);
-    final ValueArray<LongValue> jobKeysValueArrayMock = mockValueArray(jobKey);
-    when(batchRecordMock.jobKeys()).thenReturn(jobKeysValueArrayMock);
+      final JobBatchRecord batchRecordMock = mock(JobBatchRecord.class);
+      final ValueArray<JobRecord> jobsValueArrayMock = mockValueArray(jobRecord);
+      when(batchRecordMock.jobs()).thenReturn(jobsValueArrayMock);
+      final LongValue jobKey = mock(LongValue.class);
+      when(jobKey.getValue()).thenReturn(123L);
+      final ValueArray<LongValue> jobKeysValueArrayMock = mockValueArray(jobKey);
+      when(batchRecordMock.jobKeys()).thenReturn(jobKeysValueArrayMock);
 
-    final var activatedJob = mock(io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob.class);
-    when(activatedJob.jobKey()).thenReturn(123L);
-    when(activatedJob.jobRecord()).thenReturn(jobRecord);
+      final var activatedJob = mock(io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob.class);
+      when(activatedJob.jobKey()).thenReturn(123L);
+      when(activatedJob.jobRecord()).thenReturn(jobRecord);
 
-    // when
-    final var result = ResponseMapper.toActivatedJob(activatedJob);
+      // when
+      final var result = ResponseMapper.toActivatedJob(activatedJob);
 
-    // then
-    assertThat(result).satisfies(testCase.assertions);
-  }
+      // then
+      assertThat(result).satisfies(testCase.assertions);
+    }
 
-  private static JobRecord mockJobRecord(final TestCase testCase) {
-    final JobRecord jobRecord = mock(JobRecord.class);
-    when(jobRecord.getJobKind()).thenReturn(testCase.jobKind);
-    when(jobRecord.getCustomHeaders()).thenReturn(testCase.headers);
-    when(jobRecord.getTypeBuffer()).thenReturn(BufferUtil.wrapString("type"));
-    when(jobRecord.getBpmnProcessId()).thenReturn("procId");
-    when(jobRecord.getElementId()).thenReturn("elementId");
-    when(jobRecord.getProcessInstanceKey()).thenReturn(1L);
-    when(jobRecord.getProcessDefinitionVersion()).thenReturn(1);
-    when(jobRecord.getProcessDefinitionKey()).thenReturn(2L);
-    when(jobRecord.getElementInstanceKey()).thenReturn(3L);
-    when(jobRecord.getWorkerBuffer()).thenReturn(BufferUtil.wrapString("worker"));
-    when(jobRecord.getCustomHeadersBuffer()).thenReturn(BufferUtil.wrapString("{}"));
-    when(jobRecord.getVariablesBuffer()).thenReturn(BufferUtil.wrapString("{}"));
-    when(jobRecord.getRetries()).thenReturn(3);
-    when(jobRecord.getDeadline()).thenReturn(0L);
-    when(jobRecord.getVariables()).thenReturn(Map.of());
-    when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    when(jobRecord.getLength()).thenReturn(1);
-    return jobRecord;
-  }
+    private static JobRecord mockJobRecord(final ActivatedJobWithUserTaskPropsCase testCase) {
+      final JobRecord jobRecord = mock(JobRecord.class);
+      when(jobRecord.getJobKind()).thenReturn(testCase.jobKind);
+      when(jobRecord.getCustomHeaders()).thenReturn(testCase.headers);
+      when(jobRecord.getTypeBuffer()).thenReturn(BufferUtil.wrapString("type"));
+      when(jobRecord.getBpmnProcessId()).thenReturn("procId");
+      when(jobRecord.getElementId()).thenReturn("elementId");
+      when(jobRecord.getProcessInstanceKey()).thenReturn(1L);
+      when(jobRecord.getProcessDefinitionVersion()).thenReturn(1);
+      when(jobRecord.getProcessDefinitionKey()).thenReturn(2L);
+      when(jobRecord.getElementInstanceKey()).thenReturn(3L);
+      when(jobRecord.getWorkerBuffer()).thenReturn(BufferUtil.wrapString("worker"));
+      when(jobRecord.getCustomHeadersBuffer()).thenReturn(BufferUtil.wrapString("{}"));
+      when(jobRecord.getVariablesBuffer()).thenReturn(BufferUtil.wrapString("{}"));
+      when(jobRecord.getRetries()).thenReturn(3);
+      when(jobRecord.getDeadline()).thenReturn(0L);
+      when(jobRecord.getVariables()).thenReturn(Map.of());
+      when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      when(jobRecord.getLength()).thenReturn(1);
+      return jobRecord;
+    }
 
-  private static <T> ValueArray<T> mockValueArray(final T... values) {
-    final ValueArray<T> valueArrayMock = mock(ValueArray.class);
-    when(valueArrayMock.iterator()).thenReturn(List.of(values).iterator());
-    return valueArrayMock;
-  }
+    private static <T> ValueArray<T> mockValueArray(final T... values) {
+      final ValueArray<T> valueArrayMock = mock(ValueArray.class);
+      when(valueArrayMock.iterator()).thenReturn(List.of(values).iterator());
+      return valueArrayMock;
+    }
 
-  private record TestCase(
-      String name,
-      JobKind jobKind,
-      Map<String, String> headers,
-      Consumer<ActivatedJob> assertions) {
+    private record ActivatedJobWithUserTaskPropsCase(
+        String name,
+        JobKind jobKind,
+        Map<String, String> headers,
+        Consumer<ActivatedJob> assertions) {
 
-    @Override
-    public String toString() {
-      return name;
+      @Override
+      public String toString() {
+        return name;
+      }
     }
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -47,9 +47,9 @@ class ResponseMapperTest {
                   Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
                   Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
                   Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
-                  Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
+                  Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "1",
                   Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
-                  Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
+                  Protocol.USER_TASK_KEY_HEADER_NAME, "100"),
               job -> {
                 assertThat(job.hasUserTask())
                     .as("User task properties should be set for TASK_LISTENER job")
@@ -66,9 +66,9 @@ class ResponseMapperTest {
                           assertThat(props.getChangedAttributesList()).containsExactly("assignee");
                           assertThat(props.getDueDate()).isEqualTo("2024-07-01");
                           assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
-                          assertThat(props.getFormKey()).isEqualTo("formKey");
+                          assertThat(props.getFormKey()).isEqualTo(1);
                           assertThat(props.getPriority()).isEqualTo(10);
-                          assertThat(props.getUserTaskKey()).isEqualTo("utKey");
+                          assertThat(props.getUserTaskKey()).isEqualTo(100);
                         });
               }),
           new ActivatedJobWithUserTaskPropsCase(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResponseMapperTest {
+
+  static Stream<TestCase> testCasesProvider() {
+    return Stream.of(
+        new TestCase(
+            "TASK_LISTENER job with valid user task properties in headers",
+            JobKind.TASK_LISTENER,
+            Map.of(
+                Protocol.USER_TASK_ACTION_HEADER_NAME, "complete",
+                Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "john",
+                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"group1\",\"group2\"]",
+                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"user1\"]",
+                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
+                Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
+                Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
+                Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
+                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
+                Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
+            job -> {
+              assertThat(job.hasUserTask())
+                  .as("User task properties should be set for TASK_LISTENER job")
+                  .isTrue();
+              assertThat(job.getUserTask())
+                  .satisfies(
+                      props -> {
+                        // Verify all user task properties are correctly mapped
+                        assertThat(props.getAction()).isEqualTo("complete");
+                        assertThat(props.getAssignee()).isEqualTo("john");
+                        assertThat(props.getCandidateGroupsList())
+                            .containsExactly("group1", "group2");
+                        assertThat(props.getCandidateUsersList()).containsExactly("user1");
+                        assertThat(props.getChangedAttributesList()).containsExactly("assignee");
+                        assertThat(props.getDueDate()).isEqualTo("2024-07-01");
+                        assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
+                        assertThat(props.getFormKey()).isEqualTo("formKey");
+                        assertThat(props.getPriority()).isEqualTo(10);
+                        assertThat(props.getUserTaskKey()).isEqualTo("utKey");
+                      });
+            }),
+        new TestCase(
+            "TASK_LISTENER job with invalid or empty header values",
+            JobKind.TASK_LISTENER,
+            Map.of(
+                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "",
+                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "invalid_string",
+                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "132",
+                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "<not_a_number>"),
+            job -> {
+              assertThat(job.hasUserTask())
+                  .as("User task properties should be set for TASK_LISTENER job")
+                  .isTrue();
+              assertThat(job.getUserTask())
+                  .satisfies(
+                      props -> {
+                        assertThat(props.hasAction()).as("Action should not be set").isFalse();
+                        assertThat(props.hasAssignee()).as("Assignee should not be set").isFalse();
+                        assertThat(props.getCandidateGroupsList())
+                            .as("Candidate groups should be empty for invalid input")
+                            .isEmpty();
+                        assertThat(props.getCandidateUsersList())
+                            .as("Candidate users should be empty for invalid input")
+                            .isEmpty();
+                        assertThat(props.getChangedAttributesList())
+                            .as("Changed attributes should be empty for invalid input")
+                            .isEmpty();
+                        assertThat(props.hasDueDate()).as("Due date should not be set").isFalse();
+                        assertThat(props.hasFollowUpDate())
+                            .as("Follow-up date should not be set")
+                            .isFalse();
+                        assertThat(props.hasFormKey()).as("Form key should not be set").isFalse();
+                        assertThat(props.hasPriority()).as("Priority should not be set").isFalse();
+                        assertThat(props.hasUserTaskKey())
+                            .as("User task key should not be set")
+                            .isFalse();
+                      });
+            }),
+        new TestCase(
+            "TASK_LISTENER job with no headers",
+            JobKind.TASK_LISTENER,
+            Collections.emptyMap(),
+            job ->
+                assertThat(job.hasUserTask())
+                    .as(
+                        "User task properties should not be set for TASK_LISTENER job with no headers")
+                    .isFalse()),
+        new TestCase(
+            "BPMN_ELEMENT with no user task properties",
+            JobKind.BPMN_ELEMENT,
+            Collections.singletonMap("someHeader", "someValue"),
+            job ->
+                assertThat(job.hasUserTask())
+                    .as("User task properties should not be set for BPMN_ELEMENT job")
+                    .isFalse()),
+        new TestCase(
+            "EXECUTION_LISTENER with no user task properties",
+            JobKind.EXECUTION_LISTENER,
+            Collections.emptyMap(),
+            job ->
+                assertThat(job.hasUserTask())
+                    .as("User task properties should not be set for EXECUTION_LISTENER job")
+                    .isFalse()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCasesProvider")
+  void shouldMapActivatedJobWithUserTaskPropertiesBasedOnJobKind(final TestCase testCase) {
+    // given
+    final JobRecord jobRecord = mockJobRecord(testCase);
+
+    final JobBatchRecord batchRecordMock = mock(JobBatchRecord.class);
+    final ValueArray<JobRecord> jobsValueArrayMock = mockValueArray(jobRecord);
+    when(batchRecordMock.jobs()).thenReturn(jobsValueArrayMock);
+    final LongValue jobKey = mock(LongValue.class);
+    when(jobKey.getValue()).thenReturn(123L);
+    final ValueArray<LongValue> jobKeysValueArrayMock = mockValueArray(jobKey);
+    when(batchRecordMock.jobKeys()).thenReturn(jobKeysValueArrayMock);
+
+    final var activatedJob = mock(io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob.class);
+    when(activatedJob.jobKey()).thenReturn(123L);
+    when(activatedJob.jobRecord()).thenReturn(jobRecord);
+
+    // when
+    final var result = ResponseMapper.toActivatedJob(activatedJob);
+
+    // then
+    assertThat(result).satisfies(testCase.assertions);
+  }
+
+  private static JobRecord mockJobRecord(final TestCase testCase) {
+    final JobRecord jobRecord = mock(JobRecord.class);
+    when(jobRecord.getJobKind()).thenReturn(testCase.jobKind);
+    when(jobRecord.getCustomHeaders()).thenReturn(testCase.headers);
+    when(jobRecord.getTypeBuffer()).thenReturn(BufferUtil.wrapString("type"));
+    when(jobRecord.getBpmnProcessId()).thenReturn("procId");
+    when(jobRecord.getElementId()).thenReturn("elementId");
+    when(jobRecord.getProcessInstanceKey()).thenReturn(1L);
+    when(jobRecord.getProcessDefinitionVersion()).thenReturn(1);
+    when(jobRecord.getProcessDefinitionKey()).thenReturn(2L);
+    when(jobRecord.getElementInstanceKey()).thenReturn(3L);
+    when(jobRecord.getWorkerBuffer()).thenReturn(BufferUtil.wrapString("worker"));
+    when(jobRecord.getCustomHeadersBuffer()).thenReturn(BufferUtil.wrapString("{}"));
+    when(jobRecord.getVariablesBuffer()).thenReturn(BufferUtil.wrapString("{}"));
+    when(jobRecord.getRetries()).thenReturn(3);
+    when(jobRecord.getDeadline()).thenReturn(0L);
+    when(jobRecord.getVariables()).thenReturn(Map.of());
+    when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    when(jobRecord.getLength()).thenReturn(1);
+    return jobRecord;
+  }
+
+  private static <T> ValueArray<T> mockValueArray(final T... values) {
+    final ValueArray<T> valueArrayMock = mock(ValueArray.class);
+    when(valueArrayMock.iterator()).thenReturn(List.of(values).iterator());
+    return valueArrayMock;
+  }
+
+  private record TestCase(
+      String name,
+      JobKind jobKind,
+      Map<String, String> headers,
+      Consumer<ActivatedJob> assertions) {
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -110,13 +110,13 @@ message UserTaskProperties {
   optional string followUpDate = 7;
 
   // The key of the form associated with the user task.
-  optional string formKey = 8;
+  optional int64 formKey = 8;
 
   // The priority of the user task (0-100).
   optional int32 priority = 9;
 
   // The unique key identifying the user task.
-  optional string userTaskKey = 10;
+  optional int64 userTaskKey = 10;
 }
 
 message CancelProcessInstanceRequest {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -83,6 +83,40 @@ message ActivatedJob {
   string variables = 13;
   // the id of the tenant that owns the job
   string tenantId = 14;
+  // Contains user task properties if the job is of kind TASK_LISTENER
+  optional UserTaskProperties userTask = 15;
+}
+
+message UserTaskProperties {
+  // The action performed on the user task (e.g., "claim", "update", "complete").
+  optional string action = 1;
+
+  // The user assigned to the task.
+  optional string assignee = 2;
+
+  // The list of candidate groups for the user task.
+  repeated string candidateGroups = 3;
+
+  // The list of candidate users for the user task.
+  repeated string candidateUsers = 4;
+
+  // The list of attributes that were changed in the user task.
+  repeated string changedAttributes = 5;
+
+  // The due date of the user task in ISO 8601 format.
+  optional string dueDate = 6;
+
+  // The follow-up date of the user task in ISO 8601 format.
+  optional string followUpDate = 7;
+
+  // The key of the form associated with the user task.
+  optional string formKey = 8;
+
+  // The priority of the user task (0-100).
+  optional int32 priority = 9;
+
+  // The unique key identifying the user task.
+  optional string userTaskKey = 10;
 }
 
 message CancelProcessInstanceRequest {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -8272,6 +8272,59 @@ components:
             The unique key identifying the associated task, unique within the scope of the
             process instance.
           type: string
+        userTask:
+          $ref: "#/components/schemas/UserTaskProperties"
+    UserTaskProperties:
+      type: object
+      description: Contains properties of a user task.
+      properties:
+        action:
+          description: The action performed on the user task.
+          type: string
+        assignee:
+          description: The user assigned to the task.
+          type: string
+          nullable: true
+        candidateGroups:
+          description: The groups eligible to claim the task.
+          type: array
+          items:
+            type: string
+        candidateUsers:
+          description: The users eligible to claim the task.
+          type: array
+          items:
+            type: string
+        changedAttributes:
+          description: The attributes that were changed in the task.
+          type: array
+          items:
+            type: string
+        dueDate:
+          description: The due date of the user task in ISO 8601 format.
+          type: string
+          format: date-time
+          nullable: true
+        followUpDate:
+          description: The follow-up date of the user task in ISO 8601 format.
+          type: string
+          format: date-time
+          nullable: true
+        formKey:
+          description: The key of the form associated with the user task.
+          type: string
+          nullable: true
+        priority:
+          description: The priority of the user task.
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 100
+          nullable: true
+        userTaskKey:
+          description: The unique key identifying the user task.
+          type: string
+          nullable: true
     JobFailRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -13,6 +13,7 @@ import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.DocumentError;
 import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
@@ -218,7 +219,7 @@ public final class ResponseMapper {
     props.setDueDate(headers.get(Protocol.USER_TASK_DUE_DATE_HEADER_NAME));
     props.setFollowUpDate(headers.get(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME));
     props.setFormKey(headers.get(Protocol.USER_TASK_FORM_KEY_HEADER_NAME));
-    props.setPriority(toInteger(headers.get(Protocol.USER_TASK_PRIORITY_HEADER_NAME)));
+    props.setPriority(toIntegerOrNull(headers.get(Protocol.USER_TASK_PRIORITY_HEADER_NAME)));
     props.setUserTaskKey(headers.get(Protocol.USER_TASK_KEY_HEADER_NAME));
 
     return props;
@@ -230,22 +231,21 @@ public final class ResponseMapper {
     }
 
     try {
-      return OBJECT_MAPPER.readValue(
-          input, OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+      return OBJECT_MAPPER.readValue(input, new TypeReference<>() {});
     } catch (final Exception e) {
       LOG.warn("Failed to map string to list: {}", input, e);
       return List.of();
     }
   }
 
-  public static Integer toInteger(final String value) {
+  public static Integer toIntegerOrNull(final String value) {
     if (value == null || value.isEmpty()) {
       return null;
     }
     try {
       return Integer.parseInt(value);
     } catch (final NumberFormatException e) {
-      LOG.warn("Failed to parse integer from value: {}", value, e);
+      LOG.warn("Failed to parse Integer from value: {}", value, e);
       return null;
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ResponseMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ResponseMapperTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.gateway.impl.job.JobActivationResponse;
+import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskProperties;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResponseMapperTest {
+
+  static Stream<TestCase> testCasesProvider() {
+    return Stream.of(
+        new TestCase(
+            "TASK_LISTENER job with valid user task properties in headers",
+            JobKind.TASK_LISTENER,
+            Map.of(
+                Protocol.USER_TASK_ACTION_HEADER_NAME, "complete",
+                Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "john",
+                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"group1\",\"group2\"]",
+                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"user1\"]",
+                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
+                Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
+                Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
+                Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
+                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
+                Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
+            props -> {
+              // Verify all user task properties are correctly mapped
+              assertThat(props.getAction()).isEqualTo("complete");
+              assertThat(props.getAssignee()).isEqualTo("john");
+              assertThat(props.getCandidateGroups()).containsExactly("group1", "group2");
+              assertThat(props.getCandidateUsers()).containsExactly("user1");
+              assertThat(props.getChangedAttributes()).containsExactly("assignee");
+              assertThat(props.getDueDate()).isEqualTo("2024-07-01");
+              assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
+              assertThat(props.getFormKey()).isEqualTo("formKey");
+              assertThat(props.getPriority()).isEqualTo(10);
+              assertThat(props.getUserTaskKey()).isEqualTo("utKey");
+            }),
+        new TestCase(
+            "TASK_LISTENER job with invalid or empty header values",
+            JobKind.TASK_LISTENER,
+            Map.of(
+                Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "",
+                Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "invalid_string",
+                Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "132",
+                Protocol.USER_TASK_PRIORITY_HEADER_NAME, "<not_a_number>"),
+            props -> {
+              // Verify invalid or empty headers result in empty or null properties
+              assertThat(props.getAction()).as("Action should be null").isNull();
+              assertThat(props.getAssignee()).as("Assignee should be null").isNull();
+              assertThat(props.getCandidateGroups())
+                  .as("Candidate groups should be empty for invalid input")
+                  .isEmpty();
+              assertThat(props.getCandidateUsers())
+                  .as("Candidate users should be empty for invalid input")
+                  .isEmpty();
+              assertThat(props.getChangedAttributes())
+                  .as("Changed attributes should be empty for invalid input")
+                  .isEmpty();
+              assertThat(props.getDueDate()).as("Due date should be null").isNull();
+              assertThat(props.getFollowUpDate()).as("Follow-up date should be null").isNull();
+              assertThat(props.getFormKey()).as("Form key should be null").isNull();
+              assertThat(props.getPriority()).as("Priority should be null").isNull();
+              assertThat(props.getUserTaskKey()).as("User task key should be null").isNull();
+            }),
+        new TestCase(
+            "TASK_LISTENER job with empty headers map",
+            JobKind.TASK_LISTENER,
+            Collections.emptyMap(),
+            props ->
+                assertThat(props)
+                    .as(
+                        "User task properties should be null for TASK_LISTENER jobs with no headers")
+                    .isNull()),
+        new TestCase(
+            "BPMN_ELEMENT with no user task properties",
+            JobKind.BPMN_ELEMENT,
+            Collections.singletonMap("someHeader", "someValue"),
+            props ->
+                assertThat(props)
+                    .as("User task properties should be null for BPMN_ELEMENT jobs")
+                    .isNull()),
+        new TestCase(
+            "EXECUTION_LISTENER with no user task properties",
+            JobKind.EXECUTION_LISTENER,
+            Collections.emptyMap(),
+            props ->
+                assertThat(props)
+                    .as("User task properties should be null for EXECUTION_LISTENER jobs")
+                    .isNull()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("testCasesProvider")
+  void shouldMapActivatedJobWithUserTaskPropertiesBasedOnJobKind(final TestCase testCase) {
+    // given
+    final JobRecord jobRecord = mockJobRecord(testCase);
+
+    final JobBatchRecord batchRecordMock = mock(JobBatchRecord.class);
+    final ValueArray<JobRecord> jobsValueArrayMock = mockValueArray(jobRecord);
+    when(batchRecordMock.jobs()).thenReturn(jobsValueArrayMock);
+    final LongValue jobKey = mock(LongValue.class);
+    when(jobKey.getValue()).thenReturn(123L);
+    final ValueArray<LongValue> jobKeysValueArrayMock = mockValueArray(jobKey);
+    when(batchRecordMock.jobKeys()).thenReturn(jobKeysValueArrayMock);
+    final JobActivationResponse activationResponse =
+        new JobActivationResponse(123L, batchRecordMock, 10L);
+
+    // when
+    final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+    // then
+    final var jobs = result.getActivateJobsResponse().getJobs();
+    assertThat(jobs)
+        .singleElement()
+        .extracting(ActivatedJobResult::getUserTask)
+        .satisfies(testCase.assertions);
+  }
+
+  private static JobRecord mockJobRecord(final TestCase testCase) {
+    final JobRecord jobRecord = mock(JobRecord.class);
+    when(jobRecord.getJobKind()).thenReturn(testCase.jobKind);
+    when(jobRecord.getCustomHeaders()).thenReturn(testCase.headers);
+    when(jobRecord.getType()).thenReturn("type");
+    when(jobRecord.getBpmnProcessId()).thenReturn("procId");
+    when(jobRecord.getElementId()).thenReturn("elementId");
+    when(jobRecord.getProcessInstanceKey()).thenReturn(1L);
+    when(jobRecord.getProcessDefinitionVersion()).thenReturn(1);
+    when(jobRecord.getProcessDefinitionKey()).thenReturn(2L);
+    when(jobRecord.getElementInstanceKey()).thenReturn(3L);
+    when(jobRecord.getWorkerBuffer()).thenReturn(BufferUtil.wrapString("worker"));
+    when(jobRecord.getRetries()).thenReturn(3);
+    when(jobRecord.getDeadline()).thenReturn(0L);
+    when(jobRecord.getVariables()).thenReturn(Map.of());
+    when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    when(jobRecord.getLength()).thenReturn(1);
+    return jobRecord;
+  }
+
+  private static <T> ValueArray<T> mockValueArray(final T... values) {
+    final ValueArray<T> valueArrayMock = mock(ValueArray.class);
+    when(valueArrayMock.iterator()).thenReturn(List.of(values).iterator());
+    return valueArrayMock;
+  }
+
+  private record TestCase(
+      String name,
+      JobKind jobKind,
+      Map<String, String> headers,
+      Consumer<UserTaskProperties> assertions) {
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ResponseMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ResponseMapperTest.java
@@ -49,9 +49,9 @@ class ResponseMapperTest {
                   Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]",
                   Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2024-07-01",
                   Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2024-07-02",
-                  Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "formKey",
+                  Protocol.USER_TASK_FORM_KEY_HEADER_NAME, "1",
                   Protocol.USER_TASK_PRIORITY_HEADER_NAME, "10",
-                  Protocol.USER_TASK_KEY_HEADER_NAME, "utKey"),
+                  Protocol.USER_TASK_KEY_HEADER_NAME, "100"),
               props -> {
                 // Verify all user task properties are correctly mapped
                 assertThat(props.getAction()).isEqualTo("complete");
@@ -61,9 +61,9 @@ class ResponseMapperTest {
                 assertThat(props.getChangedAttributes()).containsExactly("assignee");
                 assertThat(props.getDueDate()).isEqualTo("2024-07-01");
                 assertThat(props.getFollowUpDate()).isEqualTo("2024-07-02");
-                assertThat(props.getFormKey()).isEqualTo("formKey");
+                assertThat(props.getFormKey()).isEqualTo("1");
                 assertThat(props.getPriority()).isEqualTo(10);
-                assertThat(props.getUserTaskKey()).isEqualTo("utKey");
+                assertThat(props.getUserTaskKey()).isEqualTo("100");
               }),
           new ActivatedJobWithUserTaskPropsCase(
               "TASK_LISTENER job with invalid or empty header values",


### PR DESCRIPTION
## Description

This PR enables clients to directly access user task-related attributes for jobs of kind `TASK_LISTENER` via a structured `userTask` property.

### Changes:

- **REST API**: Added a `userTask` field to `ActivatedJobResult`, mapped from custom headers when available.
- **gRPC API**: Extended the gRPC `ActivatedJob` message to include a `userTask` property.
- **Camunda Client(Java)**:
  - Introduced a new `UserTaskProperties` interface and its implementation.
  - Exposed `getUserTask()` on `ActivatedJob`, returning a typed view of user task properties.
  - Ensures compatibility by returning `null` for non-`TASK_LISTENER` jobs.
- **Zeebe Client(Java, deprecated)**:
  - Mirrored the same support for `UserTaskProperties`.
- **spring-boot-starter-camunda-sdk**:
  - Extended `ActivatedJobProxy` in `CompatActivatedJobParameterResolver` accordingly.
- **Test Coverage**:
  - Added unit and integration tests for both gRPC and REST clients/APIs.

### Motivation:

Previously, accessing user task metadata in task listener jobs required parsing raw custom headers. This was error-prone, verbose, and inconsistent across clients. By surfacing structured `userTask` properties directly on activated jobs, this PR simplifies client logic and improves developer experience.

### Notes:

- Only jobs of kind `TASK_LISTENER` will have a non-null `userTask` property.
- No changes were made to the internal job records; properties are extracted from custom headers at the API boundary.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #25890
