### PR TITLE
Optimize 8.6 fix spring security vulnerability

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -51,7 +51,7 @@
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <apache.http5-core.version>5.3.1</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
-    <spring.boot.version>3.3.10</spring.boot.version>
+    <spring.boot.version>3.3.11</spring.boot.version>
     <spring.version>6.1.17</spring.version>
     <spring.security.version>6.4.6</spring.security.version>
     <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR upgrades Spring Boot from 3.3.10 to 3.3.11 to address [CVE-2025-22235](https://jira.camunda.com/browse/SEC-1456), which affects EndpointRequest.to(...) in Spring Security.

While Optimize does not use EndpointRequest.to(...) in its codebase, Spring Boot 3.3.10 includes a vulnerable version of Spring Security (6.3.8). Spring Boot 3.3.11 includes the patched version of Spring Security (6.3.9), as recommended in the [official advisory](https://spring.io/security/cve-2025-22235).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #
