### PR TITLE
perf: use static instances for keys in objects in Record

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -26,33 +26,58 @@ import org.agrona.DirectBuffer;
 
 public final class ElementInstance extends UnpackedObject implements DbValue {
 
-  private final LongProperty parentKeyProp = new LongProperty("parentKey", -1L);
-  private final IntegerProperty childCountProp = new IntegerProperty("childCount", 0);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PARENT_KEY = new StringValue("parentKey");
+  private static final StringValue CHILD_COUNT = new StringValue("childCount");
+  private static final StringValue CHILD_ACTIVATED_COUNT = new StringValue("childActivatedCount");
+  private static final StringValue CHILD_COMPLETED_COUNT = new StringValue("childCompletedCount");
+  private static final StringValue CHILD_TERMINATED_COUNT = new StringValue("childTerminatedCount");
+  private static final StringValue JOB_KEY = new StringValue("jobKey");
+  private static final StringValue MULTI_INSTANCE_LOOP_COUNTER =
+      new StringValue("multiInstanceLoopCounter");
+  private static final StringValue INTERRUPTING_ELEMENT_ID =
+      new StringValue("interruptingElementId");
+  private static final StringValue CALLED_CHILD_INSTANCE_KEY =
+      new StringValue("calledChildInstanceKey");
+  private static final StringValue ELEMENT_RECORD = new StringValue("elementRecord");
+  private static final StringValue ACTIVE_SEQUENCE_FLOWS = new StringValue("activeSequenceFlows");
+  private static final StringValue ACTIVE_SEQUENCE_FLOW_IDS =
+      new StringValue("activeSequenceFlowIds");
+  private static final StringValue USER_TASK_KEY = new StringValue("userTaskKey");
+  private static final StringValue EXECUTION_LISTENER_INDEX =
+      new StringValue("executionListenerIndex");
+  private static final StringValue TASK_LISTENER_INDICES_RECORD =
+      new StringValue("taskListenerIndicesRecord");
+  private static final StringValue PROCESS_DEPTH = new StringValue("processDepth");
+
+  private final LongProperty parentKeyProp = new LongProperty(PARENT_KEY, -1L);
+  private final IntegerProperty childCountProp = new IntegerProperty(CHILD_COUNT, 0);
   private final IntegerProperty childActivatedCountProp =
-      new IntegerProperty("childActivatedCount", 0);
+      new IntegerProperty(CHILD_ACTIVATED_COUNT, 0);
   private final IntegerProperty childCompletedCountProp =
-      new IntegerProperty("childCompletedCount", 0);
+      new IntegerProperty(CHILD_COMPLETED_COUNT, 0);
   private final IntegerProperty childTerminatedCountProp =
-      new IntegerProperty("childTerminatedCount", 0);
-  private final LongProperty jobKeyProp = new LongProperty("jobKey", 0L);
+      new IntegerProperty(CHILD_TERMINATED_COUNT, 0);
+  private final LongProperty jobKeyProp = new LongProperty(JOB_KEY, 0L);
   private final IntegerProperty multiInstanceLoopCounterProp =
-      new IntegerProperty("multiInstanceLoopCounter", 0);
+      new IntegerProperty(MULTI_INSTANCE_LOOP_COUNTER, 0);
   private final StringProperty interruptingEventKeyProp =
-      new StringProperty("interruptingElementId", "");
+      new StringProperty(INTERRUPTING_ELEMENT_ID, "");
   private final LongProperty calledChildInstanceKeyProp =
-      new LongProperty("calledChildInstanceKey", -1L);
+      new LongProperty(CALLED_CHILD_INSTANCE_KEY, -1L);
   private final ObjectProperty<IndexedRecord> recordProp =
-      new ObjectProperty<>("elementRecord", new IndexedRecord());
+      new ObjectProperty<>(ELEMENT_RECORD, new IndexedRecord());
   private final IntegerProperty activeSequenceFlowsProp =
-      new IntegerProperty("activeSequenceFlows", 0);
+      new IntegerProperty(ACTIVE_SEQUENCE_FLOWS, 0);
   private final ArrayProperty<StringValue> activeSequenceFlowIdsProp =
-      new ArrayProperty<>("activeSequenceFlowIds", StringValue::new);
-  private final LongProperty userTaskKeyProp = new LongProperty("userTaskKey", -1L);
+      new ArrayProperty<>(ACTIVE_SEQUENCE_FLOW_IDS, StringValue::new);
+  private final LongProperty userTaskKeyProp = new LongProperty(USER_TASK_KEY, -1L);
   private final IntegerProperty executionListenerIndexProp =
-      new IntegerProperty("executionListenerIndex", 0);
+      new IntegerProperty(EXECUTION_LISTENER_INDEX, 0);
   private final ObjectProperty<TaskListenerIndicesRecord> taskListenerIndicesRecordProp =
-      new ObjectProperty<>("taskListenerIndicesRecord", new TaskListenerIndicesRecord());
+      new ObjectProperty<>(TASK_LISTENER_INDICES_RECORD, new TaskListenerIndicesRecord());
   private final BooleanProperty isSuspendedProp = new BooleanProperty("isSuspended", false);
+  private final IntegerProperty processDepth = new IntegerProperty(PROCESS_DEPTH, 1);
 
   /**
    * Expresses the current depth of the process instance in the called process tree.
@@ -68,8 +93,6 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    *     or after the property was added that are part of a root process instance created prior to
    *     the property existed, will not have a correct depth.
    */
-  private final IntegerProperty processDepth = new IntegerProperty("processDepth", 1);
-
   public ElementInstance() {
     super(17);
     declareProperty(parentKeyProp)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import org.agrona.DirectBuffer;
@@ -19,11 +20,17 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class IndexedRecord extends UnpackedObject implements DbValue {
-  private final LongProperty keyProp = new LongProperty("key", 0L);
+  // Static StringValue keys for property names
+  private static final StringValue KEY_KEY = new StringValue("key");
+  private static final StringValue STATE_KEY = new StringValue("state");
+  private static final StringValue PROCESS_INSTANCE_RECORD_KEY =
+      new StringValue("processInstanceRecord");
+
+  private final LongProperty keyProp = new LongProperty(KEY_KEY, 0L);
   private final EnumProperty<ProcessInstanceIntent> stateProp =
-      new EnumProperty<>("state", ProcessInstanceIntent.class);
+      new EnumProperty<>(STATE_KEY, ProcessInstanceIntent.class);
   private final ObjectProperty<ProcessInstanceRecord> valueProp =
-      new ObjectProperty<>("processInstanceRecord", new ProcessInstanceRecord());
+      new ObjectProperty<>(PROCESS_INSTANCE_RECORD_KEY, new ProcessInstanceRecord());
 
   IndexedRecord() {
     super(3);

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.msgpack.property;
 import io.camunda.zeebe.msgpack.MsgpackPropertyException;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.BaseValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import java.util.Iterator;
 import java.util.function.Supplier;
@@ -20,6 +21,11 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
     implements ValueArray<T> {
   public ArrayProperty(final String keyString, final Supplier<T> innerValueFactory) {
     super(keyString, new ArrayValue<>(innerValueFactory));
+    isSet = true;
+  }
+
+  public ArrayProperty(final StringValue key, final Supplier<T> innerValueFactory) {
+    super(key, new ArrayValue<>(innerValueFactory));
     isSet = true;
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BaseProperty.java
@@ -30,10 +30,17 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
   }
 
   public BaseProperty(final String keyString, final T value, final T defaultValue) {
+    this(new StringValue(keyString), value, defaultValue);
+  }
+
+  public BaseProperty(final StringValue keyString, final T value) {
+    this(keyString, value, null);
+  }
+
+  public BaseProperty(final StringValue keyString, final T value, final T defaultValue) {
     Objects.requireNonNull(keyString);
     Objects.requireNonNull(value);
-
-    key = new StringValue(keyString);
+    key = keyString;
     this.value = value;
     this.defaultValue = defaultValue;
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BinaryProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BinaryProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.BinaryValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import org.agrona.DirectBuffer;
 
 public final class BinaryProperty extends BaseProperty<BinaryValue> {
@@ -17,6 +18,14 @@ public final class BinaryProperty extends BaseProperty<BinaryValue> {
 
   public BinaryProperty(final String keyString, final DirectBuffer defaultValue) {
     super(keyString, new BinaryValue(), new BinaryValue(defaultValue, 0, defaultValue.capacity()));
+  }
+
+  public BinaryProperty(final StringValue key) {
+    super(key, new BinaryValue());
+  }
+
+  public BinaryProperty(final StringValue key, final DirectBuffer defaultValue) {
+    super(key, new BinaryValue(), new BinaryValue(defaultValue, 0, defaultValue.capacity()));
   }
 
   public DirectBuffer getValue() {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BooleanProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/BooleanProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.BooleanValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 
 public final class BooleanProperty extends BaseProperty<BooleanValue> {
 
@@ -16,6 +17,14 @@ public final class BooleanProperty extends BaseProperty<BooleanValue> {
   }
 
   public BooleanProperty(final String key, final boolean defaultValue) {
+    super(key, new BooleanValue(), new BooleanValue(defaultValue));
+  }
+
+  public BooleanProperty(final StringValue key) {
+    super(key, new BooleanValue());
+  }
+
+  public BooleanProperty(final StringValue key, final boolean defaultValue) {
     super(key, new BooleanValue(), new BooleanValue(defaultValue));
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DeltaEncodedLongArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DeltaEncodedLongArrayProperty.java
@@ -8,11 +8,16 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.DeltaEncodedLongArrayValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import java.util.Objects;
 
 public final class DeltaEncodedLongArrayProperty extends BaseProperty<DeltaEncodedLongArrayValue> {
   public DeltaEncodedLongArrayProperty(final String keyString) {
     super(keyString, new DeltaEncodedLongArrayValue());
+  }
+
+  public DeltaEncodedLongArrayProperty(final StringValue key) {
+    super(key, new DeltaEncodedLongArrayValue());
   }
 
   public long[] getValues() {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DocumentProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DocumentProperty.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.msgpack.value.DocumentValue.EMPTY_DOCUMENT;
 
 import io.camunda.zeebe.msgpack.MsgpackPropertyException;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import org.agrona.DirectBuffer;
 
 public final class DocumentProperty extends BaseProperty<DocumentValue> {
@@ -19,6 +20,11 @@ public final class DocumentProperty extends BaseProperty<DocumentValue> {
         keyString,
         new DocumentValue(),
         new DocumentValue(EMPTY_DOCUMENT, 0, EMPTY_DOCUMENT.capacity()));
+  }
+
+  public DocumentProperty(final StringValue key) {
+    super(
+        key, new DocumentValue(), new DocumentValue(EMPTY_DOCUMENT, 0, EMPTY_DOCUMENT.capacity()));
   }
 
   public DirectBuffer getValue() {

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/EnumProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/EnumProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.EnumValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 
 public final class EnumProperty<E extends Enum<E>> extends BaseProperty<EnumValue<E>> {
   public EnumProperty(final String key, final Class<E> type) {
@@ -15,6 +16,14 @@ public final class EnumProperty<E extends Enum<E>> extends BaseProperty<EnumValu
   }
 
   public EnumProperty(final String key, final Class<E> type, final E defaultValue) {
+    super(key, new EnumValue<>(type), new EnumValue<>(type, defaultValue));
+  }
+
+  public EnumProperty(final StringValue key, final Class<E> type) {
+    super(key, new EnumValue<>(type));
+  }
+
+  public EnumProperty(final StringValue key, final Class<E> type, final E defaultValue) {
     super(key, new EnumValue<>(type), new EnumValue<>(type, defaultValue));
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/IntegerProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/IntegerProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.IntegerValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 
 public final class IntegerProperty extends BaseProperty<IntegerValue> {
   public IntegerProperty(final String key) {
@@ -15,6 +16,14 @@ public final class IntegerProperty extends BaseProperty<IntegerValue> {
   }
 
   public IntegerProperty(final String key, final int defaultValue) {
+    super(key, new IntegerValue(), new IntegerValue(defaultValue));
+  }
+
+  public IntegerProperty(final StringValue key) {
+    super(key, new IntegerValue());
+  }
+
+  public IntegerProperty(final StringValue key, final int defaultValue) {
     super(key, new IntegerValue(), new IntegerValue(defaultValue));
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/LongProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/LongProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 
 public final class LongProperty extends BaseProperty<LongValue> {
   public LongProperty(final String key) {
@@ -15,6 +16,14 @@ public final class LongProperty extends BaseProperty<LongValue> {
   }
 
   public LongProperty(final String key, final long defaultValue) {
+    super(key, new LongValue(), new LongValue(defaultValue));
+  }
+
+  public LongProperty(final StringValue key) {
+    super(key, new LongValue());
+  }
+
+  public LongProperty(final StringValue key, final long defaultValue) {
     super(key, new LongValue(), new LongValue(defaultValue));
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ObjectProperty.java
@@ -8,9 +8,14 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 
 public final class ObjectProperty<T extends ObjectValue> extends BaseProperty<T> {
   public ObjectProperty(final String key, final T objectValue) {
+    super(key, objectValue, objectValue);
+  }
+
+  public ObjectProperty(final StringValue key, final T objectValue) {
     super(key, objectValue, objectValue);
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/PackedProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/PackedProperty.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.msgpack.property;
 
 import io.camunda.zeebe.msgpack.value.PackedValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import org.agrona.DirectBuffer;
 
 public class PackedProperty extends BaseProperty<PackedValue> {
@@ -16,6 +17,14 @@ public class PackedProperty extends BaseProperty<PackedValue> {
   }
 
   public PackedProperty(final String key, final DirectBuffer defaultValue) {
+    super(key, new PackedValue(), new PackedValue(defaultValue, 0, defaultValue.capacity()));
+  }
+
+  public PackedProperty(final StringValue key) {
+    super(key, new PackedValue());
+  }
+
+  public PackedProperty(final StringValue key, final DirectBuffer defaultValue) {
     super(key, new PackedValue(), new PackedValue(defaultValue, 0, defaultValue.capacity()));
   }
 

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/StringProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/StringProperty.java
@@ -22,6 +22,14 @@ public final class StringProperty extends BaseProperty<StringValue> {
     super(key, new StringValue(), new StringValue(defaultValue));
   }
 
+  public StringProperty(final StringValue key) {
+    super(key, new StringValue());
+  }
+
+  public StringProperty(final StringValue key, final String defaultValue) {
+    super(key, new StringValue(), new StringValue(defaultValue));
+  }
+
   public DirectBuffer getValue() {
     return resolveValue().getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -26,17 +26,27 @@ import java.util.stream.Collectors;
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
 
-  private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey", -1L);
-  private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
+  // Static StringValue keys for property names
+  private static final StringValue AUTHORIZATION_KEY_KEY = new StringValue("authorizationKey");
+  private static final StringValue OWNER_ID_KEY = new StringValue("ownerId");
+  private static final StringValue OWNER_TYPE_KEY = new StringValue("ownerType");
+  private static final StringValue RESOURCE_ID_KEY = new StringValue("resourceId");
+  private static final StringValue RESOURCE_TYPE_KEY = new StringValue("resourceType");
+  private static final StringValue PERMISSION_TYPES_KEY = new StringValue("permissionTypes");
+
+  private final LongProperty authorizationKeyProp = new LongProperty(AUTHORIZATION_KEY_KEY, -1L);
+  private final StringProperty ownerIdProp = new StringProperty(OWNER_ID_KEY, "");
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>(
-          "ownerType", AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
-  private final StringProperty resourceIdProp = new StringProperty("resourceId", "");
+          OWNER_TYPE_KEY, AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
+  private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID_KEY, "");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>(
-          "resourceType", AuthorizationResourceType.class, AuthorizationResourceType.UNSPECIFIED);
+          RESOURCE_TYPE_KEY,
+          AuthorizationResourceType.class,
+          AuthorizationResourceType.UNSPECIFIED);
   private final ArrayProperty<StringValue> permissionTypesProp =
-      new ArrayProperty<>("permissionTypes", StringValue::new);
+      new ArrayProperty<>(PERMISSION_TYPES_KEY, StringValue::new);
 
   public AuthorizationRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -9,17 +9,25 @@ package io.camunda.zeebe.protocol.impl.record.value.authorization;
 
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class MappingRecord extends UnifiedRecordValue implements MappingRecordValue {
 
-  private final LongProperty mappingKeyProp = new LongProperty("mappingKey", -1L);
-  private final StringProperty mappingIdProp = new StringProperty("mappingId");
-  private final StringProperty claimNameProp = new StringProperty("claimName", "");
-  private final StringProperty claimValueProp = new StringProperty("claimValue", "");
-  private final StringProperty nameProp = new StringProperty("name", "");
+  // Static StringValue keys for property names
+  private static final StringValue MAPPING_KEY_KEY = new StringValue("mappingKey");
+  private static final StringValue MAPPING_ID_KEY = new StringValue("mappingId");
+  private static final StringValue CLAIM_NAME_KEY = new StringValue("claimName");
+  private static final StringValue CLAIM_VALUE_KEY = new StringValue("claimValue");
+  private static final StringValue NAME_KEY = new StringValue("name");
+
+  private final LongProperty mappingKeyProp = new LongProperty(MAPPING_KEY_KEY, -1L);
+  private final StringProperty mappingIdProp = new StringProperty(MAPPING_ID_KEY);
+  private final StringProperty claimNameProp = new StringProperty(CLAIM_NAME_KEY, "");
+  private final StringProperty claimValueProp = new StringProperty(CLAIM_VALUE_KEY, "");
+  private final StringProperty nameProp = new StringProperty(NAME_KEY, "");
 
   public MappingRecord() {
     super(5);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_BPMN_PROCESS_ID;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_KEY;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_VERSION;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.BPMN_PROCESS_ID_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROCESS_DEFINITION_KEY_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.VERSION_KEY;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -29,9 +29,9 @@ import org.agrona.DirectBuffer;
  * user. It is similar to {@link ProcessRecord} except that it doesn't contain the actual resources.
  */
 public final class ProcessMetadata extends UnifiedRecordValue implements ProcessMetadataValue {
-  private final StringProperty bpmnProcessIdProp = new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID);
-  private final IntegerProperty versionProp = new IntegerProperty(PROP_PROCESS_VERSION);
-  private final LongProperty keyProp = new LongProperty(PROP_PROCESS_KEY);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY);
+  private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY);
+  private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
 
@@ -63,6 +63,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   @Override
   public int getVersion() {
     return versionProp.getValue();
+  }
+
+  public ProcessMetadata setVersion(final int version) {
+    versionProp.setValue(version);
+    return this;
+  }
+
+  @Override
+  public String getVersionTag() {
+    return bufferAsString(versionTagProp.getValue());
   }
 
   @Override
@@ -115,8 +125,8 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
     return this;
   }
 
-  public ProcessMetadata setVersion(final int version) {
-    versionProp.setValue(version);
+  public ProcessMetadata setVersionTag(final String versionTag) {
+    versionTagProp.setValue(versionTag);
     return this;
   }
 
@@ -180,16 +190,6 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public String getVersionTag() {
-    return bufferAsString(versionTagProp.getValue());
-  }
-
-  public ProcessMetadata setVersionTag(final String versionTag) {
-    versionTagProp.setValue(versionTag);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_BPMN_PROCESS_ID;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_KEY;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_VERSION;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.BPMN_PROCESS_ID_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROCESS_DEFINITION_KEY_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.VERSION_KEY;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
@@ -24,9 +24,9 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ProcessRecord extends UnifiedRecordValue implements Process {
-  private final StringProperty bpmnProcessIdProp = new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID);
-  private final IntegerProperty versionProp = new IntegerProperty(PROP_PROCESS_VERSION);
-  private final LongProperty keyProp = new LongProperty(PROP_PROCESS_KEY);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY);
+  private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY);
+  private final LongProperty keyProp = new LongProperty(PROCESS_DEFINITION_KEY_KEY);
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
@@ -69,6 +69,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   @Override
   public int getVersion() {
     return versionProp.getValue();
+  }
+
+  public ProcessRecord setVersion(final int version) {
+    versionProp.setValue(version);
+    return this;
+  }
+
+  @Override
+  public String getVersionTag() {
+    return BufferUtil.bufferAsString(versionTagProp.getValue());
   }
 
   @Override
@@ -116,8 +126,8 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     return this;
   }
 
-  public ProcessRecord setVersion(final int version) {
-    versionProp.setValue(version);
+  public ProcessRecord setVersionTag(final String versionTag) {
+    versionTagProp.setValue(versionTag);
     return this;
   }
 
@@ -201,16 +211,6 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
 
   public ProcessRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
-  @Override
-  public String getVersionTag() {
-    return BufferUtil.bufferAsString(versionTagProp.getValue());
-  }
-
-  public ProcessRecord setVersionTag(final String versionTag) {
-    versionTagProp.setValue(versionTag);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
@@ -44,6 +45,18 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   private static final Map<ValueType, Supplier<UnifiedRecordValue>> RECORDS_BY_TYPE =
       new EnumMap<>(ValueType.class);
+  /*
+   NOTE! When adding a new property here it must also be added to the ProtocolFactory! This class
+   contains a randomizer implementation which is used to generate a random
+   CommandDistributionRecord. The new property must be added there. Without it we won't generate a
+   complete record.
+  */
+  // Static StringValue keys for property names
+  private static final StringValue PARTITION_ID_KEY = new StringValue("partitionId");
+  private static final StringValue QUEUE_ID_KEY = new StringValue("queueId");
+  private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
+  private static final StringValue INTENT_KEY = new StringValue("intent");
+  private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
 
   // You'll need to register any of the records value's that you want to distribute
   static {
@@ -68,19 +81,13 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
         ValueType.BATCH_OPERATION_PARTITION_LIFECYCLE, BatchOperationPartitionLifecycleRecord::new);
   }
 
-  /*
-   NOTE! When adding a new property here it must also be added to the ProtocolFactory! This class
-   contains a randomizer implementation which is used to generate a random
-   CommandDistributionRecord. The new property must be added there. Without it we won't generate a
-   complete record.
-  */
-  private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
-  private final StringProperty queueIdProperty = new StringProperty("queueId", "");
+  private final IntegerProperty partitionIdProperty = new IntegerProperty(PARTITION_ID_KEY);
+  private final StringProperty queueIdProperty = new StringProperty(QUEUE_ID_KEY, "");
   private final EnumProperty<ValueType> valueTypeProperty =
-      new EnumProperty<>("valueType", ValueType.class, ValueType.NULL_VAL);
-  private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
+      new EnumProperty<>(VALUE_TYPE_KEY, ValueType.class, ValueType.NULL_VAL);
+  private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
-      new ObjectProperty<>("commandValue", new UnifiedRecordValue(10));
+      new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.error;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -22,11 +23,18 @@ public final class ErrorRecord extends UnifiedRecordValue implements ErrorRecord
 
   private static final String NULL_MESSAGE = "Without exception message.";
 
-  private final StringProperty exceptionMessageProp = new StringProperty("exceptionMessage");
-  private final StringProperty stacktraceProp = new StringProperty("stacktrace", "");
-  private final LongProperty errorEventPositionProp = new LongProperty("errorEventPosition");
+  // Static StringValue keys for property names
+  private static final StringValue EXCEPTION_MESSAGE_KEY = new StringValue("exceptionMessage");
+  private static final StringValue STACKTRACE_KEY = new StringValue("stacktrace");
+  private static final StringValue ERROR_EVENT_POSITION_KEY = new StringValue("errorEventPosition");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
 
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final StringProperty exceptionMessageProp = new StringProperty(EXCEPTION_MESSAGE_KEY);
+  private final StringProperty stacktraceProp = new StringProperty(STACKTRACE_KEY, "");
+  private final LongProperty errorEventPositionProp = new LongProperty(ERROR_EVENT_POSITION_KEY);
+
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public ErrorRecord() {
     super(4);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
@@ -19,13 +20,21 @@ import org.agrona.DirectBuffer;
 
 public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue {
 
-  private final LongProperty groupKeyProp = new LongProperty("groupKey", -1L);
-  private final StringProperty groupId = new StringProperty("groupId");
-  private final StringProperty nameProp = new StringProperty("name", "");
-  private final StringProperty descriptionProp = new StringProperty("description", "");
-  private final StringProperty entityIdProp = new StringProperty("entityId", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue GROUP_KEY_KEY = new StringValue("groupKey");
+  private static final StringValue GROUP_ID_KEY = new StringValue("groupId");
+  private static final StringValue NAME_KEY = new StringValue("name");
+  private static final StringValue DESCRIPTION_KEY = new StringValue("description");
+  private static final StringValue ENTITY_ID_KEY = new StringValue("entityId");
+  private static final StringValue ENTITY_TYPE_KEY = new StringValue("entityType");
+
+  private final LongProperty groupKeyProp = new LongProperty(GROUP_KEY_KEY, -1L);
+  private final StringProperty groupId = new StringProperty(GROUP_ID_KEY);
+  private final StringProperty nameProp = new StringProperty(NAME_KEY, "");
+  private final StringProperty descriptionProp = new StringProperty(DESCRIPTION_KEY, "");
+  private final StringProperty entityIdProp = new StringProperty(ENTITY_ID_KEY, "");
   private final EnumProperty<EntityType> entityTypeProp =
-      new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
+      new EnumProperty<>(ENTITY_TYPE_KEY, EntityType.class, EntityType.UNSPECIFIED);
 
   public GroupRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -25,26 +26,45 @@ import java.util.List;
 import org.agrona.DirectBuffer;
 
 public final class IncidentRecord extends UnifiedRecordValue implements IncidentRecordValue {
-  private final EnumProperty<ErrorType> errorTypeProp =
-      new EnumProperty<>("errorType", ErrorType.class, ErrorType.UNKNOWN);
-  private final StringProperty errorMessageProp = new StringProperty("errorMessage", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue ERROR_TYPE_KEY = new StringValue("errorType");
+  private static final StringValue ERROR_MESSAGE_KEY = new StringValue("errorMessage");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue JOB_KEY_KEY = new StringValue("jobKey");
+  private static final StringValue VARIABLE_SCOPE_KEY_KEY = new StringValue("variableScopeKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ELEMENT_INSTANCE_PATH_KEY =
+      new StringValue("elementInstancePath");
+  private static final StringValue PROCESS_DEFINITION_PATH_KEY =
+      new StringValue("processDefinitionPath");
+  private static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
 
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final EnumProperty<ErrorType> errorTypeProp =
+      new EnumProperty<>(ERROR_TYPE_KEY, ErrorType.class, ErrorType.UNKNOWN);
+  private final StringProperty errorMessageProp = new StringProperty(ERROR_MESSAGE_KEY, "");
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProp =
-      new LongProperty("processDefinitionKey", -1L);
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
-  private final StringProperty elementIdProp = new StringProperty("elementId", "");
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
-  private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
-  private final LongProperty variableScopeKeyProp = new LongProperty("variableScopeKey", -1L);
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty jobKeyProp = new LongProperty(JOB_KEY_KEY, -1L);
+  private final LongProperty variableScopeKeyProp = new LongProperty(VARIABLE_SCOPE_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final ArrayProperty<ArrayValue<LongValue>> elementInstancePathProp =
-      new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
+      new ArrayProperty<>(ELEMENT_INSTANCE_PATH_KEY, () -> new ArrayValue<>(LongValue::new));
   private final ArrayProperty<LongValue> processDefinitionPathProp =
-      new ArrayProperty<>("processDefinitionPath", LongValue::new);
+      new ArrayProperty<>(PROCESS_DEFINITION_PATH_KEY, LongValue::new);
   private final ArrayProperty<IntegerValue> callingElementPathProp =
-      new ArrayProperty<>("callingElementPath", IntegerValue::new);
+      new ArrayProperty<>(CALLING_ELEMENT_PATH_KEY, IntegerValue::new);
 
   public IncidentRecord() {
     super(13);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -28,19 +28,30 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class JobBatchRecord extends UnifiedRecordValue implements JobBatchRecordValue {
 
-  private final StringProperty typeProp = new StringProperty("type");
-  private final StringProperty workerProp = new StringProperty("worker", "");
-  private final LongProperty timeoutProp = new LongProperty("timeout", -1);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue TYPE_KEY = new StringValue("type");
+  private static final StringValue WORKER_KEY = new StringValue("worker");
+  private static final StringValue TIMEOUT_KEY = new StringValue("timeout");
+  private static final StringValue MAX_JOBS_TO_ACTIVATE_KEY = new StringValue("maxJobsToActivate");
+  private static final StringValue JOB_KEYS_KEY = new StringValue("jobKeys");
+  private static final StringValue JOBS_KEY = new StringValue("jobs");
+  private static final StringValue TENANT_IDS_KEY = new StringValue("tenantIds");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
+
+  private final StringProperty typeProp = new StringProperty(TYPE_KEY);
+  private final StringProperty workerProp = new StringProperty(WORKER_KEY, "");
+  private final LongProperty timeoutProp = new LongProperty(TIMEOUT_KEY, -1);
   private final IntegerProperty maxJobsToActivateProp =
-      new IntegerProperty("maxJobsToActivate", -1);
+      new IntegerProperty(MAX_JOBS_TO_ACTIVATE_KEY, -1);
   private final ArrayProperty<LongValue> jobKeysProp =
-      new ArrayProperty<>("jobKeys", LongValue::new);
-  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", JobRecord::new);
+      new ArrayProperty<>(JOB_KEYS_KEY, LongValue::new);
+  private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>(JOBS_KEY, JobRecord::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
-      new ArrayProperty<>("tenantIds", StringValue::new);
+      new ArrayProperty<>(TENANT_IDS_KEY, StringValue::new);
   private final ArrayProperty<StringValue> variablesProp =
-      new ArrayProperty<>("variables", StringValue::new);
-  private final BooleanProperty truncatedProp = new BooleanProperty("truncated", false);
+      new ArrayProperty<>(VARIABLES_KEY, StringValue::new);
+  private final BooleanProperty truncatedProp = new BooleanProperty(TRUNCATED_KEY, false);
 
   public JobBatchRecord() {
     super(9);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.job;
 
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_BPMN_PROCESS_ID;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_INSTANCE_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.BPMN_PROCESS_ID_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROCESS_INSTANCE_KEY_KEY;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -47,42 +47,72 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final String VARIABLES = "variables";
   private static final String ERROR_MESSAGE = "errorMessage";
 
-  private final StringProperty typeProp = new StringProperty(TYPE, EMPTY_STRING);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue TYPE_KEY = new StringValue(TYPE);
+  private static final StringValue WORKER_KEY = new StringValue("worker");
+  private static final StringValue DEADLINE_KEY = new StringValue("deadline");
+  private static final StringValue TIMEOUT_KEY = new StringValue(TIMEOUT);
+  private static final StringValue RETRIES_KEY = new StringValue(RETRIES);
+  private static final StringValue RETRY_BACKOFF_KEY = new StringValue("retryBackoff");
+  private static final StringValue RECURRING_TIME_KEY = new StringValue("recurringTime");
+  private static final StringValue CUSTOM_HEADERS_KEY = new StringValue(CUSTOM_HEADERS);
+  private static final StringValue VARIABLES_KEY = new StringValue(VARIABLES);
+  private static final StringValue ERROR_MESSAGE_KEY = new StringValue(ERROR_MESSAGE);
+  private static final StringValue ERROR_CODE_KEY = new StringValue("errorCode");
+  private static final StringValue PROCESS_DEFINITION_VERSION_KEY =
+      new StringValue("processDefinitionVersion");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue JOB_KIND_KEY = new StringValue("jobKind");
+  private static final StringValue JOB_LISTENER_EVENT_TYPE_KEY =
+      new StringValue("jobListenerEventType");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue CHANGED_ATTRIBUTES_KEY = new StringValue("changedAttributes");
+  private static final StringValue RESULT_KEY = new StringValue("result");
 
-  private final StringProperty workerProp = new StringProperty("worker", EMPTY_STRING);
-  private final LongProperty deadlineProp = new LongProperty("deadline", -1);
-  private final LongProperty timeoutProp = new LongProperty(TIMEOUT, -1);
-  private final IntegerProperty retriesProp = new IntegerProperty(RETRIES, -1);
-  private final LongProperty retryBackoffProp = new LongProperty("retryBackoff", 0);
-  private final LongProperty recurringTimeProp = new LongProperty("recurringTime", -1);
+  private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
 
-  private final PackedProperty customHeadersProp = new PackedProperty(CUSTOM_HEADERS, NO_HEADERS);
-  private final DocumentProperty variableProp = new DocumentProperty(VARIABLES);
+  private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
+  private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
+  private final LongProperty timeoutProp = new LongProperty(TIMEOUT_KEY, -1);
+  private final IntegerProperty retriesProp = new IntegerProperty(RETRIES_KEY, -1);
+  private final LongProperty retryBackoffProp = new LongProperty(RETRY_BACKOFF_KEY, 0);
+  private final LongProperty recurringTimeProp = new LongProperty(RECURRING_TIME_KEY, -1);
 
-  private final StringProperty errorMessageProp = new StringProperty(ERROR_MESSAGE, EMPTY_STRING);
-  private final StringProperty errorCodeProp = new StringProperty("errorCode", EMPTY_STRING);
+  private final PackedProperty customHeadersProp =
+      new PackedProperty(CUSTOM_HEADERS_KEY, NO_HEADERS);
+  private final DocumentProperty variableProp = new DocumentProperty(VARIABLES_KEY);
+
+  private final StringProperty errorMessageProp =
+      new StringProperty(ERROR_MESSAGE_KEY, EMPTY_STRING);
+  private final StringProperty errorCodeProp = new StringProperty(ERROR_CODE_KEY, EMPTY_STRING);
 
   private final LongProperty processInstanceKeyProp =
-      new LongProperty(PROP_PROCESS_INSTANCE_KEY, -1L);
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProp =
-      new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID, EMPTY_STRING);
+      new StringProperty(BPMN_PROCESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty processDefinitionVersionProp =
-      new IntegerProperty("processDefinitionVersion", -1);
+      new IntegerProperty(PROCESS_DEFINITION_VERSION_KEY, -1);
   private final LongProperty processDefinitionKeyProp =
-      new LongProperty("processDefinitionKey", -1L);
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final EnumProperty<JobKind> jobKindProp =
-      new EnumProperty<>("jobKind", JobKind.class, JobKind.BPMN_ELEMENT);
+      new EnumProperty<>(JOB_KIND_KEY, JobKind.class, JobKind.BPMN_ELEMENT);
   private final EnumProperty<JobListenerEventType> jobListenerEventTypeProp =
       new EnumProperty<>(
-          "jobListenerEventType", JobListenerEventType.class, JobListenerEventType.UNSPECIFIED);
-  private final StringProperty elementIdProp = new StringProperty("elementId", EMPTY_STRING);
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
+          JOB_LISTENER_EVENT_TYPE_KEY,
+          JobListenerEventType.class,
+          JobListenerEventType.UNSPECIFIED);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, EMPTY_STRING);
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final ArrayProperty<StringValue> changedAttributesProp =
-      new ArrayProperty<>("changedAttributes", StringValue::new);
+      new ArrayProperty<>(CHANGED_ATTRIBUTES_KEY, StringValue::new);
   private final ObjectProperty<JobResult> resultProp =
-      new ObjectProperty<>("result", new JobResult());
+      new ObjectProperty<>(RESULT_KEY, new JobResult());
 
   public JobRecord() {
     super(22);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -30,12 +30,20 @@ import java.util.stream.StreamSupport;
 })
 public class JobResult extends UnpackedObject implements JobResultValue {
 
-  private final BooleanProperty deniedProp = new BooleanProperty("denied", false);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue DENIED_KEY = new StringValue("denied");
+  private static final StringValue CORRECTED_ATTRIBUTES_KEY =
+      new StringValue("correctedAttributes");
+  private static final StringValue CORRECTIONS_KEY = new StringValue("corrections");
+  private static final StringValue DENIED_REASON_KEY = new StringValue("deniedReason");
+
+  private final BooleanProperty deniedProp = new BooleanProperty(DENIED_KEY, false);
   private final ArrayProperty<StringValue> correctedAttributesProp =
-      new ArrayProperty<>("correctedAttributes", StringValue::new);
+      new ArrayProperty<>(CORRECTED_ATTRIBUTES_KEY, StringValue::new);
   private final ObjectProperty<JobResultCorrections> correctionsProp =
-      new ObjectProperty<>("corrections", new JobResultCorrections());
-  private final StringProperty deniedReasonProp = new StringProperty("deniedReason", EMPTY_STRING);
+      new ObjectProperty<>(CORRECTIONS_KEY, new JobResultCorrections());
+  private final StringProperty deniedReasonProp =
+      new StringProperty(DENIED_REASON_KEY, EMPTY_STRING);
 
   public JobResult() {
     super(4);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
@@ -29,14 +29,23 @@ import org.agrona.DirectBuffer;
 public final class JobResultCorrections extends UnpackedObject
     implements JobResultCorrectionsValue {
 
-  private final StringProperty assigneeProp = new StringProperty("assignee", "");
-  private final StringProperty dueDateProp = new StringProperty("dueDate", "");
-  private final StringProperty followUpDateProp = new StringProperty("followUpDate", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue ASSIGNEE_KEY = new StringValue("assignee");
+  private static final StringValue DUE_DATE_KEY = new StringValue("dueDate");
+  private static final StringValue FOLLOW_UP_DATE_KEY = new StringValue("followUpDate");
+  private static final StringValue CANDIDATE_USERS_LIST_KEY = new StringValue("candidateUsersList");
+  private static final StringValue CANDIDATE_GROUPS_LIST_KEY =
+      new StringValue("candidateGroupsList");
+  private static final StringValue PRIORITY_KEY = new StringValue("priority");
+
+  private final StringProperty assigneeProp = new StringProperty(ASSIGNEE_KEY, "");
+  private final StringProperty dueDateProp = new StringProperty(DUE_DATE_KEY, "");
+  private final StringProperty followUpDateProp = new StringProperty(FOLLOW_UP_DATE_KEY, "");
   private final ArrayProperty<StringValue> candidateUsersListProp =
-      new ArrayProperty<>("candidateUsersList", StringValue::new);
+      new ArrayProperty<>(CANDIDATE_USERS_LIST_KEY, StringValue::new);
   private final ArrayProperty<StringValue> candidateGroupsListProp =
-      new ArrayProperty<>("candidateGroupsList", StringValue::new);
-  private final IntegerProperty priorityProp = new IntegerProperty("priority", -1);
+      new ArrayProperty<>(CANDIDATE_GROUPS_LIST_KEY, StringValue::new);
+  private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, -1);
 
   public JobResultCorrections() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.message;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
@@ -19,8 +20,11 @@ import java.util.stream.StreamSupport;
 public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
+  // Static StringValue key to avoid memory waste
+  private static final StringValue MESSAGE_KEYS_KEY = new StringValue("messageKeys");
+
   private final ArrayProperty<LongValue> messageKeysProp =
-      new ArrayProperty<>("messageKeys", LongValue::new);
+      new ArrayProperty<>(MESSAGE_KEYS_KEY, LongValue::new);
 
   public MessageBatchRecord() {
     super(1);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
@@ -24,16 +25,28 @@ import org.agrona.DirectBuffer;
 public final class MessageCorrelationRecord extends UnifiedRecordValue
     implements MessageCorrelationRecordValue {
 
-  private final StringProperty nameProp = new StringProperty("name");
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
-  private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue NAME_KEY = new StringValue("name");
+  private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
+  private static final StringValue REQUEST_ID_KEY = new StringValue("requestId");
+  private static final StringValue REQUEST_STREAM_ID_KEY = new StringValue("requestStreamId");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
 
-  private final LongProperty messageKey = new LongProperty("messageKey", -1L);
-  private final LongProperty requestIdProp = new LongProperty("requestId", -1L);
-  private final IntegerProperty requestStreamIdProp = new IntegerProperty("requestStreamId", -1);
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+  private final StringProperty nameProp = new StringProperty(NAME_KEY);
+  private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+  private final StringProperty tenantIdProp =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  private final LongProperty messageKey = new LongProperty(MESSAGE_KEY_KEY, -1L);
+  private final LongProperty requestIdProp = new LongProperty(REQUEST_ID_KEY, -1L);
+  private final IntegerProperty requestStreamIdProp =
+      new IntegerProperty(REQUEST_STREAM_ID_KEY, -1);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
 
   public MessageCorrelationRecord() {
     super(7);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
@@ -22,16 +23,24 @@ import org.agrona.DirectBuffer;
 
 public final class MessageRecord extends UnifiedRecordValue implements MessageRecordValue {
 
-  private final StringProperty nameProp = new StringProperty("name");
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
-  // TTL in milliseconds
-  private final LongProperty timeToLiveProp = new LongProperty("timeToLive");
-  private final LongProperty deadlineProp = new LongProperty("deadline", -1);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue NAME_KEY = new StringValue("name");
+  private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue TIME_TO_LIVE_KEY = new StringValue("timeToLive");
+  private static final StringValue DEADLINE_KEY = new StringValue("deadline");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue MESSAGE_ID_KEY = new StringValue("messageId");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
-  private final StringProperty messageIdProp = new StringProperty("messageId", "");
+  private final StringProperty nameProp = new StringProperty(NAME_KEY);
+  private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY);
+  private final LongProperty timeToLiveProp = new LongProperty(TIME_TO_LIVE_KEY);
+  private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
+
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+  private final StringProperty messageIdProp = new StringProperty(MESSAGE_ID_KEY, "");
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageRecord() {
     super(7);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
@@ -23,18 +24,31 @@ import org.agrona.DirectBuffer;
 public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValue
     implements MessageStartEventSubscriptionRecordValue {
 
-  private final LongProperty processDefinitionKeyProp =
-      new LongProperty("processDefinitionKey", -1L);
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
-  private final StringProperty messageNameProp = new StringProperty("messageName", "");
-  private final StringProperty startEventIdProp = new StringProperty("startEventId", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue MESSAGE_NAME_KEY = new StringValue("messageName");
+  private static final StringValue START_EVENT_ID_KEY = new StringValue("startEventId");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
+  private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
-  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final StringProperty messageNameProp = new StringProperty(MESSAGE_NAME_KEY, "");
+  private final StringProperty startEventIdProp = new StringProperty(START_EVENT_ID_KEY, "");
+
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty messageKeyProp = new LongProperty(MESSAGE_KEY_KEY, -1L);
+  private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY, "");
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageStartEventSubscriptionRecord() {
     super(9);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -24,17 +25,28 @@ import org.agrona.DirectBuffer;
 public final class MessageSubscriptionRecord extends UnifiedRecordValue
     implements MessageSubscriptionRecordValue {
 
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
-  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
-  private final StringProperty messageNameProp = new StringProperty("messageName", "");
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
-  private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
+  private static final StringValue MESSAGE_NAME_KEY = new StringValue("messageName");
+  private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
 
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+  private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final LongProperty messageKeyProp = new LongProperty(MESSAGE_KEY_KEY, -1L);
+  private final StringProperty messageNameProp = new StringProperty(MESSAGE_NAME_KEY, "");
+  private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY, "");
+  private final BooleanProperty interruptingProp = new BooleanProperty(INTERRUPTING_KEY, true);
+
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageSubscriptionRecord() {
     super(9);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -7,18 +7,18 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -26,19 +26,33 @@ import org.agrona.DirectBuffer;
 public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     implements ProcessMessageSubscriptionRecordValue {
 
+  // Static StringValue keys for property names
+  private static final StringValue SUBSCRIPTION_PARTITION_ID_KEY =
+      new StringValue("subscriptionPartitionId");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue MESSAGE_KEY_KEY = new StringValue("messageKey");
+  private static final StringValue MESSAGE_NAME_KEY = new StringValue("messageName");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue INTERRUPTING_KEY = new StringValue("interrupting");
+  private static final StringValue CORRELATION_KEY_KEY = new StringValue("correlationKey");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+
   private final IntegerProperty subscriptionPartitionIdProp =
-      new IntegerProperty("subscriptionPartitionId");
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
-  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
-  private final StringProperty messageNameProp = new StringProperty("messageName", "");
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
-  private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
-  private final StringProperty elementIdProp = new StringProperty("elementId", "");
+      new IntegerProperty(SUBSCRIPTION_PARTITION_ID_KEY);
+  private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+  private final LongProperty elementInstanceKeyProp = new LongProperty(ELEMENT_INSTANCE_KEY_KEY);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final LongProperty messageKeyProp = new LongProperty(MESSAGE_KEY_KEY, -1L);
+  private final StringProperty messageNameProp = new StringProperty(MESSAGE_NAME_KEY, "");
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+  private final BooleanProperty interruptingProp = new BooleanProperty(INTERRUPTING_KEY, true);
+  private final StringProperty correlationKeyProp = new StringProperty(CORRELATION_KEY_KEY, "");
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessMessageSubscriptionRecord() {
     super(11);
@@ -121,7 +135,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getBpmnProcessId() {
-    return bufferAsString(bpmnProcessIdProp.getValue());
+    return BufferUtil.bufferAsString(bpmnProcessIdProp.getValue());
   }
 
   public ProcessMessageSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
@@ -136,12 +150,12 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getMessageName() {
-    return bufferAsString(messageNameProp.getValue());
+    return BufferUtil.bufferAsString(messageNameProp.getValue());
   }
 
   @Override
   public String getCorrelationKey() {
-    return bufferAsString(correlationKeyProp.getValue());
+    return BufferUtil.bufferAsString(correlationKeyProp.getValue());
   }
 
   public ProcessMessageSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
@@ -151,7 +165,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getElementId() {
-    return bufferAsString(getElementIdBuffer());
+    return BufferUtil.bufferAsString(getElementIdBuffer());
   }
 
   @Override
@@ -196,7 +210,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
 
   @Override
   public String getTenantId() {
-    return bufferAsString(tenantIdProp.getValue());
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
   }
 
   public ProcessMessageSubscriptionRecord setTenantId(final String tenantId) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/metrics/UsageMetricRecord.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
@@ -19,14 +20,22 @@ import org.agrona.DirectBuffer;
 
 public class UsageMetricRecord extends UnifiedRecordValue implements UsageMetricRecordValue {
 
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue INTERVAL_TYPE_KEY = new StringValue("intervalType");
+  private static final StringValue EVENT_TYPE_KEY = new StringValue("eventType");
+  private static final StringValue START_TIME_KEY = new StringValue("startTime");
+  private static final StringValue END_TIME_KEY = new StringValue("endTime");
+  private static final StringValue VALUES_KEY = new StringValue("values");
+  private static final StringValue RESET_TIME_KEY = new StringValue("resetTime");
+
   private final EnumProperty<IntervalType> intervalTypeProp =
-      new EnumProperty<>("intervalType", IntervalType.class, IntervalType.ACTIVE);
+      new EnumProperty<>(INTERVAL_TYPE_KEY, IntervalType.class, IntervalType.ACTIVE);
   private final EnumProperty<EventType> eventTypeProp =
-      new EnumProperty<>("eventType", EventType.class, EventType.NONE);
-  private final LongProperty resetTimeProp = new LongProperty("resetTime", -1);
-  private final LongProperty startTimeProp = new LongProperty("startTime", -1);
-  private final LongProperty endTimeProp = new LongProperty("endTime", -1);
-  private final DocumentProperty valuesProp = new DocumentProperty("values");
+      new EnumProperty<>(EVENT_TYPE_KEY, EventType.class, EventType.NONE);
+  private final LongProperty resetTimeProp = new LongProperty(RESET_TIME_KEY, -1);
+  private final LongProperty startTimeProp = new LongProperty(START_TIME_KEY, -1);
+  private final LongProperty endTimeProp = new LongProperty(END_TIME_KEY, -1);
+  private final DocumentProperty valuesProp = new DocumentProperty(VALUES_KEY);
 
   public UsageMetricRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -29,20 +29,30 @@ import org.agrona.DirectBuffer;
 public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
     implements ProcessInstanceCreationRecordValue {
 
-  private final StringProperty bpmnProcessIdProperty = new StringProperty("bpmnProcessId", "");
-  private final LongProperty processDefinitionKeyProperty =
-      new LongProperty("processDefinitionKey", -1);
-  private final IntegerProperty versionProperty = new IntegerProperty("version", -1);
-  private final StringProperty tenantIdProperty =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final DocumentProperty variablesProperty = new DocumentProperty("variables");
-  private final LongProperty processInstanceKeyProperty =
-      new LongProperty("processInstanceKey", -1);
-  private final ArrayProperty<StringValue> fetchVariablesProperty =
-      new ArrayProperty<>("fetchVariables", StringValue::new);
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue VERSION_KEY = new StringValue("version");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue FETCH_VARIABLES_KEY = new StringValue("fetchVariables");
+  private static final StringValue START_INSTRUCTIONS_KEY = new StringValue("startInstructions");
 
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1);
+  private final IntegerProperty versionProperty = new IntegerProperty(VERSION_KEY, -1);
+  private final StringProperty tenantIdProperty =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final DocumentProperty variablesProperty = new DocumentProperty(VARIABLES_KEY);
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
+  private final ArrayProperty<StringValue> fetchVariablesProperty =
+      new ArrayProperty<>(FETCH_VARIABLES_KEY, StringValue::new);
   private final ArrayProperty<ProcessInstanceCreationStartInstruction> startInstructionsProperty =
-      new ArrayProperty<>("startInstructions", ProcessInstanceCreationStartInstruction::new);
+      new ArrayProperty<>(START_INSTRUCTIONS_KEY, ProcessInstanceCreationStartInstruction::new);
 
   private final ArrayProperty<ProcessInstanceCreationRuntimeInstruction>
       runtimeInstructionsProperty =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
@@ -23,7 +24,10 @@ import org.agrona.DirectBuffer;
 public final class ProcessInstanceCreationStartInstruction extends ObjectValue
     implements ProcessInstanceCreationStartInstructionValue {
 
-  private final StringProperty elementIdProp = new StringProperty("elementId");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY);
 
   public ProcessInstanceCreationStartInstruction() {
     super(1);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import java.util.List;
@@ -17,13 +18,21 @@ import java.util.List;
 public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
     implements ProcessInstanceMigrationRecordValue {
 
-  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue TARGET_PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("targetProcessDefinitionKey");
+  private static final StringValue MAPPING_INSTRUCTIONS_KEY =
+      new StringValue("mappingInstructions");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final LongProperty targetProcessDefinitionKeyProperty =
-      new LongProperty("targetProcessDefinitionKey");
+      new LongProperty(TARGET_PROCESS_DEFINITION_KEY_KEY);
   private final ArrayProperty<ProcessInstanceMigrationMappingInstruction>
       mappingInstructionsProperty =
           new ArrayProperty<>(
-              "mappingInstructions", ProcessInstanceMigrationMappingInstruction::new);
+              MAPPING_INSTRUCTIONS_KEY, ProcessInstanceMigrationMappingInstruction::new);
 
   public ProcessInstanceMigrationRecord() {
     super(3);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -22,19 +23,28 @@ import java.util.stream.Collectors;
 public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
     implements ProcessInstanceModificationRecordValue {
 
-  private final LongProperty processInstanceKeyProperty = new LongProperty("processInstanceKey");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue TERMINATE_INSTRUCTIONS_KEY =
+      new StringValue("terminateInstructions");
+  private static final StringValue ACTIVATE_INSTRUCTIONS_KEY =
+      new StringValue("activateInstructions");
+  private static final StringValue ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY =
+      new StringValue("activatedElementInstanceKeys");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY);
   private final ArrayProperty<ProcessInstanceModificationTerminateInstruction>
       terminateInstructionsProperty =
           new ArrayProperty<>(
-              "terminateInstructions", ProcessInstanceModificationTerminateInstruction::new);
+              TERMINATE_INSTRUCTIONS_KEY, ProcessInstanceModificationTerminateInstruction::new);
   private final ArrayProperty<ProcessInstanceModificationActivateInstruction>
       activateInstructionsProperty =
           new ArrayProperty<>(
-              "activateInstructions", ProcessInstanceModificationActivateInstruction::new);
+              ACTIVATE_INSTRUCTIONS_KEY, ProcessInstanceModificationActivateInstruction::new);
 
-  @Deprecated(since = "8.1.3")
   private final ArrayProperty<LongValue> activatedElementInstanceKeys =
-      new ArrayProperty<>("activatedElementInstanceKeys", LongValue::new);
+      new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
 
   public ProcessInstanceModificationRecord() {
     super(4);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue.ProcessInstanceModificationVariableInstructionValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -26,8 +27,12 @@ import org.agrona.DirectBuffer;
 public final class ProcessInstanceModificationVariableInstruction extends ObjectValue
     implements ProcessInstanceModificationVariableInstructionValue {
 
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
-  private final StringProperty elementIdProp = new StringProperty("elementId", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
 
   public ProcessInstanceModificationVariableInstruction() {
     super(2);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
@@ -30,47 +31,57 @@ import org.agrona.DirectBuffer;
 public final class ProcessInstanceRecord extends UnifiedRecordValue
     implements ProcessInstanceRecordValue {
 
-  public static final String PROP_PROCESS_BPMN_PROCESS_ID = "bpmnProcessId";
-  public static final String PROP_PROCESS_INSTANCE_KEY = "processInstanceKey";
-  public static final String PROP_PROCESS_ELEMENT_ID = "elementId";
-  public static final String PROP_PROCESS_VERSION = "version";
-  public static final String PROP_PROCESS_KEY = "processDefinitionKey";
-  public static final String PROP_PROCESS_BPMN_TYPE = "bpmnElementType";
-  public static final String PROP_PROCESS_SCOPE_KEY = "flowScopeKey";
-  public static final String PROP_PROCESS_EVENT_TYPE = "bpmnEventType";
-  public static final String PROP_TENANT_ID = "tenantId";
+  // Static StringValue keys for property names
+  public static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  public static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
+  public static final StringValue VERSION_KEY = new StringValue("version");
+  public static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  public static final StringValue BPMN_ELEMENT_TYPE_KEY = new StringValue("bpmnElementType");
+  public static final StringValue FLOW_SCOPE_KEY_KEY = new StringValue("flowScopeKey");
+  public static final StringValue BPMN_EVENT_TYPE_KEY = new StringValue("bpmnEventType");
+  public static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  public static final StringValue PARENT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("parentProcessInstanceKey");
+  public static final StringValue PARENT_ELEMENT_INSTANCE_KEY_KEY =
+      new StringValue("parentElementInstanceKey");
+  public static final StringValue ELEMENT_INSTANCE_PATH_KEY =
+      new StringValue("elementInstancePath");
+  public static final StringValue PROCESS_DEFINITION_PATH_KEY =
+      new StringValue("processDefinitionPath");
+  public static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
 
-  private final StringProperty bpmnProcessIdProp =
-      new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID, "");
-  private final IntegerProperty versionProp = new IntegerProperty(PROP_PROCESS_VERSION, -1);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
   private final StringProperty tenantIdProp =
-      new StringProperty(PROP_TENANT_ID, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final LongProperty processDefinitionKeyProp = new LongProperty(PROP_PROCESS_KEY, -1L);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
 
   private final LongProperty processInstanceKeyProp =
-      new LongProperty(PROP_PROCESS_INSTANCE_KEY, -1L);
-  private final StringProperty elementIdProp = new StringProperty(PROP_PROCESS_ELEMENT_ID, "");
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
 
-  private final LongProperty flowScopeKeyProp = new LongProperty(PROP_PROCESS_SCOPE_KEY, -1L);
+  private final LongProperty flowScopeKeyProp = new LongProperty(FLOW_SCOPE_KEY_KEY, -1L);
 
   private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
-      new EnumProperty<>(
-          PROP_PROCESS_BPMN_TYPE, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
+      new EnumProperty<>(BPMN_ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   private final EnumProperty<BpmnEventType> bpmnEventTypeProp =
-      new EnumProperty<>(PROP_PROCESS_EVENT_TYPE, BpmnEventType.class, BpmnEventType.UNSPECIFIED);
+      new EnumProperty<>(BPMN_EVENT_TYPE_KEY, BpmnEventType.class, BpmnEventType.UNSPECIFIED);
 
   private final LongProperty parentProcessInstanceKeyProp =
-      new LongProperty("parentProcessInstanceKey", -1L);
+      new LongProperty(PARENT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty parentElementInstanceKeyProp =
-      new LongProperty("parentElementInstanceKey", -1L);
+      new LongProperty(PARENT_ELEMENT_INSTANCE_KEY_KEY, -1L);
 
   private final ArrayProperty<ArrayValue<LongValue>> elementInstancePathProp =
-      new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
+      new ArrayProperty<>(ELEMENT_INSTANCE_PATH_KEY, () -> new ArrayValue<>(LongValue::new));
   private final ArrayProperty<LongValue> processDefinitionPathProp =
-      new ArrayProperty<>("processDefinitionPath", LongValue::new);
+      new ArrayProperty<>(PROCESS_DEFINITION_PATH_KEY, LongValue::new);
   private final ArrayProperty<IntegerValue> callingElementPathProp =
-      new ArrayProperty<>("callingElementPath", IntegerValue::new);
+      new ArrayProperty<>(CALLING_ELEMENT_PATH_KEY, IntegerValue::new);
 
   public ProcessInstanceRecord() {
     super(14);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
@@ -24,15 +25,24 @@ import org.agrona.DirectBuffer;
 public final class ProcessInstanceResultRecord extends UnifiedRecordValue
     implements ProcessInstanceResultRecordValue {
 
-  private final StringProperty bpmnProcessIdProperty = new StringProperty("bpmnProcessId", "");
+  // Static StringValue keys for property names
+  public static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  public static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  public static final StringValue VERSION_KEY = new StringValue("version");
+  public static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  public static final StringValue VARIABLES_KEY = new StringValue("variables");
+  public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
-      new LongProperty("processDefinitionKey", -1);
-  private final IntegerProperty versionProperty = new IntegerProperty("version", -1);
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1);
+  private final IntegerProperty versionProperty = new IntegerProperty(VERSION_KEY, -1);
   private final StringProperty tenantIdProperty =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final DocumentProperty variablesProperty = new DocumentProperty("variables");
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final DocumentProperty variablesProperty = new DocumentProperty(VARIABLES_KEY);
   private final LongProperty processInstanceKeyProperty =
-      new LongProperty("processInstanceKey", -1);
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
 
   public ProcessInstanceResultRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.resource;
 
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -16,8 +17,12 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 public class ResourceDeletionRecord extends UnifiedRecordValue
     implements ResourceDeletionRecordValue {
 
-  private final LongProperty resourceKeyProp = new LongProperty("resourceKey");
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue RESOURCE_KEY_KEY = new StringValue("resourceKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+
+  private final LongProperty resourceKeyProp = new LongProperty(RESOURCE_KEY_KEY);
+  private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
 
   public ResourceDeletionRecord() {
     super(2);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
@@ -21,10 +22,15 @@ import org.agrona.DirectBuffer;
 
 public final class SignalRecord extends UnifiedRecordValue implements SignalRecordValue {
 
-  private final StringProperty signalNameProp = new StringProperty("signalName");
-  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  // Static StringValue keys for property names
+  private static final StringValue SIGNAL_NAME_KEY = new StringValue("signalName");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+
+  private final StringProperty signalNameProp = new StringProperty(SIGNAL_NAME_KEY);
+  private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public SignalRecord() {
     super(3);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -20,15 +21,25 @@ import org.agrona.DirectBuffer;
 public final class SignalSubscriptionRecord extends UnifiedRecordValue
     implements SignalSubscriptionRecordValue {
 
+  // Static StringValue keys for property names
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue SIGNAL_NAME_KEY = new StringValue("signalName");
+  private static final StringValue CATCH_EVENT_ID_KEY = new StringValue("catchEventId");
+  private static final StringValue CATCH_EVENT_INSTANCE_KEY_KEY =
+      new StringValue("catchEventInstanceKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+
   private final LongProperty processDefinitionKeyProp =
-      new LongProperty("processDefinitionKey", -1L);
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
-  private final StringProperty signalNameProp = new StringProperty("signalName", "");
-  private final StringProperty catchEventIdProp = new StringProperty("catchEventId", "");
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+  private final StringProperty signalNameProp = new StringProperty(SIGNAL_NAME_KEY, "");
+  private final StringProperty catchEventIdProp = new StringProperty(CATCH_EVENT_ID_KEY, "");
   private final LongProperty catchEventInstanceKeyProp =
-      new LongProperty("catchEventInstanceKey", -1L);
+      new LongProperty(CATCH_EVENT_INSTANCE_KEY_KEY, -1L);
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public SignalSubscriptionRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
@@ -20,13 +21,22 @@ import org.agrona.DirectBuffer;
 
 public final class TenantRecord extends UnifiedRecordValue implements TenantRecordValue {
   private static final long DEFAULT_KEY = -1;
-  private final LongProperty tenantKeyProp = new LongProperty("tenantKey", DEFAULT_KEY);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId");
-  private final StringProperty nameProp = new StringProperty("name", "");
-  private final StringProperty descriptionProp = new StringProperty("description", "");
-  private final StringProperty entityIdProp = new StringProperty("entityId", "");
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue TENANT_KEY_KEY = new StringValue("tenantKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue NAME_KEY = new StringValue("name");
+  private static final StringValue DESCRIPTION_KEY = new StringValue("description");
+  private static final StringValue ENTITY_ID_KEY = new StringValue("entityId");
+  private static final StringValue ENTITY_TYPE_KEY = new StringValue("entityType");
+
+  private final LongProperty tenantKeyProp = new LongProperty(TENANT_KEY_KEY, DEFAULT_KEY);
+  private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY);
+  private final StringProperty nameProp = new StringProperty(NAME_KEY, "");
+  private final StringProperty descriptionProp = new StringProperty(DESCRIPTION_KEY, "");
+  private final StringProperty entityIdProp = new StringProperty(ENTITY_ID_KEY, "");
   private final EnumProperty<EntityType> entityTypeProp =
-      new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
+      new EnumProperty<>(ENTITY_TYPE_KEY, EntityType.class, EntityType.UNSPECIFIED);
 
   public TenantRecord() {
     super(6);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.usertask;
 
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_BPMN_PROCESS_ID;
-import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROP_PROCESS_INSTANCE_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.BPMN_PROCESS_ID_KEY;
+import static io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord.PROCESS_INSTANCE_KEY_KEY;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -95,9 +95,9 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final PackedProperty customHeadersProp = new PackedProperty("customHeaders", NO_HEADERS);
 
   private final LongProperty processInstanceKeyProp =
-      new LongProperty(PROP_PROCESS_INSTANCE_KEY, -1L);
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProp =
-      new StringProperty(PROP_PROCESS_BPMN_PROCESS_ID, EMPTY_STRING);
+      new StringProperty(BPMN_PROCESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty processDefinitionVersionProp =
       new IntegerProperty("processDefinitionVersion", -1);
   private final LongProperty processDefinitionKeyProp =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -22,13 +23,18 @@ import org.agrona.DirectBuffer;
 
 public final class VariableDocumentRecord extends UnifiedRecordValue
     implements VariableDocumentRecordValue {
-  private final LongProperty scopeKeyProperty = new LongProperty("scopeKey");
+  // Static StringValue keys for property names
+  private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue UPDATE_SEMANTICS_KEY = new StringValue("updateSemantics");
+  private static final StringValue VARIABLES_KEY = new StringValue("variables");
+
+  private final LongProperty scopeKeyProperty = new LongProperty(SCOPE_KEY_KEY);
   private final EnumProperty<VariableDocumentUpdateSemantic> updateSemanticsProperty =
       new EnumProperty<>(
-          "updateSemantics",
+          UPDATE_SEMANTICS_KEY,
           VariableDocumentUpdateSemantic.class,
           VariableDocumentUpdateSemantic.PROPAGATE);
-  private final DocumentProperty variablesProperty = new DocumentProperty("variables");
+  private final DocumentProperty variablesProperty = new DocumentProperty(VARIABLES_KEY);
 
   public VariableDocumentRecord() {
     super(3);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -22,14 +23,25 @@ import org.agrona.DirectBuffer;
 
 public final class VariableRecord extends UnifiedRecordValue implements VariableRecordValue {
 
-  private final StringProperty nameProp = new StringProperty("name");
-  private final BinaryProperty valueProp = new BinaryProperty("value");
-  private final LongProperty scopeKeyProp = new LongProperty("scopeKey");
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey");
-  private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  // Static StringValue keys for property names
+  private static final StringValue NAME_KEY = new StringValue("name");
+  private static final StringValue VALUE_KEY = new StringValue("value");
+  private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+
+  private final StringProperty nameProp = new StringProperty(NAME_KEY);
+  private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
+  private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY);
+  private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY);
+  private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final StringProperty tenantIdProp =
-      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public VariableRecord() {
     super(7);


### PR DESCRIPTION
## Description
Add the possibility to use static instances of `StringValue` for keys of objects.
This reduces the memory footprint as keys do not need to be allocated and should save some cpu time as well, as there's no need to copy the string to a buffer on the constructor.

This idea came out of seeing a lot of cpu time spent on record contructors in the profiler.

It would be interesting to have a JMH benchmark to compare the performances, but I didn't have enough time to do it.

We could also just merge the first commit and then migrater record by record.
I originally migrated some records because I was curious if we could see any difference in the benchmarks environment.

### Dashboards
- [this branch](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=cs-optimize-records-benchmark&var-pod=All&var-partition=All&var-memory_state=committed&from=1751485411141&to=1751531262217)
- [ a baseline branch](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=ls-cmp&var-pod=All&var-partition=All&var-memory_state=committed&from=1751495670000&to=1751516391000)

### Comments
We can see a lower cpu usage on all three brokers, while there is not a big difference on memory usage/gc.
The record processing durations appears to to be lower, for example:
- ProcessInstance.Create:
  - 0.0025 vs 0.0029 ~ - 13%
- ProcessInstanceCreation.Create:
   - 0.0075 vs 0.025  ~ - 65%

I would like to validate this improvements with a secondary "test" like a JMH test, but maybe it's not necessary

### Shoutout
to Copilot that did most of the changes in the records :laughing: 

