### PR TITLE
feat(34483): Use inputs.isLatest for marking release as latest in camunda-platform-release.yml

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -329,6 +329,7 @@ jobs:
           artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
           draft: false
+          makeLatest: ${{ inputs.isLatest }}
           body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}


### PR DESCRIPTION

## Description

Use inputs.isLatest for marking release as latest in camunda-platform-release.yml

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes # https://github.com/camunda/camunda/issues/34483
