### PR TITLE
test: replace index descriptors mocking with stubbed implementation

### DIFF
--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -155,6 +155,12 @@
       <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy-agent</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexMappingTest.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.search.schema;
 
+import static io.camunda.search.schema.utils.SchemaTestUtil.createTestIndexDescriptor;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -19,8 +19,7 @@ public class IndexMappingTest {
   @Test
   void shouldReadIndexMappingsFileCorrectly() {
     // given
-    final var index =
-        SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
+    final var index = createTestIndexDescriptor("index_name", "/mappings.json");
 
     // when
     final var indexMapping = IndexMapping.from(index, TestObjectMapper.objectMapper());

--- a/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/IndexSchemaValidatorTest.java
@@ -7,18 +7,17 @@
  */
 package io.camunda.search.schema;
 
+import static io.camunda.search.schema.utils.SchemaTestUtil.createTestIndexDescriptor;
+import static io.camunda.search.schema.utils.SchemaTestUtil.createTestTemplateDescriptor;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.schema.exceptions.IndexSchemaValidationException;
-import io.camunda.search.schema.utils.SchemaTestUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,17 +33,16 @@ public class IndexSchemaValidatorTest {
   @Test
   void shouldDetectIndexWithAddedProperty() throws IOException {
     // given
+    final var index = createTestIndexDescriptor("index_name", "/mappings-added-property.json");
     final var currentIndices =
-        Map.of("qualified_name", jsonToIndexMappingProperties("/mappings.json", "qualified_name"));
+        Map.of(
+            index.getFullQualifiedName(),
+            jsonToIndexMappingProperties("/mappings.json", index.getFullQualifiedName()));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "alias", "index_name", "/mappings-added-property.json");
-
-    // then
     final var difference = VALIDATOR.validateIndexMappings(currentIndices, Set.of(index));
 
+    // then
     assertThat(difference)
         .containsExactly(
             entry(
@@ -59,19 +57,17 @@ public class IndexSchemaValidatorTest {
   @Test
   public void shouldDetectAnAddedIndexPropertyOnTwoIndicesWithMissingField() throws IOException {
     // given
+    final var index = createTestIndexDescriptor("qualified_name", "/mappings-added-property.json");
+    final var fullQualifiedName = index.getFullQualifiedName();
     // a schema with two indices that has a missing field
     final var currentIndices =
         Map.of(
-            "qualified_name",
-            jsonToIndexMappingProperties("/mappings.json", "qualified_name"),
-            "qualified_name_2",
-            jsonToIndexMappingProperties("/mappings.json", "qualified_name_2"));
+            fullQualifiedName,
+            jsonToIndexMappingProperties("/mappings.json", fullQualifiedName),
+            fullQualifiedName + "_2",
+            jsonToIndexMappingProperties("/mappings.json", fullQualifiedName + "_2"));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "aliasx", "qualified_name", "/mappings-added-property.json");
-
     final var difference = VALIDATOR.validateIndexMappings(currentIndices, Set.of(index));
 
     // then
@@ -93,8 +89,7 @@ public class IndexSchemaValidatorTest {
         Map.of("qualified_name", jsonToIndexMappingProperties("/mappings.json", "qualified_name"));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex("qualified_name", "alias", "index_name", "/mappings.json");
+    final var index = createTestIndexDescriptor("index_name", "/mappings.json");
 
     // then
     final var difference = VALIDATOR.validateIndexMappings(currentIndices, Set.of(index));
@@ -106,8 +101,7 @@ public class IndexSchemaValidatorTest {
   void shouldIgnoreNotCreatedIndicesFromValidation() {
 
     // given, when, then
-    final var index =
-        SchemaTestUtil.mockIndex("qualified_name", "alias", "index_name", "/mappings.json");
+    final var index = createTestIndexDescriptor("index_name", "/mappings.json");
     final var difference = VALIDATOR.validateIndexMappings(Map.of(), Set.of(index));
 
     assertThat(difference).isEmpty();
@@ -116,18 +110,17 @@ public class IndexSchemaValidatorTest {
   @Test
   public void shouldDetectAmbiguousIndexDifference() throws IOException {
     // given
+    final var currentIndex = createTestIndexDescriptor("index_name", "/mappings.json");
+    final var qualifiedName = currentIndex.getFullQualifiedName();
     final var currentIndices =
         Map.of(
-            "qualified_name",
-            jsonToIndexMappingProperties("/mappings-deleted-property.json", "qualified_name"),
-            "qualified_name_2",
+            qualifiedName,
+            jsonToIndexMappingProperties("/mappings-deleted-property.json", qualifiedName),
+            qualifiedName + "_2",
             jsonToIndexMappingProperties(
-                "/mappings-deleted-different-property.json", "qualified_name_2"));
+                "/mappings-deleted-different-property.json", qualifiedName + "_2"));
 
     // when
-    final var currentIndex =
-        SchemaTestUtil.mockIndex("qualified_name", "alias3", "index_name", "/mappings.json");
-
     // then
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(currentIndex)))
         .isInstanceOf(IndexSchemaValidationException.class)
@@ -137,20 +130,19 @@ public class IndexSchemaValidatorTest {
   @Test
   public void shouldDetectAmbiguousIndexDifferenceCaseWithDynamicProperties() throws IOException {
     // given
+    final var indexMapping =
+        createTestIndexDescriptor("index_name", "/mappings-dynamic-property.json");
+    final String fullQualifiedName = indexMapping.getFullQualifiedName();
     final var currentIndices =
         Map.of(
-            "qualified_name",
+            fullQualifiedName,
             jsonToIndexMappingProperties(
-                "/mappings-dynamic-property-properties.json", "qualified_name"),
-            "qualified_name_2",
+                "/mappings-dynamic-property-properties.json", fullQualifiedName),
+            fullQualifiedName + "_2",
             jsonToIndexMappingProperties(
-                "/mappings-dynamic-property-properties-deleted.json", "qualified_name_2"));
+                "/mappings-dynamic-property-properties-deleted.json", fullQualifiedName + "_2"));
 
     // when
-    final var indexMapping =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "alias3", "index_name", "/mappings-dynamic-property.json");
-
     // then
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(indexMapping)))
         .isInstanceOf(IndexSchemaValidationException.class)
@@ -160,21 +152,21 @@ public class IndexSchemaValidatorTest {
   @Test
   public void shouldSkipIndexDifferenceWhenRelatesToDynamicProperty() throws IOException {
     // given
+    final var indexMapping =
+        createTestIndexDescriptor("index_name", "/mappings-dynamic-property-added.json");
+    final String fullQualifiedName = indexMapping.getFullQualifiedName();
     final var currentIndices =
         Map.of(
-            "qualified_name",
-            jsonToIndexMappingProperties("/mappings-dynamic-property.json", "qualified_name"),
-            "qualified_name_2",
+            fullQualifiedName,
+            jsonToIndexMappingProperties("/mappings-dynamic-property.json", fullQualifiedName),
+            fullQualifiedName + "_2",
             jsonToIndexMappingProperties(
-                "/mappings-dynamic-property-properties.json", "qualified_name_2"));
+                "/mappings-dynamic-property-properties.json", fullQualifiedName + "_2"));
 
     // when
-    final var indexMapping =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "alias3", "index_name", "/mappings-dynamic-property-added.json");
+    final var actual = VALIDATOR.validateIndexMappings(currentIndices, Set.of(indexMapping));
 
     // then
-    final var actual = VALIDATOR.validateIndexMappings(currentIndices, Set.of(indexMapping));
     assertThat(actual).hasSize(1);
     assertThat(actual)
         .containsValue(
@@ -194,8 +186,7 @@ public class IndexSchemaValidatorTest {
             jsonToIndexMappingProperties("/mappings-added-property.json", "qualified_name"));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex("qualified_name", "alias", "index_name", "/mappings.json");
+    final var index = createTestIndexDescriptor("index_name", "/mappings.json");
 
     // then
     final var difference = VALIDATOR.validateIndexMappings(currentIndices, Set.of(index));
@@ -206,14 +197,14 @@ public class IndexSchemaValidatorTest {
   @Test
   void shouldDetectChangedIndexMappingParameters() throws IOException {
     // given
+    final var index =
+        createTestIndexDescriptor("index_name", "/mappings-changed-property-invalid.json");
     final var currentIndices =
-        Map.of("qualified_name", jsonToIndexMappingProperties("/mappings.json", "qualified_name"));
+        Map.of(
+            index.getFullQualifiedName(),
+            jsonToIndexMappingProperties("/mappings.json", index.getFullQualifiedName()));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "alias", "index_name", "/mappings-changed-property-invalid.json");
-
     // then
     assertThatThrownBy(() -> VALIDATOR.validateIndexMappings(currentIndices, Set.of(index)))
         .isInstanceOf(IndexSchemaValidationException.class)
@@ -224,25 +215,17 @@ public class IndexSchemaValidatorTest {
   @Test
   void shouldDetectIndexTemplateWithAddedProperty() throws IOException {
     // given
+    final var indexTemplate =
+        createTestTemplateDescriptor("template_name", "/mappings-added-property.json");
     final var currentMappings =
         Map.of(
-            "index_name_full_qualified_name",
-            jsonToIndexMappingProperties("/mappings.json", "index_name"));
+            indexTemplate.getFullQualifiedName(),
+            jsonToIndexMappingProperties("/mappings.json", indexTemplate.getFullQualifiedName()));
 
     // when
-    final var indexTemplate =
-        SchemaTestUtil.mockIndexTemplate(
-            "index_name",
-            "index_name.*",
-            "alias",
-            Collections.emptyList(),
-            "template_name",
-            "/mappings-added-property.json");
-    when(indexTemplate.getFullQualifiedName()).thenReturn("index_name_full_qualified_name");
-
-    // then
     final var difference = VALIDATOR.validateIndexMappings(currentMappings, Set.of(indexTemplate));
 
+    // then
     assertThat(difference)
         .containsExactly(
             entry(
@@ -262,13 +245,7 @@ public class IndexSchemaValidatorTest {
 
     // when
     final var indexTemplate =
-        SchemaTestUtil.mockIndexTemplate(
-            "index_name",
-            "index_name.*",
-            "alias",
-            Collections.emptyList(),
-            "template_name",
-            "/mappings-deleted-property.json");
+        createTestTemplateDescriptor("template_name", "/mappings-deleted-property.json");
 
     // then
     final var difference = VALIDATOR.validateIndexMappings(currentMappings, Set.of(indexTemplate));
@@ -285,9 +262,7 @@ public class IndexSchemaValidatorTest {
             jsonToIndexMappingProperties("/mappings-with-list-1.json", "qualified_name"));
 
     // when
-    final var index =
-        SchemaTestUtil.mockIndex(
-            "qualified_name", "alias", "index_name", "/mappings-with-list-2.json");
+    final var index = createTestIndexDescriptor("index_name", "/mappings-with-list-2.json");
 
     // then
     final var difference = VALIDATOR.validateIndexMappings(currentMappings, Set.of(index));

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -7,18 +7,16 @@
  */
 package io.camunda.search.schema;
 
-import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.CONFIG_PREFIX;
 import static io.camunda.search.schema.utils.SchemaTestUtil.createSchemaManager;
+import static io.camunda.search.schema.utils.SchemaTestUtil.createTestIndexDescriptor;
+import static io.camunda.search.schema.utils.SchemaTestUtil.createTestTemplateDescriptor;
 import static io.camunda.search.schema.utils.SchemaTestUtil.mappingsMatch;
-import static io.camunda.search.schema.utils.SchemaTestUtil.mockIndex;
-import static io.camunda.search.schema.utils.SchemaTestUtil.mockIndexTemplate;
 import static io.camunda.search.schema.utils.SchemaTestUtil.searchEngineClientFromConfig;
 import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +26,8 @@ import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.search.schema.utils.SchemaManagerITInvocationProvider;
+import io.camunda.search.schema.utils.TestIndexDescriptor;
+import io.camunda.search.schema.utils.TestTemplateDescriptor;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -39,7 +39,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -60,26 +59,15 @@ import org.opensearch.client.opensearch._types.OpenSearchException;
 @ExtendWith(SchemaManagerITInvocationProvider.class)
 public class SchemaManagerIT {
 
-  private IndexDescriptor index;
-  private IndexTemplateDescriptor indexTemplate;
+  private TestIndexDescriptor index;
+  private TestTemplateDescriptor indexTemplate;
   private ObjectMapper objectMapper;
 
   @BeforeEach
   public void refresh() throws IOException {
     objectMapper = TestObjectMapper.objectMapper();
-    indexTemplate =
-        mockIndexTemplate(
-            "index_name",
-            "test*",
-            "template_alias",
-            Collections.emptyList(),
-            CONFIG_PREFIX + "-template_name",
-            "/mappings.json");
-
-    index =
-        mockIndex(CONFIG_PREFIX + "-index-qualified_name", "alias", "index_name", "/mappings.json");
-
-    when(indexTemplate.getFullQualifiedName()).thenReturn(CONFIG_PREFIX + "-qualified_name");
+    indexTemplate = createTestTemplateDescriptor("template_name", "/mappings.json");
+    index = createTestIndexDescriptor("index_name", "/mappings.json");
   }
 
   @TestTemplate
@@ -182,7 +170,7 @@ public class SchemaManagerIT {
     schemaManager.initialiseResources();
 
     // when
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
 
     final Map<IndexDescriptor, Collection<IndexMappingProperty>> schemasToChange =
         Map.of(indexTemplate, Set.of());
@@ -243,8 +231,8 @@ public class SchemaManagerIT {
     schemaManager.startup();
 
     // when
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    index.setMappingsClasspathFilename("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
 
     schemaManager.startup();
 
@@ -281,23 +269,11 @@ public class SchemaManagerIT {
     schemaManager.startup();
 
     // when
-    final var newIndex =
-        mockIndex("new_index_qualified", "new_alias", "new_index", "/mappings-added-property.json");
+    final var newIndex = createTestIndexDescriptor("new_index", "/mappings-added-property.json");
     final var newIndexTemplate =
-        mockIndexTemplate(
-            "new_template_name",
-            "new_test*",
-            "new_template_alias",
-            Collections.emptyList(),
-            "new_template_name",
-            "/mappings-added-property.json");
-
-    when(newIndexTemplate.getFullQualifiedName())
-        .thenReturn(config.connect().getIndexPrefix() + "new_template_index_qualified_name");
-
+        createTestTemplateDescriptor("new_template_name", "/mappings-added-property.json");
     indices.add(newIndex);
     indexTemplates.add(newIndexTemplate);
-
     schemaManager.startup();
 
     // then
@@ -409,7 +385,7 @@ public class SchemaManagerIT {
     assertThat(mappingsMatch(retrievedIndex.get("mappings"), currentMappingsFile)).isTrue();
 
     // when
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn(newMappingsFile);
+    indexTemplate.setMappingsClasspathFilename(newMappingsFile);
 
     schemaManager.startup();
 
@@ -448,8 +424,7 @@ public class SchemaManagerIT {
     assertThat(initialMatchingIndex.at(indexSettingsToBeAppended).asText()).isEqualTo("");
 
     // when
-    when(indexTemplate.getMappingsClasspathFilename())
-        .thenReturn("/mappings-and-updated-settings.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-and-updated-settings.json");
 
     // change index template schema to have new updated settings and trigger update
     schemaManager.startup();
@@ -582,7 +557,7 @@ public class SchemaManagerIT {
     schemaManager.startup();
 
     // update the index template with a different mapping
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
 
     // when, then
     assertThat(schemaManager.isSchemaReadyForUse()).isFalse();
@@ -611,8 +586,7 @@ public class SchemaManagerIT {
     assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(0);
     assertThat(initialTemplate.at(shardsSettingPath).asInt()).isEqualTo(1);
 
-    when(indexTemplate.getMappingsClasspathFilename())
-        .thenReturn("/mappings-settings-replica-and-shards.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-settings-replica-and-shards.json");
 
     config.index().setNumberOfReplicas(5);
     config.index().setNumberOfShards(5);
@@ -730,8 +704,8 @@ public class SchemaManagerIT {
     final var schemaManager1 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
     final var schemaManager2 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
 
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    index.setMappingsClasspathFilename("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
 
     // when
     schemaManager1.startup();
@@ -763,8 +737,8 @@ public class SchemaManagerIT {
     final var schemaManager1 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
     final var schemaManager2 = createSchemaManager(Set.of(index), Set.of(indexTemplate), config);
 
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    index.setMappingsClasspathFilename("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
 
     // when
     schemaManager1.startup();
@@ -809,7 +783,7 @@ public class SchemaManagerIT {
     assertThat(mappingsMatch(initialArchiveIndex.get("mappings"), "/mappings.json")).isTrue();
 
     // when
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    indexTemplate.setMappingsClasspathFilename("/mappings-added-property.json");
     schemaManager.startup();
 
     // then
@@ -979,17 +953,9 @@ public class SchemaManagerIT {
     // in Opensearch, "dynamic" field is stored String, while in Elasticsearch it is saved as
     // boolean this gives different results in diff comparison :(
     final var mappingsFileNamePrefix = config.connect().getTypeEnum().isOpenSearch() ? "/os" : "";
-    final String indexPattern = "test_*";
     final var indexTemplate =
-        mockIndexTemplate(
-            "index_name",
-            indexPattern,
-            "template_alias",
-            Collections.emptyList(),
-            CONFIG_PREFIX + "-template_name",
-            mappingsFileNamePrefix + "/mappings-dynamic-property.json");
-
-    when(indexTemplate.getFullQualifiedName()).thenReturn(indexPattern.replace("*", ""));
+        createTestTemplateDescriptor(
+            "template_name", mappingsFileNamePrefix + "/mappings-dynamic-property.json");
 
     final var schemaManager =
         new SchemaManager(
@@ -1002,8 +968,8 @@ public class SchemaManagerIT {
     schemaManager.startup();
 
     final var runtimeIndexName = indexTemplate.getFullQualifiedName();
-    final var archiveIndexName1 = indexPattern.replace("*", "-archived_1");
-    final var archiveIndexName2 = indexPattern.replace("*", "-archived_2");
+    final var archiveIndexName1 = indexTemplate.getIndexPattern().replace("*", "-archived_1");
+    final var archiveIndexName2 = indexTemplate.getIndexPattern().replace("*", "-archived_2");
 
     // index some data to the runtime and archive indices. "world" is a dynamic property
     searchClientAdapter.index(
@@ -1033,8 +999,8 @@ public class SchemaManagerIT {
 
     // when
     // update mappings
-    when(indexTemplate.getMappingsClasspathFilename())
-        .thenReturn(mappingsFileNamePrefix + "/mappings-dynamic-property-added.json");
+    indexTemplate.setMappingsClasspathFilename(
+        mappingsFileNamePrefix + "/mappings-dynamic-property-added.json");
     schemaManager.startup();
 
     // then

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SchemaTestUtil.java
@@ -8,8 +8,6 @@
 package io.camunda.search.schema.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -26,46 +24,20 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public final class SchemaTestUtil {
 
   private SchemaTestUtil() {}
 
-  public static IndexTemplateDescriptor mockIndexTemplate(
-      final String indexName,
-      final String indexPattern,
-      final String alias,
-      final List<String> composedOf,
-      final String templateName,
-      final String mappingsFileName) {
-    final var descriptor = mock(IndexTemplateDescriptor.class);
-    when(descriptor.getIndexName()).thenReturn(indexName);
-    when(descriptor.getIndexPattern()).thenReturn(indexPattern);
-    when(descriptor.getAlias()).thenReturn(alias);
-    when(descriptor.getComposedOf()).thenReturn(composedOf);
-    when(descriptor.getTemplateName()).thenReturn(templateName);
-    when(descriptor.getMappingsClasspathFilename()).thenReturn(mappingsFileName);
-    when(descriptor.getAllVersionsIndexNameRegexPattern())
-        .thenAnswer(ignored -> descriptor.getFullQualifiedName() + ".*");
-
-    return descriptor;
+  public static TestTemplateDescriptor createTestTemplateDescriptor(
+      final String indexName, final String mappingsFileName) {
+    return new TestTemplateDescriptor(indexName, mappingsFileName);
   }
 
-  public static IndexDescriptor mockIndex(
-      final String fullQualifiedName,
-      final String alias,
-      final String indexName,
-      final String mappingsFileName) {
-    final var descriptor = mock(IndexDescriptor.class);
-    when(descriptor.getFullQualifiedName()).thenReturn(fullQualifiedName);
-    when(descriptor.getAlias()).thenReturn(alias);
-    when(descriptor.getIndexName()).thenReturn(indexName);
-    when(descriptor.getMappingsClasspathFilename()).thenReturn(mappingsFileName);
-    when(descriptor.getAllVersionsIndexNameRegexPattern()).thenReturn(fullQualifiedName + ".*");
-
-    return descriptor;
+  public static TestIndexDescriptor createTestIndexDescriptor(
+      final String indexName, final String mappingsFileName) {
+    return new TestIndexDescriptor(indexName, mappingsFileName);
   }
 
   @SuppressWarnings("unchecked")

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/TestIndexDescriptor.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/TestIndexDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.utils;
+
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.CONFIG_PREFIX;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+
+public class TestIndexDescriptor extends AbstractIndexDescriptor {
+
+  private String mappingsClasspathFilename;
+
+  private final String indexName;
+
+  public TestIndexDescriptor(
+      final String indexPrefix,
+      final boolean isElasticsearch,
+      final String indexName,
+      final String mappingsClasspathFilename) {
+    super(indexPrefix, isElasticsearch);
+    this.indexName = indexName;
+    this.mappingsClasspathFilename = mappingsClasspathFilename;
+  }
+
+  public TestIndexDescriptor(final String indexName, final String mappingsClasspathFilename) {
+    this(CONFIG_PREFIX, true, indexName, mappingsClasspathFilename);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @Override
+  public String getMappingsClasspathFilename() {
+    return mappingsClasspathFilename;
+  }
+
+  public void setMappingsClasspathFilename(final String mappingsClasspathFilename) {
+    this.mappingsClasspathFilename = mappingsClasspathFilename;
+  }
+
+  @Override
+  public String getComponentName() {
+    return "test";
+  }
+}

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/TestTemplateDescriptor.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/TestTemplateDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.utils;
+
+import static io.camunda.search.schema.utils.SchemaManagerITInvocationProvider.CONFIG_PREFIX;
+
+import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
+
+public class TestTemplateDescriptor extends AbstractTemplateDescriptor {
+
+  private String mappingsClasspathFilename;
+
+  private final String indexName;
+
+  public TestTemplateDescriptor(
+      final String indexPrefix,
+      final boolean isElasticsearch,
+      final String indexName,
+      final String mappingsClasspathFilename) {
+    super(indexPrefix, isElasticsearch);
+    this.indexName = indexName;
+    this.mappingsClasspathFilename = mappingsClasspathFilename;
+  }
+
+  public TestTemplateDescriptor(final String indexName, final String mappingsClasspathFilename) {
+    this(CONFIG_PREFIX, true, indexName, mappingsClasspathFilename);
+  }
+
+  @Override
+  public String getComponentName() {
+    return "test";
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  @Override
+  public String getMappingsClasspathFilename() {
+    return mappingsClasspathFilename;
+  }
+
+  public void setMappingsClasspathFilename(final String mappingsClasspathFilename) {
+    this.mappingsClasspathFilename = mappingsClasspathFilename;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Replaced  `mockIndex(...)` `mockIndexTemplate(...)`, which returned a mocked `IndexDescriptor` amd `IndexTemplateDescriptor`, with a simpler stub implementation using `TestIndexDescriptor` and `TestTemplateDescriptor`.

**Why?**
* The mock setup was verbose and hard to understand and to debug.
* The new `TestIndexDescriptor` and `TestTemplateDescriptor` provide a minimal concrete implementation, which is easier to maintain, reason about in tests, and closer to real-world scenarios.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
