### PR TITLE
fix: skip dynamic property mappings in Index validation

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
@@ -73,7 +73,18 @@ public record IndexMappingDifference(
         right == null ? false : right.isDynamic());
   }
 
-  private record PropertyDifference(
+  public IndexMappingDifference unsetEntriesDiffering() {
+    return new IndexMappingDifference(
+        equal,
+        entriesOnlyOnLeft,
+        entriesOnlyOnRight,
+        entriesInCommon,
+        Set.of(),
+        isLeftDynamic,
+        isRightDynamic);
+  }
+
+  record PropertyDifference(
       String name, IndexMappingProperty leftValue, IndexMappingProperty rightValue) {}
 
   /**

--- a/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/IndexMappingDifference.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -73,13 +74,25 @@ public record IndexMappingDifference(
         right == null ? false : right.isDynamic());
   }
 
-  public IndexMappingDifference unsetEntriesDiffering() {
+  public IndexMappingDifference filterEntriesDiffering(final Predicate<PropertyDifference> filter) {
     return new IndexMappingDifference(
         equal,
         entriesOnlyOnLeft,
         entriesOnlyOnRight,
         entriesInCommon,
-        Set.of(),
+        entriesDiffering.stream().filter(filter).collect(Collectors.toSet()),
+        isLeftDynamic,
+        isRightDynamic);
+  }
+
+  public IndexMappingDifference filterEntriesInCommon(
+      final Predicate<IndexMappingProperty> filter) {
+    return new IndexMappingDifference(
+        equal,
+        entriesOnlyOnLeft,
+        entriesOnlyOnRight,
+        entriesInCommon.stream().filter(filter).collect(Collectors.toSet()),
+        entriesDiffering,
         isLeftDynamic,
         isRightDynamic);
   }

--- a/schema-manager/src/test/resources/mappings-dynamic-property-added.json
+++ b/schema-manager/src/test/resources/mappings-dynamic-property-added.json
@@ -1,0 +1,17 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "object",
+        "dynamic": "true"
+      },
+      "foo": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/schema-manager/src/test/resources/mappings-dynamic-property-added.json
+++ b/schema-manager/src/test/resources/mappings-dynamic-property-added.json
@@ -7,7 +7,7 @@
       },
       "world": {
         "type": "object",
-        "dynamic": "true"
+        "dynamic": true
       },
       "foo": {
         "type": "keyword"

--- a/schema-manager/src/test/resources/mappings-dynamic-property-properties-deleted.json
+++ b/schema-manager/src/test/resources/mappings-dynamic-property-properties-deleted.json
@@ -2,12 +2,14 @@
   "mappings": {
     "dynamic": "strict",
     "properties": {
-      "hello": {
-        "type": "text"
-      },
       "world": {
         "type": "object",
-        "dynamic": true
+        "dynamic": true,
+        "properties": {
+          "header1": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/schema-manager/src/test/resources/mappings-dynamic-property-properties.json
+++ b/schema-manager/src/test/resources/mappings-dynamic-property-properties.json
@@ -7,7 +7,12 @@
       },
       "world": {
         "type": "object",
-        "dynamic": true
+        "dynamic": true,
+        "properties": {
+          "header1": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/schema-manager/src/test/resources/mappings-dynamic-property.json
+++ b/schema-manager/src/test/resources/mappings-dynamic-property.json
@@ -1,0 +1,14 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "object",
+        "dynamic": "true"
+      }
+    }
+  }
+}

--- a/schema-manager/src/test/resources/os/mappings-dynamic-property-added.json
+++ b/schema-manager/src/test/resources/os/mappings-dynamic-property-added.json
@@ -7,7 +7,10 @@
       },
       "world": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
+      },
+      "foo": {
+        "type": "keyword"
       }
     }
   }

--- a/schema-manager/src/test/resources/os/mappings-dynamic-property.json
+++ b/schema-manager/src/test/resources/os/mappings-dynamic-property.json
@@ -7,7 +7,7 @@
       },
       "world": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This pull request handles dynamic property differences in index mappings, ensuring they are ignored during schema validation if all differences pertain to dynamic properties. It also includes a new test to verify this behavior. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #34478 
