### PR TITLE
fix: add new partitions to BrokerClusterStateImpl

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -240,6 +240,7 @@ public final class BrokerTopologyManagerImpl extends Actor
                 newReplicationFactor);
             topologyToUpdate.setClusterSize(newClusterSize);
             topologyToUpdate.setPartitionsCount(newPartitionsCount);
+            clusterTopology.partitionIds().forEach(topologyToUpdate::addPartitionIfAbsent);
             topologyToUpdate.setReplicationFactor(newReplicationFactor);
           }
         });

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -452,7 +453,7 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
-  void shouldUpdatePartitionsCountFromClusterTopology() {
+  void shouldUpdatePartitionsFromClusterTopology() {
     // given
     final var broker = createBroker(1);
     notifyEvent(createMemberAddedEvent(broker));
@@ -485,6 +486,8 @@ final class BrokerTopologyManagerTest {
     Awaitility.await()
         .untilAsserted(
             () -> assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(2));
+
+    assertThat(topologyManager.getTopology().getPartitions()).isEqualTo(List.of(1, 2));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -267,6 +268,13 @@ public record ClusterConfiguration(
   public int partitionCount() {
     return (int)
         members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();
+  }
+
+  public IntStream partitionIds() {
+    return members.values().stream()
+        .flatMapToInt(m -> m.partitions().keySet().stream().mapToInt(i -> i))
+        .sorted()
+        .distinct();
   }
 
   public Integer minReplicationFactor() {


### PR DESCRIPTION
## Description
The field `partitions` was never updated when new partitions are added to the cluster.


## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

I don't think we really need backporting as that number is not changing :shrug: 