### PR TITLE
feat: migrate element instances data

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/buildMetadata.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/buildMetadata.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type V2MetaDataDto} from '../types';
+
+export const buildMetadata = (
+  metadata: V2MetaDataDto['instanceMetadata'] | null,
+  incident: {
+    errorType: {id: string; name: string};
+    errorMessage: string;
+  } | null,
+) => {
+  if (metadata === null) {
+    return '';
+  }
+
+  const {
+    flowNodeInstanceId,
+    calledProcessInstanceId,
+    calledDecisionInstanceId,
+    ...metadataSubset
+  } = metadata;
+
+  return JSON.stringify({
+    ...metadataSubset,
+    incidentErrorType: incident?.errorType.name || null,
+    incidentErrorMessage: incident?.errorMessage || null,
+    flowNodeInstanceKey: flowNodeInstanceId,
+    calledProcessInstanceKey: calledProcessInstanceId,
+    calledDecisionInstanceKey: calledDecisionInstanceId,
+  });
+};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -92,7 +92,8 @@ describe('MetadataPopover <Details />', () => {
   });
 
   it('should render Tasklist link for user tasks when configured', () => {
-    window.clientConfig = {tasklistUrl: 'https://tasklist.example.com'};
+    const tasklistUrl = 'https://tasklist.example.com';
+    vi.stubGlobal('clientConfig', {tasklistUrl});
 
     const meta: V2MetaDataDto = {
       ...baseMetaData,
@@ -112,7 +113,8 @@ describe('MetadataPopover <Details />', () => {
   });
 
   it('should not render Tasklist link for non-user tasks', () => {
-    window.clientConfig = {tasklistUrl: 'https://tasklist.example.com'};
+    const tasklistUrl = 'https://tasklist.example.com';
+    vi.stubGlobal('clientConfig', {tasklistUrl});
 
     render(<Details metaData={baseMetaData} elementId="Task_1" />, {
       wrapper: TestWrapper,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {type V2MetaDataDto} from '../types';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {baseMetaData, TestWrapper} from './mocks';
+import {Details} from './index';
+import {getExecutionDuration} from '../../Details/getExecutionDuration';
+
+describe('MetadataPopover <Details />', () => {
+  beforeEach(() => {
+    mockFetchProcessDefinitionXml().withSuccess('');
+  });
+
+  it('should render element instance details', () => {
+    render(<Details metaData={baseMetaData} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.getByText('123456789')).toBeInTheDocument();
+  });
+
+  it('should display job retries when available', () => {
+    render(<Details metaData={baseMetaData} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    expect(screen.getByText('Retries Left')).toBeInTheDocument();
+    expect(screen.getByTestId('retries-left-count')).toHaveTextContent('3');
+  });
+
+  it('should hide job retries when null', () => {
+    const meta = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        jobRetries: null,
+      },
+    };
+
+    render(<Details metaData={meta} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    expect(screen.queryByText('Retries Left')).not.toBeInTheDocument();
+  });
+
+  it('should show metadata dialog when "Show more metadata" is clicked', async () => {
+    const {user} = render(
+      <Details metaData={baseMetaData} elementId="Task_1" />,
+      {wrapper: TestWrapper},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Show more metadata'}));
+    expect(
+      screen.getByText(/Element "Task_1" 123456789 Metadata/),
+    ).toBeInTheDocument();
+  });
+
+  it('should handle null instance metadata gracefully', () => {
+    const meta: V2MetaDataDto = {
+      flowNodeInstanceId: null,
+      flowNodeId: null,
+      flowNodeType: null,
+      instanceCount: null,
+      instanceMetadata: null,
+      incident: null,
+      incidentCount: 0,
+    };
+
+    render(<Details metaData={meta} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    expect(screen.getByText('Element Instance Key')).toBeInTheDocument();
+    expect(screen.getByText('Execution Duration')).toBeInTheDocument();
+    expect(screen.queryByText('Retries Left')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Called Process Instance'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Called Decision Instance'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render Tasklist link for user tasks when configured', () => {
+    window.clientConfig = {tasklistUrl: 'https://tasklist.example.com'};
+
+    const meta: V2MetaDataDto = {
+      ...baseMetaData,
+      instanceMetadata: {
+        ...baseMetaData.instanceMetadata!,
+        type: 'USER_TASK',
+      },
+    };
+
+    render(<Details metaData={meta} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    const link = screen.getByRole('link', {name: 'Open Tasklist'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://tasklist.example.com');
+  });
+
+  it('should not render Tasklist link for non-user tasks', () => {
+    window.clientConfig = {tasklistUrl: 'https://tasklist.example.com'};
+
+    render(<Details metaData={baseMetaData} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    expect(
+      screen.queryByRole('link', {name: 'Open Tasklist'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display execution duration info', () => {
+    render(<Details metaData={baseMetaData} elementId="Task_1" />, {
+      wrapper: TestWrapper,
+    });
+
+    const calculatedExecutionDuration = getExecutionDuration(
+      baseMetaData!.instanceMetadata!.startDate,
+      baseMetaData!.instanceMetadata!.endDate,
+    );
+
+    expect(screen.getByText('Execution Duration')).toBeInTheDocument();
+    expect(screen.getByText(calculatedExecutionDuration)).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/index.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useState} from 'react';
+import {Stack} from '@carbon/react';
+import isNil from 'lodash/isNil';
+import {Link} from 'modules/components/Link';
+import {Paths} from 'modules/Routes';
+import {tracking} from 'modules/tracking';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {Header} from '../../Header';
+import {SummaryDataKey, SummaryDataValue} from '../../styled';
+import {getExecutionDuration} from '../../Details/getExecutionDuration';
+import {buildMetadata} from './buildMetadata';
+import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
+import {type V2MetaDataDto} from '../types';
+
+type Props = {
+  metaData: V2MetaDataDto;
+  elementId: string;
+};
+
+const NULL_METADATA = {
+  elementInstanceKey: null,
+  startDate: null,
+  endDate: null,
+  calledProcessInstanceId: null,
+  calledProcessDefinitionName: null,
+  calledDecisionInstanceId: null,
+  calledDecisionDefinitionName: null,
+  type: null,
+  jobRetries: null,
+} as const;
+
+const Details: React.FC<Props> = ({metaData, elementId}) => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const processDefinitionKey = useProcessDefinitionKeyContext();
+  const {data} = useProcessInstanceXml({
+    processDefinitionKey,
+  });
+  const businessObject = data?.businessObjects[elementId];
+
+  const elementName = businessObject?.name || elementId;
+
+  const {instanceMetadata, incident} = metaData;
+  const {
+    elementInstanceKey,
+    startDate,
+    endDate,
+    calledProcessInstanceId,
+    calledProcessDefinitionName,
+    calledDecisionInstanceId,
+    calledDecisionDefinitionName,
+    type,
+    jobRetries,
+  } = instanceMetadata ?? NULL_METADATA;
+
+  return (
+    <>
+      <Header
+        title="Details"
+        link={
+          !isNil(window.clientConfig?.tasklistUrl) && type === 'USER_TASK'
+            ? {
+                href: window.clientConfig!.tasklistUrl,
+                label: 'Open Tasklist',
+                onClick: () => {
+                  tracking.track({
+                    eventName: 'open-tasklist-link-clicked',
+                  });
+                },
+              }
+            : undefined
+        }
+        button={{
+          title: 'Show more metadata',
+          label: 'View',
+          onClick: () => {
+            setIsModalVisible(true);
+            tracking.track({
+              eventName: 'flow-node-instance-details-opened',
+            });
+          },
+        }}
+      />
+      <Stack gap={5}>
+        <Stack gap={3} as="dl">
+          <SummaryDataKey>Element Instance Key</SummaryDataKey>
+          <SummaryDataValue>{elementInstanceKey}</SummaryDataValue>
+        </Stack>
+        <Stack gap={3} as="dl">
+          <SummaryDataKey>Execution Duration</SummaryDataKey>
+          <SummaryDataValue>
+            {startDate ? getExecutionDuration(startDate, endDate) : '—'}
+          </SummaryDataValue>
+        </Stack>
+
+        {jobRetries !== null && (
+          <Stack gap={3} as="dl">
+            <SummaryDataKey>Retries Left</SummaryDataKey>
+            <SummaryDataValue data-testid="retries-left-count">
+              {jobRetries}
+            </SummaryDataValue>
+          </Stack>
+        )}
+
+        {businessObject?.$type === 'bpmn:CallActivity' &&
+          type !== 'MULTI_INSTANCE_BODY' && (
+            <Stack gap={3} as="dl">
+              <SummaryDataKey>Called Process Instance</SummaryDataKey>
+              <SummaryDataValue data-testid="called-process-instance">
+                {calledProcessInstanceId ? (
+                  <Link
+                    to={Paths.processInstance(calledProcessInstanceId)}
+                    title={`View ${calledProcessDefinitionName} instance ${calledProcessInstanceId}`}
+                    aria-label={`View ${calledProcessDefinitionName} instance ${calledProcessInstanceId}`}
+                  >
+                    {`${calledProcessDefinitionName} - ${calledProcessInstanceId}`}
+                  </Link>
+                ) : (
+                  'None'
+                )}
+              </SummaryDataValue>
+            </Stack>
+          )}
+
+        {businessObject?.$type === 'bpmn:BusinessRuleTask' && (
+          <Stack gap={3} as="dl">
+            <SummaryDataKey>Called Decision Instance</SummaryDataKey>
+            <SummaryDataValue>
+              {calledDecisionInstanceId ? (
+                <Link
+                  to={Paths.decisionInstance(calledDecisionInstanceId)}
+                  title={`View ${calledDecisionDefinitionName} instance ${calledDecisionInstanceId}`}
+                  aria-label={`View ${calledDecisionDefinitionName} instance ${calledDecisionInstanceId}`}
+                >
+                  {`${calledDecisionDefinitionName} - ${calledDecisionInstanceId}`}
+                </Link>
+              ) : (
+                (calledDecisionDefinitionName ?? '—')
+              )}
+            </SummaryDataValue>
+          </Stack>
+        )}
+      </Stack>
+      <JSONEditorModal
+        isVisible={isModalVisible}
+        onClose={() => setIsModalVisible(false)}
+        title={`Element "${elementName}" ${elementInstanceKey} Metadata`}
+        value={buildMetadata(instanceMetadata, incident)}
+        readOnly
+      />
+    </>
+  );
+};
+
+export {Details};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/Details/mocks.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
+import {type V2MetaDataDto} from '../types';
+
+const baseMetaData: V2MetaDataDto = {
+  flowNodeInstanceId: '123456789',
+  flowNodeId: 'Task_1',
+  flowNodeType: 'SERVICE_TASK',
+  instanceCount: 1,
+  instanceMetadata: {
+    elementInstanceKey: '123456789',
+    elementId: 'Task_1',
+    elementName: 'Service Task',
+    type: 'SERVICE_TASK',
+    state: 'COMPLETED',
+    startDate: '2023-01-15T10:00:00.000Z',
+    endDate: '2023-01-15T10:05:00.000Z',
+    processDefinitionId: 'process-def-1',
+    processInstanceKey: '111222333',
+    processDefinitionKey: '444555666',
+    hasIncident: false,
+    incidentKey: undefined,
+    tenantId: '<default>',
+    calledProcessInstanceId: '987654321',
+    calledProcessDefinitionName: 'Called Process',
+    calledDecisionInstanceId: null,
+    calledDecisionDefinitionName: null,
+    jobRetries: 3,
+    flowNodeInstanceId: '123456789',
+    flowNodeId: 'Task_1',
+    flowNodeType: 'SERVICE_TASK',
+    eventId: undefined,
+    jobType: 'httpService',
+    jobWorker: 'worker-1',
+    jobDeadline: '2023-01-15T10:10:00.000Z',
+    jobCustomHeaders: '{"timeout": "30s"}',
+    jobId: '555666777',
+  },
+  incident: null,
+  incidentCount: 0,
+};
+
+const TestWrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+  <ProcessDefinitionKeyContext.Provider value="test-process-key">
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  </ProcessDefinitionKeyContext.Provider>
+);
+
+export {TestWrapper, baseMetaData};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -32,14 +32,14 @@ import {
 import {init} from 'modules/utils/flowNodeMetadata';
 import {selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
-import {mockFetchElementInstance} from '../../../../../modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
-import {mockSearchElementInstances} from '../../../../../modules/mocks/api/v2/elementInstances/searchElementInstances.ts';
-import {mockFetchFlownodeInstancesStatistics} from '../../../../../modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics.ts';
-import {mockFetchProcessInstanceIncidents} from '../../../../../modules/mocks/api/processInstances/fetchProcessInstanceIncidents.ts';
-import {mockIncidents} from '../../../../../modules/mocks/incidents.ts';
-import {flowNodeMetaDataStore} from '../../../../../modules/stores/flowNodeMetaData.ts';
-import {incidentsStore} from '../../../../../modules/stores/incidents.ts';
-import type {ElementInstance} from '@vzeta/camunda-api-zod-schemas';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances.ts';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics.ts';
+import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents.ts';
+import {mockIncidents} from 'modules/mocks/incidents.ts';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData.ts';
+import {incidentsStore} from 'modules/stores/incidents.ts';
+import type {ElementInstance} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/calledDecisions.test.tsx
@@ -19,6 +19,9 @@ import {
   calledUnevaluatedDecisionMetadata,
   CALL_ACTIVITY_FLOW_NODE_ID,
   PROCESS_INSTANCE_ID,
+  FLOW_NODE_ID,
+  USER_TASK_FLOW_NODE_ID,
+  BUSSINESS_RULE_FLOW_NODE_ID,
 } from 'modules/mocks/metadata';
 import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess';
 import {
@@ -29,8 +32,31 @@ import {
 import {init} from 'modules/utils/flowNodeMetadata';
 import {selectFlowNode} from 'modules/utils/flowNodeSelection';
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchElementInstance} from '../../../../../modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
+import {mockSearchElementInstances} from '../../../../../modules/mocks/api/v2/elementInstances/searchElementInstances.ts';
+import {mockFetchFlownodeInstancesStatistics} from '../../../../../modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics.ts';
+import {mockFetchProcessInstanceIncidents} from '../../../../../modules/mocks/api/processInstances/fetchProcessInstanceIncidents.ts';
+import {mockIncidents} from '../../../../../modules/mocks/incidents.ts';
+import {flowNodeMetaDataStore} from '../../../../../modules/stores/flowNodeMetaData.ts';
+import {incidentsStore} from '../../../../../modules/stores/incidents.ts';
+import type {ElementInstance} from '@vzeta/camunda-api-zod-schemas';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
+
+const mockElementInstance: ElementInstance = {
+  elementInstanceKey: '2251799813699889',
+  elementId: BUSSINESS_RULE_FLOW_NODE_ID,
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'COMPLETED',
+  startDate: '2018-06-21T10:00:00.000Z',
+  endDate: '2018-06-21T10:00:00.000Z',
+  processDefinitionId: 'someKey',
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  processDefinitionKey: '2',
+  hasIncident: false,
+  tenantId: '<default>',
+};
 
 vi.mock('date-fns', async () => {
   const actual = await vi.importActual('date-fns');
@@ -44,12 +70,71 @@ describe('MetadataPopover', () => {
   beforeEach(() => {
     init('process-instance', []);
     flowNodeSelectionStore.init();
+    mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
+    mockFetchElementInstance('2251799813699889').withSuccess(
+      mockElementInstance,
+    );
+
+    mockSearchElementInstances().withSuccess({
+      items: [mockElementInstance],
+      page: {totalItems: 1},
+    });
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          elementId: USER_TASK_FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+      ],
+    });
+    mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
+  });
+
+  afterEach(() => {
+    processInstanceDetailsStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    incidentsStore.reset();
   });
 
   it('should render meta data for completed flow node', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
     mockFetchProcessDefinitionXml().withSuccess(mockCallActivityProcessXML);
     mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
     mockFetchProcessInstanceV2().withSuccess(createProcessInstance());
+
+    const mockCallActivityElementInstance: ElementInstance = {
+      ...mockElementInstance,
+      elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+    };
+
+    mockFetchElementInstance('2251799813699889').withSuccess(
+      mockCallActivityElementInstance,
+    );
+
+    mockSearchElementInstances().withSuccess({
+      items: [mockCallActivityElementInstance],
+      page: {totalItems: 1},
+    });
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -57,17 +142,12 @@ describe('MetadataPopover', () => {
         state: 'ACTIVE',
       }),
     );
-    selectFlowNode(
-      {},
-      {
-        flowNodeId: CALL_ACTIVITY_FLOW_NODE_ID,
-      },
-    );
+    selectFlowNode({}, {flowNodeId: CALL_ACTIVITY_FLOW_NODE_ID});
 
     renderPopover();
 
     expect(
-      await screen.findByText(labels.flowNodeInstanceKey),
+      await screen.findByText(labels.elementInstanceKey),
     ).toBeInTheDocument();
     expect(screen.getByText(labels.executionDuration)).toBeInTheDocument();
     expect(
@@ -88,10 +168,14 @@ describe('MetadataPopover', () => {
         calledInstanceMetadata.instanceMetadata!.calledProcessInstanceId
       }`,
     );
+
+    vi.clearAllTimers();
+    vi.useFakeTimers();
   });
 
   it('should render completed decision', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
+
     const {instanceMetadata} = calledDecisionMetadata;
 
     mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
@@ -105,7 +189,13 @@ describe('MetadataPopover', () => {
       }),
     );
 
-    selectFlowNode({}, {flowNodeId: 'BusinessRuleTask'});
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
 
     const {user} = renderPopover();
 
@@ -154,7 +244,13 @@ describe('MetadataPopover', () => {
       }),
     );
 
-    selectFlowNode({}, {flowNodeId: 'BusinessRuleTask'});
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
 
     const {user} = renderPopover();
 
@@ -209,7 +305,13 @@ describe('MetadataPopover', () => {
       }),
     );
 
-    selectFlowNode({}, {flowNodeId: 'BusinessRuleTask'});
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: BUSSINESS_RULE_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
 
     renderPopover();
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -39,9 +39,9 @@ import {
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {init} from 'modules/utils/flowNodeMetadata';
 import {selectFlowNode} from 'modules/utils/flowNodeSelection';
-import {mockFetchElementInstance} from '../../../../../modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
+import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances.ts';
-import {metadataDemoProcess} from '../../../../../modules/mocks/metadataDemoProcess.ts';
+import {metadataDemoProcess} from 'modules/mocks/metadataDemoProcess.ts';
 import {waitFor} from '@testing-library/react';
 
 const MOCK_EXECUTION_DATE = '21 seconds';

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.test.tsx
@@ -9,6 +9,7 @@
 import {screen} from 'modules/testing-library';
 import {flowNodeSelectionStore} from 'modules/stores/flowNodeSelection';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {createInstance} from 'modules/testUtils';
 import {mockIncidents} from 'modules/mocks/incidents';
 import {incidentsStore} from 'modules/stores/incidents';
@@ -29,11 +30,19 @@ import {
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+import {mockFetchFlownodeInstancesStatistics} from 'modules/mocks/api/v2/flownodeInstances/fetchFlownodeInstancesStatistics';
 import {labels, renderPopover} from './mocks';
-import {type ProcessInstance} from '@vzeta/camunda-api-zod-schemas/8.8';
+import {
+  type ProcessInstance,
+  type ElementInstance,
+} from '@vzeta/camunda-api-zod-schemas/8.8';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {init} from 'modules/utils/flowNodeMetadata';
 import {selectFlowNode} from 'modules/utils/flowNodeSelection';
+import {mockFetchElementInstance} from '../../../../../modules/mocks/api/v2/elementInstances/fetchElementInstance.ts';
+import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances.ts';
+import {metadataDemoProcess} from '../../../../../modules/mocks/metadataDemoProcess.ts';
+import {waitFor} from '@testing-library/react';
 
 const MOCK_EXECUTION_DATE = '21 seconds';
 
@@ -57,17 +66,73 @@ const mockProcessInstance: ProcessInstance = {
   hasIncident: true,
 };
 
+const mockElementInstance: ElementInstance = {
+  elementInstanceKey: '2251799813699889',
+  elementId: 'Activity_0zqism7',
+  elementName: 'Service Task',
+  type: 'SERVICE_TASK',
+  state: 'ACTIVE',
+  startDate: '2018-06-21',
+  processDefinitionId: 'process-def-1',
+  processInstanceKey: PROCESS_INSTANCE_ID,
+  processDefinitionKey: '2',
+  hasIncident: false,
+  tenantId: '<default>',
+};
+
 describe('MetadataPopover', () => {
   beforeEach(() => {
     init('process-instance', []);
     flowNodeSelectionStore.init();
-    mockFetchProcessDefinitionXml().withSuccess('');
-    mockFetchProcessDefinitionXml().withSuccess('');
+    mockFetchProcessDefinitionXml().withSuccess(metadataDemoProcess);
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockFetchElementInstance('2251799813699889').withSuccess(
+      mockElementInstance,
+    );
+
+    mockSearchElementInstances().withSuccess({
+      items: [mockElementInstance],
+      page: {totalItems: 1},
+    });
+
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          elementId: CALL_ACTIVITY_FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+        {
+          elementId: USER_TASK_FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+      ],
+    });
+    mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
+  });
+
+  afterEach(() => {
+    processInstanceDetailsStore.reset();
+    flowNodeSelectionStore.reset();
+    flowNodeMetaDataStore.reset();
+    incidentsStore.reset();
   });
 
   it('should not show unrelated data', async () => {
     mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    flowNodeMetaDataStore.setMetaData(singleInstanceMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -79,6 +144,7 @@ describe('MetadataPopover', () => {
       {},
       {
         flowNodeId: FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
       },
     );
 
@@ -114,6 +180,7 @@ describe('MetadataPopover', () => {
   it('should render meta data for incident flow node', async () => {
     mockFetchFlowNodeMetadata().withSuccess(incidentFlowNodeMetaData);
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
+    flowNodeMetaDataStore.setMetaData(incidentFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -123,12 +190,15 @@ describe('MetadataPopover', () => {
     );
     incidentsStore.init();
 
-    selectFlowNode({}, {flowNodeId: FLOW_NODE_ID});
+    selectFlowNode(
+      {},
+      {flowNodeId: FLOW_NODE_ID, flowNodeInstanceId: '2251799813699889'},
+    );
 
     renderPopover();
 
     expect(
-      await screen.findByText(labels.flowNodeInstanceKey),
+      await screen.findByText(labels.elementInstanceKey),
     ).toBeInTheDocument();
     expect(screen.getByText(labels.executionDuration)).toBeInTheDocument();
     expect(screen.getByText(labels.type)).toBeInTheDocument();
@@ -167,6 +237,8 @@ describe('MetadataPopover', () => {
 
   it('should render meta data modal', async () => {
     mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
+    mockFetchFlowNodeMetadata().withSuccess(calledInstanceMetadata);
+    flowNodeMetaDataStore.setMetaData(calledInstanceMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -178,6 +250,7 @@ describe('MetadataPopover', () => {
       {},
       {
         flowNodeId: CALL_ACTIVITY_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
       },
     );
 
@@ -192,9 +265,7 @@ describe('MetadataPopover', () => {
     );
 
     expect(
-      screen.getByText(
-        /Flow Node "Activity_0zqism7" 2251799813699889 Metadata/,
-      ),
+      screen.getByText(/Element "Activity_0zqism7" 2251799813699889 Metadata/),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: /close/i})).toBeInTheDocument();
 
@@ -239,10 +310,23 @@ describe('MetadataPopover', () => {
 
   it('should render metadata for multi instance flow nodes', async () => {
     mockFetchFlowNodeMetadata().withSuccess(multiInstancesMetadata);
+    mockFetchFlowNodeMetadata().withSuccess(multiInstancesMetadata);
+    flowNodeMetaDataStore.setMetaData(multiInstancesMetadata);
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: FLOW_NODE_ID,
+          active: 7,
+          completed: 0,
+          canceled: 0,
+          incidents: 3,
+        },
+      ],
+    });
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
-        id: '123',
+        id: PROCESS_INSTANCE_ID,
         state: 'ACTIVE',
       }),
     );
@@ -255,9 +339,11 @@ describe('MetadataPopover', () => {
 
     renderPopover();
 
-    expect(
-      await screen.findByText(/This Flow Node triggered 10 times/),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/This Element instance triggered 10 times/),
+      ).toBeInTheDocument();
+    });
     expect(
       screen.getByText(
         /To view details for any of these, select one Instance in the Instance History./,
@@ -268,12 +354,14 @@ describe('MetadataPopover', () => {
       screen.getByRole('button', {name: labels.showIncidents}),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(labels.flowNodeInstanceKey),
+      screen.queryByText(labels.elementInstanceKey),
     ).not.toBeInTheDocument();
   });
 
   it('should not render called instances for multi instance call activities', async () => {
     mockFetchFlowNodeMetadata().withSuccess(multiInstanceCallActivityMetadata);
+    mockFetchFlowNodeMetadata().withSuccess(multiInstanceCallActivityMetadata);
+    flowNodeMetaDataStore.setMetaData(multiInstanceCallActivityMetadata);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -291,7 +379,7 @@ describe('MetadataPopover', () => {
     renderPopover();
 
     expect(
-      await screen.findByText(labels.flowNodeInstanceKey),
+      await screen.findByText(labels.elementInstanceKey),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(labels.calledProcessInstance),
@@ -302,6 +390,7 @@ describe('MetadataPopover', () => {
     const {rootCauseInstance} = rootIncidentFlowNodeMetaData.incident;
 
     mockFetchFlowNodeMetadata().withSuccess(rootIncidentFlowNodeMetaData);
+    flowNodeMetaDataStore.setMetaData(rootIncidentFlowNodeMetaData);
 
     mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
 
@@ -313,7 +402,10 @@ describe('MetadataPopover', () => {
     );
     incidentsStore.init();
 
-    selectFlowNode({}, {flowNodeId: FLOW_NODE_ID});
+    selectFlowNode(
+      {},
+      {flowNodeId: FLOW_NODE_ID, flowNodeInstanceId: '2251799813699889'},
+    );
 
     renderPopover();
 
@@ -334,6 +426,8 @@ describe('MetadataPopover', () => {
     vi.stubGlobal('clientConfig', {tasklistUrl});
 
     mockFetchFlowNodeMetadata().withSuccess(userTaskFlowNodeMetaData);
+    mockFetchFlowNodeMetadata().withSuccess(userTaskFlowNodeMetaData);
+    flowNodeMetaDataStore.setMetaData(userTaskFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -342,8 +436,18 @@ describe('MetadataPopover', () => {
       }),
     );
 
-    selectFlowNode({}, {flowNodeId: USER_TASK_FLOW_NODE_ID});
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: USER_TASK_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
 
+    mockFetchElementInstance('2251799813699889').withSuccess({
+      ...mockElementInstance,
+      type: 'USER_TASK',
+    });
     renderPopover();
 
     expect(
@@ -353,6 +457,8 @@ describe('MetadataPopover', () => {
 
   it('should render retries left', async () => {
     mockFetchFlowNodeMetadata().withSuccess(retriesLeftFlowNodeMetaData);
+    mockFetchFlowNodeMetadata().withSuccess(retriesLeftFlowNodeMetaData);
+    flowNodeMetaDataStore.setMetaData(retriesLeftFlowNodeMetaData);
 
     processInstanceDetailsStore.setProcessInstance(
       createInstance({
@@ -361,11 +467,127 @@ describe('MetadataPopover', () => {
       }),
     );
 
-    selectFlowNode({}, {flowNodeId: USER_TASK_FLOW_NODE_ID});
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: USER_TASK_FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
 
     renderPopover();
 
     expect(await screen.findByText(labels.retriesLeft)).toBeInTheDocument();
     expect(screen.getByTestId('retries-left-count')).toHaveTextContent('2');
+  });
+
+  it('should fetch and display specific element instance when selected from history', async () => {
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchElementInstance('2251799813699889').withSuccess(
+      mockElementInstance,
+    );
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: FLOW_NODE_ID,
+        flowNodeInstanceId: '2251799813699889',
+      },
+    );
+
+    renderPopover();
+
+    expect(
+      await screen.findByRole('heading', {name: labels.details}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2251799813699889')).toBeInTheDocument();
+  });
+
+  it('should search for single element instance when count is 1', async () => {
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchFlownodeInstancesStatistics().withSuccess({
+      items: [
+        {
+          elementId: FLOW_NODE_ID,
+          active: 1,
+          completed: 0,
+          canceled: 0,
+          incidents: 0,
+        },
+      ],
+    });
+    mockSearchElementInstances().withSuccess({
+      items: [mockElementInstance],
+      page: {totalItems: 1},
+    });
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+
+    selectFlowNode({}, {flowNodeId: FLOW_NODE_ID});
+
+    renderPopover();
+
+    expect(
+      await screen.findByRole('heading', {name: labels.details}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2251799813699889')).toBeInTheDocument();
+  });
+
+  it('should handle failed element instance search gracefully', async () => {
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockSearchElementInstances().withNetworkError();
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+
+    selectFlowNode({}, {flowNodeId: FLOW_NODE_ID});
+
+    renderPopover();
+
+    expect(
+      screen.queryByRole('heading', {name: labels.details}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should handle failed single element instance fetch gracefully', async () => {
+    mockFetchFlowNodeMetadata().withSuccess(singleInstanceMetadata);
+    mockFetchElementInstance('invalid-key').withNetworkError();
+
+    processInstanceDetailsStore.setProcessInstance(
+      createInstance({
+        id: PROCESS_INSTANCE_ID,
+        state: 'ACTIVE',
+      }),
+    );
+
+    selectFlowNode(
+      {},
+      {
+        flowNodeId: FLOW_NODE_ID,
+        flowNodeInstanceId: 'invalid-key',
+      },
+    );
+
+    renderPopover();
+
+    expect(
+      screen.queryByRole('heading', {name: labels.details}),
+    ).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -33,6 +33,8 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const elementId = flowNodeSelectionStore.state.selection?.flowNodeId;
   const elementInstanceId =
     flowNodeSelectionStore.state.selection?.flowNodeInstanceId;
+  const isMultiInstance =
+    flowNodeSelectionStore.state.selection?.isMultiInstance;
   const {metaData} = flowNodeMetaDataStore.state;
 
   const {data: statistics} = useFlownodeInstancesStatistics();
@@ -43,13 +45,14 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
       (stat) => stat.elementId === elementId,
     );
     if (!elementStats) return 0;
+    if (isMultiInstance) return 1;
     return (
       elementStats.active +
       elementStats.completed +
       elementStats.canceled +
       elementStats.incidents
     );
-  }, [statistics, elementId]);
+  }, [statistics, elementId, isMultiInstance]);
 
   const shouldFetchElementInstances =
     instanceCount === 1 &&
@@ -63,9 +66,14 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
     });
 
   const {data: elementInstancesSearchResult, isLoading: isSearchingInstances} =
-    useElementInstancesSearch(elementId, processInstance?.processInstanceKey, {
-      enabled: shouldFetchElementInstances,
-    });
+    useElementInstancesSearch(
+      elementId,
+      processInstance?.processInstanceKey,
+      isMultiInstance,
+      {
+        enabled: shouldFetchElementInstances,
+      },
+    );
 
   const elementInstanceMetadata = useMemo(() => {
     if (elementInstanceId && elementInstance) {

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -34,7 +34,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const elementInstanceId =
     flowNodeSelectionStore.state.selection?.flowNodeInstanceId;
   const isMultiInstance =
-    flowNodeSelectionStore.state.selection?.isMultiInstance;
+    flowNodeSelectionStore.state.selection?.isMultiInstance ?? false;
   const {metaData} = flowNodeMetaDataStore.state;
 
   const {data: statistics} = useFlownodeInstancesStatistics();
@@ -67,8 +67,8 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
 
   const {data: elementInstancesSearchResult, isLoading: isSearchingInstances} =
     useElementInstancesSearch(
-      elementId,
-      processInstance?.processInstanceKey,
+      elementId ?? '',
+      processInstance?.processInstanceKey ?? '',
       isMultiInstance,
       {
         enabled: shouldFetchElementInstances,

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/index.tsx
@@ -14,10 +14,15 @@ import {observer} from 'mobx-react';
 import {flip, offset} from '@floating-ui/react-dom';
 import {Header} from '../Header';
 import {Stack} from '@carbon/react';
-import {Details} from '../Details';
 import {Incident} from '../Incident';
 import {MultiIncidents} from '../MultiIncidents';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useElementInstancesSearch} from 'modules/queries/elementInstances/useElementInstancesSearch';
+import {useElementInstance} from 'modules/queries/elementInstances/useElementInstance';
+import {useFlownodeInstancesStatistics} from 'modules/queries/flownodeInstancesStatistics/useFlownodeInstancesStatistics';
+import {useMemo} from 'react';
+import {Details} from './Details';
+import {createV2InstanceMetadata} from './types';
 
 type Props = {
   selectedFlowNodeRef?: SVGGraphicsElement | null;
@@ -25,10 +30,70 @@ type Props = {
 
 const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
   const {data: processInstance} = useProcessInstance();
-  const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
+  const elementId = flowNodeSelectionStore.state.selection?.flowNodeId;
+  const elementInstanceId =
+    flowNodeSelectionStore.state.selection?.flowNodeInstanceId;
   const {metaData} = flowNodeMetaDataStore.state;
 
-  if (flowNodeId === undefined || metaData === null) {
+  const {data: statistics} = useFlownodeInstancesStatistics();
+
+  const instanceCount = useMemo(() => {
+    if (!statistics?.items || !elementId) return null;
+    const elementStats = statistics.items.find(
+      (stat) => stat.elementId === elementId,
+    );
+    if (!elementStats) return 0;
+    return (
+      elementStats.active +
+      elementStats.completed +
+      elementStats.canceled +
+      elementStats.incidents
+    );
+  }, [statistics, elementId]);
+
+  const shouldFetchElementInstances =
+    instanceCount === 1 &&
+    !elementInstanceId &&
+    !!processInstance?.processInstanceKey &&
+    !!elementId;
+
+  const {data: elementInstance, isLoading: isFetchingInstance} =
+    useElementInstance(elementInstanceId ?? '', {
+      enabled: !!elementInstanceId && !!elementId,
+    });
+
+  const {data: elementInstancesSearchResult, isLoading: isSearchingInstances} =
+    useElementInstancesSearch(elementId, processInstance?.processInstanceKey, {
+      enabled: shouldFetchElementInstances,
+    });
+
+  const elementInstanceMetadata = useMemo(() => {
+    if (elementInstanceId && elementInstance) {
+      return elementInstance;
+    }
+
+    if (
+      !elementInstanceId &&
+      instanceCount === 1 &&
+      elementInstancesSearchResult?.items?.length === 1
+    ) {
+      return elementInstancesSearchResult.items[0];
+    }
+
+    return null;
+  }, [
+    elementInstanceId,
+    elementInstance,
+    instanceCount,
+    elementInstancesSearchResult,
+  ]);
+
+  if (
+    elementId === undefined ||
+    metaData === null ||
+    (shouldFetchElementInstances && isSearchingInstances) ||
+    (!!elementInstanceId && isFetchingInstance)
+  ) {
     return null;
   }
 
@@ -46,10 +111,10 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
       variant="arrow"
     >
       <Stack gap={3}>
-        {metaData.instanceCount !== null && metaData.instanceCount > 1 && (
+        {instanceCount !== null && instanceCount > 1 && !elementInstanceId && (
           <>
             <Header
-              title={`This Flow Node triggered ${metaData.instanceCount} times`}
+              title={`This Element instance triggered ${instanceCount} times`}
             />
             <Content>
               To view details for any of these, select one Instance in the
@@ -58,9 +123,18 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
           </>
         )}
 
-        {instanceMetadata !== null && (
+        {elementInstanceMetadata && (
           <>
-            <Details metaData={metaData} flowNodeId={flowNodeId} />
+            <Details
+              metaData={{
+                ...metaData,
+                instanceMetadata: createV2InstanceMetadata(
+                  instanceMetadata,
+                  elementInstanceMetadata,
+                ),
+              }}
+              elementId={elementInstanceMetadata.elementId}
+            />
             {incident !== null && (
               <>
                 <Divider />
@@ -69,7 +143,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
                   incident={incident}
                   onButtonClick={() => {
                     incidentsStore.clearSelection();
-                    incidentsStore.toggleFlowNodeSelection(flowNodeId);
+                    incidentsStore.toggleFlowNodeSelection(elementId);
                     incidentsStore.toggleErrorTypeSelection(
                       incident.errorType.id,
                     );
@@ -87,7 +161,7 @@ const MetadataPopover = observer(({selectedFlowNodeRef}: Props) => {
               count={incidentCount}
               onButtonClick={() => {
                 incidentsStore.clearSelection();
-                incidentsStore.toggleFlowNodeSelection(flowNodeId);
+                incidentsStore.toggleFlowNodeSelection(elementId);
                 incidentsStore.setIncidentBarOpen(true);
               }}
             />

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/mocks.tsx
@@ -15,7 +15,7 @@ import {LocationLog} from 'modules/utils/LocationLog';
 import {useEffect} from 'react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MetadataPopover} from '.';
-import {ProcessInstance} from 'modules/testUtils/pages/ProcessInstance';
+import {ProcessInstance} from 'modules/testUtils/pages/ProcessInstance/v2';
 import {render} from 'modules/testing-library';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -34,7 +34,9 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
   return (
     <ProcessDefinitionKeyContext.Provider value="123">
       <QueryClientProvider client={getMockQueryClient()}>
-        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+        <MemoryRouter
+          initialEntries={[Paths.processInstance('2251799813685591')]}
+        >
           <Routes>
             <Route path={Paths.processInstance()} element={children} />
             <Route path={Paths.decisionInstance()} element={<></>} />

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
+import {type ElementInstance} from '@vzeta/camunda-api-zod-schemas';
+
+// V2 Element Instance Metadata - extends the old structure but with v2 element instance fields will be removed after other components migration
+type V2InstanceMetadata = {
+  elementInstanceKey: string;
+  elementId: string;
+  elementName?: string;
+  type: ElementInstance['type'];
+  state?: ElementInstance['state'];
+  startDate: string;
+  endDate: string | null;
+  processDefinitionId?: string;
+  processInstanceKey?: string;
+  processDefinitionKey?: string;
+  hasIncident?: boolean;
+  incidentKey?: string;
+  tenantId?: string;
+  calledProcessInstanceId: string | null;
+  calledProcessDefinitionName: string | null;
+  calledDecisionInstanceId: string | null;
+  calledDecisionDefinitionName: string | null;
+  jobRetries: number | null;
+  flowNodeInstanceId?: string;
+  flowNodeId?: string;
+  flowNodeType?: string;
+  eventId?: string;
+  jobType?: string | null;
+  jobWorker?: string | null;
+  jobDeadline?: string | null;
+  jobCustomHeaders?: string | null;
+  jobId?: string | null;
+};
+
+type V2MetaDataDto = Omit<MetaDataDto, 'instanceMetadata'> & {
+  instanceMetadata: V2InstanceMetadata | null;
+};
+
+// Utility function to create V2 instance metadata from old metadata + migrated element instance
+function createV2InstanceMetadata(
+  oldMetadata: MetaDataDto['instanceMetadata'],
+  elementInstance: ElementInstance,
+): V2InstanceMetadata {
+  return {
+    calledProcessInstanceId: oldMetadata?.calledProcessInstanceId ?? null,
+    calledProcessDefinitionName:
+      oldMetadata?.calledProcessDefinitionName ?? null,
+    calledDecisionInstanceId: oldMetadata?.calledDecisionInstanceId ?? null,
+    calledDecisionDefinitionName:
+      oldMetadata?.calledDecisionDefinitionName ?? null,
+    jobRetries: oldMetadata?.jobRetries ?? null,
+    elementInstanceKey: elementInstance.elementInstanceKey,
+    elementId: elementInstance.elementId,
+    elementName: elementInstance.elementName,
+    type: elementInstance.type,
+    state: elementInstance.state,
+    startDate: elementInstance.startDate || '',
+    endDate: elementInstance.endDate || null,
+    processDefinitionId: elementInstance.processDefinitionId,
+    processInstanceKey: elementInstance.processInstanceKey,
+    processDefinitionKey: elementInstance.processDefinitionKey,
+    hasIncident: elementInstance.hasIncident,
+    incidentKey: elementInstance.incidentKey,
+    tenantId: elementInstance.tenantId,
+    flowNodeInstanceId: elementInstance.elementInstanceKey,
+    flowNodeId: elementInstance.elementId,
+    flowNodeType: elementInstance.type,
+  };
+}
+
+export type {V2InstanceMetadata, V2MetaDataDto};
+export {createV2InstanceMetadata};

--- a/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/MetadataPopover/v2/types.ts
@@ -7,7 +7,7 @@
  */
 
 import {type MetaDataDto} from 'modules/api/processInstances/fetchFlowNodeMetaData';
-import {type ElementInstance} from '@vzeta/camunda-api-zod-schemas';
+import {type ElementInstance} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 // V2 Element Instance Metadata - extends the old structure but with v2 element instance fields will be removed after other components migration
 type V2InstanceMetadata = {

--- a/operate/client/src/modules/mocks/metadata.ts
+++ b/operate/client/src/modules/mocks/metadata.ts
@@ -13,6 +13,7 @@ const CALL_ACTIVITY_FLOW_NODE_ID = 'Activity_0zqism7'; // this need to match the
 const USER_TASK_FLOW_NODE_ID = 'UserTask';
 const FLOW_NODE_INSTANCE_ID = '2251799813699889';
 const PROCESS_INSTANCE_ID = '2251799813685591';
+const BUSSINESS_RULE_FLOW_NODE_ID = 'BusinessRuleTask';
 
 const baseInstanceMetadata: MetaDataDto['instanceMetadata'] = {
   flowNodeId: FLOW_NODE_ID,
@@ -230,4 +231,5 @@ export {
   CALL_ACTIVITY_FLOW_NODE_ID,
   FLOW_NODE_ID,
   USER_TASK_FLOW_NODE_ID,
+  BUSSINESS_RULE_FLOW_NODE_ID,
 };

--- a/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstance.ts
@@ -12,28 +12,27 @@ import type {ElementInstance} from '@vzeta/camunda-api-zod-schemas/8.8';
 
 const ELEMENT_INSTANCE_QUERY_KEY = 'elementInstance';
 
-function getQueryKey(elementInstanceKey?: string) {
-  return [ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey];
-}
-
 const useElementInstance = <T = ElementInstance>(
   elementInstanceKey: string,
-  select?: (data: ElementInstance) => T,
+  options?: {
+    select?: (data: ElementInstance) => T;
+    enabled?: boolean;
+  },
 ) => {
   return useQuery({
-    queryKey: getQueryKey(elementInstanceKey),
+    queryKey: [ELEMENT_INSTANCE_QUERY_KEY, elementInstanceKey],
     queryFn: elementInstanceKey
       ? async () => {
           const {response, error} = await fetchElementInstance({
             elementInstanceKey,
           });
-
           if (response !== null) return response;
           throw error;
         }
       : skipToken,
-    select,
+    select: options?.select,
+    enabled: options?.enabled,
   });
 };
 
-export {ELEMENT_INSTANCE_QUERY_KEY, useElementInstance};
+export {useElementInstance};

--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -13,23 +13,27 @@ import type {QueryElementInstancesRequestBody} from '@vzeta/camunda-api-zod-sche
 const ELEMENT_INSTANCES_SEARCH_QUERY_KEY = 'elementInstancesSearch';
 
 const useElementInstancesSearch = (
-  elementId: string | undefined,
-  processInstanceKey: string | undefined,
-  isMultiInstance: boolean | undefined,
+  elementId: string,
+  processInstanceKey: string,
+  isMultiInstance: boolean,
   options: {enabled: boolean} = {enabled: true},
 ) => {
-  const payload: QueryElementInstancesRequestBody = {
-    filter: {
-      elementId,
-      processInstanceKey: processInstanceKey ?? '',
-      type: isMultiInstance ? 'MULTI_INSTANCE_BODY' : undefined,
-    },
-    page: {limit: 1},
-  };
-
   return useQuery({
-    queryKey: [ELEMENT_INSTANCES_SEARCH_QUERY_KEY, payload],
+    queryKey: [
+      ELEMENT_INSTANCES_SEARCH_QUERY_KEY,
+      elementId,
+      processInstanceKey,
+      isMultiInstance,
+    ],
     queryFn: async () => {
+      const payload: QueryElementInstancesRequestBody = {
+        filter: {
+          elementId,
+          processInstanceKey,
+          type: isMultiInstance ? 'MULTI_INSTANCE_BODY' : undefined,
+        },
+        page: {limit: 1},
+      };
       const {response, error} = await searchElementInstances(payload);
       if (response !== null) {
         return response;

--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -12,22 +12,28 @@ import type {QueryElementInstancesRequestBody} from '@vzeta/camunda-api-zod-sche
 
 const ELEMENT_INSTANCES_SEARCH_QUERY_KEY = 'elementInstancesSearch';
 
-function getQueryKey(params: QueryElementInstancesRequestBody) {
-  return [ELEMENT_INSTANCES_SEARCH_QUERY_KEY, params];
-}
-
 const useElementInstancesSearch = (
-  params: QueryElementInstancesRequestBody,
+  elementId: string | undefined,
+  processInstanceKey: string | undefined,
+  options: {enabled: boolean} = {enabled: true},
 ) => {
+  const payload: QueryElementInstancesRequestBody = {
+    filter: {
+      elementId,
+      processInstanceKey: processInstanceKey ?? '',
+    },
+    page: {limit: 1},
+  };
+
   return useQuery({
-    queryKey: getQueryKey(params),
+    queryKey: [ELEMENT_INSTANCES_SEARCH_QUERY_KEY, payload],
     queryFn: () =>
-      searchElementInstances(params).then(({response, error}) => {
+      searchElementInstances(payload).then(({response, error}) => {
         if (response !== null) return response;
         throw error;
       }),
-    enabled: !!params,
+    ...options,
   });
 };
 
-export {useElementInstancesSearch, ELEMENT_INSTANCES_SEARCH_QUERY_KEY};
+export {useElementInstancesSearch};

--- a/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
+++ b/operate/client/src/modules/queries/elementInstances/useElementInstancesSearch.ts
@@ -15,23 +15,27 @@ const ELEMENT_INSTANCES_SEARCH_QUERY_KEY = 'elementInstancesSearch';
 const useElementInstancesSearch = (
   elementId: string | undefined,
   processInstanceKey: string | undefined,
+  isMultiInstance: boolean | undefined,
   options: {enabled: boolean} = {enabled: true},
 ) => {
   const payload: QueryElementInstancesRequestBody = {
     filter: {
       elementId,
       processInstanceKey: processInstanceKey ?? '',
+      type: isMultiInstance ? 'MULTI_INSTANCE_BODY' : undefined,
     },
     page: {limit: 1},
   };
 
   return useQuery({
     queryKey: [ELEMENT_INSTANCES_SEARCH_QUERY_KEY, payload],
-    queryFn: () =>
-      searchElementInstances(payload).then(({response, error}) => {
-        if (response !== null) return response;
-        throw error;
-      }),
+    queryFn: async () => {
+      const {response, error} = await searchElementInstances(payload);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
     ...options,
   });
 };

--- a/operate/client/src/modules/testUtils/pages/ProcessInstance/v2/MetadataPopover.ts
+++ b/operate/client/src/modules/testUtils/pages/ProcessInstance/v2/MetadataPopover.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export class MetaDataPopover {
+  readonly labels = {
+    // headings
+    details: /^details$/i,
+    incidents: /^incidents$/i,
+    incident: /^incident$/i,
+    // view buttons
+    showMoreMetadata: /^show more metadata$/i,
+    showIncidents: /^show incidents$/i,
+    showIncident: /^show incident$/i,
+    // details
+    elementInstanceKey: /^element instance key$/i,
+    executionDuration: /^execution duration$/i,
+    calledProcessInstance: /^called process instance$/i,
+    calledDecisionInstance: /^called decision instance$/i,
+    retriesLeft: /^retries left$/i,
+    // incidents
+    type: /^type$/i,
+    errorMessage: /^error message$/i,
+    rootCauseProcessInstance: /^root cause process instance$/i,
+    rootCauseDecisionInstance: /^root cause decision instance$/i,
+  } as const;
+}

--- a/operate/client/src/modules/testUtils/pages/ProcessInstance/v2/index.ts
+++ b/operate/client/src/modules/testUtils/pages/ProcessInstance/v2/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {MetaDataPopover} from './MetadataPopover';
+
+export class ProcessInstance {
+  readonly metadataPopover: MetaDataPopover;
+
+  constructor() {
+    this.metadataPopover = new MetaDataPopover();
+  }
+}


### PR DESCRIPTION
## Description

This PR migrates the element instance data of `MetadataPopover` component. 

- Migrates MetadataPopover to use v2 element instance data endpoints with backward compatibility
- Implements proper query logic for single vs. multi-instance scenarios
- Start the process of updating "flow node" with "element"

## Checklist

## Related issues

closes #33209 
