### PR TITLE
Restore `RoutingState` in `dynamic-config` from runtime state

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/common/LoggingBackupStore.java
@@ -64,7 +64,7 @@ public class LoggingBackupStore implements BackupStore {
   @Override
   public CompletableFuture<BackupStatusCode> markFailed(
       final BackupIdentifier id, final String failureReason) {
-    logger.atLevel(level).log("Marking {} as failed", id, failureReason);
+    logger.atLevel(level).log("Marking {} as failed: {}", id, failureReason);
     return store.markFailed(id, failureReason);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -230,7 +230,6 @@ public final class ZeebePartitionFactory {
       runtimeDirectory = raftPartition.dataDirectory().toPath().resolve("runtime");
     }
     return new StateControllerImpl(
-        partitionId,
         zeebeRocksDbFactory,
         snapshotStore,
         runtimeDirectory,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/StateController.java
@@ -10,9 +10,8 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
-import io.camunda.zeebe.snapshots.transfer.SnapshotTransferService;
 
-public interface StateController extends AutoCloseable, SnapshotTransferService.TakeSnapshot {
+public interface StateController extends AutoCloseable {
   /**
    * Takes a snapshot based on the given position. The position is a last processed lower bound
    * event position. When the returned future completes successfully the transient snapshot will be

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -294,6 +294,8 @@ public class StateControllerImpl implements StateController {
                   "Expected to take snapshot for partition %d, but was called for partition %d",
                   partitionId, partition)));
     }
+    LOG.debug(
+        "Taking snapshot for partition {} at position {}", partitionId, lastProcessedPosition);
     return takeTransientSnapshot(lastProcessedPosition)
         .andThen(PersistableSnapshot::persist, control);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotApiHandlerTransitionStep.java
@@ -35,7 +35,7 @@ public class SnapshotApiHandlerTransitionStep implements PartitionTransitionStep
       final var service =
           new SnapshotTransferServiceImpl(
               context.getPersistedSnapshotStore(),
-              context.getStateController(),
+              context.getSnapshotDirector(),
               context.getPartitionId(),
               (from, to) ->
                   context.snapshotCopy().copySnapshot(from, to, Set.of(ColumnFamilyScope.GLOBAL)),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -115,6 +115,7 @@ public final class BackupApiRequestHandler
             .requestId(requestId)
             .requestStreamId(requestStreamId);
     final var checkpointRecord = new CheckpointRecord().setCheckpointId(requestReader.backupId());
+    LOG.debug("Taking backup with id {} for partition {}", requestReader.backupId(), partitionId);
     final var written =
         logStreamWriter.tryWrite(
             WriteContext.internal(), LogAppendEntry.of(metadata, checkpointRecord));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -71,7 +71,6 @@ public final class AsyncSnapshottingTest {
 
     snapshotController =
         new StateControllerImpl(
-            1,
             DefaultZeebeDbFactory.defaultFactory(),
             persistedSnapshotStore,
             rootDirectory.resolve("runtime"),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -28,10 +28,8 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTran
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -471,12 +469,6 @@ public class RandomizedPartitionTransitionTest {
     @Override
     public void close() throws Exception {
       throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
-    public ActorFuture<PersistedSnapshot> takeSnapshot(
-        final int partition, final long lastProcessedPosition, final ConcurrencyControl control) {
-      return CompletableActorFuture.completed(null);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -74,7 +74,6 @@ public final class StateControllerImplTest {
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");
     snapshotController =
         new StateControllerImpl(
-            1,
             DefaultZeebeDbFactory.defaultFactory(),
             store,
             runtimeDirectory,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -83,7 +83,6 @@ public class LargeStateControllerPerformanceTest {
     // given
     final var controller =
         new StateControllerImpl(
-            1,
             context.dbFactory(),
             context.snapshotStore(),
             context.temporaryFolder().resolve("runtime"),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
@@ -23,9 +23,11 @@ import java.util.zip.CRC32C;
  * a fixed-size header containing a version and a checksum, followed by the serialized
  * configuration.
  */
-final class PersistedClusterConfiguration {
+public final class PersistedClusterConfiguration {
   // Header is a single byte for the version, followed by a long for the checksum.
   public static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
+  // The filename format for the persisted routing info, where %d is replaced by the partition ID.
+  public static final String PERSISTED_ROUTING_INFO_FILENAME_FORMAT = "routing-state-%d.pb";
   // Constant version, to be incremented if the format changes.
   private static final byte VERSION = 1;
   private final Path topologyFile;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -7,15 +7,21 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,17 +46,30 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
 
   @Override
   public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
-    if (configuration.routingState().isPresent()) {
-      return CompletableActorFuture.completed(configuration);
-    }
-    // read it from the file
     RoutingState routingState = null;
+    AwaitRedistributionCompletion operation = null;
     if (routingStatePath.isPresent() && Files.exists(routingStatePath.get())) {
       final byte[] routingStateContent;
       try {
         routingStateContent = Files.readAllBytes(routingStatePath.get());
         routingState =
             serializer.deserializeRoutingState(routingStateContent, 0, routingStateContent.length);
+        operation =
+            switch (routingState.requestHandling()) {
+              case final RequestHandling.ActivePartitions activePartitions ->
+                  new AwaitRedistributionCompletion(
+                      MemberId.from("0"),
+                      activePartitions.basePartitionCount()
+                          + activePartitions.additionalActivePartitions().size()
+                          + activePartitions.inactivePartitions().size(),
+                      new TreeSet<>(activePartitions.inactivePartitions()));
+              case final RequestHandling.AllPartitions allPartitions ->
+                  // no need to add an operation
+                  null;
+              default ->
+                  throw new IllegalStateException(
+                      "Unexpected request handling type: " + routingState.requestHandling());
+            };
         LOG.debug(
             "Initialized routing state from file '{}': {}", routingStatePath.get(), routingState);
       } catch (final IOException e) {
@@ -63,12 +82,16 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
       LOG.debug("Initializing routing state with static partition count: {}", staticPartitionCount);
       routingState = RoutingState.initializeWithPartitionCount(staticPartitionCount);
     }
+    var pendingChanges = configuration.pendingChanges();
+    if (pendingChanges.isEmpty() && operation != null) {
+      pendingChanges = Optional.of(ClusterChangePlan.init(1L, List.of(operation)));
+    }
     final var withRoutingState =
         new ClusterConfiguration(
             configuration.version(),
             configuration.members(),
             configuration.lastChange(),
-            configuration.pendingChanges(),
+            pendingChanges,
             Optional.of(routingState));
     return CompletableActorFuture.completed(withRoutingState);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationSerializer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 
 public interface ClusterConfigurationSerializer {
 
@@ -20,4 +21,9 @@ public interface ClusterConfigurationSerializer {
 
   ClusterConfiguration decodeClusterTopology(
       byte[] encodedClusterTopology, final int offset, final int length);
+
+  byte[] serializeRoutingState(RoutingState routingState);
+
+  RoutingState deserializeRoutingState(
+      byte[] encodedRoutingState, final int offset, final int length);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -131,6 +131,31 @@ public class ProtoBufSerializer
     }
   }
 
+  @Override
+  public byte[] serializeRoutingState(final RoutingState routingState) {
+    return encodeRoutingState(routingState).toByteArray();
+  }
+
+  @Override
+  public RoutingState deserializeRoutingState(
+      final byte[] encodedRoutingState, final int offset, final int length) {
+    final var buffer = ByteBuffer.wrap(encodedRoutingState, offset, length);
+    try {
+      final var state = Topology.RoutingState.parseFrom(buffer);
+      return decodeRoutingState(state);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  public Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
+    return Topology.RoutingState.newBuilder()
+        .setVersion(routingState.version())
+        .setRequestHandling(encodeRequestHandling(routingState.requestHandling()))
+        .setMessageCorrelation(encodeMessageCorrelation(routingState.messageCorrelation()))
+        .build();
+  }
+
   private ClusterConfiguration decodeClusterTopology(
       final Topology.ClusterTopology encodedClusterTopology) {
 
@@ -536,14 +561,6 @@ public class ProtoBufSerializer
       case CORRELATION_NOT_SET ->
           throw new IllegalArgumentException("Unknown message correlation type");
     };
-  }
-
-  private Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
-    return Topology.RoutingState.newBuilder()
-        .setVersion(routingState.version())
-        .setRequestHandling(encodeRequestHandling(routingState.requestHandling()))
-        .setMessageCorrelation(encodeMessageCorrelation(routingState.messageCorrelation()))
-        .build();
   }
 
   private Topology.RequestHandling encodeRequestHandling(final RequestHandling requestHandling) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -166,7 +166,8 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(true, 2).modify(currentTopology).join();
+    currentTopology =
+        new RoutingStateInitializer(2, Optional.empty()).modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;
@@ -197,7 +198,8 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(true, 2).modify(currentTopology).join();
+    currentTopology =
+        new RoutingStateInitializer(2, Optional.empty()).modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;

--- a/zeebe/dynamic-config/src/test/resources/log4j2-test.xml
+++ b/zeebe/dynamic-config/src/test/resources/log4j2-test.xml
@@ -17,6 +17,7 @@
 
   <Loggers>
     <Logger name="io.camunda.zeebe.topology" level="trace"/>
+    <Logger name="io.camunda.zeebe.dynamic" level="debug"/>
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -32,7 +32,8 @@ public interface RoutingState {
     record HashMod(int partitionCount) implements MessageCorrelation {
       public HashMod {
         if (partitionCount <= 0) {
-          throw new IllegalArgumentException("Partition count must be positive");
+          throw new IllegalArgumentException(
+              "Partition count must be positive, was " + partitionCount);
         }
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -47,7 +47,11 @@ public final class DbRoutingState implements MutableRoutingState {
   @Override
   public Set<Integer> currentPartitions() {
     key.wrapString(CURRENT_KEY);
-    return columnFamily.get(key).getPartitions();
+    final var currentRoutingInfo = columnFamily.get(key);
+    if (currentRoutingInfo == null) {
+      return Set.of();
+    }
+    return currentRoutingInfo.getPartitions();
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -82,12 +82,12 @@ public class ScaleUpPartitionsTest {
                   b.withBrokerConfig(this::configureBackupStore)
                       .withBrokerConfig(
                           bb -> {
-                        bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
-                        bb.getCluster()
-                            .getMembership()
-                            .setSyncInterval(Duration.ofSeconds(1))
-                            .setGossipInterval(Duration.ofSeconds(1));
-                      }))
+                            bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
+                            bb.getCluster()
+                                .getMembership()
+                                .setSyncInterval(Duration.ofSeconds(1))
+                                .setGossipInterval(Duration.ofSeconds(1));
+                          }))
           .build();
 
   @BeforeEach

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -11,29 +11,46 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.DEFAULT_PROCESS_ID;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.deployProcessModel;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.fail;
 
+import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
 import io.camunda.client.CamundaClient;
+import io.camunda.management.backups.StateCode;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Objects;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @ZeebeIntegration
 public class ScaleUpPartitionsTest {
   private static final Logger LOG = LoggerFactory.getLogger(ScaleUpPartitionsTest.class);
@@ -41,9 +58,16 @@ public class ScaleUpPartitionsTest {
   private static final int PARTITIONS_COUNT = 3;
   private static final String JOB_TYPE = "job";
   private static final String PROCESS_ID = DEFAULT_PROCESS_ID;
-  @AutoClose CamundaClient camundaClient;
+  // must be static so that it's initialized before the cluster
+  @TempDir private static Path backupPath;
 
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
+  @AutoClose CamundaClient camundaClient;
   private ClusterActuator clusterActuator;
+  private BackupActuator backupActuator;
+
+  private final String containerName =
+      RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase();
 
   @TestZeebe
   private final TestCluster cluster =
@@ -55,8 +79,9 @@ public class ScaleUpPartitionsTest {
           .withReplicationFactor(3)
           .withBrokerConfig(
               b ->
-                  b.withBrokerConfig(
-                      bb -> {
+                  b.withBrokerConfig(this::configureBackupStore)
+                      .withBrokerConfig(
+                          bb -> {
                         bb.getExperimental().getFeatures().setEnablePartitionScaling(true);
                         bb.getCluster()
                             .getMembership()
@@ -69,6 +94,17 @@ public class ScaleUpPartitionsTest {
   void createClient() {
     camundaClient = cluster.availableGateway().newClientBuilder().build();
     clusterActuator = ClusterActuator.of(cluster.availableGateway());
+    backupActuator = BackupActuator.of(cluster.availableGateway());
+  }
+
+  private void configureBackupStore(final BrokerBasedProperties bb) {
+    final var backup = bb.getData().getBackup();
+    backup.setStore(BackupStoreType.AZURE);
+    final var azure = backup.getAzure();
+
+    backup.setStore(BackupStoreType.AZURE);
+    azure.setBasePath(containerName);
+    azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
   }
 
   @Test
@@ -186,6 +222,54 @@ public class ScaleUpPartitionsTest {
             () -> {
               assertThat(bootstrapSnapshotDirectory).doesNotExist();
             });
+  }
+
+  @Test
+  public void shouldBePossibleToRestoreAsAfterScalingUp() throws IOException {
+    // given
+    final var desiredPartitionCount = PARTITIONS_COUNT + 1;
+    cluster.awaitHealthyTopology();
+    final var backupId = 1L;
+
+    // when
+    scaleToPartitions(desiredPartitionCount);
+    awaitScaleUpCompletion(desiredPartitionCount);
+
+    final var routingStateAfterScaling = clusterActuator.getTopology().getRouting();
+
+    backupActuator.take(backupId);
+
+    Awaitility.await("until backup is ready")
+        .timeout(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () -> {
+              try {
+                final var backupInfo = backupActuator.status(backupId);
+                assertThat(backupInfo.getState()).isEqualTo(StateCode.COMPLETED);
+              } catch (final Exception e) {
+                LOG.error("Failed to get backup status for backupId: {}", backupId, e);
+                fail(e);
+              }
+            });
+    cluster.brokers().values().forEach(TestSpringApplication::stop);
+
+    for (final var broker : cluster.brokers().values()) {
+      LOG.debug("Restoring broker: {}", broker.nodeId());
+      final var dataFolder = Path.of(broker.brokerConfig().getData().getDirectory());
+      FileUtil.deleteFolderIfExists(dataFolder);
+
+      Files.createDirectories(dataFolder);
+      try (final var restoreApp =
+          new TestRestoreApp(broker.brokerConfig()).withBackupId(backupId)) {
+        assertThatNoException().isThrownBy(restoreApp::start);
+      }
+    }
+
+    // then
+    // the topology is restored to the desired partition count and message correlation
+    final var topology = clusterActuator.getTopology();
+    assertThat(topology.getRouting()).isEqualTo(routingStateAfterScaling);
   }
 
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -268,8 +268,16 @@ public class ScaleUpPartitionsTest {
 
     // then
     // the topology is restored to the desired partition count and message correlation
-    final var topology = clusterActuator.getTopology();
-    assertThat(topology.getRouting()).isEqualTo(routingStateAfterScaling);
+    cluster.brokers().values().parallelStream().forEach(TestSpringApplication::start);
+    Awaitility.await("until topology is restored correctly")
+        .untilAsserted(
+            () -> {
+              final var topology = clusterActuator.getTopology();
+              assertThat(topology.getRouting().getRequestHandling())
+                  .isEqualTo(routingStateAfterScaling.getRequestHandling());
+              assertThat(topology.getRouting().getMessageCorrelation())
+                  .isEqualTo(routingStateAfterScaling.getMessageCorrelation());
+            });
   }
 
   private void awaitScaleUpCompletion(final int desiredPartitionCount) {

--- a/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
+++ b/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout
-        pattern="%d{HH:mm:ss.SSS} [%X{actor-scheduler}] [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-scheduler}] [%X{actor-name}] [%t] %X %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -69,6 +69,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -263,6 +263,10 @@ public class PartitionRestoreService {
           try (final var db = factory.createDb(snapshotPath.toFile())) {
             final var ctx = db.createContext();
             final var state = new DbRoutingState(db, ctx);
+            if (!state.isInitialized()) {
+              LOG.warn("RoutingState is not initialized, skipping restore");
+              return;
+            }
             final var routingState = RoutingUtil.routingState(2L, state);
             LOG.debug(
                 "Restoring RoutingState for partition {}: {}", partition.id().id(), routingState);
@@ -287,6 +291,8 @@ public class PartitionRestoreService {
             } catch (final IOException e) {
               throw new RuntimeException(e);
             }
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
           }
         });
   }

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -15,21 +15,35 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.db.AccessMetricsConfiguration;
+import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
+import io.camunda.zeebe.db.ConsistencyChecksSettings;
+import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.RestorableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.slf4j.Logger;
@@ -40,8 +54,8 @@ public class PartitionRestoreService {
   private static final Logger LOG = LoggerFactory.getLogger(PartitionRestoreService.class);
   final BackupStore backupStore;
   final int partitionId;
-
   final Path rootDirectory;
+  private final Path routingPath;
   private final RaftPartition partition;
   private final int brokerId;
   private final CRC32CChecksumProvider checksumProvider;
@@ -49,11 +63,13 @@ public class PartitionRestoreService {
 
   public PartitionRestoreService(
       final BackupStore backupStore,
+      final Path routingPath,
       final RaftPartition partition,
       final int brokerId,
       final CRC32CChecksumProvider checksumProvider,
       final MeterRegistry meterRegistry) {
     this.backupStore = backupStore;
+    this.routingPath = routingPath;
     partitionId = partition.id().id();
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
@@ -80,6 +96,16 @@ public class PartitionRestoreService {
               resetLogToCheckpointPosition(backup.descriptor().checkpointPosition(), rootDirectory);
               return backup.descriptor();
             })
+        .thenCompose(
+            backupDescriptor ->
+                // if there is no snapshot, then there's no routing info to restore.
+                backupDescriptor.snapshotId().isEmpty()
+                    ? CompletableFuture.completedFuture(backupDescriptor)
+                    : restoreRoutingInfo(
+                            rootDirectory
+                                .resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY)
+                                .resolve(backupDescriptor.snapshotId().get()))
+                        .thenApply(ok -> backupDescriptor))
         .toCompletableFuture();
 
     // TODO: As an additional consistency check:
@@ -223,6 +249,46 @@ public class PartitionRestoreService {
               LOG.info("Downloading backup {} to {}", backup, tempRestoringDirectory);
               return backupStore.restore(backup, tempRestoringDirectory);
             });
+  }
+
+  private CompletableFuture<Void> restoreRoutingInfo(final Path snapshotPath) {
+    final var factory =
+        new ZeebeRocksDbFactory<ZbColumnFamilies>(
+            new RocksDbConfiguration(),
+            new ConsistencyChecksSettings(),
+            new AccessMetricsConfiguration(Kind.NONE, partition.id().id()),
+            () -> meterRegistry);
+    return CompletableFuture.runAsync(
+        () -> {
+          try (final var db = factory.createDb(snapshotPath.toFile())) {
+            final var ctx = db.createContext();
+            final var state = new DbRoutingState(db, ctx);
+            final var routingState = RoutingUtil.routingState(2L, state);
+            LOG.debug(
+                "Restoring RoutingState for partition {}: {}", partition.id().id(), routingState);
+            final var bytes = new ProtoBufSerializer().serializeRoutingState(routingState);
+            final var routingInfoFile =
+                routingPath.resolve(
+                    PersistedClusterConfiguration.PERSISTED_ROUTING_INFO_FILENAME_FORMAT.formatted(
+                        partition.id().id()));
+            try (final var file =
+                FileChannel.open(
+                    routingInfoFile,
+                    Set.of(
+                        StandardOpenOption.TRUNCATE_EXISTING,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE))) {
+              if (file.write(ByteBuffer.wrap(bytes)) < bytes.length) {
+                throw new IOException(
+                    "Failed to write completely routing info to file, written %d bytes: %d, expected bytes: %d"
+                        .formatted(file.position(), bytes.length));
+              }
+              file.force(true);
+            } catch (final IOException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        });
   }
 
   private CompletionStage<BackupIdentifier> findValidBackup(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import java.util.HashSet;
 import java.util.Set;
 
 public class RoutingUtil {
@@ -20,11 +21,13 @@ public class RoutingUtil {
 
     final var desiredPartitions = state.desiredPartitions();
     final var currentPartitions = state.currentPartitions();
+    final var inactivePartitions = new HashSet<>(desiredPartitions);
+    currentPartitions.forEach(inactivePartitions::remove);
     return desiredPartitions.equals(currentPartitions)
         ? new RequestHandling.AllPartitions(currentPartitions.size())
         // check if we need to do it better;
         : new RequestHandling.ActivePartitions(
-            currentPartitions.size(), Set.of(), desiredPartitions);
+            currentPartitions.size(), Set.of(), inactivePartitions);
   }
 
   public static MessageCorrelation messageCorrelation(final DbRoutingState state) {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.restore;
+
+public class RoutingUtil {
+}

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RoutingUtil.java
@@ -7,5 +7,34 @@
  */
 package io.camunda.zeebe.restore;
 
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import java.util.Set;
+
 public class RoutingUtil {
+
+  public static RequestHandling requestHandling(final DbRoutingState state) {
+
+    final var desiredPartitions = state.desiredPartitions();
+    final var currentPartitions = state.currentPartitions();
+    return desiredPartitions.equals(currentPartitions)
+        ? new RequestHandling.AllPartitions(currentPartitions.size())
+        // check if we need to do it better;
+        : new RequestHandling.ActivePartitions(
+            currentPartitions.size(), Set.of(), desiredPartitions);
+  }
+
+  public static MessageCorrelation messageCorrelation(final DbRoutingState state) {
+    return switch (state.messageCorrelation()) {
+      case final HashMod hashMod ->
+          new RoutingState.MessageCorrelation.HashMod(hashMod.partitionCount());
+    };
+  }
+
+  public static RoutingState routingState(final long version, final DbRoutingState state) {
+    return new RoutingState(version, requestHandling(state), messageCorrelation(state));
+  }
 }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -97,7 +97,12 @@ class PartitionRestoreServiceTest {
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile(), meterRegistry);
     restoreService =
         new PartitionRestoreService(
-            backupStore, raftPartition, nodeId, snapshotPath -> Map.of(), meterRegistry);
+            backupStore,
+            dataDirectoryToRestore,
+            raftPartition,
+            nodeId,
+            snapshotPath -> Map.of(),
+            meterRegistry);
 
     journal =
         SegmentedJournal.builder(meterRegistry)

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -156,6 +156,9 @@ class PartitionRestoreServiceTest {
     assertThat(dataDirectoryToRestore).isNotEmptyDirectory();
 
     final Set<String> restoredSegmentFiles = getRegularFiles(dataDirectoryToRestore);
+    // the Routing state file is not part of the backup, but it's generated from the RocksDB
+    // snapshot
+    restoredSegmentFiles.remove("routing-state-1.pb");
     assertThat(restoredSegmentFiles)
         .describedAs("All segment files has been restored")
         .containsExactlyInAnyOrderElementsOf(backup.segments().names());

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/SnapshotCopy.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.db;
 
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
-import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -18,19 +16,6 @@ import java.util.Set;
  * also method to compare two snapshots that can be useful when testing.
  */
 public interface SnapshotCopy {
-
-  /**
-   * Helper function that can be used to compare or copy two snapshots. Particularly useful for
-   * testing.
-   *
-   * @param fromPath path of the readonly snapshot that will be associated to "from" arguments in
-   *     {@link CopyContextConsumer}
-   * @param toDBPath path of the snapshot that will be associated to "to" arguments in {@link
-   *     CopyContextConsumer}
-   * @param consumer that can access both DB instances.
-   */
-  void withContexts(final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer);
-
   /**
    * Copies the content of a snapshot from a path to another path, copying only the columns with a
    * certain scope
@@ -40,22 +25,4 @@ public interface SnapshotCopy {
    * @param scope the scope of the columns to copy
    */
   void copySnapshot(Path fromPath, Path toPath, Set<ColumnFamilyScope> scope);
-
-  interface CopyContextConsumer {
-
-    /**
-     * Callback that will be invoked when the two DBs are opened. The arguments of this function
-     * cannot escape this method, as they will be closed once this method returns.
-     *
-     * @param fromDB DB located at fromPath
-     * @param fromCtx transaction context at fromPath
-     * @param toDB DB located at toPath
-     * @param toCtx transaction context at toPath
-     */
-    void accept(
-        ZeebeTransactionDb<ZbColumnFamilies> fromDB,
-        TransactionContext fromCtx,
-        ZeebeTransactionDb<ZbColumnFamilies> toDB,
-        TransactionContext toCtx);
-  }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/DbNullKey.java
@@ -5,18 +5,18 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.db.impl.rocksdb.transaction;
+package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.DbKey;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /** This class is used only internally by #isEmpty to search for same column family prefix. */
-final class DbNullKey implements DbKey {
+public final class DbNullKey implements DbKey {
 
   public static final DbNullKey INSTANCE = new DbNullKey();
 
-  DbNullKey() {}
+  public DbNullKey() {}
 
   @Override
   public void wrap(final DirectBuffer buffer, final int offset, final int length) {
@@ -24,12 +24,12 @@ final class DbNullKey implements DbKey {
   }
 
   @Override
-  public void write(final MutableDirectBuffer buffer, final int offset) {
-    // do nothing
+  public int getLength() {
+    return 0;
   }
 
   @Override
-  public int getLength() {
-    return 0;
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    // do nothing
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/PrefixReadOptions.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/PrefixReadOptions.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import org.rocksdb.ReadOptions;
+
+public class PrefixReadOptions {
+  public static ReadOptions readOptions() {
+    return new ReadOptions()
+        .setPrefixSameAsStart(true)
+        .setTotalOrderSeek(false)
+        // setting a positive value to read-ahead is only useful when using network storage with
+        // high latency, at the cost of making iterators more expensive (memory and computation
+        // wise)
+        .setReadaheadSize(0);
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -8,19 +8,13 @@
 package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.SnapshotCopy;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.RawTransactionalColumnFamily;
-import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransaction;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.nio.file.Path;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RocksDBSnapshotCopy implements SnapshotCopy {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotCopy.class);
   private final ZeebeRocksDbFactory<ZbColumnFamilies> factory;
 
   public RocksDBSnapshotCopy(final ZeebeRocksDbFactory<ZbColumnFamilies> factory) {
@@ -28,58 +22,12 @@ public class RocksDBSnapshotCopy implements SnapshotCopy {
   }
 
   @Override
-  public void withContexts(
-      final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer) {
-    try (final var toDB = factory.createDb(toDBPath.toFile());
-        final var fromDB = factory.createDb(fromPath.toFile())) {
-      final var fromCtx = fromDB.createContext();
-      final var toCtx = toDB.createContext();
-      consumer.accept(fromDB, fromCtx, toDB, toCtx);
-    }
-  }
-
-  @Override
   public void copySnapshot(
-      final Path fromPath, final Path toDBPath, final Set<ColumnFamilyScope> scopes) {
-    withContexts(fromPath, toDBPath, scoped(scopes));
-  }
-
-  private CopyContextConsumer scoped(final Set<ColumnFamilyScope> scopes) {
-    return (fromDB, fromCtx, toDB, toCtx) -> {
-      final var abort = new AtomicBoolean(false);
-      toCtx.runInTransaction(
-          () -> {
-            final var toTransaction = (ZeebeTransaction) toCtx.getCurrentTransaction();
-            for (final var cf : ZbColumnFamilies.values()) {
-              if (abort.get()) {
-                break;
-              }
-              if (!scopes.contains(cf.partitionScope())) {
-                continue;
-              }
-              LOG.debug("Copying column family '{}'", cf);
-              final var fromCf = new RawTransactionalColumnFamily(fromDB, cf, fromCtx);
-              final var toCf = new RawTransactionalColumnFamily(toDB, cf, toCtx);
-              fromCf.forEach(
-                  (key, keyOffset, keyLen, value, valueOffset, valueLen) -> {
-                    try {
-                      toCf.rawPut(
-                          toTransaction, key, keyOffset, keyLen, value, valueOffset, valueLen);
-                      return true;
-                    } catch (final Exception e) {
-                      LOG.error(
-                          "Failed to copy column family '{}' on key {} and value with length {} terminating.",
-                          cf,
-                          new String(key),
-                          value.length);
-                      LOG.error("Exception", e);
-                      abort.set(true);
-                      return false;
-                    }
-                  });
-            }
-            toTransaction.commit();
-          });
-    };
+      final Path fromPath, final Path toPath, final Set<ColumnFamilyScope> scopes) {
+    try (final var fromDB =
+            (SnapshotOnlyDb<ZbColumnFamilies>) factory.openSnapshotOnlyDb(fromPath.toFile());
+        final var toDB = factory.createDb(toPath.toFile())) {
+      fromDB.copySnapshot(toDB, scopes);
+    }
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopy.java
@@ -30,12 +30,11 @@ public class RocksDBSnapshotCopy implements SnapshotCopy {
   @Override
   public void withContexts(
       final Path fromPath, final Path toDBPath, final CopyContextConsumer consumer) {
-    try (final var toDB = factory.createDb(toDBPath.toFile())) {
-      try (final var fromDB = factory.createDb(fromPath.toFile())) {
-        final var fromCtx = fromDB.createContext();
-        final var toCtx = toDB.createContext();
-        consumer.accept(fromDB, fromCtx, toDB, toCtx);
-      }
+    try (final var toDB = factory.createDb(toDBPath.toFile());
+        final var fromDB = factory.createDb(fromPath.toFile())) {
+      final var fromCtx = fromDB.createContext();
+      final var toCtx = toDB.createContext();
+      consumer.accept(fromDB, fromCtx, toDB, toCtx);
     }
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -135,7 +135,7 @@ final class SnapshotOnlyDb<ColumnFamilyType extends Enum<? extends EnumValue> & 
                   new DbNullKey(),
                   (prefixKey, prefixLength) -> {
                     try (final RocksIterator iterator = db.newIterator(readOptions)) {
-                      RawTransactionalColumnFamily.forEach(
+                      RawTransactionalColumnFamily.forEachPreallocated(
                           iterator,
                           cf,
                           prefixKey,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ColumnFamilyContext.java
@@ -33,7 +33,7 @@ public class ColumnFamilyContext {
   private int keyLength;
   private final long columnFamilyPrefix;
 
-  ColumnFamilyContext(final long columnFamilyPrefix) {
+  public ColumnFamilyContext(final long columnFamilyPrefix) {
     this.columnFamilyPrefix = columnFamilyPrefix;
     prefixKeyBuffers = new ArrayDeque<>();
     prefixKeyBuffers.add(new ExpandableArrayBuffer());
@@ -115,7 +115,7 @@ public class ColumnFamilyContext {
     }
   }
 
-  ByteBuffer keyWithColumnFamily(DbKey key) {
+  ByteBuffer keyWithColumnFamily(final DbKey key) {
     final var bytes = ByteBuffer.allocate(Long.BYTES + key.getLength());
     final var buffer = new UnsafeBuffer(bytes);
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamily.java
@@ -174,7 +174,10 @@ public class RawTransactionalColumnFamily {
         shouldVisitNext = visitor.visit(keyBytes, 0, keyLen, valueBytes, 0, valueLen);
       } catch (final Exception e) {
         LOG.error(
-            "Error visiting key {} in column family {}", new String(keyBytes), columnFamily, e);
+            "Error visiting key {} in column family {}",
+            new String(keyBytes, 0, keyLen),
+            columnFamily,
+            e);
         shouldVisitNext = false;
       }
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
 import io.camunda.zeebe.protocol.ColumnFamilyScope;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.protocol.ScopedColumnFamily;

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics;
 import io.camunda.zeebe.db.impl.NoopColumnFamilyMetrics;
+import io.camunda.zeebe.db.impl.rocksdb.DbNullKey;
 import io.camunda.zeebe.db.impl.rocksdb.Loggers;
+import io.camunda.zeebe.db.impl.rocksdb.PrefixReadOptions;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.metrics.RocksDBMetricExporter;
 import io.camunda.zeebe.protocol.EnumValue;
@@ -80,14 +82,7 @@ public class ZeebeTransactionDb<
     this.meterRegistry = meterRegistry;
     metricExporter = new RocksDBMetricExporter(meterRegistry);
 
-    prefixReadOptions =
-        new ReadOptions()
-            .setPrefixSameAsStart(true)
-            .setTotalOrderSeek(false)
-            // setting a positive value to read-ahead is only useful when using network storage with
-            // high latency, at the cost of making iterators more expensive (memory and computation
-            // wise)
-            .setReadaheadSize(0);
+    prefixReadOptions = PrefixReadOptions.readOptions();
     closables.add(prefixReadOptions);
     defaultReadOptions = new ReadOptions();
     closables.add(defaultReadOptions);

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
@@ -144,7 +144,7 @@ public class RocksDBSnapshotCopyTest {
                     if (channel.read(bb) < 0) {
                       break;
                     }
-                    crc.update(bb.array());
+                    crc.update(bb);
                   }
                   return Map.entry(path.toString(), crc.getValue());
                 } catch (final IOException e) {

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/RawTransactionalColumnFamilyTest.java
@@ -47,7 +47,7 @@ public class RawTransactionalColumnFamilyTest {
     context = db.createContext();
 
     for (final var cf : ZbColumnFamilies.values()) {
-      final var rawCF = new RawTransactionalColumnFamily(db, cf, context);
+      final var rawCF = new RawTransactionalColumnFamily(db, cf);
       columnFamilies.put(cf, rawCF);
     }
   }
@@ -80,6 +80,7 @@ public class RawTransactionalColumnFamilyTest {
     // when
     final var i = new MutableReference<>(0);
     rawCF.forEach(
+        context,
         ((rawKey, keyOffset, keyLen, value, valueOffset, valueLen) -> {
           final var cfContext = new ColumnFamilyContext(cf.getValue());
           assertThat(keyOffset).isZero();


### PR DESCRIPTION
## Description
Before this PR, the state of the `dynamic-config` module are lost when a backup/restore is performed.
However, this poses a problem as the `RoutingState` from that config is used to route requests to the broker, so it must reflect the runtime state in `RocksDB`.

To make the two states converge, we follow this procedure:
- when restoring:
  - node 0 (the coordinator) is assigned to restore partition 1
  - partition 1 contains up to date information about the routing
  - after the snapshot has been restored, it's quickly open in order to read the `DbRoutingState`
  - the `RoutingState` for the `dynamic-config` is generated from the runtime state and saved into a `routing-state-$partition.pb` protobuf file containing just the RoutingState persisted as a protobuf.
 - when initializing:
   - the last `ClusterConfigInitializer` in the chain is `RoutingInfoInitializer`: it will read the state from the protobuf (if present) and it will use that as routing state for the configuration in the coordinator node.
   - non coordinator nodes will converge to the same state based on sync/gossip
   - The persisted state in the protobuf does not necessarily reflect the latest state as there might be some records in the log that might change that
   - In order to get to the latest state `AwaitRedistributionCompletion` and `AwaitRelocationCompletion` are inserted into the pending operations, so that the routing state is updated when all records are processed, in the same way it happens normally during scaling.

Added an integration test that verifies that when a backup is taken after scaling, the updated number of brokers are included into the `RoutingState`

### Dependencies:
- [x] #34529
- [x]  #34481
## Related issues

closes #34146
